### PR TITLE
AI chat: instruct the model to recover from typos via search

### DIFF
--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -408,6 +408,14 @@ Node to break down: "${targetNode.text}"`;
         ? `When the user says "this" or "here", they mean the focused node above. Use its id as parentId for "add a child" requests unless told otherwise.`
         : `When the user says "add X" without a parent, use parentId "${rootId}".`;
 
+      // Tell the model to recover from typos with whatever search tool it
+      // has. Anthropic gets semantic_search; Ollama only sees search_nodes
+      // (the local 14B model drifts when both are exposed at once).
+      const typoRecoveryHint =
+        provider.name === 'anthropic'
+          ? `If the user names a node that doesn't appear in the tree above, treat it as a possible typo or paraphrase — try search_nodes (substring) or semantic_search (meaning) before assuming they meant something literal. E.g. "rename the lawyer node" on a map with no "lawyer" likely means "layer". When still unsure after one search, ask one short clarifying question instead of guessing.`
+          : `If the user names a node that doesn't appear in the tree above, treat it as a possible typo — try search_nodes with the closest substring before assuming they meant something literal. E.g. "rename the lawyer node" on a map with no "lawyer" likely means "layer". When still unsure, ask one short clarifying question instead of guessing.`;
+
       const systemPrompt = `You manage a project mindmap. Reply ONLY in English.
 
 mapId = "${body.mapId}"
@@ -422,7 +430,8 @@ Rules:
 1. Only use IDs shown in [id:...] above. Never invent an ID.
 2. For move_node: "source" is the node being moved, "destination" is where it goes.
 3. One tool call per message. Confirm what you did in one short English sentence.
-4. You cannot delete nodes.`;
+4. You cannot delete nodes.
+5. ${typoRecoveryHint}`;
 
       // Round-trip prior turns' tool calls + results so the model can see
       // what it actually did — without these blocks it second-guesses its


### PR DESCRIPTION
## Summary

Customer feedback (Michael Heaven, 2026-05-14): *"The AI chat seems quite sensitive to exact wording. For example, if I type 'lawyer' instead of 'layer', it seems to go off track rather than understanding the likely intent."*

The system prompt didn't tell the model to handle typos at all — when the user named a node that wasn't in the rendered tree, the model either invented something or took the literal word seriously. This adds one rule that tells the model to try a search tool first and ask a short clarifying question if still unsure.

## Changes

Single-file change in \`routes/ai.ts\`. New rule 5 in the chat system prompt, provider-aware text:

- **Anthropic:** suggests both \`search_nodes\` (substring) and \`semantic_search\` (meaning).
- **Ollama:** only \`search_nodes\` — the local 14B model drifts when both search tools coexist (already gated upstream in \`chatExtras.providers\`).

Example wording: *"rename the lawyer node" on a map with no "lawyer" likely means "layer".*

## Test plan

- [ ] On Anthropic: ask the AI to act on a node with a one-letter typo → model runs search_nodes or semantic_search, then acts on the right node
- [ ] On Anthropic: on a really ambiguous case → model asks one short clarifying question instead of guessing
- [ ] On Ollama: same flow but using search_nodes
- [ ] Pre-existing rules 1-4 still take effect (id discipline, move_node arg order, one tool call per turn, no deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)