### PR TITLE
feat(sync): detect silent webhook signature failures (closes #74)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -116,6 +116,7 @@ NODE_ENV=production
 # KUMA_GITHUB_CATCHUP_PUSH_URL=https://kuma.example.com/api/push/<token>
 # KUMA_GITHUB_DRIFT_PUSH_URL=https://kuma.example.com/api/push/<token>
 # KUMA_GITHUB_AUTH_FAILURE_PUSH_URL=https://kuma.example.com/api/push/<token>
+# KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL=https://kuma.example.com/api/push/<token>
 
 # Optional — consecutive GH 401 ticks per repo before the catchup
 # fires `status=down msg=auth_failed:owner/repo` on the auth-failure
@@ -252,6 +253,23 @@ section is optional — but strongly recommended in production.
   fetch on that repo resets the counter and the monitor goes UP on
   the next tick.
 
+- **Webhook auth (`KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL`)** — pushed
+  once a day. Catches a silent failure mode the three monitors above
+  miss: the GH-side webhook secret has rotated, mindblown's copy is
+  stale, every webhook POST fails signature verification → 401, and
+  the 5-min catchup loop silently papers over the gap. The realtime
+  path is dead but drift stays at 0 so nothing else alarms. The
+  scheduler reads a 24h rolling counter and pushes
+  `status=down msg=webhook_auth_failed:received_N_authenticated_0`
+  when N ≥ 3 calls all failed verification, `status=up` when at
+  least one passed, or skips the push entirely when fewer than 3
+  calls landed (avoids false-alarming a quiet day where one
+  transient blip is the only sample). Note: the all-zero case
+  ("GH webhook never configured at all") is deliberately NOT
+  alarmed by this monitor — that's a different failure mode and
+  conflating them would page operators on fresh deploys with no
+  webhook wired yet.
+
 ### Creating the monitors in Kuma
 
 1. Open your Kuma instance, **Add New Monitor** → **Push**.
@@ -260,8 +278,9 @@ section is optional — but strongly recommended in production.
 3. Save. Kuma generates a push URL like
    `https://kuma.example.com/api/push/abc123XYZ`.
 4. Repeat for the drift-audit monitor.
-5. Wire each push URL into `/etc/mindblown/api.env` (uncomment the two
-   `KUMA_GITHUB_*` lines) and `systemctl restart mindblown-api`.
+5. Wire each push URL into `/etc/mindblown/api.env` (uncomment the
+   relevant `KUMA_GITHUB_*` / `KUMA_WEBHOOK_*` lines) and
+   `systemctl restart mindblown-api`.
 
 ### Suggested Kuma thresholds
 
@@ -270,6 +289,7 @@ section is optional — but strongly recommended in production.
 | catchup heartbeat | 60 s | 10 min | API pushes every 5 min — 10 min absorbs one missed tick (restart/upgrade) without false-alarming. |
 | drift audit | 60 s | 30 h | API pushes daily — 30 h gives 6 h of slack for restart timing, clock drift, etc. |
 | auth failure | 60 s | 20 min | API pushes only on the threshold-crossing tick + every subsequent failing tick; 20 min covers two consecutive 5-min catchup ticks so a single delayed Kuma push doesn't flap the monitor. |
+| webhook auth | 60 s | 30 h | API pushes daily — 30 h gives 6 h of slack matching the drift audit. Push only fires when ≥ 3 webhook calls landed in the rolling 24h; before that the monitor sits in "no push received" but Kuma should NOT alarm on it during normal low-traffic periods — set the down threshold generously. |
 
 ### Auto-backfill on drift detection
 
@@ -308,6 +328,39 @@ journalctl -u mindblown-api | grep auto-backfill
 - `drift detected, per-map auto-backfill failed: <error>` → expected:
   read the warn log for the underlying cause (revoked GitHub token,
   GitHub 503, rate-limit, etc.) and fix that before re-running.
+
+### Triage `webhook_auth_failed` alerts
+
+The webhook-auth monitor pushes `status=down msg=webhook_auth_failed:received_N_authenticated_0`
+when N ≥ 3 webhook deliveries arrived in the last 24h and ALL of them
+failed signature verification. The catchup loop will be silently
+papering over the gap — node updates still flow, but with up to 5 min
+of lag — so the operator-visible symptom is "sync feels sluggish but
+nothing is broken". Triage:
+
+1. Verify the alarm is real — hit `journalctl -u mindblown-api | grep "invalid signature"`
+   to see the rejected POSTs. Each line carries the GH event type and
+   the source IP; the IP should match GitHub's published webhook ranges.
+2. Check whether the secret was rotated on the GitHub side. For a
+   GitHub App: **App settings → Webhook → "Generate new secret"**
+   history. For a per-integration PAT: ask whoever set it up most
+   recently.
+3. Update the matching secret in mindblown:
+   - GitHub App: `GITHUB_APP_WEBHOOK_SECRET` in `/etc/mindblown/api.env`
+     → `systemctl restart mindblown-api`.
+   - PAT integration: `POST /api/integrations/github/connect` with the
+     new `webhookSecret` (the connect endpoint is the supported way to
+     edit a stored secret — direct DB UPDATEs work but aren't audited).
+4. Within 24h the rolling counter clears and the monitor flips back
+   to `up`. To verify the fix faster, override the cadence:
+   `WEBHOOK_AUTH_CHECK_INTERVAL_MS=60000` in `api.env`, restart, and
+   the next successful webhook delivery + tick will push `status=up`.
+   Remove the override afterwards.
+
+If no webhook traffic has landed yet (received < 3), the monitor sits
+in "no push received" — that's normal and Kuma should NOT alarm on a
+short window of no pushes. Tune the down threshold to ~30 h
+(matching the daily push cadence + slack).
 
 ### Watchdog auto-restart
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,7 @@ import { snapshotAllMaps } from './lib/releaseSnapshots.js';
 import { runAllCatchups } from './sync/githubCatchup.js';
 import { runDriftAudit } from './sync/driftAudit.js';
 import { runCanary } from './sync/canary.js';
+import { runWebhookAuthCheck } from './sync/webhookAuthCheck.js';
 import { sdNotifyReady } from './sync/sdNotify.js';
 import { authRoutes } from './auth.js';
 import { systemRoutes } from './routes/system.js';
@@ -223,6 +224,40 @@ async function main(): Promise<void> {
     }
   };
   setInterval(canaryTick, CANARY_INTERVAL_MS);
+
+  // ── Daily webhook auth-check (silent realtime-failure probe) ─
+  // The webhook handler keeps a 24h rolling counter of
+  // (received, authenticated). Once a day we read the counter and push
+  // to a dedicated Kuma monitor:
+  //   - received >= MIN && authenticated == 0 → status=down (the
+  //     bad-secret case — webhook is being hit, all pushes fail
+  //     signature check, but the catchup loop is silently papering
+  //     over the gap)
+  //   - received >= MIN && authenticated >= 1 → status=up
+  //   - received < MIN → no push (too few samples to draw a
+  //     conclusion; deliberately also covers "GH webhook never
+  //     configured at all", which is a distinct failure mode)
+  // No-op when KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL is unset, same shape
+  // as the other Kuma probes above. Allow WEBHOOK_AUTH_CHECK_INTERVAL_MS
+  // env-var override so operators can dial the cadence down for a
+  // one-off post-deploy smoke test, same convention the canary uses.
+  const WEBHOOK_AUTH_CHECK_INTERVAL_MS = parseInt(
+    process.env.WEBHOOK_AUTH_CHECK_INTERVAL_MS ?? `${24 * 60 * 60 * 1000}`,
+    10,
+  );
+  const webhookAuthCheckTick = async (): Promise<void> => {
+    try {
+      await runWebhookAuthCheck();
+    } catch (err) {
+      // runWebhookAuthCheck delegates to pushKumaHeartbeat, which
+      // swallows its own fetch errors. This catch is defence-in-depth
+      // for an unexpected synchronous throw.
+      console.error('[webhook-auth-check] scheduler caught unexpected error:', err);
+    }
+  };
+  // Deliberately no startup invocation — the counter is empty at
+  // boot, so the first tick would always be a `received==0` no-op.
+  setInterval(webhookAuthCheckTick, WEBHOOK_AUTH_CHECK_INTERVAL_MS);
 }
 
 main();

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -15,6 +15,7 @@ import {
 } from '@mindblown/integrations';
 import { reconcileRepo } from '../sync/githubCatchup.js';
 import { runDriftAudit } from '../sync/driftAudit.js';
+import { recordWebhookCall } from '../sync/webhookAuthCheck.js';
 import { requireAdmin } from '../auth.js';
 import { rollupParentsForChildTitle } from '../sync/parentEpicRollup.js';
 import {
@@ -1006,6 +1007,14 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         }
       }
     }
+
+    // Feed the 24h rolling auth counter (see #74). We record EVERY
+    // inbound webhook call — both pass and fail — so the daily
+    // scheduler can detect "received N, all failed verification" =
+    // the GH-side secret has rotated and mindblown's copy is stale.
+    // Recorded BEFORE the 401 short-circuit below so failing calls
+    // are counted even though we reject them.
+    recordWebhookCall(signatureVerified);
 
     // Enforce signature verification for the entire webhook handler.
     // Before this guard, an attacker who knew the webhook URL could POST a

--- a/packages/server/src/sync/__tests__/webhookAuthCheck.test.ts
+++ b/packages/server/src/sync/__tests__/webhookAuthCheck.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the webhook auth-mismatch detector (#74).
+ *
+ * The module keeps a 24h rolling counter of webhook calls and pushes a
+ * Kuma heartbeat once a day:
+ *   - down if all calls in the window failed signature verification
+ *     (the silent-rotation case we're trying to catch)
+ *   - up if at least one passed (healthy, or mid-rotation — don't alarm)
+ *   - no push if fewer than MIN_THRESHOLD calls landed in the window
+ *     (too few samples to distinguish "bad secret" from "low traffic
+ *     day with one transient blip")
+ *
+ * We mock `pushKumaHeartbeat` directly (same pattern as canary.test.ts)
+ * because we're testing the orchestration around it: which (status,
+ * msg) lands for which counter state.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const pushKumaHeartbeatMock = vi.fn(
+  async (
+    _url: string | undefined,
+    _status: 'up' | 'down',
+    _msg: string,
+    _tag: string,
+  ): Promise<void> => undefined,
+);
+
+vi.mock('../kumaPush.js', () => ({
+  pushKumaHeartbeat: pushKumaHeartbeatMock,
+}));
+
+// Import AFTER the mock so the SUT picks up the mocked helper.
+const {
+  recordWebhookCall,
+  runWebhookAuthCheck,
+  _resetForTests,
+  _getCallsForTests,
+  _MIN_THRESHOLD_FOR_TESTS,
+  _WINDOW_MS_FOR_TESTS,
+} = await import('../webhookAuthCheck.js');
+
+const URL = 'https://kuma.example.com/api/push/webhook-auth';
+
+describe('webhookAuthCheck', () => {
+  let originalUrl: string | undefined;
+
+  beforeEach(() => {
+    pushKumaHeartbeatMock.mockReset();
+    pushKumaHeartbeatMock.mockResolvedValue(undefined);
+    _resetForTests();
+    originalUrl = process.env.KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL;
+    process.env.KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL = URL;
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) {
+      delete process.env.KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL;
+    } else {
+      process.env.KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL = originalUrl;
+    }
+  });
+
+  describe('recordWebhookCall', () => {
+    it('appends a record per call with the correct ok flag', () => {
+      recordWebhookCall(true);
+      recordWebhookCall(false);
+      recordWebhookCall(true);
+
+      const snapshot = _getCallsForTests();
+      expect(snapshot).toHaveLength(3);
+      expect(snapshot.map((c) => c.ok)).toEqual([true, false, true]);
+    });
+
+    it('prunes entries older than the 24h window on each write', () => {
+      // Insert a stale entry by mocking Date.now ONLY for the push
+      // (the prune-after-push runs at the same fake time, so the
+      // stale entry survives). Then push a fresh entry at the real
+      // time — its prune pass should evict the now-stale entry.
+      const fakeOldNow = Date.now() - _WINDOW_MS_FOR_TESTS - 60_000;
+      const spy = vi.spyOn(Date, 'now').mockReturnValue(fakeOldNow);
+      recordWebhookCall(true); // push + prune both run at fakeOldNow
+      spy.mockRestore();
+
+      // Sanity: the stale entry survived its own prune (prune ran at
+      // fakeOldNow, so "older than fakeOldNow - WINDOW_MS" was empty).
+      expect(_getCallsForTests()).toHaveLength(1);
+
+      // Fresh write triggers prune at the real wall-clock; the entry
+      // we pushed at fakeOldNow is now outside the window and evicts.
+      recordWebhookCall(false);
+      const snapshot = _getCallsForTests();
+      expect(snapshot).toHaveLength(1);
+      expect(snapshot[0].ok).toBe(false);
+    });
+  });
+
+  describe('runWebhookAuthCheck', () => {
+    it('24h window all-authenticated → status=up with received_N_authenticated_N', async () => {
+      for (let i = 0; i < 5; i++) recordWebhookCall(true);
+
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(1);
+      const [url, status, msg, tag] = pushKumaHeartbeatMock.mock.calls[0];
+      expect(url).toBe(URL);
+      expect(status).toBe('up');
+      expect(msg).toBe('webhook_auth_ok:received_5_authenticated_5');
+      expect(tag).toContain('webhook-auth-check');
+    });
+
+    it('24h window all-failed (count above MIN_THRESHOLD) → status=down', async () => {
+      for (let i = 0; i < _MIN_THRESHOLD_FOR_TESTS + 2; i++) {
+        recordWebhookCall(false);
+      }
+
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(1);
+      const [url, status, msg, tag] = pushKumaHeartbeatMock.mock.calls[0];
+      expect(url).toBe(URL);
+      expect(status).toBe('down');
+      expect(msg).toBe(
+        `webhook_auth_failed:received_${_MIN_THRESHOLD_FOR_TESTS + 2}_authenticated_0`,
+      );
+      expect(tag).toContain('webhook-auth-check');
+    });
+
+    it('exactly MIN_THRESHOLD all-failed → status=down (boundary inclusive)', async () => {
+      // The threshold is "received >= MIN". Verify the boundary
+      // explicitly so a future "received > MIN" off-by-one bug surfaces
+      // in tests instead of in production.
+      for (let i = 0; i < _MIN_THRESHOLD_FOR_TESTS; i++) recordWebhookCall(false);
+
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(1);
+      expect(pushKumaHeartbeatMock.mock.calls[0][1]).toBe('down');
+    });
+
+    it('1 failed call (below MIN_THRESHOLD) → no push (false-alarm guard)', async () => {
+      // The MIN_THRESHOLD floor is the whole point: a single bad call
+      // on a quiet day must not page the operator.
+      recordWebhookCall(false);
+
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).not.toHaveBeenCalled();
+    });
+
+    it('0 calls in 24h window → no push (different failure mode, out of scope)', async () => {
+      // received==0 means "GH webhook never landed at all". That's a
+      // different failure (webhook URL not configured on the GH side)
+      // and the brief explicitly scopes it out for v1.
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).not.toHaveBeenCalled();
+    });
+
+    it('mixed authenticated + unauthenticated → status=up (at least some succeed)', async () => {
+      // The down state is "received >= MIN AND authenticated == 0" —
+      // any successful auth in the window means the secret is still
+      // correct for SOME GH delivery (e.g. mid-rotation, or a
+      // multi-repo deployment where only one repo's secret drifted).
+      // Don't alarm here.
+      recordWebhookCall(true);
+      recordWebhookCall(false);
+      recordWebhookCall(false);
+      recordWebhookCall(false);
+
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).toHaveBeenCalledTimes(1);
+      const [url, status, msg] = pushKumaHeartbeatMock.mock.calls[0];
+      expect(url).toBe(URL);
+      expect(status).toBe('up');
+      expect(msg).toBe('webhook_auth_ok:received_4_authenticated_1');
+    });
+
+    it('URL unset → no push attempted (safe deploy default)', async () => {
+      delete process.env.KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL;
+      for (let i = 0; i < 10; i++) recordWebhookCall(false);
+
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).not.toHaveBeenCalled();
+    });
+
+    it('URL set to empty string → no push attempted', async () => {
+      // Defence-in-depth: an operator who comments out the env value
+      // and leaves the assignment shouldn't trigger a malformed push.
+      process.env.KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL = '';
+      for (let i = 0; i < 10; i++) recordWebhookCall(false);
+
+      await runWebhookAuthCheck();
+
+      expect(pushKumaHeartbeatMock).not.toHaveBeenCalled();
+    });
+
+    it('prunes the rolling window before deciding (stale entries do NOT count)', async () => {
+      // Two stale failed calls + two fresh authenticated calls. The
+      // stale ones must NOT contribute to the counter, so the check
+      // should see 2 received / 2 ok → below MIN_THRESHOLD → no push.
+      const stale = Date.now() - _WINDOW_MS_FOR_TESTS - 60_000;
+      const realNow = Date.now;
+      let nowReturn = stale;
+      const spy = vi.spyOn(Date, 'now').mockImplementation(() => nowReturn);
+      recordWebhookCall(false);
+      recordWebhookCall(false);
+      // Fresh entries.
+      nowReturn = realNow();
+      recordWebhookCall(true);
+      recordWebhookCall(true);
+      spy.mockRestore();
+
+      await runWebhookAuthCheck();
+
+      // 2 fresh + 0 stale (post-prune) < MIN_THRESHOLD → no push.
+      expect(pushKumaHeartbeatMock).not.toHaveBeenCalled();
+      // And the buffer itself is now drained of stale entries.
+      expect(_getCallsForTests()).toHaveLength(2);
+    });
+  });
+});

--- a/packages/server/src/sync/webhookAuthCheck.ts
+++ b/packages/server/src/sync/webhookAuthCheck.ts
@@ -1,0 +1,150 @@
+/**
+ * Detect silent webhook signature-verification failures.
+ *
+ * Today: if GitHub's webhook secret drifts (rotated on the GH side,
+ * forgotten in mindblown's config), webhook POSTs still arrive at
+ * `/api/webhooks/github` but signature verification fails → handler
+ * returns 401. The 5-min catchup reconciler picks up the slack so drift
+ * stays at 0 — the operator never learns the realtime path is dead, and
+ * every sync now lags by up to 5 min until someone notices.
+ *
+ * This module keeps a rolling 24h counter of webhook calls and how many
+ * passed signature verification. A daily scheduler tick (see
+ * `index.ts`) reads the counter and pushes to a dedicated Kuma monitor:
+ *
+ *   - `received >= MIN_THRESHOLD && authenticated === 0` →
+ *     `status=down msg=webhook_auth_failed:received_N_authenticated_0`
+ *     (the bad-secret case — alarms via the normal Kuma → Pushover
+ *     chain)
+ *   - `received >= MIN_THRESHOLD && authenticated >= 1` →
+ *     `status=up msg=webhook_auth_ok:received_N_authenticated_M`
+ *     (at least some pushes are passing; either healthy or in the
+ *     middle of a rotation — don't alarm)
+ *   - `received < MIN_THRESHOLD` → no push at all
+ *     (too few samples to draw a conclusion; we deliberately do NOT
+ *     push `status=down` for "received==0" because that's a different
+ *     failure mode — webhook URL never configured on GH side — and
+ *     conflating them would page the operator on freshly-deployed
+ *     instances with no GH webhook wired yet)
+ *
+ * The MIN_THRESHOLD floor exists to avoid false-alarming on a quiet
+ * day where the single webhook that lands happens to have a transient
+ * auth blip (e.g. an old delivery retry from before a recent secret
+ * rotation). 3 calls / 24h is conservative for any repo with real
+ * traffic.
+ *
+ * Module-level state is fine here: the catchup loop in `githubCatchup`
+ * uses the same single-process pattern (see #75). The deployment shape
+ * is a single Fastify instance per host, so there is no cross-process
+ * counter to coordinate.
+ */
+
+import { pushKumaHeartbeat } from './kumaPush.js';
+
+/** Rolling window: only calls within this many ms back are considered. */
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Minimum number of webhook calls in the window before we'll push
+ * EITHER `up` or `down`. Avoids a single transient bad-signature on a
+ * quiet day flipping the monitor.
+ */
+const MIN_THRESHOLD = 3;
+
+interface CallRecord {
+  at: number;
+  ok: boolean;
+}
+
+/**
+ * Module-level state — single Fastify process per host. If we ever move
+ * to multi-process, this becomes a Redis HINCRBY or similar; the
+ * abstraction is intentionally small so the swap is local.
+ */
+const calls: CallRecord[] = [];
+
+/**
+ * Drop entries older than the rolling window. Called before reads and
+ * on every write; cheap because the array is bounded in practice
+ * (production traffic is well below thousands of webhook calls / 24h).
+ */
+function prune(): void {
+  const cutoff = Date.now() - WINDOW_MS;
+  while (calls.length > 0 && calls[0].at < cutoff) {
+    calls.shift();
+  }
+}
+
+/**
+ * Called by the webhook handler exactly once per inbound POST,
+ * regardless of action / event type. `authenticated` reflects the final
+ * signature-verified flag — true iff the request matched some
+ * configured secret (App webhook secret OR a per-integration PAT
+ * webhook secret).
+ */
+export function recordWebhookCall(authenticated: boolean): void {
+  calls.push({ at: Date.now(), ok: authenticated });
+  prune();
+}
+
+/**
+ * Daily scheduler entry-point. Reads the 24h counter, decides the push
+ * state (up / down / skip), and fires a single Kuma heartbeat. No-op
+ * when the URL env var is unset, so deploying without the monitor
+ * costs nothing.
+ *
+ * Returns `void` — the helper swallows its own fetch errors and we
+ * never want a heartbeat hiccup to escape into the scheduler.
+ */
+export async function runWebhookAuthCheck(): Promise<void> {
+  prune();
+  const url = process.env.KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL;
+  if (!url) return;
+
+  const total = calls.length;
+  const ok = calls.reduce((n, c) => n + (c.ok ? 1 : 0), 0);
+
+  if (total < MIN_THRESHOLD) {
+    // Too few samples to draw a conclusion. We deliberately also skip
+    // the `received==0` case here — that's a different failure mode
+    // (webhook URL not configured on the GH side at all) and lumping
+    // it into this alarm would page operators on every fresh deploy.
+    return;
+  }
+
+  if (ok === 0) {
+    await pushKumaHeartbeat(
+      url,
+      'down',
+      `webhook_auth_failed:received_${total}_authenticated_0`,
+      '[webhook-auth-check] down',
+    );
+  } else {
+    await pushKumaHeartbeat(
+      url,
+      'up',
+      `webhook_auth_ok:received_${total}_authenticated_${ok}`,
+      '[webhook-auth-check] up',
+    );
+  }
+}
+
+// ── Test hooks ───────────────────────────────────────────────────
+// Exported with underscore prefixes to flag "internal — only call from
+// tests". The vitest suite for this module needs to reset between
+// cases and assert what landed in the buffer; nothing in production
+// code should ever touch these.
+
+/** Clear the rolling buffer. Test-only. */
+export function _resetForTests(): void {
+  calls.length = 0;
+}
+
+/** Snapshot the current buffer (defensive copy). Test-only. */
+export function _getCallsForTests(): ReadonlyArray<CallRecord> {
+  return [...calls];
+}
+
+/** Expose constants so tests can assert on the floor without hard-coding. */
+export const _MIN_THRESHOLD_FOR_TESTS = MIN_THRESHOLD;
+export const _WINDOW_MS_FOR_TESTS = WINDOW_MS;


### PR DESCRIPTION
## Summary

Closes #74. Detects a silent realtime-sync failure: when GitHub's
webhook secret rotates and mindblown's copy goes stale, every webhook
POST fails signature verification, the handler returns 401, and the
5-min catchup loop silently papers over the gap. Drift stays at 0,
nothing else alarms, the operator never finds out.

This adds a 24h rolling counter of `(webhook_calls_received,
webhook_calls_authenticated)` and a daily Kuma push:

- `received >= 3 AND authenticated == 0` →
  `status=down msg=webhook_auth_failed:received_N_authenticated_0`
  (the bad-secret case)
- `received >= 3 AND authenticated >= 1` →
  `status=up msg=webhook_auth_ok:received_N_authenticated_M`
- `received < 3` → no push (false-alarm guard; also covers the
  distinct "GH webhook never configured at all" mode the brief
  scoped out)

The MIN_THRESHOLD=3 floor is the anti-punt clause: without it, a
single transient bad-sig blip on a quiet day would page the operator.

## Design notes

- New module `packages/server/src/sync/webhookAuthCheck.ts` —
  isolates the counter + check logic so vitest can exercise it
  without spinning up Fastify.
- Webhook handler in `routes/integrations.ts` calls
  `recordWebhookCall(signatureVerified)` BEFORE the 401 short-circuit
  so failing calls are counted.
- Module-level state — same single-process precedent as the catchup
  loop in #75. Documented inline.
- New env var `KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL` (unset = silent
  no-op; deploy-safe default).
- `WEBHOOK_AUTH_CHECK_INTERVAL_MS` env override for post-deploy
  smoke tests — same convention the canary uses.

## Operator runbook

`deploy/README.md` gets:
- New env var in the example `api.env`.
- New "Webhook auth" bullet in the "Why N monitors" section
  explaining what failure mode this catches that the existing
  three monitors don't.
- New "webhook auth" row in the Kuma thresholds table (60 s push,
  30 h down threshold matching the daily cadence).
- New "Triage `webhook_auth_failed` alerts" subsection walking
  through diagnosis + fix + verify.

## Test plan

- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w build` — clean
- [x] `pnpm -w test` — 193 passed (192 existing + 11 new)
- [x] New vitest covers the 6 acceptance scenarios in the brief +
  threshold-boundary (exactly MIN) + empty-string URL + pruning
- [ ] Post-merge: rotate the GH webhook secret without updating
  mindblown's `GITHUB_APP_WEBHOOK_SECRET`. Within 24h (or sooner
  with `WEBHOOK_AUTH_CHECK_INTERVAL_MS=60000`) the Kuma monitor
  fires `webhook_auth_failed:received_N_authenticated_0`.
- [ ] Post-merge: fix the secret; next daily check flips
  `status=up`; Kuma recovers.