### PR TITLE
feat(sync): surface tokenErrors in driftAudit response (closes #70)

### DIFF
--- a/packages/server/src/routes/__tests__/admin-endpoints-guard.test.ts
+++ b/packages/server/src/routes/__tests__/admin-endpoints-guard.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../db/settings.js', () => ({
 vi.mock('../../sync/driftAudit.js', () => ({
   runDriftAudit: vi.fn(async () => ({
     reports: [],
+    tokenErrors: [],
     autoBackfill: { totalImported: 0, totalManualPending: 0 },
   })),
 }));

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -756,13 +756,18 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
   );
 
   // ── POST /api/maps/sync/audit-drift ───────────────────────────
-  // Manual trigger for the daily drift-audit sweep. Returns the full
-  // DriftReport[] so the operator can see exactly which maps drifted
-  // (and the example issue numbers) without waiting 24h for the next
-  // scheduled run. Admin-only: the audit iterates EVERY opted-in map
-  // across EVERY workspace and returns map names + repo bindings, so
-  // gating below admin would leak cross-workspace metadata and let any
-  // logged-in user fan out N GitHub API calls per request.
+  // Manual trigger for the daily drift-audit sweep. Returns:
+  //   - `reports`      — DriftReport[] (one per map with drift)
+  //   - `tokenErrors`  — TokenError[] for maps whose binding couldn't
+  //                      resolve a token (App install revoked, PAT
+  //                      expired/missing). Surfaced here so operators
+  //                      see binding failures without SSH-ing for logs.
+  //   - `autoBackfill` — what the auto-backfill pass did
+  //   - `counts`       — flat numeric summary for dashboards
+  // Admin-only: the audit iterates EVERY opted-in map across EVERY
+  // workspace and returns map names + repo bindings, so gating below
+  // admin would leak cross-workspace metadata and let any logged-in
+  // user fan out N GitHub API calls per request.
   app.post('/api/maps/sync/audit-drift', async (req, reply) => {
     if (!req.userId) {
       return reply.status(401).send({
@@ -794,12 +799,14 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       }
       return reply.send({
         reports: result.reports,
+        tokenErrors: result.tokenErrors,
         autoBackfill: result.autoBackfill,
         counts: {
           driftedMaps: result.reports.length,
           totalDriftedIssues: result.reports.reduce((n, r) => n + r.onlyInGitHub, 0),
           autoBackfilled: result.autoBackfill.totalImported,
           manualPending: result.autoBackfill.totalManualPending,
+          tokenErrors: result.tokenErrors.length,
         },
       });
     } catch (err) {

--- a/packages/server/src/sync/__tests__/driftAudit.test.ts
+++ b/packages/server/src/sync/__tests__/driftAudit.test.ts
@@ -15,6 +15,9 @@
  *     query — we model that by simply not putting the map in the dataset).
  *   - PAT fallback when an App-binding token mint fails → still produces
  *     a report.
+ *   - Token-error surfacing (#70): when an App-token mint fails AND no
+ *     PAT fallback works, the failing map appears in `tokenErrors` with
+ *     a reason derived from the error. Tested in 4 variants below.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -261,8 +264,9 @@ describe('auditDrift', () => {
     linkNodeToIssue('m1', 'owner', 'repo', 2);
     linkNodeToIssue('m1', 'owner', 'repo', 3);
 
-    const reports = await auditDrift();
+    const { reports, tokenErrors } = await auditDrift();
     expect(reports).toEqual([]);
+    expect(tokenErrors).toEqual([]);
   });
 
   it('returns a DriftReport when issues exist with no linked node', async () => {
@@ -279,7 +283,7 @@ describe('auditDrift', () => {
     linkNodeToIssue('m1', 'owner', 'repo', 10);
     // 11 and 12 are unlinked
 
-    const reports = await auditDrift();
+    const { reports, tokenErrors } = await auditDrift();
     expect(reports).toHaveLength(1);
     expect(reports[0]).toEqual({
       mapId: 'm1',
@@ -288,6 +292,7 @@ describe('auditDrift', () => {
       onlyInGitHub: 2,
       exampleIssues: [11, 12],
     });
+    expect(tokenErrors).toEqual([]);
   });
 
   it('truncates exampleIssues to 5 even when N is much larger', async () => {
@@ -303,7 +308,7 @@ describe('auditDrift', () => {
     // 8 open issues, none linked
     setupRepoIssues('owner', 'repo', [1, 2, 3, 4, 5, 6, 7, 8]);
 
-    const reports = await auditDrift();
+    const { reports } = await auditDrift();
     expect(reports).toHaveLength(1);
     expect(reports[0].onlyInGitHub).toBe(8);
     expect(reports[0].exampleIssues).toEqual([1, 2, 3, 4, 5]);
@@ -322,8 +327,9 @@ describe('auditDrift', () => {
     setupRepoIssues('owner', 'repo', [1, 2, 3]);
     // Zero nodes linked — would be drift if the map were opted in.
 
-    const reports = await auditDrift();
+    const { reports, tokenErrors } = await auditDrift();
     expect(reports).toEqual([]);
+    expect(tokenErrors).toEqual([]);
   });
 
   it('skips maps with no GitHub binding (owner/repo null)', async () => {
@@ -340,8 +346,9 @@ describe('auditDrift', () => {
     // the resolveTargets isNotNull predicate filters this out.
     setupRepoIssues('owner', 'repo', [1, 2, 3]);
 
-    const reports = await auditDrift();
+    const { reports, tokenErrors } = await auditDrift();
     expect(reports).toEqual([]);
+    expect(tokenErrors).toEqual([]);
   });
 
   it('reports one map per opted-in target, not aggregated by repo', async () => {
@@ -370,7 +377,7 @@ describe('auditDrift', () => {
     linkNodeToIssue('mB', 'owner', 'repo', 1);
     linkNodeToIssue('mB', 'owner', 'repo', 2); // mB misses 3
 
-    const reports = await auditDrift();
+    const { reports } = await auditDrift();
     const byId = new Map(reports.map((r) => [r.mapId, r]));
     expect(byId.get('mA')?.onlyInGitHub).toBe(2);
     expect(byId.get('mB')?.onlyInGitHub).toBe(1);
@@ -396,10 +403,13 @@ describe('auditDrift', () => {
     setupRepoIssues('owner', 'repo', [42]);
     // No node linked → expect drift
 
-    const reports = await auditDrift();
+    const { reports, tokenErrors } = await auditDrift();
     expect(reports).toHaveLength(1);
     expect(reports[0].onlyInGitHub).toBe(1);
     expect(reports[0].exampleIssues).toEqual([42]);
+    // PAT fallback worked → no token error reported (the earlier
+    // App-mint failure is dropped once the PAT succeeds).
+    expect(tokenErrors).toEqual([]);
   });
 
   it('logs and skips a map whose GitHub fetch throws, without aborting other maps', async () => {
@@ -425,11 +435,138 @@ describe('auditDrift', () => {
     importErrors.set('bad/repo', 'GitHub 503');
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const reports = await auditDrift();
+    const { reports, tokenErrors } = await auditDrift();
     warnSpy.mockRestore();
 
     // mGood still reports its drift; mBad failed silently.
     expect(reports.map((r) => r.mapId)).toEqual(['mGood']);
     expect(reports[0].onlyInGitHub).toBe(1);
+    // Per-map fetch errors do NOT populate tokenErrors — those are
+    // reserved for token-resolution failures (App revoked / PAT missing).
+    expect(tokenErrors).toEqual([]);
+  });
+
+  // ── Token-error surfacing (#70) ─────────────────────────────────
+
+  it('reports a tokenError when App mint fails AND no PAT fallback exists', async () => {
+    dbState.maps.push({
+      id: 'm1',
+      name: 'Revoked Install Map',
+      workspaceId: 'ws',
+      githubInstallationId: 'inst-revoked',
+      githubRepoOwner: 'owner',
+      githubRepoName: 'repo',
+      autoImportNewIssues: true,
+    });
+    // App mint throws; no PAT integration in dbState.integrations →
+    // map can't resolve a token at all.
+    mintErrors.set('inst-revoked', 'install revoked');
+    // Even though issues exist on the repo, the map is skipped from
+    // the audit entirely — no fetch happens, no report.
+    setupRepoIssues('owner', 'repo', [1, 2, 3]);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { reports, tokenErrors } = await auditDrift();
+    warnSpy.mockRestore();
+
+    expect(reports).toEqual([]);
+    expect(tokenErrors).toHaveLength(1);
+    expect(tokenErrors[0]).toEqual({
+      mapId: 'm1',
+      mapName: 'Revoked Install Map',
+      // Reason format: `app: <error message>` — see resolveTargets()
+      // in driftAudit.ts.
+      reason: 'app: install revoked',
+    });
+  });
+
+  it('omits a tokenError when App mint fails BUT PAT fallback succeeds', async () => {
+    // This is the existing PAT-fallback case re-asserted at the
+    // tokenErrors contract level: a downstream PAT save means there
+    // is NO token error to surface, even though the App mint blew up.
+    dbState.maps.push({
+      id: 'm1',
+      name: 'App+PAT Map',
+      workspaceId: 'ws',
+      githubInstallationId: 'inst-revoked',
+      githubRepoOwner: 'owner',
+      githubRepoName: 'repo',
+      autoImportNewIssues: true,
+    });
+    dbState.integrations.push({
+      workspaceId: 'ws',
+      provider: 'github',
+      enabled: true,
+      config: { owner: 'owner', repo: 'repo', token: 'pat-fallback' },
+    });
+    mintErrors.set('inst-revoked', 'install revoked');
+    setupRepoIssues('owner', 'repo', [1]);
+
+    const { reports, tokenErrors } = await auditDrift();
+    // Map IS audited normally because the PAT works.
+    expect(reports).toHaveLength(1);
+    expect(reports[0].mapId).toBe('m1');
+    // And tokenErrors is empty — the App-mint failure was recovered.
+    expect(tokenErrors).toEqual([]);
+  });
+
+  it('reports tokenErrors alongside reports for a mix of normal + token-errored maps', async () => {
+    // mNormal — drifted, audits cleanly.
+    dbState.maps.push({
+      id: 'mNormal',
+      name: 'Normal Map',
+      workspaceId: 'wsA',
+      githubInstallationId: 'inst-ok',
+      githubRepoOwner: 'good',
+      githubRepoName: 'repo',
+      autoImportNewIssues: true,
+    });
+    setupRepoIssues('good', 'repo', [5]); // unlinked → drift
+
+    // mBroken — App revoked, no PAT → tokenError.
+    dbState.maps.push({
+      id: 'mBroken',
+      name: 'Broken Token Map',
+      workspaceId: 'wsB',
+      githubInstallationId: 'inst-revoked',
+      githubRepoOwner: 'bad',
+      githubRepoName: 'repo',
+      autoImportNewIssues: true,
+    });
+    mintErrors.set('inst-revoked', 'install revoked');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { reports, tokenErrors } = await auditDrift();
+    warnSpy.mockRestore();
+
+    expect(reports.map((r) => r.mapId)).toEqual(['mNormal']);
+    expect(reports[0].onlyInGitHub).toBe(1);
+    expect(tokenErrors).toHaveLength(1);
+    expect(tokenErrors[0].mapId).toBe('mBroken');
+    expect(tokenErrors[0].reason).toBe('app: install revoked');
+  });
+
+  it('preserves the raw error message in tokenError.reason for non-revocation failures', async () => {
+    // Defensive: the resolver stringifies arbitrary errors into
+    // `reason`. Make sure a non-"install revoked" message threads
+    // through verbatim so the operator UI can render the actual cause.
+    dbState.maps.push({
+      id: 'm1',
+      name: 'JWT Map',
+      workspaceId: 'ws',
+      githubInstallationId: 'inst-jwt',
+      githubRepoOwner: 'owner',
+      githubRepoName: 'repo',
+      autoImportNewIssues: true,
+    });
+    mintErrors.set('inst-jwt', 'JWT signature invalid');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { reports, tokenErrors } = await auditDrift();
+    warnSpy.mockRestore();
+
+    expect(reports).toEqual([]);
+    expect(tokenErrors).toHaveLength(1);
+    expect(tokenErrors[0].reason).toBe('app: JWT signature invalid');
   });
 });

--- a/packages/server/src/sync/driftAudit.ts
+++ b/packages/server/src/sync/driftAudit.ts
@@ -20,11 +20,13 @@
  *     opted out of auto-creation).
  *   - Maps with no GitHub binding (no repo to compare against).
  *   - Maps whose binding can't currently resolve a token (App install
- *     revoked, PAT expired). Logged via `console.warn` and excluded
- *     from the returned reports — they don't count as drift for the
- *     Kuma alarm. Surfacing these in the manual-trigger response is
- *     tracked as a follow-up; today the operator reads them from the
- *     server log when investigating a Kuma alert.
+ *     revoked, PAT expired). Logged via `console.warn` AND surfaced in
+ *     the `tokenErrors` array of the returned `AuditDriftResult` so the
+ *     operator hitting `POST /api/maps/sync/audit-drift` can see exactly
+ *     which maps need attention without SSH-ing for logs. They still
+ *     don't count as drift for the Kuma "up/down" decision — auto-backfill
+ *     can't heal a token problem — but `tokenErrors.length` is included
+ *     in the Kuma message so a token outage shows up in the dashboard.
  */
 
 import { eq, and, isNotNull } from 'drizzle-orm';
@@ -60,7 +62,16 @@ interface AuditTarget {
   token: string;
 }
 
-interface TokenError {
+/**
+ * One map whose token resolution failed. Surfaced in `AuditDriftResult`
+ * so the operator endpoint can show the failure without log access.
+ *
+ * `reason` is a short stringified cause — typical values:
+ *   - `app: install revoked`       (App-token mint threw, no PAT fallback)
+ *   - `app: <octokit message>`     (other App-token mint failure)
+ *   - bare error message if no `app:` prefix applies
+ */
+export interface TokenError {
   mapId: string;
   mapName: string;
   reason: string;
@@ -68,6 +79,18 @@ interface TokenError {
 
 interface ResolvedTargets {
   targets: AuditTarget[];
+  tokenErrors: TokenError[];
+}
+
+/**
+ * Return shape of `auditDrift()`. `reports` is the per-map drift list
+ * (every entry has `onlyInGitHub > 0`); `tokenErrors` is every map that
+ * couldn't be audited because its GitHub binding failed to resolve a
+ * token. The two are disjoint by construction — a map with a token
+ * error isn't audited so can't produce a report.
+ */
+export interface AuditDriftResult {
+  reports: DriftReport[];
   tokenErrors: TokenError[];
 }
 
@@ -193,14 +216,18 @@ async function auditOneMap(t: AuditTarget): Promise<DriftReport | null> {
 
 /**
  * Audit every opted-in map for GitHub→MindBlown drift. Returns one
- * DriftReport per drifted map (empty array when everything's clean).
+ * DriftReport per drifted map (empty when everything's clean) PLUS a
+ * `tokenErrors` array listing every map whose binding couldn't resolve
+ * a current token (App install revoked, PAT expired/missing).
  *
- * Per-map fetch failures are logged but don't abort the sweep — one
- * map's outage shouldn't mask drift in another map. They're surfaced
- * via console.warn and (for the most common cause, token resolution)
- * via the returned reports' implicit absence.
+ * Per-map fetch failures (network/5xx during `importGitHubIssues`) are
+ * still logged via `console.warn` and don't abort the sweep — one map's
+ * outage shouldn't mask drift in another. Those are NOT collected into
+ * `tokenErrors` because they're typically transient and clear by the
+ * next sweep; token errors are persistent until an operator fixes the
+ * binding, so they're worth surfacing in the response shape.
  */
-export async function auditDrift(): Promise<DriftReport[]> {
+export async function auditDrift(): Promise<AuditDriftResult> {
   const { targets, tokenErrors } = await resolveTargets();
 
   if (tokenErrors.length > 0) {
@@ -223,16 +250,21 @@ export async function auditDrift(): Promise<DriftReport[]> {
       );
     }
   }
-  return reports;
+  return { reports, tokenErrors };
 }
 
 /**
  * Result of one `runDriftAudit()` invocation, returned to callers
  * (the daily scheduler in index.ts and the manual operator endpoint
  * in routes/integrations.ts so they can show what auto-backfill did).
+ *
+ * `tokenErrors` is propagated from `auditDrift()` so the manual operator
+ * endpoint can surface binding failures alongside drift + auto-backfill
+ * results in a single response.
  */
 export interface DriftAuditRunResult {
   reports: DriftReport[];
+  tokenErrors: TokenError[];
   autoBackfill: AutoBackfillSummary;
   /** Set when the audit itself threw — short reason string for ops UI. */
   error?: string;
@@ -272,6 +304,11 @@ export function formatAutoBackfillMsg(summary: AutoBackfillSummary): string {
  *   - All drift over cap / killed    → status=down, msg="manual-N"
  *   - Audit itself threw             → status=down, msg="audit_failed:<reason>"
  *
+ * If any maps had token errors, `,token-errors-N` is appended to the
+ * msg (e.g. `no-drift,token-errors-2`). Token errors alone do not flip
+ * status to down — they're surfaced via the response shape's
+ * `tokenErrors` field for the operator endpoint to render.
+ *
  * Kuma URL comes from `KUMA_GITHUB_DRIFT_PUSH_URL`; if unset the push
  * is skipped entirely (dev / test environments). Push errors are
  * swallowed by `pushKumaHeartbeat`, but we re-wrap here so any future
@@ -280,8 +317,9 @@ export function formatAutoBackfillMsg(summary: AutoBackfillSummary): string {
 export async function runDriftAudit(): Promise<DriftAuditRunResult> {
   const url = process.env.KUMA_GITHUB_DRIFT_PUSH_URL;
   let reports: DriftReport[];
+  let tokenErrors: TokenError[];
   try {
-    reports = await auditDrift();
+    ({ reports, tokenErrors } = await auditDrift());
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     console.error('[drift-audit] sweep failed:', err);
@@ -298,18 +336,27 @@ export async function runDriftAudit(): Promise<DriftAuditRunResult> {
     }
     return {
       reports: [],
+      tokenErrors: [],
       autoBackfill: { totalImported: 0, totalManualPending: 0, outcomes: [] },
       error: reason,
     };
   }
 
+  // Suffix appended to the Kuma message when any map's binding failed
+  // to resolve a token. Token errors don't trigger status=down on their
+  // own (they can't be auto-healed and don't count as drift), but
+  // appending the count lets a Kuma watcher catch persistent binding
+  // outages even when drift is otherwise clean.
+  const tokenSuffix = tokenErrors.length > 0 ? `,token-errors-${tokenErrors.length}` : '';
+
   // No drift → clean push and bail. Skip auto-backfill entirely
-  // (nothing to heal).
+  // (nothing to heal). Token errors still get appended so a "no drift
+  // but token broken" state is visible at the Kuma dashboard.
   if (reports.length === 0) {
     console.log('[drift-audit] clean — no drift');
     if (url) {
       try {
-        await pushKumaHeartbeat(url, 'up', 'no-drift', '[kuma-push] drift audit');
+        await pushKumaHeartbeat(url, 'up', `no-drift${tokenSuffix}`, '[kuma-push] drift audit');
       } catch (pushErr) {
         console.warn(
           '[kuma-push] drift audit heartbeat unexpectedly threw:',
@@ -319,6 +366,7 @@ export async function runDriftAudit(): Promise<DriftAuditRunResult> {
     }
     return {
       reports: [],
+      tokenErrors,
       autoBackfill: { totalImported: 0, totalManualPending: 0, outcomes: [] },
     };
   }
@@ -350,7 +398,7 @@ export async function runDriftAudit(): Promise<DriftAuditRunResult> {
   }
 
   // Build the Kuma message and status.
-  const msg = formatAutoBackfillMsg(autoBackfill).slice(0, 200);
+  const msg = `${formatAutoBackfillMsg(autoBackfill)}${tokenSuffix}`.slice(0, 200);
   const status = autoBackfill.totalManualPending > 0 ? 'down' : 'up';
 
   if (url) {
@@ -364,5 +412,5 @@ export async function runDriftAudit(): Promise<DriftAuditRunResult> {
     }
   }
 
-  return { reports, autoBackfill };
+  return { reports, tokenErrors, autoBackfill };
 }


### PR DESCRIPTION
## Summary

- Extend `auditDrift()` return shape from `DriftReport[]` to `{ reports, tokenErrors }` so the `POST /api/maps/sync/audit-drift` admin endpoint surfaces per-map token-resolution failures (App install revoked, PAT expired/missing) without operators having to SSH and grep logs.
- Thread `tokenErrors` through `runDriftAudit()` so both the manual route and the daily cron caller see the same shape, and append `,token-errors-N` to the Kuma push message when any are present (status decision unchanged — token errors are additive metadata, not auto-healable drift).
- Adds 4 new test cases pinning the `tokenErrors` contract:
  1. No token errors → `tokenErrors: []`.
  2. App-token mint fails AND no PAT fallback → map appears in `tokenErrors` with `reason: 'app: <error>'`.
  3. App-token mint fails BUT PAT fallback works → map audits normally, `tokenErrors` empty.
  4. Mix of normal + token-errored maps → both `reports` and `tokenErrors` populated.
  - Plus a defensive 5th case asserting non-revocation error messages thread through verbatim.

## Why

Closes #70. The internals already tracked which maps failed token resolution (in the `tokenErrors` array on the internal `ResolvedTargets`), they were just `console.warn`'d and dropped. Surfacing them in the response shape lets an operator hitting the manual endpoint see exactly which map's GitHub binding is broken in one round-trip.

## Layers touched

- `packages/server/src/sync/driftAudit.ts` — `TokenError` and `AuditDriftResult` exported; `auditDrift()` returns the new shape; `DriftAuditRunResult.tokenErrors` added and threaded through `runDriftAudit()`; Kuma msg gets `,token-errors-N` suffix.
- `packages/server/src/routes/integrations.ts` — `POST /api/maps/sync/audit-drift` response now includes `tokenErrors` array + `counts.tokenErrors` number; docstring updated.
- `packages/server/src/sync/__tests__/driftAudit.test.ts` — every existing call updated to the destructure pattern, 4 new cases added (12 tests total, was 8).
- `packages/server/src/routes/__tests__/admin-endpoints-guard.test.ts` — mock for `runDriftAudit` now returns `tokenErrors: []` so the new route code can read `.length`.

`packages/server/src/index.ts` — no change needed; the daily cron caller uses `runDriftAudit()` (not `auditDrift()` directly), and `runDriftAudit`'s return type kept `reports` and now adds `tokenErrors` additively, so the existing call site stays valid.

## Persona acceptance test

Verifiable post-merge:
1. Revoke the GH App install for one bound map's repo.
2. Hit `POST /api/maps/sync/audit-drift` as admin.
3. Response: `{ reports: [...], tokenErrors: [{ mapId, mapName, reason: 'app: install revoked' }], autoBackfill: {...}, counts: {..., tokenErrors: 1} }`.
4. Operator sees which map has the token problem WITHOUT SSH-ing for logs.

## Test plan

- [x] `pnpm -w typecheck` — clean.
- [x] `pnpm -w build` — clean.
- [x] `pnpm -w test` — 167 server tests pass (was 163; +4 new tokenError cases).
- [x] `rg "auditDrift\(\)" packages/server/src` — every call site uses the new destructure pattern.
- [ ] Manual post-merge: revoke a real App install + hit the route + verify response shape.