### PR TITLE
feat(ui): surface ingestErrored/stateSyncErrored on reconcile result (closes #67)

### DIFF
--- a/packages/mindmap/src/GitHubPanel.tsx
+++ b/packages/mindmap/src/GitHubPanel.tsx
@@ -661,6 +661,25 @@ export function GitHubSettingsDialog({
               {reconcileResult.repo}: {reconcileResult.applied} updated, {reconcileResult.ingested ?? 0} ingested, {reconcileResult.fetched} checked
             </span>
           )}
+          {reconcileResult &&
+            !reconcileResult.error &&
+            ((reconcileResult.ingestErrored ?? 0) > 0 ||
+              (reconcileResult.stateSyncErrored ?? 0) > 0) && (
+              <span
+                data-testid="reconcile-errors-warning"
+                style={{
+                  fontSize: 11,
+                  background: '#fef3c7',
+                  border: '1px solid #fde68a',
+                  color: '#92400e',
+                  padding: '3px 8px',
+                  borderRadius: 4,
+                  fontWeight: 600,
+                }}
+              >
+                ⚠ Last sync had {reconcileResult.ingestErrored ?? 0} ingest failures and {reconcileResult.stateSyncErrored ?? 0} state-sync failures — will retry next tick.
+              </span>
+            )}
           {reconcileResult?.error && (
             <span style={{ fontSize: 11, color: '#991b1b' }}>
               {reconcileResult.error}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -438,6 +438,18 @@ export interface GitHubReconcileResult {
   noTransition: number;
   /** Nodes auto-created in the ingest pass (issues with no linked node yet). */
   ingested: number;
+  /**
+   * Count of per-issue / per-inbox errors raised during the ingest pass.
+   * When >0 the server deliberately does NOT bump `lastSyncedAt` so the next
+   * catch-up tick will re-fetch the failed issues. Surfaced in the UI as an
+   * inline warning so partial failures are observable to the operator.
+   */
+  ingestErrored: number;
+  /**
+   * Count of node-update errors hit during the state-sync loop. Same retry
+   * semantics as `ingestErrored` — the next tick will retry the window.
+   */
+  stateSyncErrored: number;
   durationMs: number;
   since: string | null;
   error?: string;


### PR DESCRIPTION
## Summary

- The server-side GitHub catchup tracks per-tick `ingestErrored` and `stateSyncErrored` counters on `ReconcileResult`. They're already passed through to the client by `POST /api/maps/:mapId/github/reconcile` (see `packages/server/src/routes/integrations.ts:839` — `reply.send(result)` is a straight pass-through), but the frontend `GitHubReconcileResult` interface didn't declare them, so the UI couldn't see them.
- Extends `GitHubReconcileResult` in `packages/mindmap/src/api.ts` with `ingestErrored: number` and `stateSyncErrored: number`.
- Adds a conditional amber inline warning in `packages/mindmap/src/GitHubPanel.tsx` next to the reconcile result, using the existing amber palette (`#fef3c7` / `#fde68a` / `#92400e`) already used by the "Only in GitHub" sync bucket.

## Warning text + gating

The conditional that gates the warning render:

```tsx
{reconcileResult &&
  !reconcileResult.error &&
  ((reconcileResult.ingestErrored ?? 0) > 0 ||
    (reconcileResult.stateSyncErrored ?? 0) > 0) && (
    <span data-testid="reconcile-errors-warning" style={{ /* amber pill */ }}>
      ⚠ Last sync had {reconcileResult.ingestErrored ?? 0} ingest failures and {reconcileResult.stateSyncErrored ?? 0} state-sync failures — will retry next tick.
    </span>
)}
```

The `?? 0` fallback keeps the UI safe against older server builds that haven't started reporting the counters yet (treats absent as zero, so no false warnings).

## Server change

None required. `POST /api/maps/:mapId/github/reconcile` calls `reconcileRepo(...)` and returns the whole `ReconcileResult` object via `reply.send(result)`. The fields ship on the wire as-is. Confirmed by grepping `packages/server/src/sync/githubCatchup.ts` (counters populated at lines 60, 71, 240, 288–300, 365–367) and `packages/server/src/routes/integrations.ts:839`.

## Tests

The `@mindblown/mindmap` package has no test runner configured (no `test` script, no vitest/jest devDep). Adding the first frontend test would require setting up the testing infrastructure, which is out of scope for this UX surface fix. The new element carries `data-testid="reconcile-errors-warning"` so a future test can target it directly once the runner lands.

Server-side coverage already exists for the counters in `packages/server/src/sync/__tests__/githubCatchup.test.ts` (tests at lines 204, 215, 273, 282).

## Verification

- `pnpm -w typecheck` — clean, 11/11 tasks successful.
- `pnpm -w build` — clean, 7/7 tasks successful (mindmap rebuilt fresh, server rebuilt fresh, others cached).
- `pnpm -w test` — all 8 packages pass (server suite cached against main worktree path; the only fresh test run this round was `@mindblown/mcp`, 3/3 passed). No tests added/removed in this PR.
- `rg "ingestErrored" packages/mindmap/src` → 4 hits (type definition + JSDoc reference + 2 UI usages); `stateSyncErrored` → 3 hits.

## Persona acceptance test (post-merge)

1. With a map bound to a repo where catchup has been hitting errors (e.g. revoke the GH App install), click "Reconcile with GitHub" in the GitHubPanel.
2. The amber warning pill should render alongside the existing summary, showing the two failure counts and the retry hint.
3. With a healthy repo, hit reconcile again — the warning must NOT render (the `?? 0` and the `> 0` guards together ensure no false positives, including against older server builds that don't yet return the fields).

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)