### PR TITLE
GitHub import: honor epic→issue hierarchy from body references

### DIFF
--- a/packages/integrations/src/github.ts
+++ b/packages/integrations/src/github.ts
@@ -423,6 +423,84 @@ export interface ImportedIssue {
   groupLabel: string | null;
   /** GitHub milestone title, if the issue belongs to one. */
   milestoneTitle: string | null;
+  /**
+   * Parent issue number from the same repo, if a hierarchy was detected.
+   * See parseParentRelationships for the patterns that count.
+   */
+  parentNumber: number | null;
+}
+
+/**
+ * Infer a parent-issue number for each issue by scanning bodies for the two
+ * conventions teams actually use to express an "epic → task" hierarchy in
+ * GitHub:
+ *
+ * 1. **Task-list children.** An epic issue lists its children as markdown
+ *    checkboxes: `- [ ] #42`. Each referenced issue gets that epic as parent.
+ * 2. **Explicit parent declaration.** A child issue starts its body with
+ *    `Parent: #5`, `Epic: #5`, `Sub-issue of #5`, or `Part of #5`.
+ *
+ * Only edges where both endpoints are in the import batch survive — we can't
+ * link to an issue we didn't fetch. Cycles are broken by dropping the closing
+ * edge. First-detected parent wins for any given child.
+ */
+export function parseParentRelationships(issues: GitHubIssue[]): Map<number, number> {
+  const inBatch = new Set(issues.map((i) => i.number));
+  const parentOf = new Map<number, number>();
+
+  // Pass 1 — task lists in epic bodies.
+  // `- [ ] #42` or `- [x] owner/repo#42`. Same-repo cross-references only;
+  // we deliberately ignore cross-repo (we can't link to nodes outside this map).
+  const taskListRe = /^\s*[-*]\s+\[[ xX]\]\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gm;
+  for (const issue of issues) {
+    const body = issue.body ?? '';
+    let m: RegExpExecArray | null;
+    const re = new RegExp(taskListRe.source, taskListRe.flags);
+    while ((m = re.exec(body)) !== null) {
+      const childNum = Number.parseInt(m[1], 10);
+      if (childNum === issue.number) continue;
+      if (!inBatch.has(childNum)) continue;
+      if (parentOf.has(childNum)) continue;
+      parentOf.set(childNum, issue.number);
+    }
+  }
+
+  // Pass 2 — explicit parent declarations near the top of the body.
+  // Capped at ~500 chars to avoid matching the same phrase buried in
+  // long discussion or a closing checklist. Word boundary stops "parents"
+  // (or longer words) from being matched as "parent".
+  const parentRe = /(?:^|\n)\s*(?:parent|epic|sub-?issue\s+of|part\s+of)\b[:\s]*#(\d+)/i;
+  for (const issue of issues) {
+    if (parentOf.has(issue.number)) continue;
+    const head = (issue.body ?? '').slice(0, 500);
+    const m = parentRe.exec(head);
+    if (!m) continue;
+    const parentNum = Number.parseInt(m[1], 10);
+    if (parentNum === issue.number) continue;
+    if (!inBatch.has(parentNum)) continue;
+    parentOf.set(issue.number, parentNum);
+  }
+
+  // Pass 3 — break cycles. Walking parent→...→ancestor from each child must
+  // terminate; if we see the same node twice in a chain, drop the edge that
+  // closes the cycle so the rest of the chain can still be honored.
+  const settled = new Set<number>();
+  for (const start of [...parentOf.keys()]) {
+    if (settled.has(start)) continue;
+    const onPath = new Set<number>();
+    let cur: number | undefined = start;
+    while (cur !== undefined && !settled.has(cur)) {
+      if (onPath.has(cur)) {
+        parentOf.delete(cur);
+        break;
+      }
+      onPath.add(cur);
+      cur = parentOf.get(cur);
+    }
+    for (const n of onPath) settled.add(n);
+  }
+
+  return parentOf;
 }
 
 /**
@@ -462,6 +540,8 @@ export async function importGitHubIssues(
     if (issues.length >= 1000) break;
   }
 
+  const parentOf = parseParentRelationships(issues);
+
   return issues.map((issue) => {
     // Prefer milestone's functional part for grouping (e.g. "V1: 3. Erweiterte Funktionen" → "Erweiterte Funktionen")
     // Fall back to first non-priority label if no milestone
@@ -482,6 +562,7 @@ export async function importGitHubIssues(
       externalLink: buildExternalLink(repoOwner, repoName, issue),
       groupLabel,
       milestoneTitle: issue.milestone?.title ?? null,
+      parentNumber: parentOf.get(issue.number) ?? null,
     };
   });
 }

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -452,20 +452,6 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         }
       }
 
-      // ── Group by functional label for tree structure ──────────────
-      const groups = new Map<string, typeof importedIssues>();
-      const ungrouped: typeof importedIssues = [];
-
-      for (const item of importedIssues) {
-        if (item.groupLabel) {
-          const group = groups.get(item.groupLabel) ?? [];
-          group.push(item);
-          groups.set(item.groupLabel, group);
-        } else {
-          ungrouped.push(item);
-        }
-      }
-
       const createdNodes: Array<{ nodeId: string; issueNumber: number }> = [];
       const linkedNodes: Array<{ nodeId: string; issueNumber: number }> = [];
       const skippedNodes: Array<{ nodeId: string; issueNumber: number }> = [];
@@ -496,6 +482,56 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         if (!existingByText.has(key)) existingByText.set(key, n.id);
       }
 
+      // ── Hierarchy resolution ──────────────────────────────────────
+      // importGitHubIssues already inferred parentNumber (task-list + body
+      // "Parent: #N" patterns). We now want each child issue to land under
+      // its parent's node, falling through to milestone/label grouping only
+      // when no parent can be resolved in this batch or in pre-existing nodes.
+      const importedByNumber = new Map<number, typeof importedIssues[0]>();
+      for (const item of importedIssues) {
+        importedByNumber.set(item.issue.number, item);
+      }
+
+      const externalIdOf = (n: number) => `${owner}/${repo}#${n}`;
+      const nodeIdByIssueNumber = new Map<number, string>();
+
+      // An item is a "root" in the import iff it has no parentNumber, or its
+      // parent isn't anywhere reachable (not in this batch, not in the DB).
+      // Roots are the ones that need group/Backlog branch placement; everything
+      // else attaches to a concrete parent node id.
+      const isRootForImport = (item: typeof importedIssues[0]): boolean => {
+        if (item.parentNumber == null) return true;
+        if (importedByNumber.has(item.parentNumber)) return false;
+        if (existingByExternalId.has(externalIdOf(item.parentNumber))) return false;
+        return true;
+      };
+
+      const resolveParentNode = (
+        item: typeof importedIssues[0],
+      ): string | null => {
+        if (item.parentNumber == null) return null;
+        const fromBatch = nodeIdByIssueNumber.get(item.parentNumber);
+        if (fromBatch) return fromBatch;
+        const fromExisting = existingByExternalId.get(externalIdOf(item.parentNumber));
+        if (fromExisting) return fromExisting;
+        return null;
+      };
+
+      // ── Group ROOTS by functional label for branch creation ───────
+      // (Child items will attach to their parent node and bypass this entirely.)
+      const groups = new Map<string, typeof importedIssues>();
+      const ungrouped: typeof importedIssues = [];
+      for (const item of importedIssues) {
+        if (!isRootForImport(item)) continue;
+        if (item.groupLabel) {
+          const group = groups.get(item.groupLabel) ?? [];
+          group.push(item);
+          groups.set(item.groupLabel, group);
+        } else {
+          ungrouped.push(item);
+        }
+      }
+
       // Helper to get the version ID for an issue
       const getIdsForIssue = (item: typeof importedIssues[0]) => {
         if (!item.milestoneTitle) return {};
@@ -505,18 +541,20 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         return versionId ? { versionId } : {};
       };
 
-      // Process one issue: skip / link-to-existing / create-new.
-      // Returns 'created' if a fresh node was made under newParentFn (lazy),
-      // 'linked' if attached to an existing node, or 'skipped' if already linked.
+      // Process one issue: skip / link-to-existing / create-new under getParentId.
+      // Returns the resolved node id (whether newly created, linked to an
+      // existing match, or already-linked skip) so children can attach to it.
+      // `getParentId` is lazy so we don't create empty branch nodes when every
+      // item in a group ends up routed to an existing node.
       const processItem = async (
         item: typeof importedIssues[0],
-        newParentFn: () => Promise<string>,
-      ): Promise<'created' | 'linked' | 'skipped'> => {
+        getParentId: () => Promise<string>,
+      ): Promise<string> => {
         // (1) Already linked?
         const existingId = existingByExternalId.get(item.externalLink.externalId);
         if (existingId) {
           skippedNodes.push({ nodeId: existingId, issueNumber: item.issue.number });
-          return 'skipped';
+          return existingId;
         }
 
         // (2) Text match on an unlinked existing node?
@@ -535,11 +573,11 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
           // same batch can't re-link it.
           existingByExternalId.set(item.externalLink.externalId, textMatchId);
           linkedNodes.push({ nodeId: textMatchId, issueNumber: item.issue.number });
-          return 'linked';
+          return textMatchId;
         }
 
         // (3) Create new child under the branch (lazy — only create branch if needed).
-        const parentId = await newParentFn();
+        const parentId = await getParentId();
         const childNode = await nodeDb.createNode({
           mapId: req.params.mapId,
           parentId,
@@ -564,29 +602,23 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         existingByExternalId.set(item.externalLink.externalId, childNode.id);
         existingByText.set(normalizeText(item.issue.title), childNode.id);
         createdNodes.push({ nodeId: childNode.id, issueNumber: item.issue.number });
-        return 'created';
+        return childNode.id;
       };
 
-      // Create functional group branch nodes and their children (lazily)
-      for (const [label, items] of groups) {
-        let branchId: string | null = null;
-        const ensureBranch = async (): Promise<string> => {
-          if (branchId) return branchId;
-          const branchNode = await nodeDb.createNode({
-            mapId: req.params.mapId,
-            parentId: parentNodeId,
-            text: label,
-            createdBy,
-          });
-          branchId = branchNode.id;
-          return branchId;
-        };
-        for (const item of items) {
-          await processItem(item, ensureBranch);
-        }
-      }
-
-      // Create ungrouped issues under a "Backlog" branch (lazily)
+      // ── Phase A: process ROOTS through group/Backlog branches ─────
+      const branchIds = new Map<string, string>();
+      const ensureBranch = (label: string) => async (): Promise<string> => {
+        const cached = branchIds.get(label);
+        if (cached) return cached;
+        const branchNode = await nodeDb.createNode({
+          mapId: req.params.mapId,
+          parentId: parentNodeId,
+          text: label,
+          createdBy,
+        });
+        branchIds.set(label, branchNode.id);
+        return branchNode.id;
+      };
       let backlogId: string | null = null;
       const ensureBacklog = async (): Promise<string> => {
         if (backlogId) return backlogId;
@@ -599,8 +631,48 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         backlogId = backlogNode.id;
         return backlogId;
       };
+
+      for (const [label, items] of groups) {
+        const ensureThisBranch = ensureBranch(label);
+        for (const item of items) {
+          const nodeId = await processItem(item, ensureThisBranch);
+          nodeIdByIssueNumber.set(item.issue.number, nodeId);
+        }
+      }
       for (const item of ungrouped) {
-        await processItem(item, ensureBacklog);
+        const nodeId = await processItem(item, ensureBacklog);
+        nodeIdByIssueNumber.set(item.issue.number, nodeId);
+      }
+
+      // ── Phase B: process CHILDREN, draining parents-first ─────────
+      // Each pass picks up items whose parent is now known (either freshly
+      // created in Phase A, created earlier in this loop, or pre-existing in
+      // the DB). Loops until a pass makes no progress — anything still left
+      // is a cycle remainder the parser couldn't break, flushed as a root.
+      const pendingChildren = importedIssues.filter((i) => !isRootForImport(i));
+      let madeProgress = true;
+      while (pendingChildren.length > 0 && madeProgress) {
+        madeProgress = false;
+        for (let i = 0; i < pendingChildren.length; ) {
+          const item = pendingChildren[i];
+          const parentNodeId = resolveParentNode(item);
+          if (parentNodeId == null) {
+            i++;
+            continue;
+          }
+          const nodeId = await processItem(item, async () => parentNodeId);
+          nodeIdByIssueNumber.set(item.issue.number, nodeId);
+          pendingChildren.splice(i, 1);
+          madeProgress = true;
+        }
+      }
+      // Cycle leftovers — fall through to group/Backlog so nothing is dropped.
+      for (const item of pendingChildren) {
+        const fallback = item.groupLabel
+          ? ensureBranch(item.groupLabel)
+          : ensureBacklog;
+        const nodeId = await processItem(item, fallback);
+        nodeIdByIssueNumber.set(item.issue.number, nodeId);
       }
 
       broadcast(req.params.mapId, { type: 'github:imported', count: createdNodes.length });


### PR DESCRIPTION
## Summary

Customer report (Michael Heaven, 2026-05-14): importing a repo with epics + 849 requirement issues collapsed all 849 under a single epic branch instead of splitting them across the epic structure. Root cause: the importer grouped by exactly one signal (milestone, fallback to first non-priority label), so any repo where most issues share a single label or milestone — which is most real repos — produced one giant branch.

Addresses the P0 backlog node *"Initial ingestion mapped 849 requirements under a single epic instead of splitting across the full epic structure"*.

## Changes

**`packages/integrations/src/github.ts`**
- New exported `parseParentRelationships(issues)` that infers parent edges from two conventions teams actually use:
  1. **Task-list children** — an epic body containing `- [ ] #42` (or `- [x] owner/repo#42`) marks issue 42 as a child of the epic.
  2. **Explicit parent declaration** — a child body starting with `Parent: #5`, `Epic: #5`, `Sub-issue of #5`, or `Part of #5` names its parent (word-boundary-anchored so `Parents` / `epicness` don't trigger).
- Edges where either endpoint is outside the import batch are dropped; cycles are broken (drop the closing edge); first-detected parent wins per child.
- New `ImportedIssue.parentNumber: number | null` field — purely additive, so all existing consumers keep working.

**`packages/server/src/routes/integrations.ts`** — import endpoint
- New `resolveParentNode(item)` picks a concrete parent node id from either (a) this-batch issues already processed or (b) pre-existing DB nodes with the matching `externalId`.
- Roots (no parent / unreachable parent) go through the existing milestone/label grouping into branches.
- A drain loop then processes children once their parent's node id is known. Cycle remainders are flushed as roots so nothing is dropped.
- `processItem` now returns the resolved node id (whether newly created, linked, or skipped to existing) so children can attach. Lazy branch creation preserved — empty branches still don't get materialised.

## Other consumers verified
- Preview endpoint (`/api/maps/:mapId/github/preview`) discards group metadata, so the new field is invisible to it.
- MCP `import_github_issues` tool and the mindmap UI only consume the response counts, which are unchanged.

## Test plan

- [ ] Import a repo where an epic body contains `- [ ] #42` checkboxes → issue 42 lands under the epic's node, not under the milestone/label branch.
- [ ] Import a repo where child issues start with `Parent: #5` → land under issue 5's node.
- [ ] Import where parent isn't in the same batch but exists in the DB from a prior import → child lands under the existing parent node.
- [ ] Import where parent isn't anywhere → child falls back to the milestone/label branch (no orphan dropped).
- [ ] Verify dedup still works — re-importing the same issues skips by externalId and links by text match without duplicating.
- [ ] Issue body `My parents like #20` does NOT create a parent edge (word boundary check).
- [ ] Smoke-tested the parser unit with task-list, explicit, false-positive, out-of-batch, and cycle cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)