### PR TITLE
Chat panels: minimise to a pill, side-by-side allowed when minimised

### DIFF
--- a/packages/mindmap/src/AIChatPanel.tsx
+++ b/packages/mindmap/src/AIChatPanel.tsx
@@ -52,6 +52,7 @@ interface ChatMessage {
 interface Props {
   mapId: string;
   onClose: () => void;
+  onMinimise?: () => void;
 }
 
 // Persisted-message key per map. Survives Map Chat toggling AI Chat off,
@@ -97,7 +98,7 @@ function storeMessages(mapId: string, messages: ChatMessage[]): void {
   }
 }
 
-export function AIChatPanel({ mapId, onClose }: Props) {
+export function AIChatPanel({ mapId, onClose, onMinimise }: Props) {
   // Initialize from storage so toggling Map Chat / × / reload doesn't wipe
   // the conversation. Lazy initializer runs once per mount.
   const [messages, setMessages] = useState<ChatMessage[]>(() =>
@@ -420,6 +421,16 @@ export function AIChatPanel({ mapId, onClose }: Props) {
             Clear
           </button>
         )}
+        {onMinimise && (
+          <button
+            onClick={onMinimise}
+            style={minimiseBtnStyle}
+            title="Minimise"
+            aria-label="Minimise"
+          >
+            −
+          </button>
+        )}
         <button onClick={onClose} style={closeBtnStyle} title="Close (your chat is saved)">&times;</button>
       </div>
 
@@ -655,6 +666,17 @@ const clearBtnStyle: React.CSSProperties = {
   padding: '2px 8px',
   marginRight: 4,
   lineHeight: 1.4,
+  fontFamily: 'inherit',
+};
+
+const minimiseBtnStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  fontSize: 20,
+  color: '#94a3b8',
+  cursor: 'pointer',
+  padding: '0 6px',
+  lineHeight: 1,
   fontFamily: 'inherit',
 };
 

--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -708,6 +708,80 @@ function SprintIndicator({
   );
 }
 
+/**
+ * A small floating pill rendered in place of a docked chat panel when the
+ * user has minimised it. Click the label to restore the panel, click × to
+ * fully close. Stacked above the TicketButton in the bottom-right corner.
+ */
+function MinimisedChip({
+  label,
+  color,
+  bottom,
+  onExpand,
+  onClose,
+}: {
+  label: string;
+  color: string;
+  bottom: number;
+  onExpand: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        right: 20,
+        bottom,
+        zIndex: 40,
+        display: 'flex',
+        alignItems: 'stretch',
+        height: 32,
+        borderRadius: 16,
+        background: '#fff',
+        border: `1px solid ${color}`,
+        boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
+        overflow: 'hidden',
+        fontFamily: 'inherit',
+      }}
+    >
+      <button
+        onClick={onExpand}
+        title={`Restore ${label}`}
+        style={{
+          padding: '0 12px',
+          background: 'transparent',
+          border: 'none',
+          color,
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        {label}
+      </button>
+      <button
+        onClick={onClose}
+        title="Close"
+        aria-label="Close"
+        style={{
+          padding: '0 10px',
+          background: 'transparent',
+          border: 'none',
+          borderLeft: `1px solid ${color}33`,
+          color: '#94a3b8',
+          fontSize: 16,
+          lineHeight: 1,
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
 // ── Main App ───────────────────────────────────────────────────
 
 export function App() {
@@ -750,7 +824,9 @@ export function App() {
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [githubSettingsOpen, setGithubSettingsOpen] = useState(false);
   const [aiChatOpen, setAiChatOpen] = useState(false);
+  const [aiChatMinimised, setAiChatMinimised] = useState(false);
   const [mapChatOpen, setMapChatOpen] = useState(false);
+  const [mapChatMinimised, setMapChatMinimised] = useState(false);
   const mapChatUnread = useMapChatUnread(currentMapId, rootNodeId, mapChatOpen);
   const [workspaceSettingsOpen, setWorkspaceSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -1234,8 +1310,20 @@ export function App() {
           {/* AI Chat toggle */}
           <button
             onClick={() => {
-              setAiChatOpen((v) => !v);
-              setMapChatOpen(false);
+              // Three states: closed → fully open, minimised → restore,
+              // open → close. Bringing AI Chat fully on screen force-minimises
+              // (not closes) a fully-open Map chat — both 380px right-docks
+              // overlap, but its conversation is preserved.
+              if (!aiChatOpen) {
+                setAiChatOpen(true);
+                setAiChatMinimised(false);
+                if (mapChatOpen && !mapChatMinimised) setMapChatMinimised(true);
+              } else if (aiChatMinimised) {
+                setAiChatMinimised(false);
+                if (mapChatOpen && !mapChatMinimised) setMapChatMinimised(true);
+              } else {
+                setAiChatOpen(false);
+              }
             }}
             style={{
               padding: '3px 10px',
@@ -1256,8 +1344,16 @@ export function App() {
           {/* Map chat toggle (talk to other people on this map) */}
           <button
             onClick={() => {
-              setMapChatOpen((v) => !v);
-              setAiChatOpen(false);
+              if (!mapChatOpen) {
+                setMapChatOpen(true);
+                setMapChatMinimised(false);
+                if (aiChatOpen && !aiChatMinimised) setAiChatMinimised(true);
+              } else if (mapChatMinimised) {
+                setMapChatMinimised(false);
+                if (aiChatOpen && !aiChatMinimised) setAiChatMinimised(true);
+              } else {
+                setMapChatOpen(false);
+              }
             }}
             title={
               mapChatUnread > 0
@@ -1538,19 +1634,48 @@ export function App() {
         />
       )}
 
-      {/* AI Chat Panel */}
-      {aiChatOpen && currentMapId && (
+      {/* AI Chat Panel — full panel when open & !minimised, chip when minimised */}
+      {aiChatOpen && currentMapId && !aiChatMinimised && (
         <AIChatPanel
           mapId={currentMapId}
+          onClose={() => setAiChatOpen(false)}
+          onMinimise={() => setAiChatMinimised(true)}
+        />
+      )}
+      {aiChatOpen && currentMapId && aiChatMinimised && (
+        <MinimisedChip
+          label="AI Chat"
+          color="#3b82f6"
+          bottom={72}
+          onExpand={() => {
+            setAiChatMinimised(false);
+            // Force-minimise (not close) the other chat if it's fully open,
+            // so the two 380px right-docked panels don't overlap. Leave it
+            // alone if it's already minimised or fully closed.
+            if (mapChatOpen && !mapChatMinimised) setMapChatMinimised(true);
+          }}
           onClose={() => setAiChatOpen(false)}
         />
       )}
 
-      {/* Map Chat Panel */}
-      {mapChatOpen && currentMapId && rootNodeId && (
+      {/* Map Chat Panel — same minimise pattern */}
+      {mapChatOpen && currentMapId && rootNodeId && !mapChatMinimised && (
         <MapChatPanel
           mapId={currentMapId}
           rootNodeId={rootNodeId}
+          onClose={() => setMapChatOpen(false)}
+          onMinimise={() => setMapChatMinimised(true)}
+        />
+      )}
+      {mapChatOpen && currentMapId && rootNodeId && mapChatMinimised && (
+        <MinimisedChip
+          label={mapChatUnread > 0 ? `Map chat · ${mapChatUnread > 99 ? '99+' : mapChatUnread}` : 'Map chat'}
+          color="#0ea5e9"
+          bottom={aiChatOpen && aiChatMinimised ? 116 : 72}
+          onExpand={() => {
+            setMapChatMinimised(false);
+            if (aiChatOpen && !aiChatMinimised) setAiChatMinimised(true);
+          }}
           onClose={() => setMapChatOpen(false)}
         />
       )}

--- a/packages/mindmap/src/MapChatPanel.tsx
+++ b/packages/mindmap/src/MapChatPanel.tsx
@@ -11,18 +11,32 @@ export function MapChatPanel({
   mapId,
   rootNodeId,
   onClose,
+  onMinimise,
 }: {
   mapId: string;
   rootNodeId: string;
   onClose: () => void;
+  onMinimise?: () => void;
 }) {
   return (
     <div style={panelStyle}>
       <div style={headerStyle}>
         <span style={{ fontWeight: 600, fontSize: 14 }}>Map chat</span>
-        <button onClick={onClose} style={closeBtnStyle} aria-label="Close">
-          &times;
-        </button>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {onMinimise && (
+            <button
+              onClick={onMinimise}
+              style={minimiseBtnStyle}
+              aria-label="Minimise"
+              title="Minimise"
+            >
+              −
+            </button>
+          )}
+          <button onClick={onClose} style={closeBtnStyle} aria-label="Close" title="Close">
+            &times;
+          </button>
+        </div>
       </div>
       <div style={bodyStyle}>
         <CommentsPanel
@@ -66,6 +80,16 @@ const closeBtnStyle: React.CSSProperties = {
   color: '#94a3b8',
   cursor: 'pointer',
   padding: '0 4px',
+  lineHeight: 1,
+};
+
+const minimiseBtnStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  fontSize: 20,
+  color: '#94a3b8',
+  cursor: 'pointer',
+  padding: '0 6px',
   lineHeight: 1,
 };
 


### PR DESCRIPTION
## Summary

Customer feedback (Michael Heaven, 2026-05-14): *"There should be an easier way to minimise or collapse sections/chat."*

Both AI Chat and Map Chat are right-docked 380px panels. Before this:
- The only off-state was closing them entirely
- Opening one forcibly **closed** the other (mutual exclusion at the open level)
- Even with the new persistence, there was no "set this aside but keep it visible" affordance

## Changes

**New − minimise button** on each panel's header. When minimised, the panel collapses to a small pill above the TicketButton in the bottom-right corner; clicking the label restores the full panel, the × closes it.

**Pill stacking:** TicketButton (bottom: 20) → AI Chat pill (72) → Map chat pill (116) when both are minimised. The Map chat pill carries the unread-count suffix the toolbar button already shows.

**Mutual exclusion relaxed:** still applies for the fully-open layout (the two 380px panels would overlap on the right edge), but a full-open chat now **force-minimises** (rather than closing) the other one — so its conversation is preserved on either side and both pills can coexist. Same treatment for both the toolbar toggle buttons and the pill expand handlers.

## Test plan

- [ ] Open AI Chat, click − → panel collapses to a blue pill bottom-right above the ticket button
- [ ] Click the pill → AI Chat panel restores
- [ ] Open AI Chat → minimise → open Map Chat → both pills visible? Wait — only the active one's pill replaces the panel. Open AI, minimise it; open Map, minimise it → BOTH pills visible, stacked
- [ ] With both minimised, expand Map chat from its pill → Map chat goes full, AI chat stays minimised (still a pill)
- [ ] Full-open AI Chat with Map Chat fully open → opening one auto-minimises the other (not closes — conversation preserved)
- [ ] Pill × button fully closes that chat (removes from screen, but persistence still saves messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)