### PR TITLE
Mindmap: floating zoom controls panel for discoverability

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -1443,6 +1443,57 @@ export function MindmapEditor() {
         </g>
       </svg>
 
+      {/* Floating zoom controls — persistent, discoverable. Bottom-left to
+          stay clear of the right-docked chat panel and the top toolbar. */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 12,
+          bottom: 12,
+          zIndex: 15,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'stretch',
+          background: '#fff',
+          border: '1px solid #e2e8f0',
+          borderRadius: 8,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+          overflow: 'hidden',
+          fontFamily: 'inherit',
+          minWidth: 44,
+        }}
+      >
+        <button
+          onClick={() => setView((v) => ({ ...v, zoom: Math.min(MAX_ZOOM, v.zoom * 1.2) }))}
+          title="Zoom in"
+          aria-label="Zoom in"
+          style={zoomCtrlBtnStyle}
+        >+</button>
+        <button
+          onClick={() => setView((v) => ({ ...v, zoom: 1 }))}
+          title="Reset zoom to 100%"
+          aria-label="Reset zoom"
+          style={{ ...zoomCtrlBtnStyle, fontSize: 11, fontWeight: 600, color: '#64748b' }}
+        >{Math.round(view.zoom * 100)}%</button>
+        <button
+          onClick={() => setView((v) => ({ ...v, zoom: Math.max(MIN_ZOOM, v.zoom / 1.2) }))}
+          title="Zoom out"
+          aria-label="Zoom out"
+          style={zoomCtrlBtnStyle}
+        >−</button>
+        <button
+          onClick={fitToScreen}
+          title="Fit to screen (Cmd/Ctrl+0)"
+          aria-label="Fit to screen"
+          style={{
+            ...zoomCtrlBtnStyle,
+            borderTop: '1px solid #e2e8f0',
+            fontSize: 16,
+            lineHeight: 1,
+          }}
+        >⛶</button>
+      </div>
+
       {/* Bulk action bar */}
       {showBulkActions && (
         <BulkActionBar
@@ -1586,4 +1637,17 @@ const ctxMenuItemStyle: React.CSSProperties = {
   cursor: 'pointer',
   fontSize: 13,
   color: '#1e293b',
+};
+
+const zoomCtrlBtnStyle: React.CSSProperties = {
+  background: '#fff',
+  border: 'none',
+  padding: '6px 0',
+  fontSize: 14,
+  fontWeight: 600,
+  color: '#475569',
+  cursor: 'pointer',
+  textAlign: 'center',
+  lineHeight: 1,
+  fontFamily: 'inherit',
 };


### PR DESCRIPTION
## Summary

Customer feedback (Michael Heaven, 2026-05-14): *"When the map gets too large, it is easy to get lost. It probably needs an auto-zoom, reset view, or 'fit to screen' option."*

The functionality already exists — \`fitToScreen()\`, Cmd/Ctrl+0, and a small text-only "Fit" button in the top-right toolbar. The problem is **discoverability**: the button is buried among other view-mode controls and easy to miss.

This adds the standard spatial-canvas zoom panel pattern (Miro / Figma / Excalidraw) in the bottom-left of the editor:

\`\`\`
┌──────┐
│  +   │
│ 75%  │  ← click resets zoom to 100%
│  −   │
├──────┤
│  ⛶   │  ← fit to screen (Cmd/Ctrl+0)
└──────┘
\`\`\`

Bottom-left placement keeps it clear of the top toolbar and the right-docked AI chat panel.

## Changes

- New floating panel in \`MindmapEditor.tsx\` with zoom in / current % (click-to-reset) / zoom out / fit-to-screen
- Reuses existing \`setView\` / \`fitToScreen\` handlers, respects \`MIN_ZOOM\` / \`MAX_ZOOM\` clamps
- Tooltips + aria-labels on every button
- Existing top-toolbar Fit button stays — it belongs in the view-mode cluster — but is no longer the only path

## Test plan

- [ ] Panel is visible in bottom-left as soon as a map loads
- [ ] +/− buttons zoom and clamp at MIN/MAX
- [ ] Clicking the % button resets zoom to 100%
- [ ] ⛶ button fits the whole map to the viewport
- [ ] Doesn't visually conflict with the open AI chat panel
- [ ] Wheel-scroll over the panel doesn't accidentally zoom the SVG underneath

🤖 Generated with [Claude Code](https://claude.com/claude-code)