### PR TITLE
feat(sync): escalate consecutive GH 401s on catchup (closes #75)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -115,6 +115,13 @@ NODE_ENV=production
 # audit, but silent failures have no external alarm. See below.
 # KUMA_GITHUB_CATCHUP_PUSH_URL=https://kuma.example.com/api/push/<token>
 # KUMA_GITHUB_DRIFT_PUSH_URL=https://kuma.example.com/api/push/<token>
+# KUMA_GITHUB_AUTH_FAILURE_PUSH_URL=https://kuma.example.com/api/push/<token>
+
+# Optional — consecutive GH 401 ticks per repo before the catchup
+# fires `status=down msg=auth_failed:owner/repo` on the auth-failure
+# Kuma monitor. Lower = louder, higher = more tolerant of a flaky
+# bridge. Default 3 (≈ 15 min on a 5-min catchup tick).
+# CATCHUP_AUTH_FAILURE_THRESHOLD=3
 
 # Optional — cap on the number of drift nodes the daily audit will
 # auto-backfill PER MAP per tick. Drift over this cap is left in
@@ -219,7 +226,7 @@ The API exposes two passive heartbeats for the GitHub→MindBlown sync
 loop. Both are no-ops unless the corresponding env var is set, so this
 section is optional — but strongly recommended in production.
 
-### Why two monitors
+### Why three monitors
 
 - **Catchup heartbeat (`KUMA_GITHUB_CATCHUP_PUSH_URL`)** — pushed once
   per catchup tick (every 5 min). Alarms when pushes stop = catchup
@@ -230,6 +237,15 @@ section is optional — but strongly recommended in production.
   with no linked MindBlown node. Alarms when push is `down` OR pushes
   stop entirely = webhook silently misconfigured on the GH side, the
   ingest path is silently throwing, etc.
+
+- **Auth failure (`KUMA_GITHUB_AUTH_FAILURE_PUSH_URL`)** — pushed only
+  when a specific repo has hit `CATCHUP_AUTH_FAILURE_THRESHOLD`
+  consecutive 401s (default 3, ≈ 15 min on a 5-min catchup tick).
+  Message is `auth_failed:owner/repo` so the alert names the bound
+  repo whose token/install needs attention; one revoked install on a
+  multi-repo deployment doesn't drown out the others. A successful
+  fetch on that repo resets the counter and the monitor goes UP on
+  the next tick.
 
 ### Creating the monitors in Kuma
 
@@ -248,6 +264,7 @@ section is optional — but strongly recommended in production.
 |---|---|---|---|
 | catchup heartbeat | 60 s | 10 min | API pushes every 5 min — 10 min absorbs one missed tick (restart/upgrade) without false-alarming. |
 | drift audit | 60 s | 30 h | API pushes daily — 30 h gives 6 h of slack for restart timing, clock drift, etc. |
+| auth failure | 60 s | 20 min | API pushes only on the threshold-crossing tick + every subsequent failing tick; 20 min covers two consecutive 5-min catchup ticks so a single delayed Kuma push doesn't flap the monitor. |
 
 ### Auto-backfill on drift detection
 

--- a/packages/integrations/src/github.ts
+++ b/packages/integrations/src/github.ts
@@ -65,6 +65,28 @@ const PRIORITY_PREFIX = 'priority:';
 
 const GITHUB_API = 'https://api.github.com';
 
+/**
+ * Thrown by every `githubFetch` call that hits a non-2xx response from
+ * the GitHub REST API.
+ *
+ * Callers that need to react to specific HTTP statuses (auth expiry, rate
+ * limit, etc.) should branch on `err instanceof GitHubApiError` and read
+ * `err.status` — the previous behaviour of grepping the `Error.message`
+ * string for "GitHub API 401" was both fragile and a foot-gun once the
+ * message format changed. The string body is still preserved on `.body`
+ * for log lines.
+ */
+export class GitHubApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+  constructor(status: number, body: string) {
+    super(`GitHub API ${status}: ${body}`);
+    this.name = 'GitHubApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
 async function githubFetch<T>(
   path: string,
   token: string,
@@ -84,7 +106,7 @@ async function githubFetch<T>(
 
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`GitHub API ${res.status}: ${body}`);
+    throw new GitHubApiError(res.status, body);
   }
 
   // 204 No Content

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -16,6 +16,7 @@ export {
   extractVersionFromMilestone,
   getGitHubIssue,
   verifyWebhookSignature,
+  GitHubApiError,
 } from './github.js';
 
 export type {

--- a/packages/server/src/sync/__tests__/githubCatchup.test.ts
+++ b/packages/server/src/sync/__tests__/githubCatchup.test.ts
@@ -65,10 +65,28 @@ vi.mock('../../db/nodes.js', () => ({
 
 vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
 
-vi.mock('@mindblown/integrations', () => ({
-  fetchChangedIssues: vi.fn(async () => []),
-  mintInstallationToken: vi.fn(async () => 'tok'),
-}));
+// Local `GitHubApiError` stand-in so the SUT's `instanceof` check
+// passes when tests throw it from the fetch mock. Class is defined
+// inside the `vi.mock` factory (hoisted) and re-imported through the
+// mocked module below — putting the class at top-level would be
+// captured by the closure BEFORE the hoist, throwing TDZ.
+vi.mock('@mindblown/integrations', () => {
+  class MockGitHubApiError extends Error {
+    readonly status: number;
+    readonly body: string;
+    constructor(status: number, body = '') {
+      super(`GitHub API ${status}: ${body}`);
+      this.name = 'GitHubApiError';
+      this.status = status;
+      this.body = body;
+    }
+  }
+  return {
+    fetchChangedIssues: vi.fn(async () => []),
+    mintInstallationToken: vi.fn(async () => 'tok'),
+    GitHubApiError: MockGitHubApiError,
+  };
+});
 
 vi.mock('../parentEpicRollup.js', () => ({
   parseParentReferences: () => [],
@@ -102,8 +120,16 @@ import {
   runAllCatchups,
   pushCatchupHeartbeat,
   isHealthyTick,
+  reconcileRepo,
+  _resetAuthFailureCountersForTests,
+  _getAuthFailureCountForTests,
   type ReconcileResult,
 } from '../githubCatchup.js';
+import { fetchChangedIssues, GitHubApiError } from '@mindblown/integrations';
+
+// Re-aliased for readability in tests: this is the mock class from
+// the `vi.mock` factory above, not the real one.
+const MockGitHubApiError = GitHubApiError;
 
 function makeResult(overrides: Partial<ReconcileResult> = {}): ReconcileResult {
   return {
@@ -289,5 +315,174 @@ describe('isHealthyTick', () => {
     expect(
       isHealthyTick([makeResult({ error: 'fetch: 503' })]),
     ).toBe(false);
+  });
+});
+
+// ── 401-escalation tests (#75) ───────────────────────────────────
+//
+// Scenario: `fetchChangedIssues` throws a `GitHubApiError` with
+// `status=401` (App install revoked, PAT expired, etc.). The catchup
+// must track consecutive failures per repo and push a dedicated Kuma
+// alarm once we cross `CATCHUP_AUTH_FAILURE_THRESHOLD`. On any
+// successful fetch the counter resets.
+
+const fetchChangedIssuesMock = vi.mocked(fetchChangedIssues);
+
+function makeTarget(owner: string, repo: string) {
+  return {
+    owner,
+    repo,
+    resolveToken: async (): Promise<string> => 'tok',
+  };
+}
+
+describe('reconcileRepo → 401 auth-failure escalation (#75)', () => {
+  beforeEach(() => {
+    _resetAuthFailureCountersForTests();
+    pushKumaMock.mockReset();
+    pushKumaMock.mockResolvedValue(undefined);
+    fetchChangedIssuesMock.mockReset();
+    delete process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL;
+    delete process.env.CATCHUP_AUTH_FAILURE_THRESHOLD;
+  });
+
+  afterEach(() => {
+    _resetAuthFailureCountersForTests();
+    delete process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL;
+    delete process.env.CATCHUP_AUTH_FAILURE_THRESHOLD;
+  });
+
+  it('does NOT push on the first 401 (counter below default threshold of 3)', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(401, 'Bad credentials'));
+
+    const result = await reconcileRepo(makeTarget('o', 'r'));
+
+    expect(result.error).toMatch(/^fetch: GitHub API 401/);
+    expect(pushKumaMock).not.toHaveBeenCalled();
+    expect(_getAuthFailureCountForTests('o/r')).toBe(1);
+  });
+
+  it('does NOT push on the second consecutive 401', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(401, 'Bad credentials'));
+
+    await reconcileRepo(makeTarget('o', 'r'));
+    await reconcileRepo(makeTarget('o', 'r'));
+
+    expect(pushKumaMock).not.toHaveBeenCalled();
+    expect(_getAuthFailureCountForTests('o/r')).toBe(2);
+  });
+
+  it('pushes status=down msg=auth_failed:owner/repo on the third consecutive 401', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(401, 'Bad credentials'));
+
+    await reconcileRepo(makeTarget('o', 'r'));
+    await reconcileRepo(makeTarget('o', 'r'));
+    await reconcileRepo(makeTarget('o', 'r'));
+
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    const [url, status, msg, tag] = pushKumaMock.mock.calls[0];
+    expect(url).toBe('https://kuma/api/push/auth');
+    expect(status).toBe('down');
+    expect(msg).toBe('auth_failed:o/r');
+    expect(tag).toContain('github auth failure');
+    expect(_getAuthFailureCountForTests('o/r')).toBe(3);
+  });
+
+  it('continues to push on every subsequent 401 once over the threshold', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(401, 'Bad credentials'));
+
+    // 4 consecutive 401s: ticks 3 and 4 each push.
+    for (let i = 0; i < 4; i++) {
+      await reconcileRepo(makeTarget('o', 'r'));
+    }
+
+    // Pushes fired on ticks 3 and 4.
+    expect(pushKumaMock).toHaveBeenCalledTimes(2);
+    expect(pushKumaMock.mock.calls[0][2]).toBe('auth_failed:o/r');
+    expect(pushKumaMock.mock.calls[1][2]).toBe('auth_failed:o/r');
+    expect(_getAuthFailureCountForTests('o/r')).toBe(4);
+  });
+
+  it('resets the counter to 0 on the next successful fetch', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    fetchChangedIssuesMock
+      .mockRejectedValueOnce(new MockGitHubApiError(401, 'Bad credentials'))
+      .mockRejectedValueOnce(new MockGitHubApiError(401, 'Bad credentials'))
+      .mockResolvedValueOnce([]) // success — counter resets
+      .mockRejectedValueOnce(new MockGitHubApiError(401, 'Bad credentials'));
+
+    await reconcileRepo(makeTarget('o', 'r')); // 1 failure
+    await reconcileRepo(makeTarget('o', 'r')); // 2 failures
+    expect(_getAuthFailureCountForTests('o/r')).toBe(2);
+    await reconcileRepo(makeTarget('o', 'r')); // success → reset
+    expect(_getAuthFailureCountForTests('o/r')).toBe(0);
+    await reconcileRepo(makeTarget('o', 'r')); // 1 failure again
+    expect(_getAuthFailureCountForTests('o/r')).toBe(1);
+
+    // Counter never crossed threshold across this run — no push.
+    expect(pushKumaMock).not.toHaveBeenCalled();
+  });
+
+  it('tracks counters PER repo — repo A escalating must not affect repo B', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    fetchChangedIssuesMock.mockImplementation(async (owner) => {
+      throw new MockGitHubApiError(401, `Bad credentials for ${owner}`);
+    });
+
+    // Repo A: 3 failures → push.
+    await reconcileRepo(makeTarget('a', 'a'));
+    await reconcileRepo(makeTarget('a', 'a'));
+    await reconcileRepo(makeTarget('a', 'a'));
+    // Repo B: 1 failure → no push.
+    await reconcileRepo(makeTarget('b', 'b'));
+
+    // Exactly one push — and it's for repo A.
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    expect(pushKumaMock.mock.calls[0][2]).toBe('auth_failed:a/a');
+    expect(_getAuthFailureCountForTests('a/a')).toBe(3);
+    expect(_getAuthFailureCountForTests('b/b')).toBe(1);
+  });
+
+  it('honours CATCHUP_AUTH_FAILURE_THRESHOLD=1 — first 401 immediately pushes', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    process.env.CATCHUP_AUTH_FAILURE_THRESHOLD = '1';
+    fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(401, 'Bad credentials'));
+
+    await reconcileRepo(makeTarget('o', 'r'));
+
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    expect(pushKumaMock.mock.calls[0][2]).toBe('auth_failed:o/r');
+  });
+
+  it('does NOT push when KUMA_GITHUB_AUTH_FAILURE_PUSH_URL is unset (no-op like catchup heartbeat)', async () => {
+    delete process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL;
+    fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(401, 'Bad credentials'));
+
+    // 5 consecutive 401s — would push twice if the URL were set.
+    for (let i = 0; i < 5; i++) {
+      await reconcileRepo(makeTarget('o', 'r'));
+    }
+
+    expect(pushKumaMock).not.toHaveBeenCalled();
+    // Counter still ticks up — the env-var gate is at the push side
+    // only, so a later turn-on of the alarm sees the right state.
+    expect(_getAuthFailureCountForTests('o/r')).toBe(5);
+  });
+
+  it('does NOT escalate on a non-401 fetch error (5xx, network)', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(503, 'Service Unavailable'));
+
+    await reconcileRepo(makeTarget('o', 'r'));
+    await reconcileRepo(makeTarget('o', 'r'));
+    await reconcileRepo(makeTarget('o', 'r'));
+    await reconcileRepo(makeTarget('o', 'r'));
+
+    expect(pushKumaMock).not.toHaveBeenCalled();
+    expect(_getAuthFailureCountForTests('o/r')).toBe(0);
   });
 });

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -16,7 +16,11 @@
 
 import { eq, and, isNotNull, sql } from 'drizzle-orm';
 import type { GitHubIssue } from '@mindblown/integrations';
-import { fetchChangedIssues, mintInstallationToken } from '@mindblown/integrations';
+import {
+  fetchChangedIssues,
+  mintInstallationToken,
+  GitHubApiError,
+} from '@mindblown/integrations';
 import type { ExternalLink, Node } from '@mindblown/core';
 
 import { db } from '../db/connection.js';
@@ -30,6 +34,65 @@ import {
 import { ingestNewIssuesForRepo } from './githubIngest.js';
 import { pushKumaHeartbeat } from './kumaPush.js';
 import { sdNotifyWatchdog } from './sdNotify.js';
+
+// ── Per-repo auth-failure tracking (#75) ─────────────────────────
+//
+// Consecutive 401 ticks per `${owner}/${repo}` key. When this hits
+// `CATCHUP_AUTH_FAILURE_THRESHOLD` (default 3), the catchup pushes
+// `status=down msg=auth_failed:owner/repo` to a dedicated Kuma push
+// monitor (`KUMA_GITHUB_AUTH_FAILURE_PUSH_URL`). On any successful
+// fetch the counter resets to 0.
+//
+// Concurrency: a single mindblown-api process serialises catchup
+// ticks (`runAllCatchups` is invoked from the catchup scheduler, not
+// concurrently), so the in-memory `Map` is safe without a lock. Two
+// concurrent processes hitting the same DB would each track their
+// own counter — fine, they'd just escalate independently.
+const consecutiveAuthFailures = new Map<string, number>();
+
+const DEFAULT_AUTH_FAILURE_THRESHOLD = 3;
+
+function getAuthFailureThreshold(): number {
+  const raw = process.env.CATCHUP_AUTH_FAILURE_THRESHOLD;
+  if (!raw) return DEFAULT_AUTH_FAILURE_THRESHOLD;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_AUTH_FAILURE_THRESHOLD;
+  return n;
+}
+
+/**
+ * Reset (for tests) the per-repo consecutive-auth-failure counter.
+ * Production code never calls this — it's exported only so unit tests
+ * can start each case from a clean slate without leaking state across
+ * cases. The module-level `Map` is private otherwise.
+ */
+export function _resetAuthFailureCountersForTests(): void {
+  consecutiveAuthFailures.clear();
+}
+
+/**
+ * Snapshot the per-repo counter (for tests). Production code does not
+ * read this.
+ */
+export function _getAuthFailureCountForTests(repoLabel: string): number {
+  return consecutiveAuthFailures.get(repoLabel) ?? 0;
+}
+
+/**
+ * Push the `auth_failed` alarm to Kuma. No-op when the env var is
+ * unset (same pattern as the catchup heartbeat — dev/test environments
+ * don't need to wire this).
+ */
+async function pushAuthFailureAlarm(repoLabel: string): Promise<void> {
+  const url = process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL;
+  if (!url) return;
+  await pushKumaHeartbeat(
+    url,
+    'down',
+    `auth_failed:${repoLabel}`,
+    '[kuma-push] github auth failure',
+  );
+}
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -222,6 +285,30 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
   try {
     issues = await fetchChangedIssues(target.owner, target.repo, token, sinceWithOverlap);
   } catch (err) {
+    // 401-specific escalation path (#75). The "auth revoked" failure
+    // mode looks identical to a transient fetch error in the existing
+    // path — the operator sees `error: fetch: GitHub API 401` and has
+    // to grep logs to diagnose. Track consecutive 401s per repo and
+    // fire a dedicated Kuma alarm once we've crossed the threshold,
+    // so the operator gets `auth_failed:owner/repo` instead of a
+    // generic "catchup is broken".
+    if (err instanceof GitHubApiError && err.status === 401) {
+      const next = (consecutiveAuthFailures.get(repoLabel) ?? 0) + 1;
+      consecutiveAuthFailures.set(repoLabel, next);
+      const threshold = getAuthFailureThreshold();
+      if (next >= threshold) {
+        // Push every tick once we're over the threshold (not just
+        // the threshold-crossing tick). Kuma's "down" state is
+        // sticky as long as the pushes keep arriving with `down`;
+        // letting subsequent ticks fall silent would cause Kuma to
+        // also alarm on "monitor went dark" after its push-timeout,
+        // which double-counts the same incident. Keeping the alarm
+        // hot every tick also means a fixed install (real success)
+        // immediately resets the counter and the next clean tick
+        // can let the monitor go UP again.
+        await pushAuthFailureAlarm(repoLabel);
+      }
+    }
     return {
       repo: repoLabel,
       fetched: 0, applied: 0, skipped: 0, noTransition: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,
@@ -230,6 +317,13 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
       error: `fetch: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
+
+  // Successful fetch — clear the per-repo auth-failure counter so the
+  // next 401 starts over at 1. This MUST happen even if subsequent
+  // passes (ingest, rollup) fail, because the auth-failure detector
+  // is specifically about the GitHub credential, not about downstream
+  // node-write errors.
+  consecutiveAuthFailures.delete(repoLabel);
 
   const externalIds = issues.map((i) => `${target.owner}/${target.repo}#${i.number}`);
   const linkIndex = await findNodesByExternalIds(externalIds);


### PR DESCRIPTION
## Summary

Closes #75. Track consecutive GH 401 ticks **per repo** in the catchup
loop, and after a threshold push `status=down msg=auth_failed:owner/repo`
to a dedicated Kuma monitor instead of letting the generic
catchup-heartbeat go DOWN with no diagnosis.

## What changes

- **`packages/integrations/src/github.ts`** — `githubFetch` now throws a
  `GitHubApiError` (exported) carrying the HTTP status on `.status`.
  Same `.message` format as before so log lines are unchanged.
- **`packages/server/src/sync/githubCatchup.ts`** — module-level
  `consecutiveAuthFailures: Map<string, number>` tracks per-repo state.
  - On a `GitHubApiError` with `status === 401`: increment counter;
    if `>= CATCHUP_AUTH_FAILURE_THRESHOLD` (default 3), push the alarm.
  - On any successful fetch: counter resets to 0 BEFORE the ingest /
    rollup passes (those failing doesn't mean the credential is bad).
  - Concurrency: a single mindblown-api process serialises catchup
    ticks, so the in-memory `Map` is safe (documented in the code).
- **`packages/server/src/sync/__tests__/githubCatchup.test.ts`** — 9 new
  tests covering: below-threshold no-push, threshold-crossing push,
  every-tick-after-threshold push, success-resets-counter, per-repo
  isolation, `CATCHUP_AUTH_FAILURE_THRESHOLD=1` override, env-var-unset
  no-op, non-401 errors don't escalate.
- **`deploy/README.md`** — documents the two new env vars
  (`KUMA_GITHUB_AUTH_FAILURE_PUSH_URL`, `CATCHUP_AUTH_FAILURE_THRESHOLD`)
  and the suggested 20 min Kuma "down" threshold.

## Design choices flagged in the brief

- **Every-tick vs threshold-crossing-only push** (spec said "choose"):
  picked **every tick past threshold**. Rationale: keeps the Kuma
  monitor reliably DOWN without depending on Kuma's own push-timeout,
  and means a real fix immediately produces a clean tick + reset, so
  the next tick can let the monitor go UP again. The
  threshold-crossing-only variant would require Kuma's push-timeout to
  also tick down for the alarm to stay visible.
- **Custom error class instead of string-grep**: the previous
  `throw new Error("GitHub API 401: ...")` shape worked for the
  existing "any fetch error is the same" path, but is too fragile to
  branch on. `GitHubApiError` carries `.status` as a typed field and is
  exported from `@mindblown/integrations` for downstream callers.
- **In-memory Map, not DB**: a restart resets the counter, which is the
  conservative choice — after restart we re-observe whether the 401 is
  still happening before alarming. No across-process coordination
  needed because catchup is single-process by design.

## Persona acceptance test

1. Open the GitHub repo's Settings → Installed GitHub Apps → Suspend.
2. Within ~15 min (3 × 5-min catchup ticks), Kuma's auth-failure
   monitor fires `status=down msg=auth_failed:owner/repo`.
3. Re-enable the install.
4. Next catchup tick → counter resets, monitor goes UP again.

## Test plan

- [x] `pnpm -w typecheck` clean
- [x] `pnpm -w build` clean
- [x] `pnpm -w test` — **172 passed** (was 130 before this PR + an
      unrelated 42 from PR #81 that just merged to master). `+9` from
      the new auth-escalation tests.
- [x] `rg "consecutiveAuthFailures" packages/server/src` matches in
      `githubCatchup.ts` only (no leaked imports).

## New env vars

| Var | Default | Purpose |
|---|---|---|
| `KUMA_GITHUB_AUTH_FAILURE_PUSH_URL` | unset → silent no-op | Kuma push monitor for `auth_failed:owner/repo` alarms. |
| `CATCHUP_AUTH_FAILURE_THRESHOLD` | `3` | Consecutive 401 ticks before the alarm fires. Min 1. |