### PR TITLE
feat(observability): weekly synthetic Pushover canary (closes #76)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -116,6 +116,11 @@ NODE_ENV=production
 # KUMA_GITHUB_CATCHUP_PUSH_URL=https://kuma.example.com/api/push/<token>
 # KUMA_GITHUB_DRIFT_PUSH_URL=https://kuma.example.com/api/push/<token>
 
+# Optional — Uptime-Kuma push URL for the weekly Pushover-canary
+# (alarm-chain liveness probe). Unset = canary is disabled. See the
+# "Pushover canary" section below for the full operator runbook.
+# KUMA_ALARM_CANARY_PUSH_URL=https://kuma.example.com/api/push/<token>
+
 # Optional — cap on the number of drift nodes the daily audit will
 # auto-backfill PER MAP per tick. Drift over this cap is left in
 # place so the Kuma alarm escalates to a human. Set to 0 to disable
@@ -317,6 +322,102 @@ The manual trigger runs the same auto-backfill + Kuma push the
 scheduled audit does, so it's a faithful end-to-end smoke test of the
 auto-repair flow. API-key auth is deliberately rejected — this is a
 session-only operator surface.
+
+## Pushover canary (weekly alarm-chain liveness probe)
+
+The catchup heartbeat + drift audit alarm when the GitHub sync breaks.
+But they only exercise the **delivery chain** (mindblown → Kuma →
+Pushover) during a real outage. If Pushover credentials silently
+expire, or the Kuma monitor loses its notification link, we'd only
+find out during the next actual incident — by which point the
+operator is flying blind.
+
+The canary fires a synthetic `status=down` push to a dedicated Kuma
+monitor once a week, waits 60 s, then fires `status=up` to recover.
+If the chain works, the operator gets a Pushover saying "synthetic
+test" once a week. If the chain is broken, either the Pushover never
+arrives (Pushover credentials expired) or Kuma's own "missing push"
+threshold alarms (mindblown-api dead) — either way the breakage
+surfaces within a week instead of during the next real incident.
+
+### 1. Create the Kuma monitor
+
+1. **Add New Monitor** → **Push**.
+2. Name: `mindblown-alarm-canary`.
+3. Heartbeat interval: 60 s.
+4. **Down threshold: 90 s.** This is the critical bit — short enough
+   that the synthetic `status=down` trips Kuma's alarm channel before
+   the ack push lands 60 s later, so the monitor briefly flips to
+   `down`, fires its notification, then recovers when the ack
+   arrives.
+5. Save. Copy the generated push URL.
+
+### 2. Route to a dedicated Pushover device (recommended)
+
+A weekly Pushover that says "synthetic-test" on your main device is
+annoying. Configure a separate Pushover device key for the canary
+monitor so it doesn't spam the channel you actually triage from:
+
+1. In Pushover, register a second device (e.g. `mindblown-canary`).
+   You can use the iOS/Android Pushover app's "Add Device" flow, or
+   create a virtual device via the Pushover web UI.
+2. In Kuma, **Settings → Notifications**, add a new Pushover
+   notification with that device key.
+3. Link the new notification to the `mindblown-alarm-canary` monitor
+   only — leave your main GitHub-sync monitors pointing at the
+   default device.
+
+This way a weekly "I'm alive" ping lands on a phone surface you can
+mute or silence, while real outage alerts on the main monitors still
+escalate normally.
+
+### 3. Wire the env var
+
+Add to `/etc/mindblown/api.env`:
+
+```bash
+KUMA_ALARM_CANARY_PUSH_URL=https://kuma.example.com/api/push/<token>
+```
+
+Then `systemctl restart mindblown-api`.
+
+### 4. Verify on first deploy
+
+The scheduler runs every 7 days, so you don't want to wait a week to
+confirm the wiring works. Override the interval with the
+`CANARY_INTERVAL_MS` env var for a single test run:
+
+```bash
+# As root, edit api.env and add at the bottom:
+CANARY_INTERVAL_MS=60000
+
+systemctl restart mindblown-api
+```
+
+Within ~60 s the canary fires `status=down`. Kuma's 90 s "down"
+threshold trips, you get a Pushover saying `synthetic-test` (or
+similar — Pushover renders the Kuma monitor name + msg). 60 s later
+the canary fires `status=up`, Kuma flips back to up, the next push
+60 s after that keeps it green.
+
+**Once confirmed, REMOVE the `CANARY_INTERVAL_MS` line from
+`api.env`** so it falls back to the weekly default, and restart:
+
+```bash
+# Remove the CANARY_INTERVAL_MS line
+systemctl restart mindblown-api
+```
+
+### Notes
+
+- The canary intentionally has **no startup invocation** — we don't
+  want a Pushover on every restart/upgrade. The first push lands
+  `CANARY_INTERVAL_MS` after process start.
+- The canary is a **pure no-op** when `KUMA_ALARM_CANARY_PUSH_URL` is
+  unset, so deploying without the env var costs nothing.
+- Both pushes are best-effort: the ack push fires even if the down
+  push throws, so a transient error during the first push can't
+  leave the monitor stuck in `down` state.
 
 ## What's NOT in the LXC backup
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { seedIfEmpty } from './db/seed.js';
 import { snapshotAllMaps } from './lib/releaseSnapshots.js';
 import { runAllCatchups } from './sync/githubCatchup.js';
 import { runDriftAudit } from './sync/driftAudit.js';
+import { runCanary } from './sync/canary.js';
 import { sdNotifyReady } from './sync/sdNotify.js';
 import { authRoutes } from './auth.js';
 import { systemRoutes } from './routes/system.js';
@@ -198,6 +199,30 @@ async function main(): Promise<void> {
   // operators can hit POST /api/maps/sync/audit-drift to force a run
   // post-deploy.
   setInterval(driftAuditTick, DRIFT_AUDIT_INTERVAL_MS);
+
+  // ── Weekly Pushover canary (alarm-chain liveness probe) ──────
+  // Fires a `status=down` then `status=up` to a dedicated Kuma push
+  // monitor once a week. Confirms the catchup-heartbeat → Kuma →
+  // Pushover chain is alive without waiting for a real outage to
+  // exercise it. No-op when `KUMA_ALARM_CANARY_PUSH_URL` is unset.
+  // Allow `CANARY_INTERVAL_MS` env-var override so operators can dial
+  // the cadence down for a one-off post-deploy smoke test, then put
+  // it back to weekly afterwards. Deliberately no startup invocation
+  // — we don't want a Pushover on every restart/upgrade.
+  const CANARY_INTERVAL_MS = parseInt(
+    process.env.CANARY_INTERVAL_MS ?? `${7 * 24 * 60 * 60 * 1000}`,
+    10,
+  );
+  const canaryTick = async (): Promise<void> => {
+    try {
+      await runCanary();
+    } catch (err) {
+      // runCanary handles its own per-push error paths; this is
+      // defence-in-depth for an unexpected synchronous throw.
+      console.error('[canary] scheduler caught unexpected error:', err);
+    }
+  };
+  setInterval(canaryTick, CANARY_INTERVAL_MS);
 }
 
 main();

--- a/packages/server/src/sync/__tests__/canary.test.ts
+++ b/packages/server/src/sync/__tests__/canary.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for `runCanary` — the weekly synthetic alarm-chain probe.
+ *
+ * We mock `pushKumaHeartbeat` directly (rather than `global.fetch` as
+ * `kumaPush.test.ts` does) because we're testing the orchestration
+ * around it: URL-is-unset = no fetch, both pushes fire with the right
+ * (status, msg, tag), and the ack still fires even if the down push
+ * throws. `pushKumaHeartbeat`'s own swallow-fetch-error behaviour has
+ * its own test file.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const pushKumaHeartbeatMock = vi.fn(
+  async (
+    _url: string | undefined,
+    _status: 'up' | 'down',
+    _msg: string,
+    _tag: string,
+  ): Promise<void> => undefined,
+);
+
+vi.mock('../kumaPush.js', () => ({
+  pushKumaHeartbeat: pushKumaHeartbeatMock,
+}));
+
+// Import AFTER the mock so the SUT picks up the mocked helper.
+const { runCanary } = await import('../canary.js');
+
+describe('runCanary', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    pushKumaHeartbeatMock.mockReset();
+    pushKumaHeartbeatMock.mockResolvedValue(undefined);
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT call pushKumaHeartbeat when the URL is undefined', async () => {
+    await runCanary(undefined, 0);
+    expect(pushKumaHeartbeatMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call pushKumaHeartbeat when the URL is empty', async () => {
+    await runCanary('', 0);
+    expect(pushKumaHeartbeatMock).not.toHaveBeenCalled();
+  });
+
+  it('fires down then up with the correct status, msg, and tag', async () => {
+    const url = 'https://kuma.example.com/api/push/canary-token';
+    await runCanary(url, 0);
+
+    expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(2);
+
+    const [downCall, upCall] = pushKumaHeartbeatMock.mock.calls;
+
+    // First push: status=down, synthetic-test msg, canary down tag.
+    expect(downCall[0]).toBe(url);
+    expect(downCall[1]).toBe('down');
+    expect(downCall[2]).toBe('synthetic-test');
+    expect(downCall[3]).toContain('canary');
+
+    // Second push: status=up, synthetic-test-ack msg, canary ack tag.
+    expect(upCall[0]).toBe(url);
+    expect(upCall[1]).toBe('up');
+    expect(upCall[2]).toBe('synthetic-test-ack');
+    expect(upCall[3]).toContain('canary');
+  });
+
+  it('fires the ack push even when the down push throws', async () => {
+    // First call (down) throws synchronously; second (up) resolves.
+    pushKumaHeartbeatMock
+      .mockRejectedValueOnce(new Error('down-fail'))
+      .mockResolvedValueOnce(undefined);
+
+    const url = 'https://kuma.example.com/api/push/canary-token';
+    await expect(runCanary(url, 0)).resolves.toBeUndefined();
+
+    // Both calls must have happened: ack MUST fire even on down failure.
+    expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(2);
+    expect(pushKumaHeartbeatMock.mock.calls[0][1]).toBe('down');
+    expect(pushKumaHeartbeatMock.mock.calls[1][1]).toBe('up');
+
+    // And we warn-logged the failure (defence-in-depth catch).
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArgs = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warnArgs).toContain('canary');
+    expect(warnArgs).toContain('down-fail');
+  });
+
+  it('still resolves cleanly when the ack push throws', async () => {
+    // Down resolves; ack throws — we don't want runCanary to reject.
+    pushKumaHeartbeatMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('ack-fail'));
+
+    const url = 'https://kuma.example.com/api/push/canary-token';
+    await expect(runCanary(url, 0)).resolves.toBeUndefined();
+
+    expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArgs = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warnArgs).toContain('ack-fail');
+  });
+
+  it('reads URL from process.env.KUMA_ALARM_CANARY_PUSH_URL when no arg is passed', async () => {
+    const original = process.env.KUMA_ALARM_CANARY_PUSH_URL;
+    process.env.KUMA_ALARM_CANARY_PUSH_URL = 'https://kuma.example.com/api/push/from-env';
+    try {
+      // Call with default arg = read from env.
+      await runCanary(undefined, 0);
+    } finally {
+      if (original === undefined) delete process.env.KUMA_ALARM_CANARY_PUSH_URL;
+      else process.env.KUMA_ALARM_CANARY_PUSH_URL = original;
+    }
+    // Default-arg evaluation happens at call time only when arg is
+    // *omitted*; passing `undefined` explicitly still uses the default,
+    // so we expect a call with the env URL.
+    expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(2);
+    expect(pushKumaHeartbeatMock.mock.calls[0][0]).toBe(
+      'https://kuma.example.com/api/push/from-env',
+    );
+  });
+});

--- a/packages/server/src/sync/canary.ts
+++ b/packages/server/src/sync/canary.ts
@@ -1,0 +1,80 @@
+/**
+ * Weekly synthetic Pushover-canary.
+ *
+ * The catchup-heartbeat → Kuma → Pushover chain is normally only
+ * exercised during a real outage. If Pushover credentials silently
+ * expire, or a Kuma monitor loses its notification link, we'd only
+ * find out during an actual incident.
+ *
+ * This canary fires a `status=down&msg=synthetic-test` push to a
+ * dedicated Kuma monitor (`mindblown-alarm-canary`) once a week, waits
+ * a short while, then fires a `status=up&msg=synthetic-test-ack` to
+ * recover the monitor. If the down push trips the alarm chain, the
+ * operator gets a Pushover. If the chain is broken, the canary stops
+ * arriving and Kuma's "missing push" threshold alarms instead — either
+ * way the breakage surfaces within a week instead of during the next
+ * real incident.
+ *
+ * Wiring:
+ *   - `KUMA_ALARM_CANARY_PUSH_URL` — required; unset = scheduler no-op.
+ *   - The Kuma monitor should be configured with a short "down"
+ *     threshold (e.g. 90 s) so the synthetic down trips a notification
+ *     before the ack push lands ~60 s later.
+ *   - The Kuma monitor's notification link CAN target a dedicated
+ *     Pushover device so the canary doesn't spam the main channel;
+ *     that's a Kuma-side configuration, not a server-side one. See
+ *     `deploy/README.md` for the operator runbook.
+ *
+ * Both pushes are best-effort: each is wrapped in its own try/catch and
+ * the ack push fires even if the down push threw. The helper
+ * (`pushKumaHeartbeat`) already swallows its own fetch errors, so the
+ * try/catch here is defence-in-depth against an unexpected synchronous
+ * throw (e.g. a bug in the helper itself).
+ */
+
+import { pushKumaHeartbeat } from './kumaPush.js';
+
+/**
+ * Delay between the synthetic `status=down` push and the `status=up`
+ * ack. Long enough for Kuma to register the down state and fire its
+ * notification, short enough that the monitor recovers within the
+ * operator's normal triage latency. Exported so tests can override.
+ */
+export const CANARY_ACK_DELAY_MS = 60 * 1000;
+
+/**
+ * Fire a synthetic `status=down` then `status=up` push to the canary
+ * Kuma monitor. No-op when the URL env var is unset. The ack push
+ * fires even if the down push throws — we never want to leave the
+ * monitor stuck in `down` state because of a transient error during
+ * the first push.
+ */
+export async function runCanary(
+  url: string | undefined = process.env.KUMA_ALARM_CANARY_PUSH_URL,
+  ackDelayMs: number = CANARY_ACK_DELAY_MS,
+): Promise<void> {
+  if (!url) return;
+
+  try {
+    await pushKumaHeartbeat(url, 'down', 'synthetic-test', '[canary] down');
+  } catch (err) {
+    // `pushKumaHeartbeat` swallows its own fetch errors, so reaching
+    // this branch implies an unexpected synchronous throw. Log and
+    // continue — the ack push MUST still fire so the monitor recovers.
+    console.warn(
+      '[canary] down push threw unexpectedly:',
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, ackDelayMs));
+
+  try {
+    await pushKumaHeartbeat(url, 'up', 'synthetic-test-ack', '[canary] ack');
+  } catch (err) {
+    console.warn(
+      '[canary] ack push threw unexpectedly:',
+      err instanceof Error ? err.message : err,
+    );
+  }
+}


### PR DESCRIPTION
## Motivation

The catchup-heartbeat → Kuma → Pushover chain is only exercised during a real outage today. If Pushover credentials silently expire, or the Kuma monitor loses its notification link, we'd only learn during the next actual incident — at which point the operator is already flying blind.

This PR ships a weekly synthetic probe of the whole chain. Closes #76.

## Summary

- New `runCanary` in `packages/server/src/sync/canary.ts`, scheduled from `index.ts` next to the other in-process crons (`runSnapshot`, `runCatchup`, `driftAuditTick`). Fires `status=down&msg=synthetic-test` to a dedicated Kuma monitor (`mindblown-alarm-canary`), waits 60 s, then fires `status=up&msg=synthetic-test-ack`.
- Honours `CANARY_INTERVAL_MS` env-var override so operators can dial the cadence down for a one-off post-deploy smoke test, then back to weekly.
- No-op when `KUMA_ALARM_CANARY_PUSH_URL` is unset. No startup invocation — restarts/upgrades don't spam Pushover.
- Both pushes are best-effort: ack fires even when the down push throws, so a transient first-push failure can't leave the monitor stuck in `down` state.

## Layers touched

- `packages/server/src/sync/canary.ts` — new module, reuses `pushKumaHeartbeat`.
- `packages/server/src/index.ts` — scheduler wiring + `CANARY_INTERVAL_MS` env override.
- `packages/server/src/sync/__tests__/canary.test.ts` — 6 new tests.
- `deploy/README.md` — full operator runbook (Kuma monitor setup, dedicated Pushover device, env-var wiring, first-deploy verification flow).

## Test plan

- [x] `pnpm -w typecheck` clean.
- [x] `pnpm -w build` clean.
- [x] `pnpm -w test` — 169 tests pass (151 pre-PR + 6 new canary tests + 12 from base-branch admin-guard work picked up via rebase).
- New canary tests cover: (1) unset URL = no fetch; (2) empty URL = no fetch; (3) both pushes fire with the correct (status, msg, tag); (4) ack push fires even if down push throws; (5) `runCanary` resolves cleanly when ack throws; (6) `process.env.KUMA_ALARM_CANARY_PUSH_URL` is the default URL source.

## Operator acceptance test (post-deploy)

1. Create Kuma push monitor `mindblown-alarm-canary` with **down threshold 90 s** (critical: short enough that the synthetic `status=down` trips before the ack lands 60 s later).
2. Link the monitor to a dedicated Pushover device (e.g. `mindblown-canary`) so the weekly probe doesn't spam the main channel — Kuma-side config, documented in the README.
3. Set `KUMA_ALARM_CANARY_PUSH_URL` in `/etc/mindblown/api.env`. Restart.
4. For first-deploy verification, temporarily add `CANARY_INTERVAL_MS=60000` to `api.env`, restart, watch the Pushover land within ~90 s.
5. Remove `CANARY_INTERVAL_MS`, restart — falls back to weekly default.
6. Going forward: receive one Pushover per week. If it stops, the chain is broken; if it lands, the chain works.

## Anti-punt

The persona test above is the full operator flow — no MCP surface, no UI control, no route handler is needed for this feature (it's a server-side cron) — and the README documents every step needed to wire it up cleanly post-merge.