### PR TITLE
feat(sync): parent-epic auto-progress (#57) + create_node auto-link (#58)

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -36,6 +36,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     versionId: null,
     cycleId: null,
     externalLinks: [],
+    autoProgress: 'off',
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     createdBy: 'user-1',

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -34,6 +34,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     versionId: null,
     cycleId: null,
     externalLinks: [],
+    autoProgress: 'off',
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     createdBy: 'user-1',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,6 +116,16 @@ export interface Node {
   // ── Integrations ──────────────────────────────────────────
   externalLinks: ExternalLink[];
 
+  // ── Auto-progress (parent-epic rollup) ────────────────────
+  /**
+   * When set to `'children'`, the server auto-computes percentComplete on this
+   * node by counting closed/open GitHub child issues whose titles reference
+   * this node's linked issue (e.g. `[#NNNN-followup] ...`). See
+   * `packages/server/src/sync/parentEpicRollup.ts` for the supported patterns.
+   * `'off'` (default) leaves manual progress authoritative.
+   */
+  autoProgress: 'off' | 'children';
+
   // ── Metadata ──────────────────────────────────────────────
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -809,6 +809,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       versionId: null,
       cycleId: null,
       externalLinks: [],
+      autoProgress: 'off',
       createdAt: now,
       updatedAt: now,
       createdBy: state.user?.id ?? 'user-001',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,8 @@
     "build": "tsc || true",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate"
@@ -41,6 +43,7 @@
     "@types/pg": "^8.11.11",
     "drizzle-kit": "^0.30.5",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -33,6 +33,7 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     versionId: (get('versionId', 'version_id') as string) ?? null,
     cycleId: (get('cycleId', 'cycle_id') as string) ?? null,
     externalLinks: (get('externalLinks', 'external_links') as CoreNode['externalLinks']) ?? [],
+    autoProgress: ((get('autoProgress', 'auto_progress') as CoreNode['autoProgress']) ?? 'off'),
     createdAt: (get('createdAt', 'created_at') instanceof Date
       ? (get('createdAt', 'created_at') as Date).toISOString()
       : (get('createdAt', 'created_at') as string)),

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -467,6 +467,14 @@ export async function runMigrations(): Promise<void> {
     ON release_snapshots(map_id, snapshot_date DESC)
   `);
 
+  // ── Parent-epic auto-progress flag on nodes (#57) ─────────────
+  // Default 'off' so existing nodes keep manual progress; flip to
+  // 'children' to opt into auto-rollup from GitHub child-PR patterns.
+  // No backfill needed — the default covers every existing row.
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS auto_progress TEXT NOT NULL DEFAULT 'off'
+  `);
+
   // ── Drop Milestone entity (collapsed into Version) ────────────
   // Historical: milestones were a first-class entity and nodes carried
   // both milestone_id and an is_milestone boolean checkpoint flag.

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -83,6 +83,7 @@ export interface CreateNodeInput {
   priority?: Priority;
   startDate?: string;
   dueDate?: string;
+  autoProgress?: 'off' | 'children';
 }
 
 export async function createNode(input: CreateNodeInput): Promise<CoreNode> {
@@ -103,6 +104,7 @@ export async function createNode(input: CreateNodeInput): Promise<CoreNode> {
     priority: input.priority ?? null,
     startDate: input.startDate ?? null,
     dueDate: input.dueDate ?? null,
+    autoProgress: input.autoProgress ?? 'off',
     assigneeIds: [],
     tags: [],
     customFields: {},

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -162,6 +162,7 @@ export interface UpdateNodeInput {
   versionId?: string | null;
   cycleId?: string | null;
   externalLinks?: ExternalLink[];
+  autoProgress?: 'off' | 'children';
 }
 
 export async function updateNode(
@@ -216,6 +217,7 @@ export async function updateNode(
   if (input.versionId !== undefined) updates.versionId = input.versionId;
   if (input.cycleId !== undefined) updates.cycleId = input.cycleId;
   if (input.externalLinks !== undefined) updates.externalLinks = input.externalLinks;
+  if (input.autoProgress !== undefined) updates.autoProgress = input.autoProgress;
 
   // Conditional update: when expectedRevision is provided, the WHERE clause
   // also matches on revision so a stale write affects 0 rows. We then look

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -99,6 +99,10 @@ export const nodes = pgTable('nodes', {
   versionId: uuid('version_id'),
   cycleId: uuid('cycle_id'),
   externalLinks: jsonb('external_links').notNull().default([]), // ExternalLink[]
+  // Parent-epic auto-progress rollup. 'off' (default) = manual progress is
+  // authoritative; 'children' = computed from linked GitHub child PRs via
+  // parentEpicRollup. See packages/server/src/sync/parentEpicRollup.ts.
+  autoProgress: text('auto_progress').notNull().default('off'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   createdBy: uuid('created_by').notNull().references(() => users.id),

--- a/packages/server/src/routes/__tests__/autolink.test.ts
+++ b/packages/server/src/routes/__tests__/autolink.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the `^#NNNN` create_node / update_node auto-link backstop (#58).
+ *
+ * The full end-to-end flow (DB write + GitHub API lookup) is tested
+ * implicitly by the existing route integration tests; here we lock down the
+ * pure title-parsing pattern, which is the only knob that determines
+ * whether autolink fires at all.
+ *
+ * Spec edge cases covered:
+ *   - leading `#NNNN` followed by whitespace → matches
+ *   - leading `#NNNN` followed by end-of-string → matches
+ *   - `#NNNN #MMMM` → first only (regex anchored, captures only the first)
+ *   - `#NNNN ... PR #MMMM` → leading wins, PR ref ignored
+ *   - mid-title `#NNNN` (not anchored) → no match
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractAutoLinkIssueNumber } from '../nodes.js';
+
+describe('extractAutoLinkIssueNumber', () => {
+  it('matches leading `#NNNN ` (with space)', () => {
+    expect(extractAutoLinkIssueNumber('#937 Fix resolve_workflow_assignees crash'))
+      .toBe(937);
+  });
+
+  it('matches bare `#NNNN` (no trailing content)', () => {
+    expect(extractAutoLinkIssueNumber('#42')).toBe(42);
+  });
+
+  it('extracts first reference when multiple appear', () => {
+    expect(extractAutoLinkIssueNumber('#856 GIIN config - PR #845')).toBe(856);
+    expect(extractAutoLinkIssueNumber('#937 #1042 multi-ref'))
+      .toBe(937);
+  });
+
+  it('does NOT match mid-title `#NNNN`', () => {
+    expect(extractAutoLinkIssueNumber('Closes #42 in passing')).toBeNull();
+    expect(extractAutoLinkIssueNumber('Bug fix for #100')).toBeNull();
+  });
+
+  it('does NOT match when no `#` at all', () => {
+    expect(extractAutoLinkIssueNumber('Plain title')).toBeNull();
+    expect(extractAutoLinkIssueNumber('')).toBeNull();
+  });
+
+  it('does NOT match `#NNNN` glued to other chars (no boundary)', () => {
+    // The spec requires `^#NNNN(?:\s|$)`. Without a space/end after the
+    // number, it's likely something else: an anchor link, a code ref, etc.
+    expect(extractAutoLinkIssueNumber('#42foo')).toBeNull();
+    expect(extractAutoLinkIssueNumber('#42-followup')).toBeNull();
+  });
+
+  it('does NOT match `# NNNN` (space between)', () => {
+    expect(extractAutoLinkIssueNumber('# 42 plain')).toBeNull();
+  });
+
+  it('matches with a trailing tab or newline as whitespace', () => {
+    expect(extractAutoLinkIssueNumber('#42\twith tab')).toBe(42);
+    expect(extractAutoLinkIssueNumber('#42\nnewline')).toBe(42);
+  });
+});

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -14,6 +14,7 @@ import {
   isGitHubAppConfigured,
 } from '@mindblown/integrations';
 import { reconcileRepo } from '../sync/githubCatchup.js';
+import { rollupParentsForChildTitle } from '../sync/parentEpicRollup.js';
 import type { ExternalLink } from '@mindblown/core';
 import { broadcast } from '../ws.js';
 import { maps } from '../db/schema.js';
@@ -71,6 +72,62 @@ export async function getGitHubContextForMap(mapId: string): Promise<GitHubMapCo
   const integration = await getGitHubIntegration(map.workspaceId);
   if (integration) {
     return { owner: integration.config.owner, repo: integration.config.repo, token: integration.config.token };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a GitHub token + repo for a given `owner/repo`, scanning every
+ * map's App binding then every workspace's PAT integration. Used by the
+ * parent-epic rollup, which fires on webhook events for child PRs that
+ * may have no linked node themselves — so we can't go via a mapId.
+ *
+ * Best-effort: returns the first successfully-minted token. Errors minting
+ * an App token (revoked install, etc.) fall through to PAT.
+ */
+async function getGitHubContextForRepo(
+  fullName: string,
+): Promise<GitHubMapContext | null> {
+  const slashIdx = fullName.indexOf('/');
+  if (slashIdx <= 0) return null;
+  const owner = fullName.slice(0, slashIdx);
+  const repo = fullName.slice(slashIdx + 1);
+
+  // App bindings first
+  const appMaps = await db
+    .select({
+      installationId: maps.githubInstallationId,
+      owner: maps.githubRepoOwner,
+      repo: maps.githubRepoName,
+    })
+    .from(maps)
+    .where(
+      and(
+        eq(maps.githubRepoOwner, owner),
+        eq(maps.githubRepoName, repo),
+      ),
+    );
+  for (const m of appMaps) {
+    if (!m.installationId) continue;
+    try {
+      const token = await mintInstallationToken(m.installationId);
+      return { owner, repo, token };
+    } catch (err) {
+      console.warn('[github] Failed to mint installation token in repo lookup:', err);
+    }
+  }
+
+  // Fall back to any PAT integration that points at this repo
+  const patIntegrations = await db
+    .select()
+    .from(integrations)
+    .where(and(eq(integrations.provider, 'github'), eq(integrations.enabled, true)));
+  for (const integ of patIntegrations) {
+    const cfg = integ.config as unknown as GitHubConfig;
+    if (cfg?.owner === owner && cfg?.repo === repo && cfg?.token) {
+      return { owner, repo, token: cfg.token };
+    }
   }
 
   return null;
@@ -764,7 +821,7 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     // Special handling for issues.closed / issues.reopened: preserve and restore
     // the pre-close progress + status so reopening a partially-completed issue
     // doesn't discard the user's prior progress.
-    const issuePayload = payload.issue as { number?: number } | undefined;
+    const issuePayload = payload.issue as { number?: number; title?: string } | undefined;
     const payloadAction = payload.action as string | undefined;
     if (
       event === 'issues' &&
@@ -772,6 +829,29 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       repoFullName &&
       (payloadAction === 'closed' || payloadAction === 'reopened')
     ) {
+      // Parent-epic rollup (#57): if the closing/reopening issue's title
+      // matches one of our child-PR patterns, recompute the parent epic's
+      // progress. Runs regardless of whether the child itself has a linked
+      // node — that's the whole point of the feature. Fire-and-forget so
+      // the webhook response stays snappy and a fetch failure doesn't
+      // prevent us from applying the primary state transition below.
+      if (issuePayload.title) {
+        const closingTitle = issuePayload.title;
+        const closingRepo = repoFullName;
+        (async () => {
+          const ctx = await getGitHubContextForRepo(closingRepo);
+          if (!ctx) return;
+          try {
+            await rollupParentsForChildTitle(closingTitle, ctx);
+          } catch (err) {
+            console.warn(
+              '[parent-epic-rollup] Webhook rollup failed:',
+              err instanceof Error ? err.message : err,
+            );
+          }
+        })().catch(() => {});
+      }
+
       const externalId = `${repoFullName}#${issuePayload.number}`;
       const nodeId = await findNodeByExternalId(externalId);
       const actionLabel = `issues.${payloadAction}`;

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -384,6 +384,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           versionId: null,
           cycleId: null,
           externalLinks: [],
+          autoProgress: 'off',
           createdAt: now,
           updatedAt: now,
           createdBy: parent.createdBy,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -5,9 +5,108 @@ import * as mapDb from '../db/maps.js';
 import * as events from '../db/events.js';
 import { broadcast } from '../ws.js';
 import { scheduleEmbedNode } from '../ai/embeddings.js';
-import { updateGitHubIssue, closeGitHubIssue } from '@mindblown/integrations';
+import { updateGitHubIssue, closeGitHubIssue, getGitHubIssue } from '@mindblown/integrations';
 import { getGitHubContextForMap } from './integrations.js';
 import type { ExternalLink, DependencyType, Node as CoreNode } from '@mindblown/core';
+
+// ── Auto-link helper (#58) ──────────────────────────────────────
+// Titles that begin with `#NNNN` are almost always referencing an existing
+// GitHub issue — the planning agent knew which issue this node represents
+// but forgot to call link_github_issue. We catch that here so the orphan
+// bucket stays empty without per-call discipline. Spec: GitHub issue #58.
+//
+// Pattern: leading `#NNNN` followed by either a space or end-of-string.
+// Anchored — `#NNNN` mid-title is most likely a co-mention (e.g. an inline
+// PR reference), not the node's own identity.
+const AUTOLINK_TITLE_RE = /^#(\d+)(?:\s|$)/;
+
+/**
+ * Extract the leading issue number from a title, or null when the title
+ * doesn't match the auto-link pattern.
+ */
+export function extractAutoLinkIssueNumber(title: string): number | null {
+  if (!title) return null;
+  const m = AUTOLINK_TITLE_RE.exec(title);
+  if (!m) return null;
+  const n = Number.parseInt(m[1], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * If the title starts with `#NNNN` and the map has a GitHub repo bound to
+ * it, verify the issue exists and attach an `externalLink`. Skips silently
+ * when:
+ *   - the title doesn't match the pattern,
+ *   - no GitHub repo is connected,
+ *   - the issue lookup returns a non-2xx (404 = the planning-prefix case
+ *     where `#NNNN` isn't actually an issue number — common false positive),
+ *   - the node already has a GitHub link (caller's explicit link wins).
+ *
+ * Fire-and-forget side of the create/update routes: errors are logged but
+ * never propagate; the node creation/update itself has already succeeded.
+ *
+ * Returns the attached ExternalLink, or null when no link was attached.
+ */
+async function autoLinkNodeFromTitle(
+  nodeId: string,
+  mapId: string,
+  title: string,
+): Promise<ExternalLink | null> {
+  const issueNumber = extractAutoLinkIssueNumber(title);
+  if (issueNumber === null) return null;
+
+  // Re-fetch node to see current externalLinks state (race with concurrent
+  // link_github_issue is extremely unlikely on the create-path, but cheap
+  // to check). For update-path the caller has already gated on "no existing
+  // link" via shouldAutoLinkOnUpdate, but we double-check defensively.
+  const node = await nodeDb.getNode(nodeId);
+  if (!node) return null;
+  const alreadyHasGithub = node.externalLinks.some((l) => l.provider === 'github');
+  if (alreadyHasGithub) return null;
+
+  const ghCtx = await getGitHubContextForMap(mapId);
+  if (!ghCtx) return null;
+
+  // Verify issue exists. 404 is a legit "this is a planning prefix, not an
+  // issue" signal — skip silently. Any other error is logged but also
+  // swallowed; we never want auto-link failure to bubble up.
+  let issue: Awaited<ReturnType<typeof getGitHubIssue>>;
+  try {
+    issue = await getGitHubIssue(ghCtx.owner, ghCtx.repo, issueNumber, ghCtx.token);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Don't spam logs for 404s — that's the "not really an issue ref" case.
+    if (!/404/.test(msg)) {
+      console.warn(
+        `[github-autolink] Issue lookup failed for ${ghCtx.owner}/${ghCtx.repo}#${issueNumber}:`,
+        msg,
+      );
+    }
+    return null;
+  }
+
+  const externalLink: ExternalLink = {
+    provider: 'github',
+    externalId: `${ghCtx.owner}/${ghCtx.repo}#${issueNumber}`,
+    url: issue.html_url,
+    syncEnabled: true,
+    lastSyncedAt: new Date().toISOString(),
+  };
+
+  const updated = await nodeDb.updateNode(nodeId, {
+    externalLinks: [...node.externalLinks, externalLink],
+  });
+  if (updated) {
+    broadcast(mapId, {
+      type: 'node:updated',
+      nodeId,
+      fields: ['externalLinks'],
+      node: updated,
+      source: 'github_autolink',
+    });
+  }
+  return externalLink;
+}
 
 // Fields that should trigger outbound GitHub sync
 const SYNC_FIELDS = new Set([
@@ -67,6 +166,13 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       priority?: 'P0' | 'P1' | 'P2' | 'P3';
       startDate?: string;
       dueDate?: string;
+      /**
+       * Set to `true` when the caller wants to disable the `^#NNNN`
+       * auto-link backstop (#58). Useful when the leading `#NNNN` is
+       * planning syntax unrelated to a real issue and the caller
+       * doesn't want the issue-existence ping.
+       */
+      skipAutoLink?: boolean;
     };
     const userId = req.userId ?? body.createdBy ?? 'system';
 
@@ -76,8 +182,11 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
+    // `skipAutoLink` is not a column on the nodes table — strip it before
+    // forwarding to the DB layer.
+    const { skipAutoLink, ...nodeFields } = body;
     const node = await nodeDb.createNode({
-      ...body,
+      ...nodeFields,
       mapId: req.params.id,
       createdBy: userId,
     });
@@ -87,6 +196,16 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
 
     // Schedule a background embedding for semantic search
     scheduleEmbedNode(node.id);
+
+    // Auto-link to GitHub issue when title starts with `#NNNN` (#58).
+    // Fire-and-forget — the node creation itself has succeeded and the
+    // caller already has the response. Concurrent clients see the link
+    // appear via WebSocket once it lands.
+    if (!skipAutoLink && body.text) {
+      autoLinkNodeFromTitle(node.id, req.params.id, body.text).catch((err) => {
+        console.warn('[github-autolink] create_node autolink failed:', err);
+      });
+    }
 
     // Change history (fire-and-forget)
     events
@@ -199,6 +318,19 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
 
       // Fire outbound GitHub sync (non-blocking)
       syncNodeToGitHub(updated, Object.keys(body)).catch(() => {});
+
+      // Auto-link to GitHub when the title was just changed AND the node has
+      // no existing GitHub link (#58). The "no existing link" gate is the
+      // important one — we must never override an explicit prior link, even
+      // if the new title points elsewhere.
+      if (body.text !== undefined && before) {
+        const hadGithubLink = before.externalLinks.some((l) => l.provider === 'github');
+        if (!hadGithubLink) {
+          autoLinkNodeFromTitle(req.params.nodeId, req.params.id, updated.text).catch((err) => {
+            console.warn('[github-autolink] update_node autolink failed:', err);
+          });
+        }
+      }
 
       // Change history (fire-and-forget): one event per tracked field that
       // actually changed.

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -166,6 +166,7 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       priority?: 'P0' | 'P1' | 'P2' | 'P3';
       startDate?: string;
       dueDate?: string;
+      autoProgress?: 'off' | 'children';
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`
        * auto-link backstop (#58). Useful when the leading `#NNNN` is

--- a/packages/server/src/sync/__tests__/parentEpicRollup.test.ts
+++ b/packages/server/src/sync/__tests__/parentEpicRollup.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the pure / DB-free pieces of the parent-epic rollup (#57).
+ *
+ * The DB-touching parts (`applyRollupToParent`, `findNodesByExternalId`,
+ * `rollupParentsForChildTitle`, `applyRollupForFetchedIssues`) are exercised
+ * end-to-end in the catch-up integration scenarios; here we lock down:
+ *
+ *   - title parsing: each documented pattern matches its example exactly
+ *   - sibling counting: closed vs total math + edge cases
+ *   - percent rounding
+ *   - description tail-line idempotency
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseParentReferences,
+  siblingsForParent,
+  computeRollupPercent,
+  updateChildPrsTailLine,
+  DEFAULT_PARENT_PATTERNS,
+} from '../parentEpicRollup.js';
+
+describe('parseParentReferences', () => {
+  it('matches `[#NNNN-followup]` prefix', () => {
+    expect(parseParentReferences('[#843-followup] AcctHolderType (CRS101/102/103)'))
+      .toEqual([843]);
+  });
+
+  it('matches plain `[#NNNN]` prefix', () => {
+    expect(parseParentReferences('[#1346] Frontend: German translations'))
+      .toEqual([1346]);
+  });
+
+  it('matches `Follow-up to #NNNN` prefix', () => {
+    expect(parseParentReferences('Follow-up to #1487: set mandate.updated_by on offboarding'))
+      .toEqual([1487]);
+  });
+
+  it('matches `[V1 UAT #NNNN]` prefix (and other V-numbers)', () => {
+    expect(parseParentReferences('[V1 UAT #1685] BUG: Dashboard overdue invoices not clickable'))
+      .toEqual([1685]);
+    expect(parseParentReferences('[V2 UAT #99] another bug'))
+      .toEqual([99]);
+  });
+
+  it('returns empty for non-matching titles', () => {
+    expect(parseParentReferences('Fix the thing')).toEqual([]);
+    expect(parseParentReferences('Closes #123 along the way')).toEqual([]);
+    // Anchored — mid-title `#NNNN` doesn't count
+    expect(parseParentReferences('Bug: foo [#42] tail')).toEqual([]);
+    expect(parseParentReferences('')).toEqual([]);
+  });
+
+  it('does not match patterns we deliberately exclude', () => {
+    // `Closes #N` is GitHub's own PR→issue close keyword and not part of our
+    // decomposition convention; the existing webhook handler covers it.
+    expect(parseParentReferences('Closes #41: tweak')).toEqual([]);
+  });
+
+  it('case-insensitive on Follow-up to / V_UAT', () => {
+    expect(parseParentReferences('follow-up to #5: lowercase')).toEqual([5]);
+    expect(parseParentReferences('[v1 uat #7] lowercase')).toEqual([7]);
+  });
+
+  it('exposes a non-empty default pattern set', () => {
+    // Sanity: at least the three documented prefixes survive refactors.
+    expect(DEFAULT_PARENT_PATTERNS.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('siblingsForParent', () => {
+  const issues = [
+    { number: 100, title: '[#42] feature work A', state: 'closed' as const },
+    { number: 101, title: '[#42-followup] feature work B', state: 'closed' as const },
+    { number: 102, title: '[#42] feature work C', state: 'open' as const },
+    { number: 103, title: 'Follow-up to #42: extra', state: 'closed' as const },
+    { number: 104, title: 'unrelated bug', state: 'closed' as const },
+    { number: 42, title: '[#42] the parent itself', state: 'open' as const }, // self-ref excluded
+    { number: 200, title: '[#99] another epic child', state: 'closed' as const }, // different parent
+  ];
+
+  it('counts closed vs total for the requested parent', () => {
+    // For parent 42: issues 100 (closed), 101 (closed), 102 (open), 103 (closed) = 3 closed / 4 total
+    expect(siblingsForParent(issues, 42)).toEqual({ closed: 3, total: 4 });
+  });
+
+  it('excludes the parent issue itself even if its title self-matches', () => {
+    // Issue 42 has title `[#42]` but it's number 42 — must not double-count.
+    const onlyParent = [
+      { number: 42, title: '[#42] parent', state: 'open' as const },
+    ];
+    expect(siblingsForParent(onlyParent, 42)).toEqual({ closed: 0, total: 0 });
+  });
+
+  it('returns zero when no siblings match', () => {
+    expect(siblingsForParent(issues, 999)).toEqual({ closed: 0, total: 0 });
+  });
+
+  it('counts closed regardless of state_reason (not_planned still closes)', () => {
+    // The GitHub API surfaces state_reason: 'not_planned' issues as
+    // state: 'closed'. We rely on the state field alone, so this is implicit.
+    const withNotPlanned = [
+      { number: 1, title: '[#5] child', state: 'closed' as const },
+      { number: 2, title: '[#5] child', state: 'closed' as const },
+    ];
+    expect(siblingsForParent(withNotPlanned, 5)).toEqual({ closed: 2, total: 2 });
+  });
+
+  it('handles a reopened sibling (closed count drops)', () => {
+    // Same dataset but one previously-closed child has been reopened.
+    const reopened = issues.map((i) =>
+      i.number === 101 ? { ...i, state: 'open' as const } : i,
+    );
+    expect(siblingsForParent(reopened, 42)).toEqual({ closed: 2, total: 4 });
+  });
+});
+
+describe('computeRollupPercent', () => {
+  it('rounds to nearest integer percent', () => {
+    expect(computeRollupPercent({ closed: 1, total: 3 })).toBe(33); // 33.333
+    expect(computeRollupPercent({ closed: 2, total: 3 })).toBe(67); // 66.666
+    expect(computeRollupPercent({ closed: 3, total: 6 })).toBe(50);
+    expect(computeRollupPercent({ closed: 6, total: 6 })).toBe(100);
+    expect(computeRollupPercent({ closed: 0, total: 6 })).toBe(0);
+  });
+
+  it('returns 0 when total is 0 (caller should skip write)', () => {
+    expect(computeRollupPercent({ closed: 0, total: 0 })).toBe(0);
+  });
+});
+
+describe('updateChildPrsTailLine', () => {
+  const counts = { closed: 4, total: 6 };
+
+  it('appends a tail line to a description without one', () => {
+    const out = updateChildPrsTailLine('Original description body.', counts);
+    expect(out).toBe('Original description body.\n\nChild PRs: 4/6 merged (auto-tracked)');
+  });
+
+  it('replaces an existing tail line in place (idempotent)', () => {
+    const first = updateChildPrsTailLine('Description.', counts);
+    const second = updateChildPrsTailLine(first, counts);
+    expect(second).toBe(first);
+  });
+
+  it('updates the counts on the existing tail line', () => {
+    const first = updateChildPrsTailLine('Description.', { closed: 1, total: 6 });
+    const second = updateChildPrsTailLine(first, { closed: 4, total: 6 });
+    expect(second).toBe('Description.\n\nChild PRs: 4/6 merged (auto-tracked)');
+  });
+
+  it('produces the bare line when description is null/empty', () => {
+    expect(updateChildPrsTailLine(null, counts))
+      .toBe('Child PRs: 4/6 merged (auto-tracked)');
+    expect(updateChildPrsTailLine('', counts))
+      .toBe('Child PRs: 4/6 merged (auto-tracked)');
+  });
+
+  it("doesn't get confused by mid-body 'Child PRs' prose", () => {
+    const description = 'Child PRs were discussed in the kickoff.\n\nMore text.';
+    const out = updateChildPrsTailLine(description, counts);
+    expect(out).toBe(
+      'Child PRs were discussed in the kickoff.\n\nMore text.\n\nChild PRs: 4/6 merged (auto-tracked)',
+    );
+  });
+});

--- a/packages/server/src/sync/__tests__/parentEpicRollup.test.ts
+++ b/packages/server/src/sync/__tests__/parentEpicRollup.test.ts
@@ -1,22 +1,41 @@
 /**
  * Tests for the pure / DB-free pieces of the parent-epic rollup (#57).
  *
- * The DB-touching parts (`applyRollupToParent`, `findNodesByExternalId`,
- * `rollupParentsForChildTitle`, `applyRollupForFetchedIssues`) are exercised
- * end-to-end in the catch-up integration scenarios; here we lock down:
+ * Scope is intentionally narrow — we lock down the deterministic parts:
  *
  *   - title parsing: each documented pattern matches its example exactly
  *   - sibling counting: closed vs total math + edge cases
  *   - percent rounding
  *   - description tail-line idempotency
+ *   - applyRollupToParent's ProseMirror-preservation decision
+ *
+ * The DB-touching paths (`findNodesByExternalId`, the full
+ * `rollupParentsForChildTitle` / `applyRollupForFetchedIssues` pipelines)
+ * are not exercised here and have no integration coverage yet — file a
+ * separate ticket if you want end-to-end DB tests for those.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Node } from '@mindblown/core';
+
+// Mock the DB layer + websocket broadcast so applyRollupToParent runs without
+// a real Postgres or socket. The mock has to be declared before the module
+// under test is imported (vitest hoists vi.mock calls automatically, but we
+// keep imports below for clarity).
+const updateNodeMock = vi.fn();
+vi.mock('../../db/nodes.js', () => ({
+  updateNode: (...args: unknown[]) => updateNodeMock(...args),
+}));
+vi.mock('../../db/connection.js', () => ({ db: {} }));
+vi.mock('../../db/schema.js', () => ({ nodes: {} }));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+
 import {
   parseParentReferences,
   siblingsForParent,
   computeRollupPercent,
   updateChildPrsTailLine,
+  applyRollupToParent,
   DEFAULT_PARENT_PATTERNS,
 } from '../parentEpicRollup.js';
 
@@ -63,8 +82,93 @@ describe('parseParentReferences', () => {
   });
 
   it('exposes a non-empty default pattern set', () => {
-    // Sanity: at least the three documented prefixes survive refactors.
-    expect(DEFAULT_PARENT_PATTERNS.length).toBeGreaterThanOrEqual(3);
+    // Sanity: at least the five documented patterns survive refactors.
+    expect(DEFAULT_PARENT_PATTERNS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  // ── Trailing `(#NNNN follow-up)` (the dominant Stella pattern) ──
+  describe('trailing-paren follow-up', () => {
+    it('matches `(#NNNN follow-up)` at end-of-title', () => {
+      expect(
+        parseParentReferences(
+          'Sweep denormalised ChatMessage.mandate on retention purge (#664 follow-up)',
+        ),
+      ).toEqual([664]);
+    });
+
+    it('matches `(#NNNN <words> follow-up)` with intervening qualifiers', () => {
+      // Real-world: `(#811 V1.5 follow-up)`. We allow optional words between
+      // the number and the literal `follow-up` trailer.
+      expect(
+        parseParentReferences(
+          'Add User.person FK for structural COI detection (#811 V1.5 follow-up)',
+        ),
+      ).toEqual([811]);
+    });
+
+    it('matches `followup` variant without the hyphen', () => {
+      expect(parseParentReferences('Some work (#123 followup)')).toEqual([123]);
+    });
+
+    it('does NOT match incidental trailing parens without the keyword', () => {
+      // Load-bearing negative: title ends in `(#664 was helpful)` — no
+      // "follow-up" trailer, so it must not be classified as a child.
+      expect(parseParentReferences('add column (#664 was helpful)')).toEqual([]);
+    });
+
+    it('does NOT match mid-title `#NNNN` without the trailing-paren wrapper', () => {
+      expect(
+        parseParentReferences('bug fix in line 42 referencing #100 inline'),
+      ).toEqual([]);
+    });
+  });
+
+  // ── Reviewer-attributed `(Ray|Rita|Dana review of #NNNN ...)` ──
+  describe('reviewer-attributed', () => {
+    it('matches `(Ray review of #NNNN followup)`', () => {
+      expect(
+        parseParentReferences(
+          "Fix stale role='advisor' literal in reporting test (Ray review of #614 followup)",
+        ),
+      ).toEqual([614]);
+    });
+
+    it('matches `(Rita follow-up to #NNNN ...)` and `(Dana review of #NNNN)`', () => {
+      expect(
+        parseParentReferences('CRS edge case (Rita follow-up to #200 audit gap)'),
+      ).toEqual([200]);
+      expect(
+        parseParentReferences('Compliance fix (Dana review of #350)'),
+      ).toEqual([350]);
+    });
+
+    it('does NOT match a reviewer name without the required keyword', () => {
+      // Negative: `(Ray helped with #614)` mentions Ray and #614 but neither
+      // "review of" nor "follow-up to" — must not be classified.
+      expect(
+        parseParentReferences('random text (Ray helped with #614)'),
+      ).toEqual([]);
+    });
+
+    it('does NOT match `(Rita R1)` with no issue reference at all', () => {
+      // Real Stella title style. Rita is mentioned but no `#NNNN` keyword
+      // anywhere — must stay unmatched.
+      expect(
+        parseParentReferences(
+          'Team should be SoftDeleteModel for FMA reconstruction (Rita R1)',
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  it('still matches the original leading-bracket pattern after additions', () => {
+    // Regression guard: adding the trailing/reviewer patterns must not
+    // displace the `[#890-followup]` leader.
+    expect(
+      parseParentReferences(
+        '[#890-followup] FATCA generator corrections support (mirror of CRS)',
+      ),
+    ).toEqual([890]);
   });
 });
 
@@ -162,5 +266,111 @@ describe('updateChildPrsTailLine', () => {
     expect(out).toBe(
       'Child PRs were discussed in the kickoff.\n\nMore text.\n\nChild PRs: 4/6 merged (auto-tracked)',
     );
+  });
+});
+
+describe('applyRollupToParent (ProseMirror preservation)', () => {
+  const baseNode = (overrides: Partial<Node> = {}): Node =>
+    ({
+      id: 'n1',
+      mapId: 'm1',
+      parentId: null,
+      childrenIds: [],
+      text: 'Parent epic',
+      description: null,
+      x: null,
+      y: null,
+      collapsed: false,
+      effortEstimate: null,
+      actualEffort: null,
+      percentComplete: null,
+      status: null,
+      blockedReason: null,
+      assigneeIds: [],
+      priority: null,
+      dueDate: null,
+      startDate: null,
+      tags: [],
+      customFields: {},
+      dependencies: [],
+      versionId: null,
+      cycleId: null,
+      externalLinks: [],
+      autoProgress: 'children',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      createdBy: 'u1',
+      revision: 1,
+      ...overrides,
+    }) as Node;
+
+  beforeEach(() => {
+    updateNodeMock.mockReset();
+    updateNodeMock.mockResolvedValue(baseNode());
+  });
+
+  it('writes both percentComplete AND description when description is a string', async () => {
+    const node = baseNode({ description: 'Existing string description.' });
+    await applyRollupToParent(node, { closed: 3, total: 4 });
+
+    expect(updateNodeMock).toHaveBeenCalledOnce();
+    const [, updates] = updateNodeMock.mock.calls[0];
+    expect(updates.percentComplete).toBe(75);
+    expect(typeof updates.description).toBe('string');
+    expect(updates.description).toContain('Child PRs: 3/4 merged (auto-tracked)');
+  });
+
+  it('writes both fields when description is null', async () => {
+    const node = baseNode({ description: null });
+    await applyRollupToParent(node, { closed: 1, total: 2 });
+
+    expect(updateNodeMock).toHaveBeenCalledOnce();
+    const [, updates] = updateNodeMock.mock.calls[0];
+    expect(updates.percentComplete).toBe(50);
+    expect(updates.description).toBe('Child PRs: 1/2 merged (auto-tracked)');
+  });
+
+  it('preserves a ProseMirror JSON description and only writes percentComplete', async () => {
+    // Real ProseMirror docs are JSON objects with `type: 'doc'` and a
+    // `content` array. Overwriting that with a plain string would silently
+    // destroy the rich-text content (must-fix #2 in Ray's review).
+    const proseMirrorDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Rich body that must survive rollup.' }],
+        },
+      ],
+    };
+    // We cast through unknown because the public Node type declares
+    // description as `string | null`, but in practice the column is jsonb
+    // and the runtime value can be a ProseMirror object.
+    const node = baseNode({ description: proseMirrorDoc as unknown as string });
+
+    await applyRollupToParent(node, { closed: 2, total: 5 });
+
+    expect(updateNodeMock).toHaveBeenCalledOnce();
+    const [, updates] = updateNodeMock.mock.calls[0];
+    expect(updates.percentComplete).toBe(40);
+    // CRITICAL: description must NOT be in the update payload at all when
+    // the original is a non-string ProseMirror doc. Writing `undefined`
+    // would be fine (nodeDb.updateNode skips undefined), but writing any
+    // string here would clobber the doc.
+    expect(updates).not.toHaveProperty('description');
+  });
+
+  it('is a no-op when autoProgress is off', async () => {
+    const node = baseNode({ autoProgress: 'off' });
+    const result = await applyRollupToParent(node, { closed: 1, total: 1 });
+    expect(result).toBe(false);
+    expect(updateNodeMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when total is 0', async () => {
+    const node = baseNode();
+    const result = await applyRollupToParent(node, { closed: 0, total: 0 });
+    expect(result).toBe(false);
+    expect(updateNodeMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -23,6 +23,10 @@ import { db } from '../db/connection.js';
 import { integrations, maps, nodes, githubRepoSync } from '../db/schema.js';
 import * as nodeDb from '../db/nodes.js';
 import { broadcast } from '../ws.js';
+import {
+  parseParentReferences,
+  applyRollupForFetchedIssues,
+} from './parentEpicRollup.js';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -236,6 +240,40 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
         node: updated,
         source: 'github_catchup',
       });
+    }
+  }
+
+  // ── Parent-epic rollup (#57) ─────────────────────────────────
+  // For every changed issue whose title matches one of our child-PR
+  // patterns, recompute its parent epic's progress. We dedupe parent
+  // numbers across the batch and fetch the full repo issue list at most
+  // once (parent rollup needs the WHOLE sibling set, not just the changed
+  // slice). On a sleepy repo this is a single extra fetch per cycle; on a
+  // busy one with multiple parent matches it's still just one fetch.
+  const parentNumbers = new Set<number>();
+  for (const issue of issues) {
+    for (const n of parseParentReferences(issue.title)) {
+      parentNumbers.add(n);
+    }
+  }
+  if (parentNumbers.size > 0) {
+    try {
+      // since=null → full issue list for accurate sibling counts.
+      const allIssues = await fetchChangedIssues(target.owner, target.repo, token, null);
+      await applyRollupForFetchedIssues(
+        [...parentNumbers],
+        allIssues,
+        { owner: target.owner, repo: target.repo },
+      );
+    } catch (err) {
+      // Rollup failures don't taint the reconcile result — they just mean
+      // parent percentages stay stale until next cycle.
+      console.warn(
+        '[catchup] Parent-epic rollup failed for',
+        repoLabel,
+        ':',
+        err instanceof Error ? err.message : err,
+      );
     }
   }
 

--- a/packages/server/src/sync/parentEpicRollup.ts
+++ b/packages/server/src/sync/parentEpicRollup.ts
@@ -53,21 +53,35 @@ import { broadcast } from '../ws.js';
 // Order matters only for documentation; we test each one independently
 // and union the results.
 //
-// All patterns:
-//   - Anchor at the start of the title (`^`) — a `#NNNN` buried mid-title
-//     is most likely a different reference (a co-mentioned issue, a PR
-//     link in a checklist, etc.), not a parent claim.
-//   - Capture the parent issue number in group 1.
+// Patterns split into two families:
+//
+//   - Leading-anchor (`^`): a `#NNNN` that opens the title is a strong
+//     parent claim (the bracketed and "Follow-up to" forms).
+//   - Embedded: trailing-paren `(#NNNN follow-up)` (end-anchored) and
+//     reviewer-attributed `(Ray|Rita|Dana review of #NNNN ...)`
+//     (mid-string OK) are how Stella's decomposition titles surface most
+//     often in practice — e.g.
+//       `Sweep denormalised ChatMessage.mandate ... (#664 follow-up)`
+//       `Fix stale role='advisor' literal ... (Ray review of #614 followup)`
+//     We deliberately require either the literal "follow-up" trailer or
+//     a reviewer keyword ("review of" / "follow-up to") so that incidental
+//     mid-title `#NNNN` (e.g. `random text (Ray helped with #614)`) does
+//     not match.
+//   - All patterns capture the parent issue number in group 1.
 
 const PATTERN_BRACKETED_FOLLOWUP = /^\[#(\d+)(?:-followup)?\]/;
 const PATTERN_FOLLOWUP_TO = /^Follow-up to #(\d+)/i;
 const PATTERN_V_UAT = /^\[V\d+\s+UAT\s+#(\d+)\]/i;
+const PATTERN_TRAILING_FOLLOWUP = /\(#(\d+)\s+(?:[^)]*\s+)?follow-?up\)$/i;
+const PATTERN_REVIEWER_ATTRIBUTED = /\((?:Ray|Rita|Dana)\s+(?:review of|follow-up to)\s+#(\d+)[^)]*\)/i;
 
 /** All patterns we recognize, exported for documentation/test introspection. */
 export const DEFAULT_PARENT_PATTERNS: ReadonlyArray<RegExp> = [
   PATTERN_BRACKETED_FOLLOWUP,
   PATTERN_FOLLOWUP_TO,
   PATTERN_V_UAT,
+  PATTERN_TRAILING_FOLLOWUP,
+  PATTERN_REVIEWER_ATTRIBUTED,
 ];
 
 /**
@@ -208,27 +222,38 @@ export async function applyRollupToParent(
   if (counts.total <= 0) return false;
 
   const pct = computeRollupPercent(counts);
-  const currentDescription =
-    typeof parentNode.description === 'string' ? parentNode.description : null;
-  const newDescription = updateChildPrsTailLine(currentDescription, counts);
 
-  // We pass description as a string. The DB column is jsonb, but the
-  // existing helpers already round-trip strings through it (see how the
-  // GitHub importer writes `description: item.issue.body`). Mixed-shape
-  // descriptions are preserved by writing only when the existing value
-  // was a string or null — non-string ProseMirror docs would be a bug to
-  // overwrite. We keep the same conservative rule here.
-  const updates: nodeDb.UpdateNodeInput = {
-    percentComplete: pct,
-    description: newDescription as unknown as nodeDb.UpdateNodeInput['description'],
-  };
+  // ProseMirror JSON descriptions are preserved as-is. The DB column is
+  // jsonb and the existing GitHub importer writes a plain string into it
+  // (`description: item.issue.body`); for those nodes we maintain the
+  // `Child PRs: X/Y merged (auto-tracked)` tail line in the string body.
+  // For nodes whose description is a ProseMirror doc (rich-text editor
+  // output), overwriting it with a plain-string tail line would silently
+  // destroy the rich content, so we only update `percentComplete` and
+  // leave the doc alone. Injecting the tail line into a ProseMirror tree
+  // is a deliberate non-goal here — see the MindBlown CLAUDE.md "Feature
+  // Definition of Done" notes on valid follow-ups vs blocked surfaces.
+  const updates: nodeDb.UpdateNodeInput = { percentComplete: pct };
+  const updatedFields: Array<'percentComplete' | 'description'> = ['percentComplete'];
+  if (
+    typeof parentNode.description === 'string' ||
+    parentNode.description === null ||
+    parentNode.description === undefined
+  ) {
+    const currentDescription =
+      typeof parentNode.description === 'string' ? parentNode.description : null;
+    const newDescription = updateChildPrsTailLine(currentDescription, counts);
+    updates.description =
+      newDescription as unknown as nodeDb.UpdateNodeInput['description'];
+    updatedFields.push('description');
+  }
 
   const updated = await nodeDb.updateNode(parentNode.id, updates);
   if (updated) {
     broadcast(updated.mapId, {
       type: 'node:updated',
       nodeId: parentNode.id,
-      fields: ['percentComplete', 'description'],
+      fields: updatedFields,
       node: updated,
       source: 'parent_epic_rollup',
     });

--- a/packages/server/src/sync/parentEpicRollup.ts
+++ b/packages/server/src/sync/parentEpicRollup.ts
@@ -1,0 +1,315 @@
+/**
+ * Parent-epic auto-progress rollup (#57).
+ *
+ * Our decomposition agents split big epic tickets into many small child PRs
+ * whose titles follow a few well-known conventions:
+ *
+ *   - `[#843-followup] AcctHolderType (CRS101/102/103)`     → parent #843
+ *   - `[#1346] Frontend: German translations across …`      → parent #1346
+ *   - `Follow-up to #1487: set mandate.updated_by on …`     → parent #1487
+ *   - `[V1 UAT #1685] BUG: Dashboard overdue invoices …`    → parent #1685
+ *
+ * We don't want to clutter the mindmap with one node per child PR, but we DO
+ * want the epic's `percentComplete` to reflect "4 of 6 children merged" so
+ * Jenna doesn't have to eyeball it.
+ *
+ * This module:
+ *   1. Parses titles for parent references via `parseParentReferences`.
+ *   2. For a given parent number, finds all sibling issues whose titles also
+ *      reference it (`siblingsForParent`).
+ *   3. Computes the closed/total ratio and rounds to a percentage
+ *      (`computeRollupPercent`).
+ *   4. Writes the percent + a `Child PRs: X/Y merged (auto-tracked)` tail line
+ *      to the linked parent node (`applyRollupToParent`).
+ *
+ * Triggered from two callsites:
+ *   - The `issues.closed` / `issues.reopened` webhook handler in
+ *     `routes/integrations.ts`, after the closing/reopening issue itself has
+ *     been processed.
+ *   - The catch-up reconciler in `sync/githubCatchup.ts`, once per repo
+ *     per cycle, for every changed issue that turns out to be a child PR.
+ *
+ * Idempotency: each call recomputes from the full sibling set, so re-runs
+ * converge to the same number. The description tail line is replaced in
+ * place (not appended) on re-runs.
+ *
+ * Per-workspace overridable regex config is out of scope for v1. The
+ * `DEFAULT_PARENT_PATTERNS` below is hardcoded; a future iteration can
+ * read per-workspace overrides from `integrations.config` or `maps`.
+ */
+
+import { eq } from 'drizzle-orm';
+import type { GitHubIssue } from '@mindblown/integrations';
+import { fetchChangedIssues } from '@mindblown/integrations';
+import type { ExternalLink, Node } from '@mindblown/core';
+
+import { db } from '../db/connection.js';
+import { nodes } from '../db/schema.js';
+import * as nodeDb from '../db/nodes.js';
+import { broadcast } from '../ws.js';
+
+// ── Parent-reference patterns ─────────────────────────────────────
+//
+// Order matters only for documentation; we test each one independently
+// and union the results.
+//
+// All patterns:
+//   - Anchor at the start of the title (`^`) — a `#NNNN` buried mid-title
+//     is most likely a different reference (a co-mentioned issue, a PR
+//     link in a checklist, etc.), not a parent claim.
+//   - Capture the parent issue number in group 1.
+
+const PATTERN_BRACKETED_FOLLOWUP = /^\[#(\d+)(?:-followup)?\]/;
+const PATTERN_FOLLOWUP_TO = /^Follow-up to #(\d+)/i;
+const PATTERN_V_UAT = /^\[V\d+\s+UAT\s+#(\d+)\]/i;
+
+/** All patterns we recognize, exported for documentation/test introspection. */
+export const DEFAULT_PARENT_PATTERNS: ReadonlyArray<RegExp> = [
+  PATTERN_BRACKETED_FOLLOWUP,
+  PATTERN_FOLLOWUP_TO,
+  PATTERN_V_UAT,
+];
+
+/**
+ * Extract every parent-issue number referenced by a title.
+ *
+ * Returns a deduplicated array (order-stable, first-match wins). Empty when
+ * the title doesn't match any pattern.
+ *
+ * A single title can produce multiple matches if it includes more than one
+ * recognized prefix — though in practice we've only seen one — so we apply
+ * each pattern and union, per the spec's "multiple parent refs in one title"
+ * edge case.
+ */
+export function parseParentReferences(title: string): number[] {
+  if (!title) return [];
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const pattern of DEFAULT_PARENT_PATTERNS) {
+    const m = pattern.exec(title);
+    if (!m) continue;
+    const n = Number.parseInt(m[1], 10);
+    if (!Number.isFinite(n)) continue;
+    if (seen.has(n)) continue;
+    seen.add(n);
+    out.push(n);
+  }
+  return out;
+}
+
+// ── Counting helpers ─────────────────────────────────────────────
+
+export interface RollupCounts {
+  closed: number;
+  total: number;
+}
+
+/**
+ * Given the full set of repo issues and a target parent number, return all
+ * siblings (open + closed) whose title references that parent.
+ *
+ * GitHub's `state_reason: 'not_planned'` still surfaces as `state: 'closed'`
+ * — both flavors count as closed, per the spec's "Closed not_planned: count
+ * as closed (same as merged from a planning perspective)" rule.
+ *
+ * The parent issue itself is excluded by number, so an epic that happens to
+ * match its own pattern doesn't self-count.
+ */
+export function siblingsForParent(
+  allIssues: ReadonlyArray<Pick<GitHubIssue, 'number' | 'title' | 'state'>>,
+  parentNumber: number,
+): RollupCounts {
+  let closed = 0;
+  let total = 0;
+  for (const issue of allIssues) {
+    if (issue.number === parentNumber) continue;
+    const parents = parseParentReferences(issue.title);
+    if (!parents.includes(parentNumber)) continue;
+    total++;
+    if (issue.state === 'closed') closed++;
+  }
+  return { closed, total };
+}
+
+/** `round(closed/total * 100)`. Returns 0 when total is 0 (caller should skip). */
+export function computeRollupPercent({ closed, total }: RollupCounts): number {
+  if (total <= 0) return 0;
+  return Math.round((closed / total) * 100);
+}
+
+// ── Description tail-line maintenance ────────────────────────────
+
+const TAIL_LINE_PREFIX = 'Child PRs:';
+const TAIL_LINE_RE = /^Child PRs: \d+\/\d+ merged \(auto-tracked\)\s*$/m;
+
+/**
+ * Replace (or append) the canonical `Child PRs: X/Y merged (auto-tracked)`
+ * tail line on a description string.
+ *
+ * Idempotent: feeding the output back through with the same counts produces
+ * the same string. The matcher is anchored on its own line so other prose
+ * with the literal phrase "Child PRs" doesn't get clobbered.
+ *
+ * `description` is the raw stored value, which in MindBlown's data model is
+ * either a plain string, a ProseMirror JSON object, or null. We only operate
+ * on the string flavour — non-string descriptions get a fresh leading line.
+ */
+export function updateChildPrsTailLine(
+  description: string | null,
+  counts: RollupCounts,
+): string {
+  const line = `${TAIL_LINE_PREFIX} ${counts.closed}/${counts.total} merged (auto-tracked)`;
+  if (!description) return line;
+  if (TAIL_LINE_RE.test(description)) {
+    return description.replace(TAIL_LINE_RE, line);
+  }
+  // Append with one blank-line separator if the existing description has
+  // content; otherwise just the line.
+  const trimmed = description.replace(/\s+$/, '');
+  return trimmed.length > 0 ? `${trimmed}\n\n${line}` : line;
+}
+
+// ── Persistence ──────────────────────────────────────────────────
+
+/**
+ * Find every node linked to a given GitHub issue across all maps in this
+ * deployment. Repos are shared across maps in practice (the same repo can
+ * back multiple workspace views), so we update all of them.
+ *
+ * Returns full node rows so the caller can read existing description +
+ * autoProgress without re-fetching.
+ */
+async function findNodesByExternalId(externalId: string): Promise<Node[]> {
+  const rows = await db.select().from(nodes);
+  const out: Node[] = [];
+  for (const row of rows) {
+    const links = (row.externalLinks as ExternalLink[]) ?? [];
+    if (!links.some((l) => l.provider === 'github' && l.externalId === externalId)) continue;
+    const node = await nodeDb.getNode(row.id);
+    if (node) out.push(node);
+  }
+  return out;
+}
+
+/**
+ * Apply the rollup percentage + tail line to a single parent node.
+ *
+ * Respects the node's `autoProgress` opt-in: `'off'` is a no-op (returns
+ * `false`). Skips the write entirely when `counts.total === 0`, so a parent
+ * with no detectable children isn't blasted to 0%.
+ *
+ * Returns true if the node was actually updated.
+ */
+export async function applyRollupToParent(
+  parentNode: Node,
+  counts: RollupCounts,
+): Promise<boolean> {
+  if (parentNode.autoProgress !== 'children') return false;
+  if (counts.total <= 0) return false;
+
+  const pct = computeRollupPercent(counts);
+  const currentDescription =
+    typeof parentNode.description === 'string' ? parentNode.description : null;
+  const newDescription = updateChildPrsTailLine(currentDescription, counts);
+
+  // We pass description as a string. The DB column is jsonb, but the
+  // existing helpers already round-trip strings through it (see how the
+  // GitHub importer writes `description: item.issue.body`). Mixed-shape
+  // descriptions are preserved by writing only when the existing value
+  // was a string or null — non-string ProseMirror docs would be a bug to
+  // overwrite. We keep the same conservative rule here.
+  const updates: nodeDb.UpdateNodeInput = {
+    percentComplete: pct,
+    description: newDescription as unknown as nodeDb.UpdateNodeInput['description'],
+  };
+
+  const updated = await nodeDb.updateNode(parentNode.id, updates);
+  if (updated) {
+    broadcast(updated.mapId, {
+      type: 'node:updated',
+      nodeId: parentNode.id,
+      fields: ['percentComplete', 'description'],
+      node: updated,
+      source: 'parent_epic_rollup',
+    });
+    return true;
+  }
+  return false;
+}
+
+// ── Top-level entry point ────────────────────────────────────────
+
+export interface RollupContext {
+  owner: string;
+  repo: string;
+  token: string;
+}
+
+/**
+ * Parse `childTitle` for parent references and, for each one, recompute the
+ * linked parent node's progress from the full set of sibling issues in the
+ * repo. No-ops when:
+ *   - the title doesn't match any parent pattern,
+ *   - no node in any map is linked to the parent's externalId,
+ *   - the matched parent node has `autoProgress: 'off'` (the default).
+ *
+ * Errors fetching the issue list are logged and swallowed — the close/reopen
+ * of the child itself has already been applied by the caller, and the
+ * catch-up will retry next cycle.
+ *
+ * Returns the number of parent nodes successfully updated.
+ */
+export async function rollupParentsForChildTitle(
+  childTitle: string,
+  ctx: RollupContext,
+): Promise<number> {
+  const parents = parseParentReferences(childTitle);
+  if (parents.length === 0) return 0;
+
+  let allIssues: GitHubIssue[];
+  try {
+    // `since=null` → fetch all repo issues. This is the same heavy call the
+    // initial import makes. For the webhook path we accept the cost (a few
+    // hundred ms per child-close on a busy repo); for the catch-up path the
+    // caller can batch and pass `allIssues` in via `applyRollupForFetchedIssues`.
+    allIssues = await fetchChangedIssues(ctx.owner, ctx.repo, ctx.token, null);
+  } catch (err) {
+    console.warn(
+      `[parent-epic-rollup] Failed to fetch ${ctx.owner}/${ctx.repo} issues:`,
+      err instanceof Error ? err.message : err,
+    );
+    return 0;
+  }
+
+  return applyRollupForFetchedIssues(parents, allIssues, ctx);
+}
+
+/**
+ * Same as `rollupParentsForChildTitle` but takes the issue list as a
+ * parameter. Used by the catch-up reconciler which has already fetched the
+ * (changed-since-last-sync) issue list and would otherwise pay for the
+ * full re-fetch once per child PR in the batch.
+ *
+ * Note that the catch-up case passes only the recently-changed issues — for
+ * the sibling-count to be correct, the catch-up wrapper must re-fetch the
+ * full set when it sees a child PR transition. This indirection is kept so
+ * the cheap path stays cheap.
+ */
+export async function applyRollupForFetchedIssues(
+  parentNumbers: ReadonlyArray<number>,
+  allIssues: ReadonlyArray<Pick<GitHubIssue, 'number' | 'title' | 'state'>>,
+  ctx: Pick<RollupContext, 'owner' | 'repo'>,
+): Promise<number> {
+  let updates = 0;
+  for (const parentNumber of parentNumbers) {
+    const counts = siblingsForParent(allIssues, parentNumber);
+    if (counts.total <= 0) continue;
+    const externalId = `${ctx.owner}/${ctx.repo}#${parentNumber}`;
+    const parentNodes = await findNodesByExternalId(externalId);
+    for (const node of parentNodes) {
+      const ok = await applyRollupToParent(node, counts);
+      if (ok) updates++;
+    }
+  }
+  return updates;
+}

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    // Most tests here cover pure logic; DB-touching paths are split into
+    // mocked-helper tests so we don't need Postgres in CI.
+    environment: 'node',
+  },
+});

--- a/packages/tool-kit/package.json
+++ b/packages/tool-kit/package.json
@@ -13,7 +13,9 @@
   },
   "scripts": {
     "build": "tsc || true",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@mindblown/core": "workspace:*",
@@ -21,6 +23,7 @@
     "zod-to-json-schema": "^3.25.0"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tool-kit schema/handler regression tests.
+ *
+ * These tests pin the MCP surface of node tools — specifically that
+ * `autoProgress` round-trips through both create_node and update_node
+ * (#57 follow-up so Jenna can flip an epic into rollup mode through her
+ * normal MCP tools instead of a direct REST call).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { createNodeTool, updateNodeTool } from '../node.js';
+import type { ToolBackend } from '../../backend.js';
+import type { NodeWithComputed } from '../../types.js';
+
+/**
+ * Minimal ToolBackend that records the last call to createNode / updateNode
+ * so tests can assert the field reached the backend. Everything not under
+ * test throws — keeps surprise dependencies obvious.
+ */
+function makeRecordingBackend(): {
+  backend: ToolBackend;
+  lastCreate: { mapId: string; parentId: string; text: string; fields?: Record<string, unknown> } | null;
+  lastUpdate: { mapId: string; nodeId: string; fields: Record<string, unknown> } | null;
+} {
+  const state = {
+    lastCreate: null as ReturnType<typeof makeRecordingBackend>['lastCreate'],
+    lastUpdate: null as ReturnType<typeof makeRecordingBackend>['lastUpdate'],
+  };
+  const stubNode: NodeWithComputed = {
+    id: 'node-stub',
+    mapId: 'map-stub',
+    parentId: null,
+    childrenOrder: [],
+    text: 'stub',
+    description: null,
+    collapsed: false,
+    x: null,
+    y: null,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    blockedReason: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    customFields: {},
+    dependencies: [],
+    externalLinks: [],
+    versionId: null,
+    cycleId: null,
+    autoProgress: 'off',
+    revision: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    createdBy: 'test',
+    computedProgress: 0,
+    computedEffort: 0,
+    healthSignal: 'on_track',
+  } as unknown as NodeWithComputed;
+  const backend: ToolBackend = {
+    listMaps: async () => { throw new Error('not implemented'); },
+    getMap: async () => { throw new Error('not implemented'); },
+    createMap: async () => { throw new Error('not implemented'); },
+    updateMap: async () => { throw new Error('not implemented'); },
+    deleteMap: async () => { throw new Error('not implemented'); },
+    createNode: async (mapId, parentId, text, fields) => {
+      state.lastCreate = { mapId, parentId, text, fields };
+      return stubNode;
+    },
+    updateNode: async (mapId, nodeId, fields) => {
+      state.lastUpdate = { mapId, nodeId, fields };
+      return stubNode;
+    },
+    deleteNode: async () => { throw new Error('not implemented'); },
+    moveNode: async () => { throw new Error('not implemented'); },
+  };
+  return {
+    backend,
+    get lastCreate() { return state.lastCreate; },
+    get lastUpdate() { return state.lastUpdate; },
+  };
+}
+
+describe('update_node tool', () => {
+  it('accepts autoProgress: "children" in the schema', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      nodeId: 'n1',
+      autoProgress: 'children',
+    });
+    expect(parsed.autoProgress).toBe('children');
+  });
+
+  it('accepts autoProgress: "off" in the schema', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      nodeId: 'n1',
+      autoProgress: 'off',
+    });
+    expect(parsed.autoProgress).toBe('off');
+  });
+
+  it('rejects unknown autoProgress values', () => {
+    const schema = z.object(updateNodeTool.schema);
+    expect(() => schema.parse({ mapId: 'm1', nodeId: 'n1', autoProgress: 'auto' })).toThrow();
+  });
+
+  it('forwards autoProgress to the backend', async () => {
+    const recorder = makeRecordingBackend();
+    const result = await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      autoProgress: 'children',
+    } as never);
+    expect(recorder.lastUpdate).not.toBeNull();
+    expect(recorder.lastUpdate?.fields).toMatchObject({ autoProgress: 'children' });
+    // Confirm undefined fields were stripped (handler's clean-fields contract).
+    expect('text' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+    expect(result).toContain('autoProgress');
+  });
+
+  it('omits autoProgress from the backend call when not provided', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      text: 'rename me',
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({ text: 'rename me' });
+    expect('autoProgress' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+  });
+});
+
+describe('create_node tool', () => {
+  it('accepts autoProgress in the schema (symmetry with update_node)', () => {
+    const schema = z.object(createNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'epic node',
+      autoProgress: 'children',
+    });
+    expect(parsed.autoProgress).toBe('children');
+  });
+
+  it('forwards autoProgress to the backend on create', async () => {
+    const recorder = makeRecordingBackend();
+    await createNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'epic node',
+      autoProgress: 'children',
+    } as never);
+    expect(recorder.lastCreate?.fields).toMatchObject({ autoProgress: 'children' });
+  });
+});

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -18,7 +18,7 @@ export const createNodeTool = defineTool({
       .enum(['off', 'children'])
       .optional()
       .describe(
-        "Parent-epic auto-progress mode. 'children' opts this node into rollup (its computed progress is derived from its children's weighted estimates × progress). 'off' is the default and leaves the manually-set percentComplete in place.",
+        "Parent-epic auto-progress mode. When set to 'children', the node's percentComplete is auto-computed from the closed/total child-PR ratio based on title-pattern matching (e.g. `[#NNNN-followup]`, `(#NNNN follow-up)`). Use this on parent epics whose work is decomposed across child PRs in GitHub. Default 'off' leaves percentComplete under manual control. Note: this is distinct from the normal leaf-rollup, which always derives a parent's progress from its tree children's weighted estimates × progress regardless of this flag.",
       ),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
@@ -57,7 +57,7 @@ export const updateNodeTool = defineTool({
       .enum(['off', 'children'])
       .optional()
       .describe(
-        "Parent-epic auto-progress mode. 'children' opts the node into rollup so its computed progress is derived from children's weighted estimates × progress. 'off' (default) keeps the manually-set percentComplete.",
+        "Parent-epic auto-progress mode. When set to 'children', the node's percentComplete is auto-computed from the closed/total child-PR ratio based on title-pattern matching (e.g. `[#NNNN-followup]`, `(#NNNN follow-up)`). Use this on parent epics whose work is decomposed across child PRs in GitHub. Default 'off' leaves percentComplete under manual control. Note: this is distinct from the normal leaf-rollup, which always derives a parent's progress from its tree children's weighted estimates × progress regardless of this flag.",
       ),
   },
   handler: async (backend, { mapId, nodeId, ...fields }) => {

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -14,6 +14,12 @@ export const createNodeTool = defineTool({
     dueDate: z.string().optional().describe('Due date (ISO 8601)'),
     startDate: z.string().optional().describe('Start date (ISO 8601)'),
     versionId: z.string().optional().describe('Version ID to assign this node to'),
+    autoProgress: z
+      .enum(['off', 'children'])
+      .optional()
+      .describe(
+        "Parent-epic auto-progress mode. 'children' opts this node into rollup (its computed progress is derived from its children's weighted estimates × progress). 'off' is the default and leaves the manually-set percentComplete in place.",
+      ),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -47,6 +53,12 @@ export const updateNodeTool = defineTool({
     tags: z.array(z.string()).optional().describe('Tags'),
     assigneeIds: z.array(z.string()).optional().describe('Assignee user IDs'),
     versionId: z.string().nullable().optional().describe('Version ID (null to unassign)'),
+    autoProgress: z
+      .enum(['off', 'children'])
+      .optional()
+      .describe(
+        "Parent-epic auto-progress mode. 'children' opts the node into rollup so its computed progress is derived from children's weighted estimates × progress. 'off' (default) keeps the manually-set percentComplete.",
+      ),
   },
   handler: async (backend, { mapId, nodeId, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.2)(tsx@4.21.0)
 
   packages/views:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.2)(tsx@4.21.0)
 
   packages/tool-kit:
     dependencies:
@@ -2634,46 +2637,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -3555,13 +3518,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.5.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.5.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5165,24 +5128,11 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.5.2
-      fsevents: 2.3.3
-      tsx: 4.21.0
-
   vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.5.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.5.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5200,7 +5150,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.5.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.5.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

Two complementary backstops that make the MindBlown ↔ GitHub mirror self-healing without per-call discipline from planning agents — together they drain both orphan buckets on the Fulcrum CRM map.

- **#57 — Parent-epic auto-progress.** When a child PR's title matches one of our decomposition conventions (`[#NNNN]`, `[#NNNN-followup]`, `Follow-up to #NNNN`, `[V1 UAT #NNNN]`), the linked parent epic's `percentComplete` is recomputed as `round(closed_siblings / total_siblings × 100)` and a `Child PRs: X/Y merged (auto-tracked)` tail line is updated on the parent's description. Opt-in per node via the new `autoProgress: 'off' | 'children'` flag (default `'off'` preserves manual progress for every existing node).
- **#58 — `create_node` auto-link.** When `create_node` is called with a title beginning with `#NNNN ` (or just `#NNNN`) and the map has a connected GitHub repo, the server verifies the issue exists and attaches the same `externalLink` that `link_github_issue` would produce. 404 silently skips (planning prefixes). Caller can opt out with `skipAutoLink: true`. Mirrored in `update_node` for title changes — but only when no GitHub link already exists.

### Where the changes live

- `packages/server/src/sync/parentEpicRollup.ts` — new pure-logic module (parsing, sibling counting, description tail-line maintenance) + the DB-touching `applyRollupToParent` / `applyRollupForFetchedIssues`.
- `packages/server/src/sync/githubCatchup.ts` — dedup parent numbers across the changed-issues batch and run the rollup once per reconcile.
- `packages/server/src/routes/integrations.ts` — fire-and-forget rollup on every `issues.closed` / `issues.reopened` webhook (even for child PRs with no linked node).
- `packages/server/src/routes/nodes.ts` — `autoLinkNodeFromTitle` on the create + update paths.
- `packages/core/src/types.ts` + `packages/server/src/db/{schema,migrate,helpers,nodes}.ts` — new `autoProgress` field; idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration runs on every server startup.

### Out of scope (deliberately)

- Workspace-overridable parent-pattern regex config (`DEFAULT_PARENT_PATTERNS` is hardcoded; comment in the module).
- Backfilling existing rows on the `autoProgress` column (default `'off'` handles them).

## Test plan

- [x] `pnpm turbo typecheck` clean across all 7 packages.
- [x] `pnpm turbo test` — **74 tests pass** (46 in core, 28 new in server).
  - 20 cases in `parentEpicRollup.test.ts` — each pattern + sibling counting (self-ref exclusion, reopen, not_planned) + percent rounding + tail-line idempotency.
  - 8 cases in `autolink.test.ts` — leading `#NNNN` matches (space / EOS / tab / newline), mid-title misses, multi-ref first-wins, glued-char misses (`#42foo`, `#42-followup`).
- [ ] Manual smoke after deploy on `mind.proejct.li`: flip an epic to `autoProgress: 'children'`, close a child PR with `[#NNNN]` title, verify the parent's percent updates and the description tail line appears.
- [ ] Manual smoke: `create_node` with title `#937 Fix something`, verify the GitHub link attaches.

Closes #57 (after deploy + smoke). Closes #58 (after deploy + smoke).