### PR TITLE
AI chat: heartbeat, watchdog, Stop button, per-tool state

### DIFF
--- a/packages/mindmap/src/AIChatPanel.tsx
+++ b/packages/mindmap/src/AIChatPanel.tsx
@@ -31,10 +31,22 @@ interface SpeechRecognition extends EventTarget {
   stop(): void;
 }
 
+type ToolCallState = 'running' | 'done' | 'error';
+
+interface ChatToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  result?: unknown;
+  state?: ToolCallState;
+}
+
 interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
-  toolCalls?: Array<{ id: string; name: string; args: Record<string, unknown>; result?: unknown }>;
+  toolCalls?: ChatToolCall[];
+  /** Non-bubble status notice (rendered as a banner under the message). */
+  statusBanner?: { kind: 'error' | 'info'; text: string };
 }
 
 interface Props {
@@ -51,6 +63,10 @@ export function AIChatPanel({ mapId, onClose }: Props) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  // Lets the user cancel an in-flight request via the Stop button. We hold a
+  // ref rather than state so the Stop click reads the current controller
+  // without dragging it through React's render loop.
+  const abortRef = useRef<AbortController | null>(null);
   // Snapshot of the input when listening starts. Each onresult event rebuilds
   // input = base + final + interim, so the user can still see what they had
   // typed before they hit the mic.
@@ -166,94 +182,126 @@ export function AIChatPanel({ mapId, onClose }: Props) {
       toolCalls: m.toolCalls,
     }));
 
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    // Commits the in-flight assistant message into state. Called after every
+    // event so the UI reflects partial progress (deltas, tool start/finish).
+    let assistantContent = '';
+    const toolCalls: ChatToolCall[] = [];
+    let banner: ChatMessage['statusBanner'] = undefined;
+    const flush = () => {
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        const draft: ChatMessage = {
+          role: 'assistant',
+          content: assistantContent,
+          toolCalls: toolCalls.map((tc) => ({ ...tc })),
+          statusBanner: banner,
+        };
+        if (last?.role === 'assistant') return [...prev.slice(0, -1), draft];
+        if (assistantContent || toolCalls.length > 0 || banner) return [...prev, draft];
+        return prev;
+      });
+    };
+
     try {
-      let assistantContent = '';
-      const toolCalls: ChatMessage['toolCalls'] = [];
       let needsRefresh = false;
 
-      for await (const event of api.aiChat(mapId, apiMessages, { selectedNodeId })) {
+      for await (const event of api.aiChat(mapId, apiMessages, {
+        selectedNodeId,
+        signal: controller.signal,
+      })) {
         switch (event.type) {
           case 'delta':
             assistantContent += event.content ?? '';
-            // Update the assistant message in real-time
-            setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last?.role === 'assistant') {
-                return [...prev.slice(0, -1), { ...last, content: assistantContent, toolCalls: [...toolCalls] }];
-              }
-              return [...prev, { role: 'assistant', content: assistantContent, toolCalls: [...toolCalls] }];
-            });
+            flush();
             break;
 
           case 'tool_call':
-            toolCalls.push({ id: event.id ?? '', name: event.name!, args: event.args ?? {} });
-            setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last?.role === 'assistant') {
-                return [...prev.slice(0, -1), { ...last, content: assistantContent, toolCalls: [...toolCalls] }];
-              }
-              return [...prev, { role: 'assistant', content: assistantContent, toolCalls: [...toolCalls] }];
+            toolCalls.push({
+              id: event.id ?? '',
+              name: event.name!,
+              args: event.args ?? {},
+              state: 'running',
             });
+            flush();
             break;
 
           case 'tool_result': {
-            // Update the tool call with its result
             const tc = toolCalls.find((t) =>
-              event.id ? t.id === event.id : t.name === event.name && !t.result,
+              event.id ? t.id === event.id : t.name === event.name && t.state === 'running',
             );
-            if (tc) tc.result = event.result;
-            // Mark that we need a map refresh if a mutating tool was called
+            if (tc) {
+              tc.result = event.result;
+              tc.state =
+                typeof event.result === 'string' && event.result.startsWith('Error:')
+                  ? 'error'
+                  : 'done';
+            }
             if (event.name !== 'get_map' && event.name !== 'search_nodes') {
               needsRefresh = true;
             }
-            setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last?.role === 'assistant') {
-                return [...prev.slice(0, -1), { ...last, content: assistantContent, toolCalls: [...toolCalls] }];
-              }
-              return [...prev, { role: 'assistant', content: assistantContent, toolCalls: [...toolCalls] }];
-            });
+            flush();
             break;
           }
 
+          case 'step_limit':
+            banner = {
+              kind: 'info',
+              text: `Stopped after ${event.maxSteps ?? 6} tool steps — ask a follow-up to continue.`,
+            };
+            flush();
+            break;
+
           case 'error':
-            assistantContent += `\n\nError: ${event.message}`;
-            setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last?.role === 'assistant') {
-                return [...prev.slice(0, -1), { ...last, content: assistantContent }];
-              }
-              return [...prev, { role: 'assistant', content: assistantContent }];
-            });
+            banner = {
+              kind: 'error',
+              text: event.message ?? 'The AI hit an error.',
+            };
+            // Any tool still marked "running" never reported back — mark it
+            // failed so the user doesn't think it's still doing something.
+            for (const tc of toolCalls) {
+              if (tc.state === 'running') tc.state = 'error';
+            }
+            flush();
             break;
         }
       }
 
-      // Ensure the final assistant message is saved
-      setMessages((prev) => {
-        const last = prev[prev.length - 1];
-        if (last?.role === 'assistant') {
-          return [...prev.slice(0, -1), { ...last, content: assistantContent, toolCalls: [...toolCalls] }];
-        }
-        if (assistantContent || toolCalls.length > 0) {
-          return [...prev, { role: 'assistant', content: assistantContent, toolCalls: [...toolCalls] }];
-        }
-        return prev;
-      });
+      flush();
 
-      // Refresh the map if any mutating tools were called
       if (needsRefresh) {
         await loadMap(mapId);
       }
     } catch (err: any) {
-      setMessages((prev) => [
-        ...prev,
-        { role: 'assistant', content: `Error: ${err.message}` },
-      ]);
+      if (controller.signal.aborted) {
+        banner = { kind: 'info', text: 'Stopped.' };
+      } else {
+        const code = (err as { code?: string }).code;
+        banner = {
+          kind: 'error',
+          text:
+            code === 'AI_DISCONNECTED'
+              ? 'Connection to the AI was lost. Try again.'
+              : err?.message
+                ? `Error: ${err.message}`
+                : 'Something went wrong.',
+        };
+      }
+      for (const tc of toolCalls) {
+        if (tc.state === 'running') tc.state = 'error';
+      }
+      flush();
     } finally {
+      if (abortRef.current === controller) abortRef.current = null;
       setLoading(false);
     }
-  }, [input, messages, loading, mapId, loadMap]);
+  }, [input, messages, loading, mapId, loadMap, selectedNodeId]);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
 
   // Latest-sendMessage ref — rec.onend captures toggleMic's closure, which
   // would otherwise see a stale sendMessage and submit with stale state.
@@ -271,6 +319,7 @@ export function AIChatPanel({ mapId, onClose }: Props) {
 
   return (
     <div style={panelStyle}>
+      <style>{`@keyframes mindblown-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }`}</style>
       {/* Header */}
       <div style={headerStyle}>
         <span style={{ fontWeight: 600, fontSize: 14 }}>AI Chat</span>
@@ -315,6 +364,9 @@ export function AIChatPanel({ mapId, onClose }: Props) {
             </div>
             {msg.toolCalls?.map((tc, j) => (
               <div key={j} style={toolCallStyle}>
+                <span style={{ ...toolBadgeStyle, ...toolBadgeVariant(tc.state) }}>
+                  {toolBadgeLabel(tc.state)}
+                </span>
                 <span style={{ fontWeight: 500 }}>{formatToolName(tc.name)}</span>
                 {tc.args && Object.keys(tc.args).length > 0 && (
                   <span style={{ color: '#64748b' }}>
@@ -322,16 +374,33 @@ export function AIChatPanel({ mapId, onClose }: Props) {
                   </span>
                 )}
                 {tc.result != null && (
-                  <div style={{ fontSize: 11, color: '#16a34a', marginTop: 2 }}>
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: tc.state === 'error' ? '#dc2626' : '#16a34a',
+                      marginTop: 2,
+                    }}
+                  >
                     {formatToolResult(tc.name, tc.result)}
                   </div>
                 )}
               </div>
             ))}
+            {msg.statusBanner && (
+              <div
+                style={
+                  msg.statusBanner.kind === 'error' ? errorBannerStyle : infoBannerStyle
+                }
+              >
+                {msg.statusBanner.text}
+              </div>
+            )}
           </div>
         ))}
-        {loading && messages[messages.length - 1]?.role === 'user' && (
-          <div style={{ ...assistantBubbleStyle, opacity: 0.5 }}>Thinking...</div>
+        {loading && (
+          <div style={workingIndicatorStyle} aria-live="polite">
+            <span style={dotPulseStyle} /> AI is working…
+          </div>
         )}
         <div ref={messagesEndRef} />
       </div>
@@ -365,19 +434,42 @@ export function AIChatPanel({ mapId, onClose }: Props) {
             <MicIcon />
           </button>
         )}
-        <button
-          onClick={() => sendMessage()}
-          disabled={loading || !input.trim()}
-          style={{
-            ...sendBtnStyle,
-            opacity: loading || !input.trim() ? 0.4 : 1,
-          }}
-        >
-          Send
-        </button>
+        {loading ? (
+          <button
+            onClick={stop}
+            title="Stop the AI"
+            aria-label="Stop"
+            style={stopBtnStyle}
+          >
+            Stop
+          </button>
+        ) : (
+          <button
+            onClick={() => sendMessage()}
+            disabled={!input.trim()}
+            style={{
+              ...sendBtnStyle,
+              opacity: !input.trim() ? 0.4 : 1,
+            }}
+          >
+            Send
+          </button>
+        )}
       </div>
     </div>
   );
+}
+
+function toolBadgeLabel(state: ToolCallState | undefined): string {
+  if (state === 'done') return '✓';
+  if (state === 'error') return '✗';
+  return '…';
+}
+
+function toolBadgeVariant(state: ToolCallState | undefined): React.CSSProperties {
+  if (state === 'done') return { background: '#dcfce7', color: '#166534' };
+  if (state === 'error') return { background: '#fee2e2', color: '#991b1b' };
+  return { background: '#e0e7ff', color: '#3730a3' };
 }
 
 // ── Formatters ─────────────────────────────────────────────────
@@ -574,4 +666,69 @@ const sendBtnStyle: React.CSSProperties = {
   fontSize: 13,
   fontWeight: 500,
   cursor: 'pointer',
+};
+
+const stopBtnStyle: React.CSSProperties = {
+  padding: '8px 16px',
+  background: '#fff',
+  color: '#dc2626',
+  border: '1px solid #fecaca',
+  borderRadius: 8,
+  fontSize: 13,
+  fontWeight: 500,
+  cursor: 'pointer',
+};
+
+const toolBadgeStyle: React.CSSProperties = {
+  display: 'inline-block',
+  minWidth: 16,
+  textAlign: 'center',
+  marginRight: 6,
+  padding: '0 5px',
+  borderRadius: 4,
+  fontSize: 10,
+  fontWeight: 700,
+  lineHeight: '14px',
+  verticalAlign: 'middle',
+};
+
+const errorBannerStyle: React.CSSProperties = {
+  marginTop: 4,
+  padding: '6px 10px',
+  background: '#fef2f2',
+  color: '#991b1b',
+  border: '1px solid #fecaca',
+  borderRadius: 6,
+  fontSize: 12,
+  maxWidth: '85%',
+};
+
+const infoBannerStyle: React.CSSProperties = {
+  marginTop: 4,
+  padding: '6px 10px',
+  background: '#fef9c3',
+  color: '#854d0e',
+  border: '1px solid #fde68a',
+  borderRadius: 6,
+  fontSize: 12,
+  maxWidth: '85%',
+};
+
+const workingIndicatorStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '6px 4px',
+  fontSize: 12,
+  color: '#64748b',
+  fontStyle: 'italic',
+};
+
+const dotPulseStyle: React.CSSProperties = {
+  display: 'inline-block',
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  background: '#3b82f6',
+  animation: 'mindblown-pulse 1s ease-in-out infinite',
 };

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -819,18 +819,25 @@ export function setAiProvider(settings: AiProviderSettings): Promise<AiProviderS
 }
 
 export interface ChatSSEEvent {
-  type: 'delta' | 'tool_call' | 'tool_result' | 'done' | 'error';
+  type: 'delta' | 'tool_call' | 'tool_result' | 'step_limit' | 'done' | 'error';
   content?: string;
   id?: string;
   name?: string;
   args?: Record<string, unknown>;
   result?: unknown;
   message?: string;
+  code?: string;
+  maxSteps?: number;
 }
 
 /**
  * Stream a chat conversation with the AI. Returns an async iterator of SSE events.
  * The AI can call tools (create/move/delete nodes) and we get notified of each step.
+ *
+ * If the underlying stream closes before a `done` or `error` event arrives
+ * (e.g. server crash, proxy timeout, killed connection), the generator throws
+ * an Error tagged `code: 'AI_DISCONNECTED'` so the UI can surface it instead
+ * of silently leaving the user staring at a half-written reply.
  */
 export async function* aiChat(
   mapId: string,
@@ -839,7 +846,7 @@ export async function* aiChat(
     content: string;
     toolCalls?: Array<{ id: string; name: string; args: Record<string, unknown>; result?: unknown }>;
   }>,
-  options?: { selectedNodeId?: string | null },
+  options?: { selectedNodeId?: string | null; signal?: AbortSignal },
 ): AsyncGenerator<ChatSSEEvent> {
   const token = getToken();
   const res = await fetch(`${BASE_URL}/api/ai/chat`, {
@@ -853,6 +860,7 @@ export async function* aiChat(
       messages,
       selectedNodeId: options?.selectedNodeId ?? null,
     }),
+    signal: options?.signal,
   });
 
   if (!res.ok) {
@@ -865,6 +873,7 @@ export async function* aiChat(
 
   const decoder = new TextDecoder();
   let buffer = '';
+  let sawTerminal = false;
 
   while (true) {
     const { done, value } = await reader.read();
@@ -881,10 +890,17 @@ export async function* aiChat(
       } else if (line.startsWith('data: ') && currentEvent) {
         try {
           const data = JSON.parse(line.slice(6));
+          if (currentEvent === 'done' || currentEvent === 'error') sawTerminal = true;
           yield { type: currentEvent as ChatSSEEvent['type'], ...data };
         } catch { /* skip malformed */ }
         currentEvent = '';
       }
     }
+  }
+
+  if (!sawTerminal && !options?.signal?.aborted) {
+    const err = new Error('Connection to the AI was lost mid-response.');
+    (err as Error & { code?: string }).code = 'AI_DISCONNECTED';
+    throw err;
   }
 }

--- a/packages/server/src/ai/providers/anthropic.ts
+++ b/packages/server/src/ai/providers/anthropic.ts
@@ -81,23 +81,26 @@ export const anthropicProvider: ChatProvider = {
       (s) => specToAnthropicTool(s) as unknown as Anthropic.Tool,
     );
 
-    const stream = client.messages.stream({
-      model: ANTHROPIC_MODEL,
-      max_tokens: opts.maxTokens ?? 4096,
-      // effort: 'high' is the floor for intelligence-sensitive work on Opus 4.7.
-      // `output_config` may not be in every SDK version's strict types yet;
-      // pass it through with a typed loosening rather than guess at the shape.
-      ...({ output_config: { effort: 'high' } } as Record<string, unknown>),
-      system: [
-        {
-          type: 'text',
-          text: opts.systemPrompt,
-          cache_control: { type: 'ephemeral' },
-        },
-      ],
-      tools,
-      messages: toAnthropicMessages(opts.messages),
-    });
+    const stream = client.messages.stream(
+      {
+        model: ANTHROPIC_MODEL,
+        max_tokens: opts.maxTokens ?? 4096,
+        // effort: 'high' is the floor for intelligence-sensitive work on Opus 4.7.
+        // `output_config` may not be in every SDK version's strict types yet;
+        // pass it through with a typed loosening rather than guess at the shape.
+        ...({ output_config: { effort: 'high' } } as Record<string, unknown>),
+        system: [
+          {
+            type: 'text',
+            text: opts.systemPrompt,
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+        tools,
+        messages: toAnthropicMessages(opts.messages),
+      },
+      opts.signal ? { signal: opts.signal } : undefined,
+    );
 
     // Per-block accumulators for tool_use input JSON, keyed by content-block index.
     const toolBlocks = new Map<

--- a/packages/server/src/ai/providers/ollama.ts
+++ b/packages/server/src/ai/providers/ollama.ts
@@ -71,13 +71,16 @@ export const ollamaProvider: ChatProvider = {
       (s: ToolSpec) => specToOpenAiTool(s) as unknown as OpenAI.ChatCompletionTool,
     );
 
-    const response = await client.chat.completions.create({
-      model: AI_MODEL,
-      messages: toOpenAiMessages(opts.systemPrompt, opts.messages),
-      tools,
-      temperature: 0.3,
-      max_tokens: opts.maxTokens ?? 2048,
-    });
+    const response = await client.chat.completions.create(
+      {
+        model: AI_MODEL,
+        messages: toOpenAiMessages(opts.systemPrompt, opts.messages),
+        tools,
+        temperature: 0.3,
+        max_tokens: opts.maxTokens ?? 2048,
+      },
+      opts.signal ? { signal: opts.signal } : undefined,
+    );
 
     const choice = response.choices[0];
     if (!choice) {

--- a/packages/server/src/ai/providers/types.ts
+++ b/packages/server/src/ai/providers/types.ts
@@ -31,6 +31,8 @@ export interface RunTurnOptions {
   messages: NormalizedMessage[];
   tools: ToolSpec[];
   maxTokens?: number;
+  /** Abort the upstream HTTP call (client disconnect or watchdog timeout). */
+  signal?: AbortSignal;
 }
 
 export type ProviderName = 'ollama' | 'anthropic';

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -304,6 +304,13 @@ Node to break down: "${targetNode.text}"`;
   // next-turn input. MAX_STEPS bounds runaway loops.
 
   const MAX_STEPS = 6;
+  // No provider event for this long → assume upstream is wedged, abort.
+  // Generous because qwen2.5:14b on Ollama can take ~90s for tool-heavy turns.
+  const TURN_WATCHDOG_MS = 120_000;
+  // Idle SSE comment cadence — keeps reverse-proxy connections alive while
+  // we wait on a non-streaming upstream (e.g. Ollama returning a whole
+  // completion in one shot). Comments are ignored by EventSource.
+  const HEARTBEAT_MS = 10_000;
 
   app.post('/api/ai/chat', async (req, reply) => {
     const body = req.body as {
@@ -337,9 +344,41 @@ Node to break down: "${targetNode.text}"`;
       'X-Accel-Buffering': 'no',
     });
 
+    // Connection state. Once the client disconnects (or we wrote `done`/`error`
+    // and ended the response) further writes would EPIPE; guard the helper.
+    let clientGone = false;
     const send = (event: string, data: unknown) => {
-      reply.raw.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+      if (clientGone || reply.raw.destroyed) return;
+      try {
+        reply.raw.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+      } catch {
+        clientGone = true;
+      }
     };
+    const heartbeat = setInterval(() => {
+      if (clientGone || reply.raw.destroyed) return;
+      try {
+        reply.raw.write(`: hb\n\n`);
+      } catch {
+        clientGone = true;
+      }
+    }, HEARTBEAT_MS);
+
+    // Per-request abort: fires on client disconnect OR watchdog timeout. We
+    // record the *reason* in a closure variable so the catch block below can
+    // distinguish "user closed the panel" from "upstream wedged" and either
+    // exit silently or surface AI_TIMEOUT to the (still-watching) user.
+    type AbortReason = 'client_disconnect' | 'timeout' | null;
+    let abortReason: AbortReason = null;
+    const controller = new AbortController();
+    const onClientClose = () => {
+      clientGone = true;
+      if (!controller.signal.aborted) {
+        abortReason = 'client_disconnect';
+        controller.abort();
+      }
+    };
+    reply.raw.on('close', onClientClose);
 
     try {
       const provider = await resolveProvider();
@@ -414,23 +453,47 @@ Rules:
         }
       }
 
+      let hitStepLimit = false;
       for (let step = 0; step < MAX_STEPS; step++) {
         let assistantText = '';
         let firstToolCall: NormalizedToolCall | null = null;
 
-        for await (const ev of provider.runTurn({
-          systemPrompt,
-          messages,
-          tools: getChatToolSpecs(provider.name),
-        })) {
-          if (ev.type === 'text_delta') {
-            assistantText += ev.text;
-            send('delta', { content: ev.text });
-          } else if (ev.type === 'tool_call') {
-            // Only the first tool call per turn \u2014 keeps both providers
-            // consistent and matches the legacy 14B-stable behavior.
-            if (!firstToolCall) firstToolCall = ev.toolCall;
+        // Watchdog: trip if the provider goes silent for too long. Reset on
+        // every event we receive. With Ollama's non-streaming runTurn the
+        // *only* event arrival is the end of the upstream completion, so the
+        // watchdog effectively caps total turn time; with Anthropic streaming
+        // the deltas arrive in milliseconds and the watchdog never trips.
+        let watchdog: NodeJS.Timeout | null = null;
+        const armWatchdog = () => {
+          if (watchdog) clearTimeout(watchdog);
+          watchdog = setTimeout(() => {
+            if (!controller.signal.aborted) {
+              abortReason = 'timeout';
+              controller.abort();
+            }
+          }, TURN_WATCHDOG_MS);
+        };
+        armWatchdog();
+
+        try {
+          for await (const ev of provider.runTurn({
+            systemPrompt,
+            messages,
+            tools: getChatToolSpecs(provider.name),
+            signal: controller.signal,
+          })) {
+            armWatchdog();
+            if (ev.type === 'text_delta') {
+              assistantText += ev.text;
+              send('delta', { content: ev.text });
+            } else if (ev.type === 'tool_call') {
+              // Only the first tool call per turn \u2014 keeps both providers
+              // consistent and matches the legacy 14B-stable behavior.
+              if (!firstToolCall) firstToolCall = ev.toolCall;
+            }
           }
+        } finally {
+          if (watchdog) clearTimeout(watchdog);
         }
 
         // Append the assistant turn so the next provider call sees the history.
@@ -441,6 +504,11 @@ Rules:
         });
 
         if (!firstToolCall) break;
+
+        // If this was the final allowed iteration and the model still wants
+        // to call tools, we'll execute this one but mark that we ran out of
+        // room to let it summarise \u2014 surface that to the UI as step_limit.
+        if (step === MAX_STEPS - 1) hitStepLimit = true;
 
         send('tool_call', {
           id: firstToolCall.id,
@@ -470,13 +538,27 @@ Rules:
           toolName: firstToolCall.name,
           content: result,
         });
+
+        if (clientGone) break;
       }
 
+      if (hitStepLimit) send('step_limit', { maxSteps: MAX_STEPS });
       send('done', {});
     } catch (err: any) {
-      send('error', { message: err.message });
+      if (abortReason === 'client_disconnect') {
+        // Client is gone, no one's listening \u2014 just unwind silently.
+      } else if (abortReason === 'timeout') {
+        send('error', {
+          code: 'AI_TIMEOUT',
+          message: `The AI took too long to respond (waited ${TURN_WATCHDOG_MS / 1000}s). Try again or simplify the request.`,
+        });
+      } else {
+        send('error', { message: err.message });
+      }
     } finally {
-      reply.raw.end();
+      clearInterval(heartbeat);
+      reply.raw.off('close', onClientClose);
+      if (!reply.raw.destroyed) reply.raw.end();
     }
   });
 


### PR DESCRIPTION
## Summary

Customer feedback (Michael Heaven, 2026-05-14): the chat would freeze on long re-sort requests with no signal whether it was still working or had failed. Diagnosis turned up three layered root causes — non-streaming Ollama upstream goes silent for ~60-120s during tool-heavy turns, chained Caddy on prod closes idle SSE, and the frontend hides its "loading" indicator the moment any assistant content appears.

Addresses these P0 backlog nodes:
- "AI chat freezes mid-operation" (root-cause + timeout/error surfacing)
- "Surface AI state explicitly: processing / waiting / completed / failed"

## Changes

**Backend (`routes/ai.ts`)**
- SSE comment heartbeat every 10s — keeps reverse-proxy connections alive across long Ollama waits
- Per-turn 120s watchdog — aborts wedged upstreams with explicit `AI_TIMEOUT` instead of hanging forever
- `AbortController` also tripped by client `close` so the upstream request actually stops when the user gives up
- New `step_limit` SSE event when MAX_STEPS (6) is exhausted mid-tool-loop — was silently truncating
- All writes guarded against EPIPE after disconnect

**Provider plumbing (`providers/{types,ollama,anthropic}.ts`)**
- `RunTurnOptions.signal` threaded through to both SDKs so abort actually cancels the upstream HTTP call

**Frontend (`api.ts` + `AIChatPanel.tsx`)**
- `aiChat` accepts `AbortSignal`; throws tagged `AI_DISCONNECTED` if the stream ends without `done`/`error` (was silent)
- Per-tool-call state badges: running …, done ✓, error ✗ — partial progress is now visible
- Persistent "AI is working…" footer while loading (was hidden the moment the first delta arrived)
- **Stop** button replaces Send while in flight
- Errors and `step_limit` render as banners under the message, not appended into the assistant bubble

## Test plan

- [ ] Send a normal short request → reply streams in, footer disappears on completion
- [ ] Ask Ollama for a re-sort / bulk operation that takes 30+ seconds → footer stays visible, tool badge shows "running" then flips to ✓
- [ ] During an in-flight request, click Stop → request aborts, "Stopped." banner appears
- [ ] Kill the server mid-stream (or pull network) → red "Connection to the AI was lost" banner appears (no half-finished bubble)
- [ ] Send a request that forces 6+ tool calls → "Stopped after 6 tool steps" banner under the final message
- [ ] Verify production behind chained Caddy: long Ollama turn no longer drops the SSE connection at ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)