### PR TITLE
refactor(sync): thread tx through nodeDb.createNode/updateNode (closes #66)

### DIFF
--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -6,6 +6,23 @@ import { hasCycle } from '@mindblown/core';
 import type { Node as CoreNode, Dependency, DependencyType, ExternalLink, Priority, CustomFieldValue, NodeMap, StatusDef } from '@mindblown/core';
 
 /**
+ * A handle that can issue queries — either the global `db` or a transaction
+ * handle (`tx`) from `db.transaction(async (tx) => ...)`. Both expose the
+ * same drizzle query-builder surface (`select`, `insert`, `update`, ...);
+ * `PgTransaction` extends `PgDatabase`, so a tx is structurally assignable
+ * to this type modulo the `$client` field that only `db` carries (and which
+ * we don't use here). Callers that want their `createNode`/`updateNode`
+ * writes to roll back with an outer transaction pass the `tx` they got
+ * from `db.transaction`; callers that don't care (the default) get
+ * autocommit on the global `db`.
+ *
+ * We extract the tx type via `Parameters` to avoid a brittle dependency
+ * on drizzle's private export paths.
+ */
+type DrizzleTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+export type DbHandle = typeof db | DrizzleTx;
+
+/**
  * Thrown by updateNode when the caller passed an expectedRevision and the
  * row's current revision doesn't match — i.e. someone else wrote first.
  * Carries the current node so the route can return it to the client.
@@ -39,6 +56,7 @@ async function deriveAutoStatus(
   mapId: string,
   currentStatus: string | null,
   newProgress: number | null | undefined,
+  handle: DbHandle = db,
 ): Promise<string | undefined> {
   const targetCategory: 'todo' | 'in_progress' | 'done' =
     newProgress == null || newProgress <= 0
@@ -47,7 +65,7 @@ async function deriveAutoStatus(
         ? 'done'
         : 'in_progress';
 
-  const [map] = await db
+  const [map] = await handle
     .select({ statusWorkflow: maps.statusWorkflow })
     .from(maps)
     .where(eq(maps.id, mapId));
@@ -86,11 +104,21 @@ export interface CreateNodeInput {
   autoProgress?: 'off' | 'children';
 }
 
-export async function createNode(input: CreateNodeInput): Promise<CoreNode> {
+export async function createNode(
+  input: CreateNodeInput,
+  /**
+   * Optional transaction handle. When provided, the insert + parent
+   * children_order update participate in the caller's tx and roll back
+   * with it. When omitted (the common case), writes go through the
+   * global `db` handle and autocommit individually.
+   */
+  txHandle?: DbHandle,
+): Promise<CoreNode> {
+  const handle: DbHandle = txHandle ?? db;
   const now = new Date();
 
   // Create the node
-  const [row] = await db.insert(nodes).values({
+  const [row] = await handle.insert(nodes).values({
     mapId: input.mapId,
     parentId: input.parentId,
     childrenOrder: [],
@@ -116,7 +144,7 @@ export async function createNode(input: CreateNodeInput): Promise<CoreNode> {
   }).returning();
 
   // Add to parent's children_order
-  const [parent] = await db.select().from(nodes).where(eq(nodes.id, input.parentId));
+  const [parent] = await handle.select().from(nodes).where(eq(nodes.id, input.parentId));
   if (parent) {
     const order = (parent.childrenOrder as string[]) ?? [];
     const idx = input.position;
@@ -125,7 +153,7 @@ export async function createNode(input: CreateNodeInput): Promise<CoreNode> {
     } else {
       order.push(row.id);
     }
-    await db.update(nodes)
+    await handle.update(nodes)
       .set({ childrenOrder: order, updatedAt: now })
       .where(eq(nodes.id, input.parentId));
   }
@@ -171,16 +199,25 @@ export async function updateNode(
   nodeId: string,
   input: UpdateNodeInput,
   expectedRevision?: number,
+  /**
+   * Optional transaction handle. When provided, the update (and the
+   * status-derivation / dependency-validation precheck reads) participate
+   * in the caller's tx and roll back with it. When omitted, writes
+   * autocommit on the global `db` handle.
+   */
+  txHandle?: DbHandle,
 ): Promise<CoreNode | null> {
+  const handle: DbHandle = txHandle ?? db;
+
   // Validate dependencies if provided
   if (input.dependencies !== undefined) {
-    await validateDependencies(nodeId, input.dependencies);
+    await validateDependencies(nodeId, input.dependencies, handle);
   }
 
   // Auto-derive status from percentComplete when status is not explicitly set
   // in this update. See deriveAutoStatus for the exact rules.
   if (input.percentComplete !== undefined && input.status === undefined) {
-    const [current] = await db
+    const [current] = await handle
       .select({ status: nodes.status, mapId: nodes.mapId })
       .from(nodes)
       .where(eq(nodes.id, nodeId));
@@ -189,6 +226,7 @@ export async function updateNode(
         current.mapId as string,
         (current.status as string | null) ?? null,
         input.percentComplete,
+        handle,
       );
       if (derived !== undefined) input.status = derived;
     }
@@ -230,7 +268,7 @@ export async function updateNode(
       ? eq(nodes.id, nodeId)
       : and(eq(nodes.id, nodeId), eq(nodes.revision, expectedRevision));
 
-  const [row] = await db.update(nodes).set(updates).where(where).returning();
+  const [row] = await handle.update(nodes).set(updates).where(where).returning();
   if (row) return dbNodeToCore(row as unknown as Record<string, unknown>);
 
   // No row affected — either the node doesn't exist, or the revision was stale.
@@ -408,12 +446,15 @@ export async function reorderChildren(
  * Build a NodeMap from all nodes sharing the same mapId as `nodeId`.
  * Used for cycle detection via the core `hasCycle` function.
  */
-async function buildNodeMapForNode(nodeId: string): Promise<{ mapId: string; nodeMap: NodeMap }> {
-  const [node] = await db.select().from(nodes).where(eq(nodes.id, nodeId));
+async function buildNodeMapForNode(
+  nodeId: string,
+  handle: DbHandle = db,
+): Promise<{ mapId: string; nodeMap: NodeMap }> {
+  const [node] = await handle.select().from(nodes).where(eq(nodes.id, nodeId));
   if (!node) throw new DependencyValidationError(`Node ${nodeId} not found`);
 
   const mapId = node.mapId as string;
-  const allNodes = await db.select().from(nodes).where(eq(nodes.mapId, mapId));
+  const allNodes = await handle.select().from(nodes).where(eq(nodes.mapId, mapId));
   const nodeMap: NodeMap = new Map();
   for (const n of allNodes) {
     const coreNode = dbNodeToCore(n as unknown as Record<string, unknown>);
@@ -426,7 +467,11 @@ async function buildNodeMapForNode(nodeId: string): Promise<{ mapId: string; nod
  * Validate a full dependency array for a node.
  * Rejects self-references and circular dependencies.
  */
-async function validateDependencies(nodeId: string, deps: Dependency[]): Promise<void> {
+async function validateDependencies(
+  nodeId: string,
+  deps: Dependency[],
+  handle: DbHandle = db,
+): Promise<void> {
   // Check for self-references
   for (const dep of deps) {
     if (dep.targetNodeId === nodeId) {
@@ -438,7 +483,7 @@ async function validateDependencies(nodeId: string, deps: Dependency[]): Promise
 
   // Check for circular dependencies by simulating the new dependency set
   if (deps.length > 0) {
-    const { nodeMap } = await buildNodeMapForNode(nodeId);
+    const { nodeMap } = await buildNodeMapForNode(nodeId, handle);
 
     // Temporarily update the node's dependencies in the map for cycle detection
     const currentNode = nodeMap.get(nodeId);

--- a/packages/server/src/sync/__tests__/githubIngest.test.ts
+++ b/packages/server/src/sync/__tests__/githubIngest.test.ts
@@ -133,7 +133,19 @@ function mockSelect(_cols?: unknown) {
 // implementation intercepts pg_advisory_xact_lock to enforce per-key
 // serialization across concurrent transactions, then releases the lock
 // when the callback resolves (modelling tx commit).
+//
+// The `__rollbacks` list on the returned tx handle lets the mocked
+// `nodeDb.createNode` / `nodeDb.updateNode` register undo callbacks for
+// the writes they made under this tx. If the cb throws, the transaction
+// mock walks the rollbacks and applies them, modelling Postgres's
+// rollback of every write in the aborted transaction. This is what lets
+// the orphan-rollback test assert that no node row remains after the
+// throw — without rollback simulation, the mock would behave as if
+// every nodeDb call autocommitted, defeating the whole point of the
+// test.
+type TxHandle = ReturnType<typeof buildTxHandle>;
 function buildTxHandle(releaseHooks: Array<() => void>) {
+  const rollbacks: Array<() => void> = [];
   return {
     execute: async (sqlObj: unknown) => {
       const raw = JSON.stringify(sqlObj);
@@ -161,7 +173,12 @@ function buildTxHandle(releaseHooks: Array<() => void>) {
         returning: async () => [],
       }),
     }),
+    /** Undo callbacks registered by tx-scoped node writes. */
+    __rollbacks: rollbacks,
   };
+}
+function isTxHandle(x: unknown): x is TxHandle {
+  return !!x && typeof x === 'object' && Array.isArray((x as { __rollbacks?: unknown }).__rollbacks);
 }
 
 vi.mock('../../db/connection.js', () => ({
@@ -189,10 +206,17 @@ vi.mock('../../db/connection.js', () => ({
       const tx = buildTxHandle(releaseHooks);
       try {
         const result = await cb(tx);
-        // tx commit — release any held advisory locks
+        // tx commit — release any held advisory locks. Drop the
+        // rollback list because the writes are now committed.
         for (const r of releaseHooks) r();
         return result;
       } catch (err) {
+        // tx rollback — walk the rollback list in reverse order so
+        // later writes undo before earlier ones (mirrors Postgres's
+        // statement-order rollback semantics), then release locks.
+        for (let i = tx.__rollbacks.length - 1; i >= 0; i--) {
+          try { tx.__rollbacks[i](); } catch { /* swallow per-undo failure */ }
+        }
         for (const r of releaseHooks) r();
         throw err;
       }
@@ -252,9 +276,17 @@ vi.mock('drizzle-orm', async () => {
   };
 });
 
+// Hook for tests that want updateNode to throw — used by the orphan
+// rollback test to simulate a failure between createNode and the end of
+// the tx callback. When set, updateNode invokes this before applying
+// its normal logic; the throw propagates out of the tx callback and
+// triggers the rollback path.
+let updateNodeThrowOnNthCall: number | null = null;
+let updateNodeMockShouldThrow: ((callIndex: number) => Error | null) | null = null;
+
 vi.mock('../../db/nodes.js', () => ({
   getNode: (id: string) => getNodeMock(id),
-  createNode: async (input: Record<string, unknown>) => {
+  createNode: async (input: Record<string, unknown>, tx?: unknown) => {
     createNodeCalls.push(input);
     const id = `node-${createNodeCalls.length}`;
     const row = {
@@ -288,23 +320,57 @@ vi.mock('../../db/nodes.js', () => ({
       createdBy: input.createdBy as string,
       revision: 1,
     };
-    // Also register it in dbState.nodes so subsequent existence pre-checks see it.
+    // Register it in dbState.nodes so subsequent existence pre-checks see it.
     dbState.nodes.set(id, {
       id,
       mapId: input.mapId as string,
       parentId: (input.parentId as string | undefined) ?? null,
       externalLinks: [],
     });
+    // If we were given a tx handle, register a rollback that removes
+    // the row from dbState (and the createNodeCalls log) when the tx
+    // aborts. Mirrors Postgres rolling back the INSERT.
+    if (isTxHandle(tx)) {
+      tx.__rollbacks.push(() => {
+        dbState.nodes.delete(id);
+        const idx = createNodeCalls.indexOf(input);
+        if (idx >= 0) createNodeCalls.splice(idx, 1);
+      });
+    }
     return row;
   },
-  updateNode: async (nodeId: string, input: Record<string, unknown>) => {
+  updateNode: async (
+    nodeId: string,
+    input: Record<string, unknown>,
+    _expectedRevision?: number,
+    tx?: unknown,
+  ) => {
+    const callIndex = updateNodeCalls.length;
     updateNodeCalls.push({ nodeId, input });
+    if (updateNodeMockShouldThrow) {
+      const err = updateNodeMockShouldThrow(callIndex);
+      if (err) throw err;
+    }
+    if (updateNodeThrowOnNthCall !== null && callIndex === updateNodeThrowOnNthCall) {
+      throw new Error(`simulated updateNode failure on call ${callIndex}`);
+    }
+    // Snapshot the pre-update externalLinks for rollback.
+    const prevRow = dbState.nodes.get(nodeId);
+    const prevExternalLinks = prevRow?.externalLinks
+      ? [...prevRow.externalLinks]
+      : [];
     // Mirror externalLinks into dbState so the existence precheck sees them.
     if (input.externalLinks) {
       const row = dbState.nodes.get(nodeId);
       if (row) {
         row.externalLinks = input.externalLinks as Array<{ provider: string; externalId: string }>;
       }
+    }
+    if (isTxHandle(tx)) {
+      tx.__rollbacks.push(() => {
+        const row = dbState.nodes.get(nodeId);
+        if (row) row.externalLinks = prevExternalLinks;
+      });
     }
     const row = dbState.nodes.get(nodeId);
     // Return a row that mirrors the production `nodeDb.updateNode` shape
@@ -363,6 +429,8 @@ function resetState() {
   createNodeCalls.length = 0;
   advisoryLocksTaken.length = 0;
   getNodeMock.mockReset();
+  updateNodeThrowOnNthCall = null;
+  updateNodeMockShouldThrow = null;
 }
 
 beforeEach(() => {
@@ -563,6 +631,50 @@ describe('ensureNodeForIssue', () => {
     // Both transactions must have called pg_advisory_xact_lock — proving
     // the lock infra was actually exercised, not bypassed.
     expect(advisoryLocksTaken.length).toBe(2);
+  });
+
+  it('tx rollback: throw after createNode leaves no orphan node (mindblown#66)', async () => {
+    // Regression: ensureNodeForIssue used to call nodeDb.createNode and
+    // nodeDb.updateNode on the global `db` handle, so each autocommitted
+    // outside the outer `db.transaction(...)` that held the advisory
+    // lock. Any throw between createNode and end-of-tx would leave an
+    // orphan row that the rollback couldn't undo.
+    //
+    // After #66, both calls receive the `tx` handle and participate in
+    // the outer tx. This test simulates a failure on the link-attach
+    // updateNode and asserts that no row remains in dbState.nodes —
+    // proving the rollback actually walked back the insert.
+    dbState.maps.set('m1', { rootNodeId: 'root-1', inboxId: 'inbox-1', createdBy: 'u1' });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+
+    const nodesBefore = new Set(dbState.nodes.keys());
+    // Make the first updateNode call inside the tx throw (this is the
+    // updateNode that attaches the externalLink + description in
+    // ensureNodeForIssue). The tx callback re-throws and the mocked
+    // db.transaction walks the rollback list, reverting the createNode.
+    updateNodeThrowOnNthCall = 0;
+
+    await expect(
+      ensureNodeForIssue(
+        'm1',
+        'inbox-1',
+        issue(77, { title: 'roll me back' }),
+        { owner: 'owner', repo: 'repo', createdBy: 'u1' },
+      ),
+    ).rejects.toThrow(/simulated updateNode failure/);
+
+    // The advisory lock was still taken (so we know we entered the tx).
+    expect(advisoryLocksTaken.length).toBe(1);
+    // Critically: after rollback, no NEW node row exists. Only the
+    // pre-existing inbox row is in dbState.
+    const nodesAfter = new Set(dbState.nodes.keys());
+    expect(nodesAfter).toEqual(nodesBefore);
+    // And no node has owner/repo#77 in its externalLinks (orphan check
+    // via the same precheck the production path uses).
+    const orphans = [...dbState.nodes.values()].filter((n) =>
+      n.externalLinks.some((l) => l.provider === 'github' && l.externalId === 'owner/repo#77'),
+    );
+    expect(orphans).toEqual([]);
   });
 
   it('broadcast payload for node:created carries the full node row', async () => {

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -346,34 +346,23 @@ export async function ensureNodeForIssue(
     }
   }
 
-  // (3) Wrap lock + precheck + create in a Postgres transaction.
-  // pg_advisory_xact_lock only holds for the duration of the current
-  // transaction; without an explicit tx, drizzle commits between every
-  // statement and the lock releases immediately — making the race
-  // protection illusory. By wrapping here, the second concurrent call
-  // for the same externalId blocks at takeIngestLock until the first
-  // call's tx commits, at which point its precheck reads the freshly-
-  // inserted externalLink and returns skipped_exists.
+  // (3) Wrap lock + precheck + create + link-update in a Postgres
+  // transaction. The advisory lock holds for the duration of this tx; the
+  // precheck SELECT, the createNode insert, and the updateNode that
+  // attaches the externalLink ALL run on the `tx` handle, so they share
+  // the same transaction scope. Two consequences:
+  //
+  //   1. Race safety: a concurrent call for the same externalId blocks
+  //      at takeIngestLock until this tx commits, then its precheck reads
+  //      the (now committed) externalLink and returns skipped_exists.
+  //   2. Atomicity: if any throw happens between createNode and end of
+  //      tx, the rollback undoes the insert + the link update together —
+  //      no orphan node is left behind. (Previously these calls ran on
+  //      the global `db` handle and autocommitted independently, which
+  //      worked by accident for the happy path but leaked on any throw
+  //      in between. mindblown#66.)
   const isClosed = issue.state === 'closed';
   const text = `#${issue.number} ${issue.title}`;
-  // NOTE(githubIngest-tx-scope): `nodeDb.createNode` and `nodeDb.updateNode`
-  // below run against the global `db` handle, NOT the `tx` we just opened.
-  // They autocommit independently of this outer transaction. The race
-  // protection still works because the advisory lock + the precheck SELECT
-  // ARE on `tx`: by the time a concurrent call B's precheck runs, call A
-  // has already released the lock (committed its tx), and A's autocommitted
-  // createNode/updateNode writes are globally visible — so B's precheck
-  // finds the row and returns skipped_exists.
-  //
-  // Fragility: if any error path between the createNode call and the end
-  // of the tx callback throws AFTER createNode has autocommitted, we leak
-  // an orphaned node (the outer tx rollback can't undo the autocommit).
-  // Today there are only two awaits between them (updateNode + the link
-  // object construction), so the window is small but nonzero.
-  //
-  // TODO(githubIngest-tx-scope): thread tx through nodeDb.createNode /
-  // nodeDb.updateNode so the whole sequence is atomic. Tracked as a
-  // follow-up after the auto-ingest PR lands.
   type TxResult =
     | { kind: 'created'; nodeId: string; node: Awaited<ReturnType<typeof nodeDb.getNode>>; link: ExternalLink }
     | { kind: 'exists'; nodeId: string };
@@ -386,14 +375,17 @@ export async function ensureNodeForIssue(
     // The create-node auto-link runs on the HTTP route, not here, so we
     // attach the externalLink ourselves so downstream sync paths
     // (reconcile, webhook close/reopen) can find the node by externalId.
-    const created = await nodeDb.createNode({
-      mapId,
-      parentId: inboxNodeId,
-      text,
-      createdBy: ctx.createdBy,
-      percentComplete: isClosed ? 100 : 0,
-      status: isClosed ? 'done' : 'todo',
-    });
+    const created = await nodeDb.createNode(
+      {
+        mapId,
+        parentId: inboxNodeId,
+        text,
+        createdBy: ctx.createdBy,
+        percentComplete: isClosed ? 100 : 0,
+        status: isClosed ? 'done' : 'todo',
+      },
+      tx,
+    );
     const link: ExternalLink = {
       provider: 'github',
       externalId,
@@ -401,10 +393,15 @@ export async function ensureNodeForIssue(
       syncEnabled: true,
       lastSyncedAt: new Date().toISOString(),
     };
-    const updated = await nodeDb.updateNode(created.id, {
-      externalLinks: [link],
-      description: issue.body ?? null,
-    });
+    const updated = await nodeDb.updateNode(
+      created.id,
+      {
+        externalLinks: [link],
+        description: issue.body ?? null,
+      },
+      undefined,
+      tx,
+    );
     // Prefer the post-update row (it has the externalLinks/description
     // populated). Fall back to `created` if updateNode returned null for
     // any reason — the broadcast will still carry a valid Node shape.


### PR DESCRIPTION
## Summary

Closes #66. Hardens `ensureNodeForIssue` against orphaned-node leaks on any throw between `createNode` and end-of-tx.

Today, `ensureNodeForIssue` wraps the advisory lock + precheck in `db.transaction(...)`, but `nodeDb.createNode` / `nodeDb.updateNode` then run on the global `db` handle — autocommitting outside the lock-protected tx. Race safety works by accident (the lock serializes prechecks; call A's autocommit is globally visible by the time call B's precheck runs), but any future error path between `createNode` and `end of tx` leaks an orphaned node with no rollback.

This PR makes both writes participate in the outer tx.

## What changed

- `packages/server/src/db/nodes.ts`
  - New exported `DbHandle` type alias = `typeof db | DrizzleTx` (extracted via `Parameters<...>` to avoid a brittle dep on drizzle's internal export paths).
  - `createNode(input, txHandle?)` — optional second param; defaults to `db`.
  - `updateNode(nodeId, input, expectedRevision?, txHandle?)` — optional fourth param; defaults to `db`.
  - Threading also goes through the helpers `updateNode` uses (`deriveAutoStatus`, `validateDependencies`, `buildNodeMapForNode`) so precheck reads share the tx's consistency view too.
- `packages/server/src/sync/githubIngest.ts`
  - `ensureNodeForIssue` passes `tx` to both `nodeDb.createNode` and `nodeDb.updateNode`.
  - Removed the `// TODO(githubIngest-tx-scope)` and the block comment explaining the autocommit fragility — both no longer apply. The new block comment explains why the tx wrap exists (race safety + atomicity) without the "by accident" caveat.
- `packages/server/src/sync/__tests__/githubIngest.test.ts`
  - Mock `db.transaction` now applies rollbacks on throw (walks a `__rollbacks` list registered by tx-scoped node writes).
  - Mocked `nodeDb.createNode` / `nodeDb.updateNode` accept the new tx param and register undo callbacks when called with one.
  - **New test** `tx rollback: throw after createNode leaves no orphan node (mindblown#66)` — simulates a throw on the link-attach `updateNode`, then asserts that `dbState.nodes` is unchanged from its pre-call snapshot and that no node has the failing externalId in its `externalLinks`.

All other call sites (`routes/nodes.ts`, `routes/ai.ts`, `routes/integrations.ts`, `ai/backend.ts`, `sync/parentEpicRollup.ts`, `sync/githubCatchup.ts`, the `ensureInboxNode` helper) are unchanged — the new param is optional and defaults to `db`, preserving autocommit behaviour for every caller that doesn't opt in.

## Verification

- `pnpm -w typecheck` — clean.
- `pnpm -w build` — clean.
- `pnpm -w test` — **139 tests pass** (138 before + 1 new orphan-rollback test). The existing race-safety test `'race safety: parallel calls with serialized advisory lock create exactly one node'` still passes unchanged.
- `rg 'TODO\(githubIngest-tx-scope\)'` — **zero matches** (was 1 before).
- `rg 'nodeDb\.(createNode|updateNode)'` — no other call site touched; everything still compiles.

## Test plan

- [x] Race-safety test (`parallel calls with serialized advisory lock create exactly one node`) still passes.
- [x] New orphan-rollback test fails on the pre-#66 code (verified mentally: without tx threading, `dbState.nodes` would still contain the created row after the throw) and passes on this PR.
- [x] Full `pnpm -w test` green.
- [ ] Post-merge on `mind.project.li`: trigger a webhook for a brand-new issue and confirm the node lands as before (no behavioural regression on the happy path).