### PR TITLE
Mindmap: fix fit-to-screen when triggered before SVG layout settles

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -476,18 +476,30 @@ export function MindmapEditor() {
 
   // ── Fit to screen function ─────────────────────────────────
 
-  const fitToScreen = useCallback(() => {
-    if (allLayoutNodes.length === 0) return;
+  // One fit attempt — returns true on success, false if the SVG isn't
+  // properly sized yet (we'll retry next frame).
+  const tryFit = useCallback((): boolean => {
+    if (allLayoutNodes.length === 0) return true; // nothing to fit; treat as done
     const svg = svgRef.current;
-    if (!svg) return;
+    if (!svg) return true;
 
-    const bounds = computeBounds(allLayoutNodes);
     const svgRect = svg.getBoundingClientRect();
     const padding = 80;
+    // SVG hasn't been laid out yet (e.g. fired immediately after a view
+    // switch, before flex sizing settled). Reading width/height as 0
+    // previously produced negative scale factors and an inverted "shrunk
+    // to a dot" transform — caller should retry next frame.
+    if (svgRect.width <= padding * 2 || svgRect.height <= padding * 2) {
+      return false;
+    }
 
+    const bounds = computeBounds(allLayoutNodes);
     const scaleX = (svgRect.width - padding * 2) / (bounds.width + padding);
     const scaleY = (svgRect.height - padding * 2) / (bounds.height + padding);
-    const zoom = Math.min(1, Math.min(scaleX, scaleY));
+    // Clamp inside [MIN_ZOOM, 1]. The upper bound stays — fitToScreen
+    // shouldn't ever ENLARGE — but the lower bound prevents pathological
+    // inputs from producing 0 / negative zoom when bounds are degenerate.
+    const zoom = Math.max(MIN_ZOOM, Math.min(1, Math.min(scaleX, scaleY)));
 
     const centerX = bounds.minX + bounds.width / 2;
     const centerY = bounds.minY + bounds.height / 2;
@@ -497,7 +509,17 @@ export function MindmapEditor() {
       panX: svgRect.width / 2 - centerX * zoom,
       panY: svgRect.height / 2 - centerY * zoom,
     });
+    return true;
   }, [allLayoutNodes]);
+
+  const fitToScreen = useCallback(() => {
+    let retries = 5;
+    const attempt = () => {
+      if (tryFit()) return;
+      if (retries-- > 0) requestAnimationFrame(attempt);
+    };
+    attempt();
+  }, [tryFit]);
 
   // Expose fitToScreen, zoomIn, zoomOut on the window for the command palette / App
   useEffect(() => {


### PR DESCRIPTION
## Summary

Customer feedback (Michael Heaven, 2026-05-14): *"Zooming between different views seems to make the sizing go a bit crazy."*

The view switcher conditionally renders MindmapEditor, so switching away (kanban, gantt, etc.) and back unmounts + remounts it. On remount, an auto-fit \`useEffect\` fires \`fitToScreen()\` once \`layoutNodes\` populates. If the parent flex container hadn't settled by then, \`getBoundingClientRect\` returned width/height ≈ 0.

The old \`fitToScreen\` had no clamp on its output:

\`\`\`ts
const zoom = Math.min(1, Math.min(scaleX, scaleY));
\`\`\`

With a zero-width SVG, \`scaleX = (0 - 160) / (bounds.width + 80)\` is **negative** — so zoom went negative and the transform became \`scale(-tiny)\`, producing the "shrunk to a mirrored dot" rendering Michael saw. Wheel-zoom clamped correctly so steady-state worked; only the auto-fit path hit this.

## Fix

- Split into \`tryFit()\` (one attempt, returns false if SVG isn't ready) and \`fitToScreen()\` (kicks off with up to 5 \`requestAnimationFrame\` retries).
- Guard explicitly against \`svgRect.width/height ≤ padding*2\` — if the SVG can't hold the padding it isn't laid out yet.
- Clamp the final zoom inside \`[MIN_ZOOM, 1]\` so degenerate bounds can't produce 0 or negative zoom on the last retry either.

## Test plan

- [ ] Open mindmap, switch to kanban, switch back → map renders at a reasonable zoom (no shrunken / mirrored map)
- [ ] Same flow but rapid: mindmap → kanban → mindmap → list → mindmap → fit still works
- [ ] Wheel-zoom still clamps to MIN_ZOOM / MAX_ZOOM (unchanged)
- [ ] Manual ⛶ button (new floating zoom panel + top-right Fit button + Cmd/Ctrl+0) still works at all viewport sizes
- [ ] Resizing the browser window or opening/closing the AI chat panel doesn't fight fitToScreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)