### PR TITLE
feat(sync): auto-backfill drift + systemd watchdog

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -274,6 +274,19 @@ history:
 when the system recovers itself; anything requiring action still
 alarms.
 
+**Triage `manual-N` alerts.** The same `manual-N` message covers two
+distinct failure modes — grep the server logs to tell them apart:
+
+```bash
+journalctl -u mindblown-api | grep auto-backfill
+```
+
+- `drift detected, all N maps over the per-day cap` → expected: hit
+  the manual backfill endpoint (or raise `AUTO_BACKFILL_MAX_PER_DAY`).
+- `drift detected, per-map auto-backfill failed: <error>` → expected:
+  read the warn log for the underlying cause (revoked GitHub token,
+  GitHub 503, rate-limit, etc.) and fix that before re-running.
+
 ### Watchdog auto-restart
 
 The unit file uses `Type=notify` + `WatchdogSec=300` so a frozen

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -115,6 +115,12 @@ NODE_ENV=production
 # audit, but silent failures have no external alarm. See below.
 # KUMA_GITHUB_CATCHUP_PUSH_URL=https://kuma.example.com/api/push/<token>
 # KUMA_GITHUB_DRIFT_PUSH_URL=https://kuma.example.com/api/push/<token>
+
+# Optional — cap on the number of drift nodes the daily audit will
+# auto-backfill PER MAP per tick. Drift over this cap is left in
+# place so the Kuma alarm escalates to a human. Set to 0 to disable
+# auto-backfill entirely (audit still runs + alarms). Default: 50.
+# AUTO_BACKFILL_MAX_PER_DAY=50
 EOF
 chmod 640 /etc/mindblown/api.env
 chown root:mindblown /etc/mindblown/api.env
@@ -243,6 +249,46 @@ section is optional — but strongly recommended in production.
 | catchup heartbeat | 60 s | 10 min | API pushes every 5 min — 10 min absorbs one missed tick (restart/upgrade) without false-alarming. |
 | drift audit | 60 s | 30 h | API pushes daily — 30 h gives 6 h of slack for restart timing, clock drift, etc. |
 
+### Auto-backfill on drift detection
+
+When the daily audit finds drift, the API attempts to self-heal by
+calling the same code path as the manual "Backfill" button in the UI
+for each drifted map. The cap is per-map per audit tick:
+
+| Setting | Default | Behaviour |
+|---|---|---|
+| `AUTO_BACKFILL_MAX_PER_DAY=50` (default) | up to 50 drift nodes per map | auto-healed; Kuma `up msg=auto-backfilled-N` |
+| drift > cap | none | left in place; Kuma `down msg=manual-N` |
+| `AUTO_BACKFILL_MAX_PER_DAY=0` | 0 | kill switch: audit still runs + alarms, nothing self-heals |
+
+The Kuma message format makes both outcomes auditable from the alert
+history:
+
+- `no-drift` — clean tick (status=up).
+- `auto-backfilled-3` — 3 nodes self-healed (status=up).
+- `manual-5` — 5 nodes left for manual ack (status=down).
+- `auto-backfilled-2,manual-3` — mixed (status=down).
+- `audit_failed:<reason>` — audit itself threw (status=down).
+
+`status=up` for full self-heal means the operator never gets paged
+when the system recovers itself; anything requiring action still
+alarms.
+
+### Watchdog auto-restart
+
+The unit file uses `Type=notify` + `WatchdogSec=300` so a frozen
+catchup loop (network stall, hung pg query) triggers a systemd-driven
+kill + restart after 5 min of no `WATCHDOG=1` pings. The catchup loop
+pings only after a fully-successful tick — partial failures
+deliberately don't reset the watchdog because that's the failure mode
+the watchdog exists to catch. Combined with `Restart=on-failure +
+RestartSec=10s`, a hung API recovers in ≤ 5 min 10 s without operator
+involvement.
+
+The READY ping is sent once Fastify has bound the port; without it,
+`Type=notify` would leave `systemctl start` blocked forever waiting
+for ready notification.
+
 ### Manual trigger
 
 For ops testing without waiting 24h for the next scheduled drift
@@ -253,8 +299,11 @@ curl -sf -X POST https://mindblown.example.com/api/maps/sync/audit-drift \
   -H "Cookie: <session cookie from your browser>" | jq .
 ```
 
-Returns `{reports: DriftReport[], counts: {...}}`. API-key auth is
-deliberately rejected — this is a session-only operator surface.
+Returns `{reports: DriftReport[], autoBackfill: {...}, counts: {...}}`.
+The manual trigger runs the same auto-backfill + Kuma push the
+scheduled audit does, so it's a faithful end-to-end smoke test of the
+auto-repair flow. API-key auth is deliberately rejected — this is a
+session-only operator surface.
 
 ## What's NOT in the LXC backup
 

--- a/deploy/mindblown-api.service
+++ b/deploy/mindblown-api.service
@@ -12,7 +12,15 @@ Wants=postgresql.service
 # (network stall, blocked pg query) — systemd kills + restarts the
 # service after 5 min of no pings.
 Type=notify
-NotifyAccess=main
+# NotifyAccess=all (not =main) because WATCHDOG=1 is sent via
+# systemd-notify(1) spawned as a child of the node process. Under
+# =main, systemd only accepts pings whose sender PID matches the
+# unit's main PID — systemd-notify(1) tries to spoof the parent PID
+# via SCM_CREDENTIALS but that needs CAP_SYS_ADMIN, which the non-root
+# child does not have, so the spoof fails and systemd rejects the
+# message. =all still restricts to processes within the unit's
+# cgroup (same security boundary — only mindblown UID is in there).
+NotifyAccess=all
 WatchdogSec=300
 
 User=mindblown

--- a/deploy/mindblown-api.service
+++ b/deploy/mindblown-api.service
@@ -5,7 +5,16 @@ After=network.target postgresql.service
 Wants=postgresql.service
 
 [Service]
-Type=simple
+# Type=notify so the API can report READY=1 when Fastify finishes
+# binding its port (see sdNotifyReady() in src/index.ts) and can ping
+# WATCHDOG=1 after every successful catchup tick. Together with
+# WatchdogSec=300 below, this auto-recovers from a frozen catchup loop
+# (network stall, blocked pg query) — systemd kills + restarts the
+# service after 5 min of no pings.
+Type=notify
+NotifyAccess=main
+WatchdogSec=300
+
 User=mindblown
 Group=mindblown
 WorkingDirectory=/opt/mindblown/packages/server
@@ -19,7 +28,7 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 ExecStart=/usr/bin/env pnpm exec tsx src/index.ts
 
 Restart=on-failure
-RestartSec=5
+RestartSec=10s
 StandardOutput=journal
 StandardError=journal
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,8 +5,8 @@ import { runMigrations } from './db/migrate.js';
 import { seedIfEmpty } from './db/seed.js';
 import { snapshotAllMaps } from './lib/releaseSnapshots.js';
 import { runAllCatchups } from './sync/githubCatchup.js';
-import { auditDrift, type DriftReport } from './sync/driftAudit.js';
-import { pushKumaHeartbeat } from './sync/kumaPush.js';
+import { runDriftAudit } from './sync/driftAudit.js';
+import { sdNotifyReady } from './sync/sdNotify.js';
 import { authRoutes } from './auth.js';
 import { systemRoutes } from './routes/system.js';
 import { registerAuthMiddleware } from './middleware/auth.js';
@@ -103,6 +103,22 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // ── Tell systemd we're up (Type=notify) ────────────────────────
+  // The mindblown-api.service unit uses `Type=notify` so dependent
+  // services (Caddy reload, etc.) only fire once we've actually bound
+  // a port. Without this `READY=1` ping, systemd waits forever in
+  // "starting up" mode → unit appears stuck and `systemctl start`
+  // never returns. Silent no-op when run outside systemd (no
+  // $NOTIFY_SOCKET).
+  try {
+    await sdNotifyReady();
+  } catch (err) {
+    console.warn(
+      '[sd-notify] READY ping unexpectedly threw:',
+      err instanceof Error ? err.message : err,
+    );
+  }
+
   // ── Release snapshot cron (daily trend history) ──────────────
   // Catch-up on startup (cheap, idempotent), then re-snapshot every
   // hour. Each hourly call upserts today's row per (map, version),
@@ -159,39 +175,18 @@ async function main(): Promise<void> {
   // apply it?", but neither alarms when the event NEVER reached us —
   // bad webhook URL on the GH side, expired install token during the
   // catchup window, an ingest exception that dropped an issue. This
-  // sweep diffs open GitHub issues against linked nodes once a day and
-  // pushes the result to a Kuma monitor. Drift > 0 → Kuma alarms via
-  // its normal channels (Pushover, etc.).
+  // sweep diffs open GitHub issues against linked nodes once a day,
+  // tries to auto-backfill any drift under the per-day cap, and pushes
+  // the result to a Kuma monitor. Drift left after auto-backfill → Kuma
+  // alarms via its normal channels (Pushover, etc.).
   const DRIFT_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
-  const runDriftAudit = async () => {
-    const url = process.env.KUMA_GITHUB_DRIFT_PUSH_URL;
-    let reports: DriftReport[];
+  const driftAuditTick = async (): Promise<void> => {
     try {
-      reports = await auditDrift();
+      await runDriftAudit();
     } catch (err) {
-      console.error('[drift-audit] sweep failed:', err);
-      // Tell Kuma the audit itself broke. Without this, an exception
-      // mid-sweep looks identical to "clean" from Kuma's vantage.
-      if (url) {
-        const msg = `audit_failed: ${err instanceof Error ? err.message : String(err)}`.slice(0, 200);
-        await pushKumaHeartbeat(url, 'down', msg, '[kuma-push] drift audit');
-      }
-      return;
-    }
-    if (reports.length === 0) {
-      console.log('[drift-audit] clean — no drift');
-      if (url) {
-        await pushKumaHeartbeat(url, 'up', 'no-drift', '[kuma-push] drift audit');
-      }
-      return;
-    }
-    const summary = reports.map((r) => `${r.mapName}=${r.onlyInGitHub} issues`).join(', ');
-    console.warn(`[drift-audit] drift detected: ${summary}`);
-    if (url) {
-      // Truncate at 200 chars so the Kuma push URL doesn't blow past
-      // common HTTP query-length limits when there are many drifted maps.
-      const msg = `drift_detected: ${summary}`.slice(0, 200);
-      await pushKumaHeartbeat(url, 'down', msg, '[kuma-push] drift audit');
+      // runDriftAudit handles its own error paths + Kuma push; this
+      // catch is defence-in-depth for an unexpected synchronous throw.
+      console.error('[drift-audit] scheduler caught unexpected error:', err);
     }
   };
   // Deliberately no startup invocation. Drift audit fans out one
@@ -202,7 +197,7 @@ async function main(): Promise<void> {
   // open issue unconditionally. Wait for the first interval tick;
   // operators can hit POST /api/maps/sync/audit-drift to force a run
   // post-deploy.
-  setInterval(runDriftAudit, DRIFT_AUDIT_INTERVAL_MS);
+  setInterval(driftAuditTick, DRIFT_AUDIT_INTERVAL_MS);
 }
 
 main();

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -14,7 +14,7 @@ import {
   isGitHubAppConfigured,
 } from '@mindblown/integrations';
 import { reconcileRepo } from '../sync/githubCatchup.js';
-import { auditDrift } from '../sync/driftAudit.js';
+import { runDriftAudit } from '../sync/driftAudit.js';
 import { requireAdmin } from '../auth.js';
 import { rollupParentsForChildTitle } from '../sync/parentEpicRollup.js';
 import {
@@ -777,12 +777,27 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     }
 
     try {
-      const reports = await auditDrift();
+      // runDriftAudit triggers the same auto-backfill code path the
+      // daily scheduler uses — manual + scheduled paths must produce
+      // identical outcomes (incl. the Kuma push) so operators can use
+      // this endpoint to test the auto-repair flow without waiting 24h.
+      const result = await runDriftAudit();
+      if (result.error) {
+        return reply.status(500).send({
+          error: {
+            code: 'DRIFT_AUDIT_FAILED',
+            message: result.error,
+          },
+        });
+      }
       return reply.send({
-        reports,
+        reports: result.reports,
+        autoBackfill: result.autoBackfill,
         counts: {
-          driftedMaps: reports.length,
-          totalDriftedIssues: reports.reduce((n, r) => n + r.onlyInGitHub, 0),
+          driftedMaps: result.reports.length,
+          totalDriftedIssues: result.reports.reduce((n, r) => n + r.onlyInGitHub, 0),
+          autoBackfilled: result.autoBackfill.totalImported,
+          manualPending: result.autoBackfill.totalManualPending,
         },
       });
     } catch (err) {

--- a/packages/server/src/sync/__tests__/autoBackfill.test.ts
+++ b/packages/server/src/sync/__tests__/autoBackfill.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the auto-backfill drift remediation sweep.
+ *
+ * `runAutoBackfill` takes a `DriftReport[]` (the output of the daily
+ * audit) and decides per-map whether to:
+ *   - heal (call `backfillMap`),
+ *   - skip (drift over the per-day cap),
+ *   - record a failure (backfillMap threw or imported 0 of N).
+ *
+ * We mock `backfillMap` directly so each test can script its return
+ * value / throw, without exercising the DB + GitHub stack.
+ *
+ * `runDriftAudit` (the end-to-end wrapper that calls audit → backfill →
+ * Kuma push) is tested separately in `driftAudit.test.ts` follow-up
+ * cases — here we only exercise the pure orchestration.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock backfillMap ──────────────────────────────────────────────
+
+type BackfillReturn = { imported: number; total: number; capped: boolean; errored: number };
+const backfillCalls: Array<{ mapId: string; opts: { maxToImport?: number; allowClosedWithinDays?: number } }> = [];
+const backfillByMap = new Map<string, BackfillReturn | Error>();
+
+vi.mock('../githubIngest.js', () => ({
+  backfillMap: async (
+    mapId: string,
+    opts: { maxToImport?: number; allowClosedWithinDays?: number },
+  ): Promise<BackfillReturn> => {
+    backfillCalls.push({ mapId, opts });
+    const programmed = backfillByMap.get(mapId);
+    if (programmed instanceof Error) throw programmed;
+    if (!programmed) {
+      // Default: heal everything requested (1:1 with maxToImport).
+      const requested = opts.maxToImport ?? 0;
+      return { imported: requested, total: requested, capped: false, errored: 0 };
+    }
+    return programmed;
+  },
+}));
+
+// ── SUT import (after mocks) ──────────────────────────────────────
+
+import { runAutoBackfill, getAutoBackfillCap } from '../autoBackfill.js';
+import type { DriftReport } from '../driftAudit.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+function driftReport(mapId: string, onlyInGitHub: number, mapName?: string): DriftReport {
+  return {
+    mapId,
+    mapName: mapName ?? `Map ${mapId}`,
+    repo: 'owner/repo',
+    onlyInGitHub,
+    exampleIssues: Array.from({ length: Math.min(5, onlyInGitHub) }, (_, i) => i + 1),
+  };
+}
+
+beforeEach(() => {
+  backfillCalls.length = 0;
+  backfillByMap.clear();
+  delete process.env.AUTO_BACKFILL_MAX_PER_DAY;
+});
+
+// ── Cap parsing ───────────────────────────────────────────────────
+
+describe('getAutoBackfillCap', () => {
+  it('defaults to 50 when env var is unset', () => {
+    delete process.env.AUTO_BACKFILL_MAX_PER_DAY;
+    expect(getAutoBackfillCap()).toBe(50);
+  });
+
+  it('parses a positive integer', () => {
+    process.env.AUTO_BACKFILL_MAX_PER_DAY = '12';
+    expect(getAutoBackfillCap()).toBe(12);
+  });
+
+  it('clamps negative values to 0 (kill-switch)', () => {
+    process.env.AUTO_BACKFILL_MAX_PER_DAY = '-5';
+    expect(getAutoBackfillCap()).toBe(0);
+  });
+
+  it('falls back to default when the value is non-numeric', () => {
+    process.env.AUTO_BACKFILL_MAX_PER_DAY = 'banana';
+    expect(getAutoBackfillCap()).toBe(50);
+  });
+
+  it('0 is recognised as the kill switch', () => {
+    process.env.AUTO_BACKFILL_MAX_PER_DAY = '0';
+    expect(getAutoBackfillCap()).toBe(0);
+  });
+});
+
+// ── Orchestration ─────────────────────────────────────────────────
+
+describe('runAutoBackfill', () => {
+  it('case 1: drift under cap → backfill called, imported=N, all healed', async () => {
+    const reports = [driftReport('m1', 3, 'Roadmap')];
+    const summary = await runAutoBackfill(reports, /* cap */ 50);
+
+    expect(backfillCalls).toHaveLength(1);
+    expect(backfillCalls[0].mapId).toBe('m1');
+    expect(backfillCalls[0].opts.maxToImport).toBe(3);
+    // Drift audit is open-only, so backfill must NOT widen to closed
+    // issues — that would sweep in unrelated stale tickets.
+    expect(backfillCalls[0].opts.allowClosedWithinDays).toBe(0);
+
+    expect(summary.totalImported).toBe(3);
+    expect(summary.totalManualPending).toBe(0);
+    expect(summary.outcomes).toEqual([
+      { mapId: 'm1', mapName: 'Roadmap', kind: 'healed', imported: 3 },
+    ]);
+  });
+
+  it('case 2: drift over cap → backfill NOT called, recorded as over-cap', async () => {
+    const reports = [driftReport('m1', 75, 'Big Drift')];
+    const summary = await runAutoBackfill(reports, /* cap */ 50);
+
+    expect(backfillCalls).toHaveLength(0);
+    expect(summary.totalImported).toBe(0);
+    expect(summary.totalManualPending).toBe(75);
+    expect(summary.outcomes).toEqual([
+      { mapId: 'm1', mapName: 'Big Drift', kind: 'over-cap', pending: 75 },
+    ]);
+  });
+
+  it('case 3: mixed reports → per-map outcome split', async () => {
+    const reports = [
+      driftReport('mUnder', 4, 'Under'),
+      driftReport('mOver', 100, 'Over'),
+    ];
+    const summary = await runAutoBackfill(reports, /* cap */ 50);
+
+    // Only the under-cap map should have called backfill.
+    expect(backfillCalls.map((c) => c.mapId)).toEqual(['mUnder']);
+
+    expect(summary.totalImported).toBe(4);
+    expect(summary.totalManualPending).toBe(100);
+
+    const byId = new Map(summary.outcomes.map((o) => [o.mapId, o]));
+    expect(byId.get('mUnder')).toEqual({
+      mapId: 'mUnder',
+      mapName: 'Under',
+      kind: 'healed',
+      imported: 4,
+    });
+    expect(byId.get('mOver')).toEqual({
+      mapId: 'mOver',
+      mapName: 'Over',
+      kind: 'over-cap',
+      pending: 100,
+    });
+  });
+
+  it('case 4: backfill throws → outcome=failed, drift counted as manual-pending', async () => {
+    backfillByMap.set('m1', new Error('install token revoked'));
+    const reports = [driftReport('m1', 3, 'Failing')];
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const summary = await runAutoBackfill(reports, /* cap */ 50);
+    warnSpy.mockRestore();
+
+    expect(summary.totalImported).toBe(0);
+    expect(summary.totalManualPending).toBe(3);
+    expect(summary.outcomes).toEqual([
+      {
+        mapId: 'm1',
+        mapName: 'Failing',
+        kind: 'failed',
+        pending: 3,
+        reason: 'install token revoked',
+      },
+    ]);
+  });
+
+  it('case 5: cap=0 (kill switch) → no backfill ever, everything queued for manual', async () => {
+    const reports = [
+      driftReport('mA', 2),
+      driftReport('mB', 5),
+    ];
+    const summary = await runAutoBackfill(reports, /* cap */ 0);
+
+    expect(backfillCalls).toHaveLength(0);
+    expect(summary.totalImported).toBe(0);
+    expect(summary.totalManualPending).toBe(7);
+    expect(summary.outcomes.every((o) => o.kind === 'over-cap')).toBe(true);
+  });
+
+  it('case 5b: AUTO_BACKFILL_MAX_PER_DAY=0 env var triggers kill switch when no cap override', async () => {
+    process.env.AUTO_BACKFILL_MAX_PER_DAY = '0';
+    const reports = [driftReport('m1', 3)];
+
+    const summary = await runAutoBackfill(reports);
+    expect(backfillCalls).toHaveLength(0);
+    expect(summary.totalImported).toBe(0);
+    expect(summary.totalManualPending).toBe(3);
+  });
+
+  it('partial heal (imported < onlyInGitHub but > 0) → counted as healed for what worked, manual-pending for the rest', async () => {
+    // backfillMap returned imported=2 even though we asked for 3 — some
+    // issues got skipped (skipped_exists, races, etc.). The orchestrator
+    // should mark this as healed (2 created) AND record 1 manual.
+    backfillByMap.set('m1', { imported: 2, total: 3, capped: false, errored: 0 });
+    const reports = [driftReport('m1', 3, 'Partial')];
+
+    const summary = await runAutoBackfill(reports, /* cap */ 50);
+    expect(summary.totalImported).toBe(2);
+    expect(summary.totalManualPending).toBe(1);
+    expect(summary.outcomes).toEqual([
+      { mapId: 'm1', mapName: 'Partial', kind: 'healed', imported: 2 },
+    ]);
+  });
+
+  it('imported=0 of N (no exception, just nothing ingested) → marked failed, not healed', async () => {
+    // Worst-case: backfillMap returned cleanly but imported zero. The
+    // most likely cause is that every candidate raced with another
+    // ingest path (skipped_exists) — that's still drift-relative-to-the-
+    // audit-snapshot until next tick.
+    backfillByMap.set('m1', { imported: 0, total: 3, capped: false, errored: 0 });
+    const reports = [driftReport('m1', 3, 'Zero')];
+
+    const summary = await runAutoBackfill(reports, /* cap */ 50);
+    expect(summary.totalImported).toBe(0);
+    expect(summary.totalManualPending).toBe(3);
+    expect(summary.outcomes[0].kind).toBe('failed');
+  });
+});

--- a/packages/server/src/sync/__tests__/githubCatchup.test.ts
+++ b/packages/server/src/sync/__tests__/githubCatchup.test.ts
@@ -88,9 +88,22 @@ vi.mock('../kumaPush.js', () => ({
     pushKumaMock(url, status, msg, tag),
 }));
 
+// Mock the systemd watchdog ping so we can verify it fires only on
+// fully-clean ticks (the failure mode the watchdog catches is a frozen
+// catchup loop — pinging on partial failures defeats its purpose).
+const sdWatchdogMock = vi.fn(async (): Promise<boolean> => true);
+vi.mock('../sdNotify.js', () => ({
+  sdNotifyWatchdog: () => sdWatchdogMock(),
+}));
+
 // ── SUT import (after mocks) ──────────────────────────────────────
 
-import { runAllCatchups, pushCatchupHeartbeat, type ReconcileResult } from '../githubCatchup.js';
+import {
+  runAllCatchups,
+  pushCatchupHeartbeat,
+  isHealthyTick,
+  type ReconcileResult,
+} from '../githubCatchup.js';
 
 function makeResult(overrides: Partial<ReconcileResult> = {}): ReconcileResult {
   return {
@@ -114,6 +127,8 @@ describe('runAllCatchups → Kuma heartbeat', () => {
   beforeEach(() => {
     pushKumaMock.mockReset();
     pushKumaMock.mockResolvedValue(undefined);
+    sdWatchdogMock.mockReset();
+    sdWatchdogMock.mockResolvedValue(true);
     delete process.env.KUMA_GITHUB_CATCHUP_PUSH_URL;
   });
 
@@ -214,5 +229,65 @@ describe('pushCatchupHeartbeat (direct helper)', () => {
     ]);
     const [, status] = pushKumaMock.mock.calls[0];
     expect(status).toBe('down');
+  });
+});
+
+describe('runAllCatchups → systemd watchdog', () => {
+  beforeEach(() => {
+    sdWatchdogMock.mockReset();
+    sdWatchdogMock.mockResolvedValue(true);
+    pushKumaMock.mockReset();
+    pushKumaMock.mockResolvedValue(undefined);
+    delete process.env.KUMA_GITHUB_CATCHUP_PUSH_URL;
+  });
+
+  it('pings the watchdog after a clean tick (zero repos, no errors)', async () => {
+    // With the DB mocked to return zero targets, results is [], every()
+    // returns true, isHealthyTick returns true → watchdog should fire.
+    await runAllCatchups();
+    expect(sdWatchdogMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when sdNotifyWatchdog rejects (notify failure must not affect main flow)', async () => {
+    sdWatchdogMock.mockRejectedValueOnce(new Error('notify socket gone'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const results = await runAllCatchups();
+    warnSpy.mockRestore();
+    expect(Array.isArray(results)).toBe(true);
+    expect(sdWatchdogMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isHealthyTick', () => {
+  it('returns true for an empty results array (sweep completed without crashing)', () => {
+    expect(isHealthyTick([])).toBe(true);
+  });
+
+  it('returns true when every repo is clean', () => {
+    expect(
+      isHealthyTick([makeResult({ fetched: 3, applied: 2 })]),
+    ).toBe(true);
+  });
+
+  it('returns false when any repo reports ingestErrored > 0', () => {
+    expect(
+      isHealthyTick([
+        makeResult(),
+        makeResult({ repo: 'b/c', ingestErrored: 1 }),
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false when any repo reports stateSyncErrored > 0', () => {
+    expect(
+      isHealthyTick([makeResult({ stateSyncErrored: 1 })]),
+    ).toBe(false);
+  });
+
+  it('returns false when any repo carries an error string', () => {
+    expect(
+      isHealthyTick([makeResult({ error: 'fetch: 503' })]),
+    ).toBe(false);
   });
 });

--- a/packages/server/src/sync/__tests__/runDriftAudit.test.ts
+++ b/packages/server/src/sync/__tests__/runDriftAudit.test.ts
@@ -1,0 +1,361 @@
+/**
+ * End-to-end tests for `runDriftAudit` — the wrapper that calls
+ * `auditDrift()` → `runAutoBackfill()` → `pushKumaHeartbeat()`.
+ *
+ * The cases here mirror the brief's "5 scenarios" but at the
+ * full-flow level — what does Kuma actually see for each combination
+ * of drift detection + auto-backfill outcome?
+ *
+ * `auditDrift` and `runAutoBackfill` are mocked directly so we exercise
+ * the orchestration / Kuma-push logic without re-testing their own
+ * internals (which have their own test files).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mocks for the SUT's collaborators ─────────────────────────────
+
+// We can't easily mock `auditDrift` from within its own module, so
+// instead we mock the GitHub fetch + DB layer underneath `auditDrift`
+// (same pattern as the existing `driftAudit.test.ts`) and let
+// `runDriftAudit` exercise the real `auditDrift`. This double-binds
+// the SUT to `auditDrift`'s own correctness, but its behaviour is
+// already pinned by the other test file's 8 cases — we only need to
+// drive its return value via the DB + GitHub mocks here.
+
+const runAutoBackfillMock = vi.fn();
+const pushKumaMock = vi.fn(
+  async (_url: string, _status: string, _msg: string, _tag: string): Promise<void> => undefined,
+);
+
+// Predicate-aware drizzle mock (same shape as driftAudit.test.ts).
+type Pred = { __pred: true; check: (row: Record<string, unknown>) => boolean };
+function isPred(x: unknown): x is Pred {
+  return !!x && typeof x === 'object' && (x as { __pred?: true }).__pred === true;
+}
+
+interface MapRow {
+  id: string;
+  name: string;
+  workspaceId: string;
+  githubInstallationId: string | null;
+  githubRepoOwner: string | null;
+  githubRepoName: string | null;
+  autoImportNewIssues: boolean;
+}
+
+const dbState = {
+  maps: [] as MapRow[],
+  nodes: [] as Array<{ id: string; mapId: string; externalLinks: Array<{ provider: string; externalId: string }> }>,
+  integrations: [] as Array<{ workspaceId: string; provider: string; enabled: boolean; config: Record<string, unknown> }>,
+  /** When set, every `db.select(...)` chain throws on resolve. */
+  failureOnSelect: null as Error | null,
+};
+
+vi.mock('drizzle-orm', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('drizzle-orm');
+  return {
+    ...actual,
+    eq: (column: { __col?: string }, value: unknown): Pred => ({
+      __pred: true,
+      check: (row) => row[column.__col ?? ''] === value,
+    }),
+    and: (...preds: Pred[]): Pred => ({
+      __pred: true,
+      check: (row) => preds.every((p) => p.check(row)),
+    }),
+    isNotNull: (column: { __col?: string }): Pred => ({
+      __pred: true,
+      check: (row) => row[column.__col ?? ''] != null,
+    }),
+  };
+});
+
+vi.mock('../../db/schema.js', () => {
+  const col = (name: string) => ({ __col: name });
+  return {
+    maps: {
+      __name: 'maps',
+      id: col('id'),
+      name: col('name'),
+      workspaceId: col('workspaceId'),
+      githubInstallationId: col('githubInstallationId'),
+      githubRepoOwner: col('githubRepoOwner'),
+      githubRepoName: col('githubRepoName'),
+      autoImportNewIssues: col('autoImportNewIssues'),
+    },
+    nodes: {
+      __name: 'nodes',
+      id: col('id'),
+      mapId: col('mapId'),
+      externalLinks: col('externalLinks'),
+    },
+    integrations: {
+      __name: 'integrations',
+      workspaceId: col('workspaceId'),
+      provider: col('provider'),
+      enabled: col('enabled'),
+    },
+  };
+});
+
+type Projection = Record<string, { __col?: string } | undefined>;
+
+function buildChain(projection?: Projection): { from: (table: { __name?: string }) => unknown } {
+  const step: { table?: string; pred?: unknown } = {};
+  const projectRow = (row: Record<string, unknown>): Record<string, unknown> => {
+    if (!projection) return row;
+    const out: Record<string, unknown> = {};
+    for (const [alias, ref] of Object.entries(projection)) {
+      const colName = ref?.__col;
+      out[alias] = colName ? row[colName] : undefined;
+    }
+    return out;
+  };
+  const resolve = async (): Promise<Record<string, unknown>[]> => {
+    if (dbState.failureOnSelect) throw dbState.failureOnSelect;
+    let rows: Record<string, unknown>[] = [];
+    if (step.table === 'maps') {
+      rows = dbState.maps.map((m) => ({ ...m }));
+    } else if (step.table === 'nodes') {
+      rows = dbState.nodes.map((n) => ({ ...n }));
+    } else if (step.table === 'integrations') {
+      rows = dbState.integrations.map((i) => ({ ...i }));
+    }
+    if (isPred(step.pred)) {
+      rows = rows.filter((r) => (step.pred as Pred).check(r));
+    }
+    return rows.map(projectRow);
+  };
+  const thenable: {
+    then: (
+      onFulfilled: (v: Record<string, unknown>[]) => unknown,
+      onRejected?: (err: unknown) => unknown,
+    ) => Promise<unknown>;
+    catch: (onRejected: (err: unknown) => unknown) => Promise<unknown>;
+    where: (pred: unknown) => unknown;
+  } = {
+    then: (onFulfilled, onRejected) => resolve().then(onFulfilled, onRejected),
+    catch: (onRejected) => resolve().catch(onRejected),
+    where: (pred: unknown) => {
+      step.pred = pred;
+      return thenable;
+    },
+  };
+  return {
+    from(table: { __name?: string }) {
+      step.table = table.__name;
+      return thenable;
+    },
+  };
+}
+
+vi.mock('../../db/connection.js', () => ({
+  db: {
+    select: (cols?: Projection) => buildChain(cols),
+  },
+}));
+
+import type { GitHubIssue } from '@mindblown/integrations';
+
+const importedByRepo = new Map<string, Array<{ issue: GitHubIssue; externalLink: { externalId: string } }>>();
+let importThrows: Error | null = null;
+
+vi.mock('@mindblown/integrations', () => ({
+  importGitHubIssues: async (owner: string, repo: string, _t: string, _o?: unknown) => {
+    if (importThrows) throw importThrows;
+    return importedByRepo.get(`${owner}/${repo}`) ?? [];
+  },
+  mintInstallationToken: async (installationId: string) => `tok-${installationId}`,
+}));
+
+vi.mock('../autoBackfill.js', () => ({
+  runAutoBackfill: (...args: unknown[]) => runAutoBackfillMock(...args),
+}));
+
+vi.mock('../kumaPush.js', () => ({
+  pushKumaHeartbeat: (...args: unknown[]) => pushKumaMock(...(args as Parameters<typeof pushKumaMock>)),
+}));
+
+// ── SUT import (after mocks) ──────────────────────────────────────
+
+import { runDriftAudit, formatAutoBackfillMsg } from '../driftAudit.js';
+import type { AutoBackfillSummary } from '../autoBackfill.js';
+
+function ghIssue(number: number): GitHubIssue {
+  return {
+    id: number * 1000,
+    number,
+    title: `Issue ${number}`,
+    body: null,
+    state: 'open',
+    labels: [],
+    assignees: [],
+    milestone: null,
+    html_url: `https://github.com/owner/repo/issues/${number}`,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    closed_at: null,
+  };
+}
+
+function setupDriftyMap(mapId: string, mapName: string, driftCount: number): void {
+  dbState.maps.push({
+    id: mapId,
+    name: mapName,
+    workspaceId: 'ws',
+    githubInstallationId: 'inst-1',
+    githubRepoOwner: 'owner',
+    githubRepoName: 'repo',
+    autoImportNewIssues: true,
+  });
+  importedByRepo.set(
+    'owner/repo',
+    Array.from({ length: driftCount }, (_, i) => ({
+      issue: ghIssue(i + 1),
+      externalLink: { externalId: `owner/repo#${i + 1}` },
+    })),
+  );
+}
+
+function summary(
+  totalImported: number,
+  totalManualPending: number,
+): AutoBackfillSummary {
+  return { totalImported, totalManualPending, outcomes: [] };
+}
+
+beforeEach(() => {
+  runAutoBackfillMock.mockReset();
+  pushKumaMock.mockReset();
+  pushKumaMock.mockResolvedValue(undefined);
+  dbState.maps = [];
+  dbState.nodes = [];
+  dbState.integrations = [];
+  dbState.failureOnSelect = null;
+  importedByRepo.clear();
+  importThrows = null;
+  process.env.KUMA_GITHUB_DRIFT_PUSH_URL = 'https://kuma.example/api/push/x';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.KUMA_GITHUB_DRIFT_PUSH_URL;
+});
+
+// ── Cases ─────────────────────────────────────────────────────────
+
+describe('runDriftAudit', () => {
+  it('no drift → Kuma status=up msg=no-drift, no auto-backfill call', async () => {
+    // No maps, no drift. auditDrift returns [], runDriftAudit pushes
+    // clean and skips autoBackfill entirely.
+    const result = await runDriftAudit();
+
+    expect(runAutoBackfillMock).not.toHaveBeenCalled();
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('up');
+    expect(msg).toBe('no-drift');
+    expect(result.reports).toEqual([]);
+    expect(result.autoBackfill).toEqual({ totalImported: 0, totalManualPending: 0, outcomes: [] });
+  });
+
+  it('drift fully auto-healed → Kuma status=up msg=auto-backfilled-N', async () => {
+    setupDriftyMap('m1', 'Map One', 3);
+    runAutoBackfillMock.mockResolvedValue(summary(3, 0));
+
+    await runDriftAudit();
+
+    expect(runAutoBackfillMock).toHaveBeenCalledTimes(1);
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('up');
+    expect(msg).toBe('auto-backfilled-3');
+  });
+
+  it('drift partially auto-healed → Kuma status=down msg=auto-backfilled-X,manual-Y', async () => {
+    setupDriftyMap('m1', 'Mixed', 4);
+    runAutoBackfillMock.mockResolvedValue(summary(2, 100));
+
+    await runDriftAudit();
+
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('down');
+    expect(msg).toBe('auto-backfilled-2,manual-100');
+  });
+
+  it('drift all over cap → Kuma status=down msg=manual-N', async () => {
+    setupDriftyMap('m1', 'Over Cap', 75);
+    runAutoBackfillMock.mockResolvedValue(summary(0, 75));
+
+    await runDriftAudit();
+
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('down');
+    expect(msg).toBe('manual-75');
+  });
+
+  it('auditDrift itself throws (DB outage) → Kuma status=down msg=audit_failed:<reason>, no auto-backfill', async () => {
+    // Force the FIRST DB query (resolveTargets in auditDrift) to throw.
+    // This bubbles out of auditDrift → runDriftAudit's outer catch.
+    dbState.failureOnSelect = new Error('drizzle connection lost');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runDriftAudit();
+    errSpy.mockRestore();
+
+    expect(runAutoBackfillMock).not.toHaveBeenCalled();
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('down');
+    expect(msg).toMatch(/^audit_failed:/);
+    expect(msg).toMatch(/drizzle connection lost/);
+    expect(result.error).toMatch(/drizzle connection lost/);
+  });
+
+  it('per-map fetch failure (importGitHubIssues throws) → swallowed by auditDrift, run still reports no-drift', async () => {
+    // This is the "case 4 — Backfill itself throws" analogue at the
+    // audit-fetch level: a per-map fetch failure is caught inside
+    // auditDrift and reported via console.warn, so the SWEEP completes
+    // and runDriftAudit pushes "no-drift" (or auto-backfill if other
+    // maps drifted). Documents the per-map error-handling contract.
+    setupDriftyMap('m1', 'Will Fail', 1);
+    importThrows = new Error('GitHub 503');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await runDriftAudit();
+    warnSpy.mockRestore();
+
+    expect(result.error).toBeUndefined();
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('up');
+    expect(msg).toBe('no-drift');
+  });
+
+  it('Kuma URL unset → no push attempted, audit still returns its result', async () => {
+    delete process.env.KUMA_GITHUB_DRIFT_PUSH_URL;
+
+    const result = await runDriftAudit();
+
+    expect(pushKumaMock).not.toHaveBeenCalled();
+    expect(result.reports).toEqual([]);
+  });
+
+  it('Kuma push itself throws → runDriftAudit still returns its result', async () => {
+    pushKumaMock.mockRejectedValueOnce(new Error('kuma 502'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await runDriftAudit();
+    warnSpy.mockRestore();
+
+    expect(result.reports).toEqual([]);
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('formatAutoBackfillMsg shapes the msg string consistently', () => {
+    expect(formatAutoBackfillMsg(summary(0, 0))).toBe('no-drift');
+    expect(formatAutoBackfillMsg(summary(3, 0))).toBe('auto-backfilled-3');
+    expect(formatAutoBackfillMsg(summary(0, 5))).toBe('manual-5');
+    expect(formatAutoBackfillMsg(summary(2, 5))).toBe('auto-backfilled-2,manual-5');
+  });
+});

--- a/packages/server/src/sync/__tests__/sdNotify.test.ts
+++ b/packages/server/src/sync/__tests__/sdNotify.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the sd_notify helper.
+ *
+ * The helper shells out to `systemd-notify(1)` because node's stdlib
+ * doesn't expose unix SOCK_DGRAM sockets in a non-dependency-laden way.
+ * We mock `node:child_process.spawn` so the test exercises the
+ * env-var gate, the args we pass, and each failure-mode branch
+ * (spawn throws, subprocess errors, subprocess exits non-zero) without
+ * actually running anything.
+ */
+
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock child_process.spawn ──────────────────────────────────────
+
+interface MockSpawnCall {
+  command: string;
+  args: string[];
+}
+
+const spawnCalls: MockSpawnCall[] = [];
+let spawnBehaviour: 'exit0' | 'exit1' | 'error' | 'throw' = 'exit0';
+
+class MockChild extends EventEmitter {
+  constructor(public command: string, public args: string[]) {
+    super();
+  }
+}
+
+vi.mock('node:child_process', () => ({
+  spawn: (command: string, args: string[], _opts: unknown) => {
+    spawnCalls.push({ command, args });
+    if (spawnBehaviour === 'throw') {
+      throw new Error('ENOENT spawn systemd-notify');
+    }
+    const child = new MockChild(command, args);
+    // Fire the appropriate event on next tick so the listener registered
+    // by the helper is attached before we emit.
+    queueMicrotask(() => {
+      if (spawnBehaviour === 'error') {
+        child.emit('error', new Error('spawn error path'));
+      } else if (spawnBehaviour === 'exit1') {
+        child.emit('exit', 1);
+      } else {
+        child.emit('exit', 0);
+      }
+    });
+    return child;
+  },
+}));
+
+// ── SUT import (after mocks) ──────────────────────────────────────
+
+import { sendNotify, sdNotifyReady, sdNotifyWatchdog } from '../sdNotify.js';
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('sendNotify', () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    spawnBehaviour = 'exit0';
+    delete process.env.NOTIFY_SOCKET;
+  });
+
+  afterEach(() => {
+    delete process.env.NOTIFY_SOCKET;
+  });
+
+  it('is a no-op when $NOTIFY_SOCKET is unset', async () => {
+    const ok = await sendNotify('READY=1');
+    expect(ok).toBe(false);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('spawns systemd-notify with the payload line(s) when $NOTIFY_SOCKET is set', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    const ok = await sendNotify('READY=1');
+    expect(ok).toBe(true);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].command).toBe('systemd-notify');
+    expect(spawnCalls[0].args).toEqual(['READY=1']);
+  });
+
+  it('passes each newline-separated payload line as a separate arg', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    const ok = await sendNotify('STATUS=Running\nWATCHDOG=1');
+    expect(ok).toBe(true);
+    expect(spawnCalls[0].args).toEqual(['STATUS=Running', 'WATCHDOG=1']);
+  });
+
+  it('returns false when the subprocess emits error (does not throw)', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    spawnBehaviour = 'error';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(sendNotify('READY=1')).resolves.toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('returns false when the subprocess exits non-zero (does not throw)', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    spawnBehaviour = 'exit1';
+    await expect(sendNotify('READY=1')).resolves.toBe(false);
+  });
+
+  it('returns false when spawn itself throws synchronously (does not throw)', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    spawnBehaviour = 'throw';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(sendNotify('READY=1')).resolves.toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('returns false when the payload is empty (no point spawning)', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    await expect(sendNotify('')).resolves.toBe(false);
+    await expect(sendNotify('\n\n')).resolves.toBe(false);
+    expect(spawnCalls).toHaveLength(0);
+  });
+});
+
+describe('sdNotifyReady / sdNotifyWatchdog', () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    spawnBehaviour = 'exit0';
+    delete process.env.NOTIFY_SOCKET;
+  });
+
+  afterEach(() => {
+    delete process.env.NOTIFY_SOCKET;
+  });
+
+  it('sdNotifyReady sends READY=1', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    await sdNotifyReady();
+    expect(spawnCalls[0].args).toEqual(['READY=1']);
+  });
+
+  it('sdNotifyWatchdog sends WATCHDOG=1', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    await sdNotifyWatchdog();
+    expect(spawnCalls[0].args).toEqual(['WATCHDOG=1']);
+  });
+
+  it('both are no-ops when $NOTIFY_SOCKET is unset', async () => {
+    await sdNotifyReady();
+    await sdNotifyWatchdog();
+    expect(spawnCalls).toHaveLength(0);
+  });
+});

--- a/packages/server/src/sync/autoBackfill.ts
+++ b/packages/server/src/sync/autoBackfill.ts
@@ -1,0 +1,154 @@
+/**
+ * Auto-backfill drift remediation.
+ *
+ * The daily drift audit (`./driftAudit.ts`) detects open GitHub issues
+ * that have no linked MindBlown node, then pushes a Kuma alarm. Before
+ * this module landed, the operator had to click "Backfill" in the UI
+ * for each drifted map to actually heal the drift. This module closes
+ * that gap: when audit finds drift below a per-day cap, it auto-invokes
+ * the same backfill code path the manual UI uses; over the cap, it
+ * leaves the drift in place so the alarm escalates to a human.
+ *
+ * Safety model:
+ *   - A per-day cap (`AUTO_BACKFILL_MAX_PER_DAY`, default 50) prevents a
+ *     misconfigured webhook + a fast-issue-opening repo from
+ *     flood-amplifying into thousands of inbox nodes overnight.
+ *   - `AUTO_BACKFILL_MAX_PER_DAY=0` is a kill switch: no map ever gets
+ *     auto-backfilled, audit still runs and alarms.
+ *   - Per-map backfill failures are caught — one map's broken token
+ *     doesn't stall remediation for the others.
+ *
+ * Kuma push semantics (set by `runDriftAudit` in `./driftAudit.ts`):
+ *   - No drift → status=up, msg="no-drift"
+ *   - Drift fully auto-healed → status=up, msg="auto-backfilled-N"
+ *   - Drift partially healed → status=down, msg="auto-backfilled-N,manual-M"
+ *   - Drift all over cap → status=down, msg="manual-N"
+ *   - Backfill threw entirely → status=down, msg="audit_failed:<reason>"
+ *
+ * The `up` for full auto-heal means the operator never gets a page when
+ * the system recovers itself; the message field carries the receipt so
+ * Kuma's history shows what self-healing did.
+ */
+
+import type { DriftReport } from './driftAudit.js';
+import { backfillMap, type BackfillMapResult } from './githubIngest.js';
+
+/**
+ * Per-map outcome from the auto-backfill sweep. Mirrors the report
+ * shape from drift audit so the Kuma message can show "this map was
+ * over cap" vs "this map's backfill threw" without dropping data.
+ */
+export type AutoBackfillMapOutcome =
+  | { mapId: string; mapName: string; kind: 'healed'; imported: number }
+  | { mapId: string; mapName: string; kind: 'over-cap'; pending: number }
+  | { mapId: string; mapName: string; kind: 'failed'; pending: number; reason: string };
+
+export interface AutoBackfillSummary {
+  /** Total nodes created across all healed maps. */
+  totalImported: number;
+  /** Total drift left behind (manual + failed). */
+  totalManualPending: number;
+  /** Map-level outcomes for the Kuma message + log line. */
+  outcomes: AutoBackfillMapOutcome[];
+}
+
+/** Default cap on auto-backfill per map per audit tick. */
+export const DEFAULT_AUTO_BACKFILL_MAX_PER_DAY = 50;
+
+/**
+ * Read the configured per-day auto-backfill cap from
+ * `AUTO_BACKFILL_MAX_PER_DAY`. Falls back to `DEFAULT_AUTO_BACKFILL_MAX_PER_DAY`
+ * if unset or unparseable. Negative values are clamped to 0 (kill
+ * switch). Exported for tests.
+ */
+export function getAutoBackfillCap(): number {
+  const raw = process.env.AUTO_BACKFILL_MAX_PER_DAY;
+  if (raw === undefined) return DEFAULT_AUTO_BACKFILL_MAX_PER_DAY;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return DEFAULT_AUTO_BACKFILL_MAX_PER_DAY;
+  return Math.max(0, parsed);
+}
+
+/**
+ * Process every drift report. For each:
+ *   - `onlyInGitHub == 0` is impossible here (audit returns only > 0),
+ *     but defensively treated as already-healed.
+ *   - `0 < onlyInGitHub <= cap` → invoke `backfillMap` for the map.
+ *   - `onlyInGitHub > cap` → skip; leave drift for the operator.
+ *
+ * Drift audit only counts open issues, so we pass
+ * `allowClosedWithinDays: 0` into backfillMap — even if a stale
+ * closed-within-window issue is unlinked, it's not part of the alarm
+ * the audit raised, so we don't sweep it in here.
+ */
+export async function runAutoBackfill(
+  reports: DriftReport[],
+  capOverride?: number,
+): Promise<AutoBackfillSummary> {
+  const cap = capOverride ?? getAutoBackfillCap();
+  const outcomes: AutoBackfillMapOutcome[] = [];
+  let totalImported = 0;
+  let totalManualPending = 0;
+
+  for (const report of reports) {
+    const { mapId, mapName, onlyInGitHub } = report;
+
+    if (onlyInGitHub <= 0) continue;
+
+    if (cap === 0 || onlyInGitHub > cap) {
+      // Either the kill switch is engaged or this map's drift is too
+      // big to safely auto-heal. Leave it for manual ack.
+      outcomes.push({ mapId, mapName, kind: 'over-cap', pending: onlyInGitHub });
+      totalManualPending += onlyInGitHub;
+      continue;
+    }
+
+    let result: BackfillMapResult;
+    try {
+      result = await backfillMap(mapId, {
+        // Drift count is open-issues-only, so cap maxToImport to that
+        // exact number — avoids reading further closed issues into the
+        // inbox by surprise.
+        maxToImport: onlyInGitHub,
+        allowClosedWithinDays: 0,
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[auto-backfill] map ${mapId} (${mapName}) — backfill threw:`,
+        reason,
+      );
+      outcomes.push({ mapId, mapName, kind: 'failed', pending: onlyInGitHub, reason });
+      totalManualPending += onlyInGitHub;
+      continue;
+    }
+
+    totalImported += result.imported;
+
+    // It's possible for `result.imported < onlyInGitHub` even without an
+    // exception — `ensureNodeForIssue` may have raced with another path
+    // (skipped_exists), or per-issue ingest may have errored. Count the
+    // residual as manual-pending so the Kuma message stays honest.
+    const residual = Math.max(0, onlyInGitHub - result.imported);
+    if (residual > 0) {
+      totalManualPending += residual;
+      // Replace the "healed" outcome with "failed" if NOTHING got
+      // imported — that's a worse signal than a partial heal and it
+      // shouldn't masquerade as success in the per-map log.
+      if (result.imported === 0) {
+        outcomes.push({
+          mapId,
+          mapName,
+          kind: 'failed',
+          pending: residual,
+          reason: `imported 0/${onlyInGitHub} (${result.errored} errored)`,
+        });
+        continue;
+      }
+    }
+
+    outcomes.push({ mapId, mapName, kind: 'healed', imported: result.imported });
+  }
+
+  return { totalImported, totalManualPending, outcomes };
+}

--- a/packages/server/src/sync/driftAudit.ts
+++ b/packages/server/src/sync/driftAudit.ts
@@ -33,6 +33,8 @@ import { importGitHubIssues, mintInstallationToken } from '@mindblown/integratio
 
 import { db } from '../db/connection.js';
 import { maps, nodes, integrations } from '../db/schema.js';
+import { pushKumaHeartbeat } from './kumaPush.js';
+import { runAutoBackfill, type AutoBackfillSummary } from './autoBackfill.js';
 
 export interface DriftReport {
   mapId: string;
@@ -222,4 +224,145 @@ export async function auditDrift(): Promise<DriftReport[]> {
     }
   }
   return reports;
+}
+
+/**
+ * Result of one `runDriftAudit()` invocation, returned to callers
+ * (the daily scheduler in index.ts and the manual operator endpoint
+ * in routes/integrations.ts so they can show what auto-backfill did).
+ */
+export interface DriftAuditRunResult {
+  reports: DriftReport[];
+  autoBackfill: AutoBackfillSummary;
+  /** Set when the audit itself threw — short reason string for ops UI. */
+  error?: string;
+}
+
+/**
+ * Build the Kuma message string from an auto-backfill summary.
+ * Exported for tests.
+ *
+ * Examples:
+ *   - clean       → "no-drift"
+ *   - all healed  → "auto-backfilled-3"
+ *   - all manual  → "manual-5"
+ *   - mixed       → "auto-backfilled-2,manual-3"
+ */
+export function formatAutoBackfillMsg(summary: AutoBackfillSummary): string {
+  const parts: string[] = [];
+  if (summary.totalImported > 0) {
+    parts.push(`auto-backfilled-${summary.totalImported}`);
+  }
+  if (summary.totalManualPending > 0) {
+    parts.push(`manual-${summary.totalManualPending}`);
+  }
+  if (parts.length === 0) return 'no-drift';
+  return parts.join(',');
+}
+
+/**
+ * Run the drift audit, attempt auto-backfill on every drift report that
+ * fits under the per-day cap, then push a single Kuma heartbeat
+ * summarising the outcome.
+ *
+ * Pushes:
+ *   - No drift                       → status=up, msg="no-drift"
+ *   - Drift fully auto-healed        → status=up, msg="auto-backfilled-N"
+ *   - Drift partially auto-healed    → status=down, msg="auto-backfilled-X,manual-Y"
+ *   - All drift over cap / killed    → status=down, msg="manual-N"
+ *   - Audit itself threw             → status=down, msg="audit_failed:<reason>"
+ *
+ * Kuma URL comes from `KUMA_GITHUB_DRIFT_PUSH_URL`; if unset the push
+ * is skipped entirely (dev / test environments). Push errors are
+ * swallowed by `pushKumaHeartbeat`, but we re-wrap here so any future
+ * helper misbehaviour can't take down the run result.
+ */
+export async function runDriftAudit(): Promise<DriftAuditRunResult> {
+  const url = process.env.KUMA_GITHUB_DRIFT_PUSH_URL;
+  let reports: DriftReport[];
+  try {
+    reports = await auditDrift();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error('[drift-audit] sweep failed:', err);
+    if (url) {
+      const msg = `audit_failed: ${reason}`.slice(0, 200);
+      try {
+        await pushKumaHeartbeat(url, 'down', msg, '[kuma-push] drift audit');
+      } catch (pushErr) {
+        console.warn(
+          '[kuma-push] drift audit heartbeat unexpectedly threw:',
+          pushErr instanceof Error ? pushErr.message : pushErr,
+        );
+      }
+    }
+    return {
+      reports: [],
+      autoBackfill: { totalImported: 0, totalManualPending: 0, outcomes: [] },
+      error: reason,
+    };
+  }
+
+  // No drift → clean push and bail. Skip auto-backfill entirely
+  // (nothing to heal).
+  if (reports.length === 0) {
+    console.log('[drift-audit] clean — no drift');
+    if (url) {
+      try {
+        await pushKumaHeartbeat(url, 'up', 'no-drift', '[kuma-push] drift audit');
+      } catch (pushErr) {
+        console.warn(
+          '[kuma-push] drift audit heartbeat unexpectedly threw:',
+          pushErr instanceof Error ? pushErr.message : pushErr,
+        );
+      }
+    }
+    return {
+      reports: [],
+      autoBackfill: { totalImported: 0, totalManualPending: 0, outcomes: [] },
+    };
+  }
+
+  // Drift detected — log + auto-backfill what we can.
+  const summary = reports.map((r) => `${r.mapName}=${r.onlyInGitHub} issues`).join(', ');
+  console.warn(`[drift-audit] drift detected: ${summary}`);
+
+  const autoBackfill = await runAutoBackfill(reports);
+
+  if (autoBackfill.totalImported > 0) {
+    const perMap = autoBackfill.outcomes
+      .filter((o) => o.kind === 'healed')
+      .map((o) => `${o.mapName}=${(o as { imported: number }).imported}`)
+      .join(', ');
+    console.log(`[auto-backfill] healed ${autoBackfill.totalImported} drift node(s): ${perMap}`);
+  }
+  if (autoBackfill.totalManualPending > 0) {
+    const perMap = autoBackfill.outcomes
+      .filter((o) => o.kind === 'over-cap' || o.kind === 'failed')
+      .map((o) => {
+        if (o.kind === 'failed') {
+          return `${o.mapName}=${(o as { pending: number }).pending} (failed: ${(o as { reason: string }).reason})`;
+        }
+        return `${o.mapName}=${(o as { pending: number }).pending} (over cap)`;
+      })
+      .join(', ');
+    console.warn(`[auto-backfill] ${autoBackfill.totalManualPending} drift node(s) need manual action: ${perMap}`);
+  }
+
+  // Build the Kuma message and status.
+  const msg = formatAutoBackfillMsg(autoBackfill).slice(0, 200);
+  const status = autoBackfill.totalManualPending > 0 ? 'down' : 'up';
+
+  if (url) {
+    try {
+      await pushKumaHeartbeat(url, status, msg, '[kuma-push] drift audit');
+    } catch (pushErr) {
+      console.warn(
+        '[kuma-push] drift audit heartbeat unexpectedly threw:',
+        pushErr instanceof Error ? pushErr.message : pushErr,
+      );
+    }
+  }
+
+  return { reports, autoBackfill };
 }

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -29,6 +29,7 @@ import {
 } from './parentEpicRollup.js';
 import { ingestNewIssuesForRepo } from './githubIngest.js';
 import { pushKumaHeartbeat } from './kumaPush.js';
+import { sdNotifyWatchdog } from './sdNotify.js';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -477,7 +478,44 @@ export async function runAllCatchups(): Promise<ReconcileResult[]> {
       err instanceof Error ? err.message : err,
     );
   }
+
+  // Watchdog ping — only fired on a healthy tick (see `isHealthyTick`).
+  // Wrapped in try/catch defensively: sdNotifyWatchdog already
+  // suppresses its own errors, but a synchronous throw at the top of
+  // the function or an unhandled rejection escaping must NOT take down
+  // the catchup return value.
+  if (isHealthyTick(results)) {
+    try {
+      await sdNotifyWatchdog();
+    } catch (err) {
+      console.warn(
+        '[sd-notify] watchdog ping unexpectedly threw:',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
   return results;
+}
+
+/**
+ * A tick is "healthy" — and therefore eligible to ping the systemd
+ * watchdog — when EVERY per-repo result reported no error, zero
+ * ingest failures, and zero state-sync failures. The watchdog exists
+ * to catch the failure mode where the catchup loop has frozen
+ * entirely; pinging on a partial-failure path would defeat its
+ * purpose by hiding exactly those incidents from systemd.
+ *
+ * An empty `results` array (no repos discovered, no work done) counts
+ * as healthy — the sweep completed without crashing, which is what
+ * the watchdog actually measures.
+ *
+ * Exported for unit-test access.
+ */
+export function isHealthyTick(results: ReconcileResult[]): boolean {
+  return results.every(
+    (r) => !r.error && r.ingestErrored === 0 && r.stateSyncErrored === 0,
+  );
 }
 
 /**

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -41,6 +41,7 @@
 
 import { and, eq, sql } from 'drizzle-orm';
 import type { GitHubIssue } from '@mindblown/integrations';
+import { importGitHubIssues, mintInstallationToken } from '@mindblown/integrations';
 import type { ExternalLink } from '@mindblown/core';
 
 import { db } from '../db/connection.js';
@@ -522,4 +523,191 @@ export async function ingestNewIssuesForRepo(
   }
 
   return summary;
+}
+
+// ── Backfill a specific map ───────────────────────────────────────
+
+/**
+ * Number of days back from "now" we consider a closed issue eligible
+ * for backfill. Matches the constant inlined in the
+ * `/api/maps/:mapId/github/ingest-new` route. Kept here so the
+ * auto-backfill caller picks up the same window without duplicating
+ * the magic number.
+ */
+export const BACKFILL_CLOSED_WINDOW_DAYS = 30;
+
+export interface BackfillMapResult {
+  /** Count of new nodes created in this map. */
+  imported: number;
+  /** Total candidates (unlinked issues passing the closed-window filter). */
+  total: number;
+  /** True when `total` exceeded `maxToImport` and we ingested only a slice. */
+  capped: boolean;
+  /** Count of issues whose per-issue ingest threw (logged inside). */
+  errored: number;
+}
+
+export interface BackfillMapOpts {
+  /**
+   * Cap on the number of issues to actually ingest in this call. Default
+   * 200 (matches the manual backfill endpoint). When `total > maxToImport`,
+   * the helper ingests the first `maxToImport` candidates and reports
+   * `capped: true`.
+   */
+  maxToImport?: number;
+  /**
+   * Override the `createdBy` attribution for new nodes. Defaults to the
+   * map's `createdBy` — used as the attribution for auto-backfill calls
+   * where there's no acting user.
+   */
+  createdBy?: string;
+  /**
+   * Closed-issue window in days. Defaults to 30 (matches the manual
+   * backfill endpoint). The auto-backfill caller from drift audit can
+   * pass 0 to restrict to open issues only, since drift only counts open.
+   */
+  allowClosedWithinDays?: number;
+}
+
+/**
+ * Bulk-backfill into a single map: fetch every issue on the bound repo,
+ * filter to unlinked + (open OR closed-within-window), then ensure a
+ * node for the first `maxToImport` of them. Resolves the GitHub token
+ * the same way as `getGitHubContextForMap` in `routes/integrations.ts`
+ * (App-installation first, PAT fallback).
+ *
+ * Extracted from the `POST /api/maps/:mapId/github/ingest-new` handler
+ * so both the operator-clicks-the-button path and the auto-backfill
+ * drift remediation path share the same code. Differences from the
+ * inline route version:
+ *
+ *   - Lives in `sync/githubIngest.ts` instead of the route file so the
+ *     audit code can import it without dragging in Fastify types.
+ *   - Returns a typed result instead of throwing for non-2xx cases;
+ *     callers decide how to surface "no integration" / "fetch failed".
+ *
+ * Throws only on token-resolution / fetch failure / no-binding — those
+ * are infra-level problems the caller needs to know about (so the drift
+ * audit's Kuma push can flip to `down`). Per-issue ingest errors are
+ * caught + counted; the helper still returns its summary.
+ */
+export async function backfillMap(
+  mapId: string,
+  opts: BackfillMapOpts = {},
+): Promise<BackfillMapResult> {
+  const maxToImport = opts.maxToImport ?? 200;
+  const allowClosedWithinDays = opts.allowClosedWithinDays ?? BACKFILL_CLOSED_WINDOW_DAYS;
+
+  const [mapRow] = await db
+    .select({
+      id: maps.id,
+      createdBy: maps.createdBy,
+      workspaceId: maps.workspaceId,
+      githubInstallationId: maps.githubInstallationId,
+      githubRepoOwner: maps.githubRepoOwner,
+      githubRepoName: maps.githubRepoName,
+    })
+    .from(maps)
+    .where(eq(maps.id, mapId));
+  if (!mapRow) {
+    throw new Error(`backfillMap: map ${mapId} not found`);
+  }
+
+  // Resolve owner/repo + token. App-binding first, then workspace PAT.
+  // This mirrors `getGitHubContextForMap` in routes/integrations.ts —
+  // we don't import it to avoid a cycle (it lives in the routes layer).
+  let owner: string | null = null;
+  let repo: string | null = null;
+  let token: string | null = null;
+
+  if (mapRow.githubInstallationId && mapRow.githubRepoOwner && mapRow.githubRepoName) {
+    try {
+      token = await mintInstallationToken(mapRow.githubInstallationId);
+      owner = mapRow.githubRepoOwner;
+      repo = mapRow.githubRepoName;
+    } catch (err) {
+      console.warn(
+        `[backfill] mint installation token failed for map ${mapId}, falling back to PAT:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  if (!token) {
+    const [integ] = await db
+      .select()
+      .from(integrations)
+      .where(
+        and(
+          eq(integrations.workspaceId, mapRow.workspaceId),
+          eq(integrations.provider, 'github'),
+          eq(integrations.enabled, true),
+        ),
+      );
+    if (integ) {
+      const cfg = integ.config as { owner?: string; repo?: string; token?: string } | null;
+      if (cfg?.owner && cfg?.repo && cfg?.token) {
+        owner = cfg.owner;
+        repo = cfg.repo;
+        token = cfg.token;
+      }
+    }
+  }
+
+  if (!owner || !repo || !token) {
+    throw new Error(`backfillMap: no GitHub binding resolvable for map ${mapId}`);
+  }
+
+  const importedIssues = await importGitHubIssues(owner, repo, token, {
+    includeAll: true,
+  });
+
+  const allExternalIds = importedIssues.map((i) => i.externalLink.externalId);
+  const linkedIds = await findNodesByExternalIds(allExternalIds);
+
+  const cutoffMs = Date.now() - allowClosedWithinDays * 24 * 60 * 60 * 1000;
+  const candidates = importedIssues
+    .filter((item) => !linkedIds.has(item.externalLink.externalId))
+    .filter((item) => {
+      if (item.issue.state === 'open') return true;
+      if (allowClosedWithinDays <= 0) return false;
+      if (!item.issue.closed_at) return true;
+      const closed = new Date(item.issue.closed_at).getTime();
+      if (Number.isNaN(closed)) return true;
+      return closed >= cutoffMs;
+    });
+
+  const total = candidates.length;
+  const slice = candidates.slice(0, maxToImport);
+  const createdBy = opts.createdBy ?? (mapRow.createdBy as string);
+
+  const inboxId = await ensureInboxNode(mapId, createdBy);
+
+  let imported = 0;
+  let errored = 0;
+  for (const item of slice) {
+    try {
+      const result = await ensureNodeForIssue(
+        mapId,
+        inboxId,
+        item.issue,
+        { owner, repo, createdBy },
+        { allowClosedWithinDays },
+      );
+      if (result.status === 'created') imported++;
+    } catch (err) {
+      errored++;
+      console.warn(
+        `[backfill] ingest #${item.issue.number} failed for map ${mapId}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  return {
+    imported,
+    total,
+    capped: total > maxToImport,
+    errored,
+  };
 }

--- a/packages/server/src/sync/sdNotify.ts
+++ b/packages/server/src/sync/sdNotify.ts
@@ -1,0 +1,104 @@
+/**
+ * Minimal sd_notify(3) client for the systemd notification socket.
+ *
+ * Used in two places:
+ *
+ *   - `sdNotifyReady()` once per process, when Fastify has bound to
+ *     its port. Without this, a `Type=notify` unit waits forever in
+ *     "starting up" → operator-visible journal noise and (worse)
+ *     systemd never starts dependent services.
+ *
+ *   - `sdNotifyWatchdog()` after every successful catchup tick. With
+ *     `WatchdogSec=300` in the unit, systemd kills + restarts the
+ *     process if it stops pinging — so a frozen catchup loop (network
+ *     stall, pg query hang) doesn't quietly silence GitHub sync.
+ *
+ * Implementation notes:
+ *
+ *   - The socket path comes from `$NOTIFY_SOCKET`. When unset (dev / test
+ *     environments not started by systemd), both helpers no-op silently.
+ *   - The wire format is plain ASCII key=value lines on a unix-domain
+ *     SOCK_DGRAM socket. systemd's notify socket is SOCK_DGRAM — node's
+ *     `node:dgram` only exposes UDP, and `node:net` exposes unix sockets
+ *     in stream mode only. Rather than pull in the `sd-notify` or
+ *     `unix-dgram` npm packages (native build, postinstall hook), we
+ *     shell out to the `systemd-notify(1)` CLI which is already present
+ *     on every host running our service (it's part of systemd itself).
+ *     Subprocess spawn is ~2 ms — negligible compared to the
+ *     once-per-startup + once-per-5-min cadence.
+ *   - All errors are caught + logged at `warn` — a broken notify socket
+ *     must NEVER take down the API.
+ */
+
+import { spawn } from 'node:child_process';
+
+/**
+ * Send a single sd_notify-format payload to systemd via `systemd-notify`.
+ * Silent no-op when `$NOTIFY_SOCKET` is unset (dev / test). Resolves
+ * true when the subprocess exited 0.
+ *
+ * Exported for tests so each kind of payload (READY=1 vs WATCHDOG=1)
+ * can be verified to flow through the same path.
+ */
+export async function sendNotify(payload: string): Promise<boolean> {
+  const socketPath = process.env.NOTIFY_SOCKET;
+  if (!socketPath) return false;
+
+  // Strip any trailing newline so we don't pass an empty extra arg.
+  const lines = payload.split('\n').filter((s) => s.length > 0);
+  if (lines.length === 0) return false;
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (ok: boolean, err?: unknown): void => {
+      if (settled) return;
+      settled = true;
+      if (err) {
+        console.warn(
+          '[sd-notify] failed:',
+          err instanceof Error ? err.message : err,
+        );
+      }
+      resolve(ok);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn('systemd-notify', lines, {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        // Inherit NOTIFY_SOCKET so systemd-notify finds the right
+        // socket — without it the binary returns 0 silently and the
+        // notify is lost.
+        env: process.env,
+      });
+    } catch (err) {
+      finish(false, err);
+      return;
+    }
+
+    child.once('error', (err) => finish(false, err));
+    child.once('exit', (code) => finish(code === 0));
+  });
+}
+
+/**
+ * Send `READY=1` once Fastify has bound to its port. Required for
+ * `Type=notify` units — without it systemd thinks the service is
+ * still starting up forever.
+ */
+export async function sdNotifyReady(): Promise<boolean> {
+  return sendNotify('READY=1');
+}
+
+/**
+ * Ping the systemd watchdog. Combined with `WatchdogSec=300` in the
+ * unit file, this prevents a frozen catchup loop (network stall,
+ * blocked pg query) from silently silencing GitHub sync — systemd
+ * kills + restarts the process after 5 min of no pings.
+ *
+ * The caller MUST only invoke this on a SUCCESSFUL tick — pinging
+ * regardless of catchup health would defeat the watchdog's purpose.
+ */
+export async function sdNotifyWatchdog(): Promise<boolean> {
+  return sendNotify('WATCHDOG=1');
+}


### PR DESCRIPTION
## Motivation

#64 made the GitHub→MindBlown sync **self-detecting** — webhooks fire a
catchup heartbeat, a daily audit pushes drift to Kuma. It was still
only **partially self-healing**: when drift was detected the operator
still had to click the Backfill button.

This PR closes the gap on both sides:

- **(d) Auto-backfill** — when drift is found and it fits under a
  per-day cap, run the existing backfill code path automatically.
  Anything over the cap stays as Kuma alarm bait, so a runaway
  webhook regression can't flood-amplify into 5000 ghost inbox nodes.

- **(e) Watchdog** — `mindblown-api.service` is now `Type=notify`
  with `WatchdogSec=300`. The catchup loop pings the watchdog only on
  a fully-clean tick. A frozen loop (network stall, hung pg query)
  triggers a systemd kill + restart within 5 min instead of silently
  silencing GitHub sync.

## Round-2 fix (Ray's review)

Ray's "should-fix" turned out to be a production landmine, so it's
addressed in this PR rather than punted:

**`NotifyAccess=main` → `NotifyAccess=all`** in
`deploy/mindblown-api.service`. The service runs as `User=mindblown`
(non-root). `WATCHDOG=1` is sent via `systemd-notify(1)` spawned as a
child of the node process. Under `NotifyAccess=main`, systemd only
accepts pings whose sender PID matches the unit's main PID.
`systemd-notify(1)` tries to spoof the parent PID via
`SCM_CREDENTIALS`, but that requires `CAP_SYS_ADMIN`, which the
non-root child does not have — so the spoof fails, the message
arrives stamped with `systemd-notify`'s own PID, systemd rejects it,
and `WatchdogSec=300` fires every 5 min → service restart-loops in
production.

`NotifyAccess=all` still confines accepted senders to the unit's
cgroup, which for us is the same security boundary (only the
`mindblown` UID's processes live there). This is the documented
systemd recipe for child-process notifications.

**If you're a future reviewer looking to "fix" this back to `=main`:
don't.** The watchdog will start dropping every ping, the service
will restart every 5 min, and you'll spend an afternoon tracking
this comment block down. Ray's review on PR #65 has the full
analysis.

Also added a one-line README runbook tip distinguishing the two
`manual-N` Kuma-message failure modes (`all maps over cap` vs
`per-map auto-backfill failed`) via `journalctl | grep auto-backfill`.

## Trade-offs

**Why a cap on auto-backfill?** Drift > 0 can mean "one webhook
dropped" (auto-heal fine) OR "webhook URL silently misconfigured for
3 weeks" (50 issues since, auto-heal NOT fine — those go straight to
the wrong map's inbox and need a human). The cap is per-map per audit
tick because the per-tick flood velocity is what hurts — we don't care
about cumulative annual volume, we care about "did one tick try to
ingest 5000 issues."

**Why no startup audit run?** Drift audit fan-outs one
`importGitHubIssues` call per opted-in map. A crashloop on boot would
hammer GitHub. Catchup is fine to run on startup because it uses a
`since=` cursor; drift audit fetches every open issue. Same rule as #64.

**Why subprocess for sd_notify?** Node's stdlib doesn't expose unix
`SOCK_DGRAM` sockets — both `node:dgram` (UDP only) and `node:net`
(stream-mode) come up short. Rather than pull in `sd-notify` /
`unix-dgram` (native build, postinstall hook) for a once-per-startup
+ once-per-5-min event, we shell out to `systemd-notify(1)` which is
already on every host running systemd. ~2 ms per ping — negligible.

**Why ping only on fully-clean ticks?** The watchdog exists to catch
the case where the catchup loop has *frozen entirely*. Pinging
regardless of per-repo health would mask exactly those incidents.
Partial-failure paths get a Kuma `down` push (already wired in #64) +
no watchdog reset → systemd restarts after 5 min if the partial
failure becomes a total one.

## Configuration

Two env vars added, both optional, both defaulted sanely:

| Env var | Default | What it does |
|---|---|---|
| `AUTO_BACKFILL_MAX_PER_DAY` | `50` | Cap on auto-backfill per map per audit tick. Set to `0` as a kill switch (audit still runs + alarms). |

The catchup + drift Kuma URL env vars are unchanged from #64.

The systemd unit gets four new directives:

```ini
Type=notify
NotifyAccess=all
WatchdogSec=300
RestartSec=10s
```

`Restart=on-failure` was already there. `RestartSec` widened from 5 to
10 to give the kernel a beat to release the listen socket between
restart cycles when the watchdog fires.

## Persona test plan (post-deploy)

### Auto-backfill, drift under cap

1. Open 3 GH issues on `FulcrumCRM/crm` rapidly, then briefly disable
   the webhook in GH so the events are dropped.
2. Wait for the daily audit OR trigger
   `POST /api/maps/sync/audit-drift` manually (admin session).
3. Confirm Kuma shows `status=up msg=auto-backfilled-3`.
4. Confirm the 3 issues now have inbox nodes in the Fulcrum CRM Roadmap.

### Auto-backfill, drift over cap (cap escalates to a human)

1. Set `AUTO_BACKFILL_MAX_PER_DAY=2`, restart mindblown-api.
2. Manufacture 3+ orphan issues as above.
3. Trigger the audit.
4. Confirm Kuma shows `status=down msg=manual-3` (no auto-action,
   alarm fires).

### Systemd watchdog

1. `pkill -STOP -f 'tsx src/index.ts'` against the mindblown-api pid.
2. Wait 6 min.
3. Confirm `systemctl status mindblown-api` shows it was killed +
   restarted (look for `WATCHDOG=`).
4. Confirm Kuma catchup heartbeat resumes within ~5 min of restart.

## Tests

- `packages/server/src/sync/__tests__/autoBackfill.test.ts` (new, 13
  cases) — the 5 brief scenarios plus cap parsing + partial-heal +
  imported-zero edge cases.
- `packages/server/src/sync/__tests__/runDriftAudit.test.ts` (new,
  9 cases) — end-to-end via the same predicate-aware drizzle mock as
  `driftAudit.test.ts`, covering all five Kuma push outcomes.
- `packages/server/src/sync/__tests__/sdNotify.test.ts` (new, 10
  cases) — env-var gate, payload args, every subprocess failure mode.
- `packages/server/src/sync/__tests__/githubCatchup.test.ts` (extended,
  +7 cases) — watchdog-ping fires on clean tick, doesn't fire on
  failed tick, doesn't throw if `sdNotifyWatchdog` rejects.

Full server suite: **138 passed**. Monorepo `pnpm -r typecheck`: clean.

## Files touched

- `packages/server/src/sync/autoBackfill.ts` (new) — `runAutoBackfill`,
  `getAutoBackfillCap`.
- `packages/server/src/sync/sdNotify.ts` (new) — `sdNotifyReady`,
  `sdNotifyWatchdog`, `sendNotify`.
- `packages/server/src/sync/driftAudit.ts` — added `runDriftAudit`
  (was inlined in `index.ts`), `formatAutoBackfillMsg`,
  `DriftAuditRunResult`. Hooks audit → auto-backfill → Kuma.
- `packages/server/src/sync/githubIngest.ts` — added `backfillMap`
  helper, extracted from the inline route body.
- `packages/server/src/sync/githubCatchup.ts` — watchdog ping after
  successful tick; exported `isHealthyTick`.
- `packages/server/src/index.ts` — uses moved `runDriftAudit`; sends
  `READY=1` after `app.listen`.
- `packages/server/src/routes/integrations.ts` — manual audit route
  uses the new `runDriftAudit` so it exercises the same auto-repair
  path the scheduler does.
- `deploy/mindblown-api.service` — `Type=notify`, `WatchdogSec=300`,
  `NotifyAccess=all`, `RestartSec=10s`.
- `deploy/README.md` — env var + watchdog + auto-backfill behaviour
  documented in the existing "observability" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
