### PR TITLE
perf(mcp): use app.inject() instead of loopback HTTP for tool handlers (closes #68)

### DIFF
--- a/packages/mcp/src/__tests__/api-inject.test.ts
+++ b/packages/mcp/src/__tests__/api-inject.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Verifies the in-process Fastify `inject` fast path for the api client.
+ *
+ * Two acceptance criteria for the #68 perf change:
+ *  1. When the bound `ApiContext` carries an `injector`, every
+ *     `api.*` call goes through it — not through `fetch`. That's
+ *     the whole point of the change (skips a localhost TCP hop).
+ *  2. When no injector is bound (stdio MCP, escape-hatch case in the
+ *     HTTP route), `request()` falls back to the existing fetch
+ *     codepath unchanged — so nothing breaks for unmigrated callers.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runWithApiContext, type Injector } from '../api.js';
+import * as api from '../api.js';
+
+describe('api client — in-process injector fast path', () => {
+  // Stash the real fetch so we can restore it between tests.
+  const realFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Stub global fetch so an accidental network call would be loud
+    // (and so the no-injector branch can be asserted against).
+    fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('routes every api call through the bound injector when one is provided (fetch is never called)', async () => {
+    const injector = vi.fn(async () => ({
+      statusCode: 200,
+      body: JSON.stringify([{ id: 'm1', name: 'Demo' }]),
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const maps = await runWithApiContext(
+      { baseUrl: 'http://unused.invalid', token: 'mb_test', injector },
+      () => api.listMaps(),
+    );
+
+    expect(maps).toEqual([{ id: 'm1', name: 'Demo' }]);
+    expect(injector).toHaveBeenCalledTimes(1);
+    expect(injector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        url: '/api/maps',
+        headers: expect.objectContaining({ Authorization: 'Bearer mb_test' }),
+      }),
+    );
+    // Critical perf invariant: NO network call.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards POST body + Content-Type through the injector unchanged', async () => {
+    const injector: Injector = vi.fn(async () => ({
+      statusCode: 200,
+      body: JSON.stringify({ id: 'n1', text: 'hi' }),
+      headers: {},
+    }));
+    const injectorMock = injector as unknown as ReturnType<typeof vi.fn>;
+
+    await runWithApiContext(
+      { baseUrl: 'http://unused.invalid', token: 'mb_test', injector },
+      () => api.createNode('map1', 'parent1', 'hi'),
+    );
+
+    expect(injectorMock).toHaveBeenCalledTimes(1);
+    const calls = injectorMock.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const call = calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call.method).toBe('POST');
+    expect(call.url).toBe('/api/maps/map1/nodes');
+    expect(call.headers['Content-Type']).toBe('application/json');
+    expect(call.headers['Authorization']).toBe('Bearer mb_test');
+    expect(typeof call.payload).toBe('string');
+    expect(JSON.parse(call.payload)).toEqual({ parentId: 'parent1', text: 'hi' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps non-2xx injector responses to ApiError with the server-side error code', async () => {
+    const injector = vi.fn(async () => ({
+      statusCode: 403,
+      body: JSON.stringify({ error: { code: 'FORBIDDEN', message: 'no soup for you' } }),
+      headers: {},
+    }));
+
+    await expect(
+      runWithApiContext(
+        { baseUrl: 'http://unused.invalid', token: 'mb_test', injector },
+        () => api.listMaps(),
+      ),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 403,
+      code: 'FORBIDDEN',
+      message: 'no soup for you',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined on a 204 No Content injector response', async () => {
+    const injector = vi.fn(async () => ({
+      statusCode: 204,
+      body: '',
+      headers: {},
+    }));
+
+    const result = await runWithApiContext(
+      { baseUrl: 'http://unused.invalid', token: 'mb_test', injector },
+      () => api.deleteMap('map1'),
+    );
+    expect(result).toBeUndefined();
+    expect(injector).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'DELETE', url: '/api/maps/map1' }),
+    );
+  });
+
+  it('falls back to fetch when no injector is bound (escape hatch / stdio path)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify([{ id: 'm2', name: 'Stdio' }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    // No injector field on the context — same as the legacy/stdio config
+    // and the same as the HTTP route's escape-hatch branch.
+    const maps = await runWithApiContext(
+      { baseUrl: 'http://escape-hatch.invalid', token: 'mb_escape' },
+      () => api.listMaps(),
+    );
+
+    expect(maps).toEqual([{ id: 'm2', name: 'Stdio' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('http://escape-hatch.invalid/api/maps');
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer mb_escape');
+  });
+});

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -14,9 +14,44 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 
+/**
+ * Light-weight shape of a Fastify `app.inject(...)` response. We only
+ * use these three fields, and we intentionally don't pull `fastify` into
+ * the `@mindblown/mcp` package's dependency closure to type this — the
+ * package still has to ship as a standalone stdio binary with no
+ * Fastify import.
+ */
+export interface InjectResponse {
+  statusCode: number;
+  body: string;
+  // Compatible with Node's `OutgoingHttpHeaders` shape (which Fastify's
+  // `inject` returns) — `number` shows up there for things like
+  // `content-length`. We don't actually read headers in the client,
+  // but the type has to match what Fastify hands us.
+  headers: Record<string, string | string[] | number | undefined>;
+}
+
+export interface InjectOptions {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  payload?: unknown;
+}
+
+/**
+ * In-process Fastify request injector. Provided by the HTTP-MCP route so
+ * tool calls run through Fastify's full lifecycle (preHandlers, auth,
+ * permission checks) without taking a localhost TCP round-trip.
+ *
+ * Stdio MCP doesn't have a Fastify instance to bind here, so this stays
+ * undefined and `request()` falls back to plain `fetch(baseUrl + path)`.
+ */
+export type Injector = (opts: InjectOptions) => Promise<InjectResponse>;
+
 interface ApiContext {
   baseUrl: string;
   token: string;
+  injector?: Injector;
 }
 
 // New env vars (`MINDBLOWN_MCP_URL` + `MINDBLOWN_MCP_TOKEN`) match the
@@ -193,6 +228,41 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   };
   if (ctx.token) {
     headers['Authorization'] = `Bearer ${ctx.token}`;
+  }
+
+  // Fast path: in-process Fastify inject. Skips localhost TCP round-trip
+  // (~1-2 ms per call) but still runs every preHandler/auth check
+  // because Fastify's `inject` is the full request lifecycle.
+  if (ctx.injector) {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    // Pass the body through as a parsed payload when possible. The
+    // request body shape on our API surface is always JSON; the
+    // wrappers stringify before calling. Fastify's inject accepts
+    // either string or object as `payload`, so pass the raw string
+    // — that preserves byte-for-byte equivalence with fetch.
+    const payload =
+      init?.body == null ? undefined : (init.body as string | Buffer);
+    const res = await ctx.injector({
+      method,
+      url: path,
+      headers,
+      payload,
+    });
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      let parsed: unknown = {};
+      try {
+        parsed = res.body ? JSON.parse(res.body) : {};
+      } catch {
+        /* non-JSON body — fall through with empty obj */
+      }
+      throw new ApiError(
+        res.statusCode,
+        (parsed as any)?.error?.message ?? `HTTP ${res.statusCode}`,
+        (parsed as any)?.error?.code,
+      );
+    }
+    if (res.statusCode === 204 || !res.body) return undefined as unknown as T;
+    return JSON.parse(res.body) as T;
   }
 
   const res = await fetch(`${ctx.baseUrl}${path}`, {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,6 +28,7 @@ import { httpBackend } from './backend.js';
 import { formatMapTree, filterMapData, formatHealthReport, formatScheduleReport, formatSprintOverview, formatNodeDetail } from './formatters.js';
 
 export { runWithApiContext } from './api.js';
+export type { Injector, InjectOptions, InjectResponse } from './api.js';
 
 /**
  * Build a fully-configured MCP server instance ready to be connected to

--- a/packages/server/src/routes/__tests__/mcp-inject.test.ts
+++ b/packages/server/src/routes/__tests__/mcp-inject.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests the MCP route's per-request injector wiring (#68).
+ *
+ * The route's contract:
+ *  - When `MINDBLOWN_INTERNAL_API_URL` is UNSET, `buildMcpInjector` returns
+ *    a wrapper around `app.inject`. Each tool call runs the full Fastify
+ *    request lifecycle in-process — no TCP roundtrip.
+ *  - When `MINDBLOWN_INTERNAL_API_URL` IS SET, it returns `undefined`,
+ *    which makes the @mindblown/mcp api client fall back to its existing
+ *    `fetch(baseUrl + path)` codepath. That's the escape hatch.
+ *
+ * We verify both branches plus the property that the injector wrapper
+ * forwards all four request fields (method, url, headers, payload) and
+ * passes through the response shape unchanged.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { buildMcpInjector } from '../mcp.js';
+
+describe('buildMcpInjector — env-var branching', () => {
+  const prev = process.env.MINDBLOWN_INTERNAL_API_URL;
+
+  beforeEach(() => {
+    delete process.env.MINDBLOWN_INTERNAL_API_URL;
+  });
+
+  afterEach(() => {
+    if (prev == null) delete process.env.MINDBLOWN_INTERNAL_API_URL;
+    else process.env.MINDBLOWN_INTERNAL_API_URL = prev;
+  });
+
+  it('returns an injector function when MINDBLOWN_INTERNAL_API_URL is unset (default fast path)', async () => {
+    const app = Fastify({ logger: false });
+    const inj = buildMcpInjector(app);
+    expect(typeof inj).toBe('function');
+    await app.close();
+  });
+
+  it('returns undefined when MINDBLOWN_INTERNAL_API_URL is set (escape hatch)', async () => {
+    process.env.MINDBLOWN_INTERNAL_API_URL = 'http://test-escape-hatch.invalid:9999';
+    const app = Fastify({ logger: false });
+    const inj = buildMcpInjector(app);
+    expect(inj).toBeUndefined();
+    await app.close();
+  });
+});
+
+describe('buildMcpInjector — routes through app.inject when bound', () => {
+  let app: FastifyInstance;
+  const prev = process.env.MINDBLOWN_INTERNAL_API_URL;
+
+  beforeEach(async () => {
+    delete process.env.MINDBLOWN_INTERNAL_API_URL;
+    app = Fastify({ logger: false });
+    // A trivial GET route, and a POST that echoes its body — the inject
+    // wrapper has to faithfully forward both.
+    app.get('/api/maps', async (req, _reply) => {
+      return [{ id: 'm1', name: 'Demo', auth: req.headers.authorization }];
+    });
+    app.post('/api/maps/:mapId/nodes', async (req, _reply) => {
+      return {
+        receivedParams: req.params,
+        receivedBody: req.body,
+        receivedAuth: req.headers.authorization,
+      };
+    });
+    app.delete('/api/maps/:mapId', async (_req, reply) => {
+      return reply.status(204).send();
+    });
+    app.get('/api/forbidden', async (_req, reply) => {
+      return reply.status(403).send({ error: { code: 'FORBIDDEN', message: 'no soup' } });
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    if (prev == null) delete process.env.MINDBLOWN_INTERNAL_API_URL;
+    else process.env.MINDBLOWN_INTERNAL_API_URL = prev;
+  });
+
+  it('forwards a GET through app.inject and returns the response shape the api client expects', async () => {
+    const injector = buildMcpInjector(app)!;
+    const res = await injector({
+      method: 'GET',
+      url: '/api/maps',
+      headers: { Authorization: 'Bearer mb_fake' },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed).toEqual([{ id: 'm1', name: 'Demo', auth: 'Bearer mb_fake' }]);
+  });
+
+  it('forwards a POST body and params through app.inject', async () => {
+    const injector = buildMcpInjector(app)!;
+    const res = await injector({
+      method: 'POST',
+      url: '/api/maps/map1/nodes',
+      headers: {
+        Authorization: 'Bearer mb_fake',
+        'Content-Type': 'application/json',
+      },
+      payload: JSON.stringify({ parentId: 'parent1', text: 'hi' }),
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.receivedParams).toEqual({ mapId: 'map1' });
+    expect(parsed.receivedBody).toEqual({ parentId: 'parent1', text: 'hi' });
+    expect(parsed.receivedAuth).toBe('Bearer mb_fake');
+  });
+
+  it('preserves 204 No Content responses through the inject path', async () => {
+    const injector = buildMcpInjector(app)!;
+    const res = await injector({
+      method: 'DELETE',
+      url: '/api/maps/map1',
+      headers: { Authorization: 'Bearer mb_fake' },
+    });
+    expect(res.statusCode).toBe(204);
+    // body for 204 is an empty string (LightMyRequest's stringified body)
+    expect(res.body === '' || res.body == null).toBe(true);
+  });
+
+  it('preserves a non-2xx response (status + body) for ApiError propagation', async () => {
+    const injector = buildMcpInjector(app)!;
+    const res = await injector({
+      method: 'GET',
+      url: '/api/forbidden',
+      headers: { Authorization: 'Bearer mb_fake' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({
+      error: { code: 'FORBIDDEN', message: 'no soup' },
+    });
+  });
+});

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -23,16 +23,23 @@
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { createMindblownMcpServer, runWithApiContext } from '@mindblown/mcp';
+import {
+  createMindblownMcpServer,
+  runWithApiContext,
+  type Injector,
+} from '@mindblown/mcp';
 import { API_KEY_PREFIX, validateApiKey } from '../lib/apiKeys.js';
 import { signToken } from '../auth.js';
 
 /**
- * Loopback base URL the MCP tool handlers' fetch() calls should target.
- * Default points to the same Fastify process by 127.0.0.1 — the MCP route
- * runs inside the server, so going out the network stack and back in is
- * silly but reuses every existing route's permission checks unchanged.
- * Configurable via env so tests can pin a port.
+ * Loopback base URL the MCP tool handlers' fetch() calls should target
+ * when we fall back to the legacy HTTP path. Only relevant when
+ * `MINDBLOWN_INTERNAL_API_URL` is set as the escape hatch (e.g. tests
+ * that want true HTTP semantics, or out-of-process diagnostics).
+ *
+ * In normal operation the route binds `app.inject` as the injector and
+ * tool handlers never touch the network — see the `app.inject` wiring
+ * inside `handleMcp` below.
  */
 function loopbackBaseUrl(_req: FastifyRequest): string {
   if (process.env.MINDBLOWN_INTERNAL_API_URL) {
@@ -40,6 +47,37 @@ function loopbackBaseUrl(_req: FastifyRequest): string {
   }
   const port = parseInt(process.env.PORT ?? '3001', 10);
   return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Build the per-request injector that backs `runWithApiContext`. Exported
+ * so the unit test in `__tests__/mcp.test.ts` can assert the env-var
+ * branching contract:
+ *
+ *  - `MINDBLOWN_INTERNAL_API_URL` UNSET → returns a wrapper around
+ *    `app.inject`. Tool calls run fully in-process, no TCP.
+ *  - `MINDBLOWN_INTERNAL_API_URL` SET → returns `undefined`, which makes
+ *    the api client fall back to `fetch(baseUrl + path)`. The escape
+ *    hatch exists for tests/diagnostics that need real HTTP semantics.
+ *
+ * Visibility is `export` (not the default) so library callers won't
+ * accidentally bind it to a non-MCP request lifecycle.
+ */
+export function buildMcpInjector(app: FastifyInstance): Injector | undefined {
+  if (process.env.MINDBLOWN_INTERNAL_API_URL) return undefined;
+  return async ({ method, url, headers, payload }) => {
+    const res = await app.inject({
+      method: method as any,
+      url,
+      headers,
+      payload: payload as any,
+    });
+    return {
+      statusCode: res.statusCode,
+      body: res.body,
+      headers: res.headers,
+    };
+  };
 }
 
 export async function mcpRoutes(app: FastifyInstance): Promise<void> {
@@ -101,6 +139,15 @@ export async function mcpRoutes(app: FastifyInstance): Promise<void> {
     const loopbackJwt = signToken({ userId: validated.userId, email: 'api-key-loopback' });
     const baseUrl = loopbackBaseUrl(req);
 
+    // Wire `app.inject` as the in-process injector — that skips localhost
+    // TCP/HTTP serialization on every tool call (~1-2 ms saved per call)
+    // but still runs every preHandler / auth check, so route-level
+    // permission semantics stay identical. If `MINDBLOWN_INTERNAL_API_URL`
+    // is set we fall back to real HTTP via the existing fetch path —
+    // that escape hatch is for tests/diagnostics that want true HTTP
+    // semantics (network errors, real cookie jars, etc).
+    const injector = buildMcpInjector(app);
+
     // Build a fresh MCP server + stateless transport for this request.
     const mcpServer = createMindblownMcpServer();
     const transport = new StreamableHTTPServerTransport({
@@ -114,7 +161,7 @@ export async function mcpRoutes(app: FastifyInstance): Promise<void> {
 
     try {
       await mcpServer.connect(transport);
-      await runWithApiContext({ baseUrl, token: loopbackJwt }, async () => {
+      await runWithApiContext({ baseUrl, token: loopbackJwt, injector }, async () => {
         await transport.handleRequest(req.raw, reply.raw, req.body);
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

- Replaces loopback `fetch('http://127.0.0.1:<PORT>/api/...')` in the HTTP MCP route with Fastify's `app.inject(...)` — every tool call now runs the full Fastify request lifecycle in-process (preHandlers, auth, permission gates), skipping localhost TCP serialization (~1-2 ms saved per call).
- Adds an optional `Injector` field on the `@mindblown/mcp` `ApiContext`. When bound, `request()` routes through it; when unbound (stdio binary, escape-hatch branch in the HTTP route), it falls back to plain `fetch(baseUrl + path)` unchanged.
- `MINDBLOWN_INTERNAL_API_URL` is preserved as the escape hatch — setting it forces the fetch path for tests/diagnostics that need true HTTP semantics.

## Design notes

- The `@mindblown/mcp` package can't depend on `fastify` (it ships as a standalone stdio binary), so the `Injector` type is a minimal `{method, url, headers, payload} => {statusCode, body, headers}` shape — small enough to satisfy duck-typing against Fastify's `inject` return.
- Non-2xx responses still parse `body.error.code` + `body.error.message` and throw the existing `ApiError`, so callers see no behavior change on the error path.
- Extracted `buildMcpInjector(app)` in `routes/mcp.ts` so the env-var branching contract is unit-testable without standing up the full MCP transport.

## Anti-punt verification

- `pnpm -w typecheck` — clean.
- `pnpm -w build` — clean.
- `pnpm -w test` — 144 server + 8 mcp tests pass, including 11 new tests for the inject path + escape hatch.
- `rg "fetch\(.*127\.0\.0\.1" packages/server/src/routes/mcp.ts` — zero matches.
- All existing MCP tool route handlers (auth + permission middleware) still fire because `app.inject` runs the full Fastify request lifecycle. Drop-in semantics.

## Tests added

- `packages/mcp/src/__tests__/api-inject.test.ts` — 5 tests asserting the api client uses the injector when bound (GET + POST), preserves Content-Type + Authorization, maps non-2xx to `ApiError`, returns undefined on 204, and falls back to fetch when unbound.
- `packages/server/src/routes/__tests__/mcp-inject.test.ts` — 6 tests asserting the env-var branching (`MINDBLOWN_INTERNAL_API_URL` set ⇒ undefined; unset ⇒ function) and that the inject wrapper forwards method/url/headers/payload to real Fastify routes for 2xx, 204, and non-2xx responses.

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge: connect Claude Code via HTTP MCP to `mind.project.li`, call `list_maps` and `update_map`, verify same results as before.
- [ ] Post-merge: measure p50 of `mcp__mindblown__list_maps` over 100 calls vs the previous baseline; should drop by ~1-2 ms per call.
- [ ] Verify tool catalog (`list_maps`, `get_map`, `create_node`, `update_node`, `search_nodes`, `github_sync_overview`) all keep working.

Closes #68.