### PR TITLE
feat(sync): drift audit cadence env-configurable (default 6h) (closes #72)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -111,8 +111,8 @@ NODE_ENV=production
 # MAIL_FROM=MindBlown <noreply@example.com>
 
 # Optional — Uptime-Kuma push URLs for GitHub-sync observability.
-# Without these, the API still runs the catchup loop + daily drift
-# audit, but silent failures have no external alarm. See below.
+# Without these, the API still runs the catchup loop + drift audit,
+# but silent failures have no external alarm. See below.
 # KUMA_GITHUB_CATCHUP_PUSH_URL=https://kuma.example.com/api/push/<token>
 # KUMA_GITHUB_DRIFT_PUSH_URL=https://kuma.example.com/api/push/<token>
 # KUMA_GITHUB_AUTH_FAILURE_PUSH_URL=https://kuma.example.com/api/push/<token>
@@ -128,7 +128,17 @@ NODE_ENV=production
 # "Pushover canary" section below for the full operator runbook.
 # KUMA_ALARM_CANARY_PUSH_URL=https://kuma.example.com/api/push/<token>
 
-# Optional — cap on the number of drift nodes the daily audit will
+# Optional — drift-audit cadence in milliseconds. Default 21600000
+# (6h). Minimum 3600000 (1h) — values below the minimum (incl. zero
+# or non-numeric) are rejected with a console warning and the default
+# is used. Tighter intervals shrink alarm-to-detect latency but
+# multiply GitHub API calls (one list-issues per opted-in map per
+# tick); the 1h floor protects against env-var typos turning the
+# audit into a rate-limit grinder. See the "GitHub-sync observability"
+# section below for the full rationale.
+# DRIFT_AUDIT_INTERVAL_MS=21600000
+
+# Optional — cap on the number of drift nodes the audit will
 # auto-backfill PER MAP per tick. Drift over this cap is left in
 # place so the Kuma alarm escalates to a human. Set to 0 to disable
 # auto-backfill entirely (audit still runs + alarms). Default: 50.
@@ -238,10 +248,12 @@ section is optional — but strongly recommended in production.
   scheduler dead, mindblown-api crashed, network broken, etc.
 
 - **Drift audit (`KUMA_GITHUB_DRIFT_PUSH_URL`)** — pushed once per
-  day. Pushes `status=down` if any opted-in map has open GitHub issues
-  with no linked MindBlown node. Alarms when push is `down` OR pushes
-  stop entirely = webhook silently misconfigured on the GH side, the
-  ingest path is silently throwing, etc.
+  drift-audit tick (every 6h by default; configurable via
+  `DRIFT_AUDIT_INTERVAL_MS`, minimum 1h). Pushes `status=down` if any
+  opted-in map has open GitHub issues with no linked MindBlown node.
+  Alarms when push is `down` OR pushes stop entirely = webhook
+  silently misconfigured on the GH side, the ingest path is silently
+  throwing, etc.
 
 - **Auth failure (`KUMA_GITHUB_AUTH_FAILURE_PUSH_URL`)** — pushed only
   when a specific repo has hit `CATCHUP_AUTH_FAILURE_THRESHOLD`
@@ -268,12 +280,12 @@ section is optional — but strongly recommended in production.
 | Monitor | Heartbeat interval | "Down" threshold | Notes |
 |---|---|---|---|
 | catchup heartbeat | 60 s | 10 min | API pushes every 5 min — 10 min absorbs one missed tick (restart/upgrade) without false-alarming. |
-| drift audit | 60 s | 30 h | API pushes daily — 30 h gives 6 h of slack for restart timing, clock drift, etc. |
+| drift audit | 60 s | 8 h | API pushes every 6 h by default — 8 h gives 2 h of slack for restart timing, clock drift, etc. If you raise `DRIFT_AUDIT_INTERVAL_MS`, raise the down threshold to `interval + 2h` to match. |
 | auth failure | 60 s | 20 min | API pushes only on the threshold-crossing tick + every subsequent failing tick; 20 min covers two consecutive 5-min catchup ticks so a single delayed Kuma push doesn't flap the monitor. |
 
 ### Auto-backfill on drift detection
 
-When the daily audit finds drift, the API attempts to self-heal by
+When the drift audit finds drift, the API attempts to self-heal by
 calling the same code path as the manual "Backfill" button in the UI
 for each drifted map. The cap is per-map per audit tick:
 
@@ -324,10 +336,48 @@ The READY ping is sent once Fastify has bound the port; without it,
 `Type=notify` would leave `systemctl start` blocked forever waiting
 for ready notification.
 
+### Tuning the drift-audit cadence
+
+The drift audit runs every **6 hours** by default. Override via
+`DRIFT_AUDIT_INTERVAL_MS` in `/etc/mindblown/api.env` (value in
+milliseconds, minimum `3600000` = 1 hour):
+
+```bash
+# Every 4 hours
+DRIFT_AUDIT_INTERVAL_MS=14400000
+
+# Every 6 hours (the default — equivalent to leaving it unset)
+DRIFT_AUDIT_INTERVAL_MS=21600000
+
+# Every 12 hours (lighter on GitHub API at large scale, longer
+# alarm-to-detect latency)
+DRIFT_AUDIT_INTERVAL_MS=43200000
+```
+
+Then `systemctl restart mindblown-api`.
+
+**Rationale.** The audit was previously hardcoded to 24h; a drift
+incident that started at 09:00 could wait until 08:59 the next day
+before alarming. Dropping to 6h caps that latency at 6h max and only
+4× the GitHub API spend (still one `list-issues` call per opted-in
+map per tick — negligible at single-digit map counts).
+
+**Floor.** Values below `3600000` (1h) — including `0`, a typo like
+`6h`, and any non-numeric string — are rejected with a console
+warning and the 6h default is used instead. The floor exists because
+`setInterval(0)` would hammer the GitHub API at the event-loop rate,
+and the same map fetched a hundred times a second would tank both
+the audit's own rate-limit budget and any other GitHub-touching code
+in the API.
+
+**If you raise the interval**, also raise the Kuma down-threshold on
+the drift-audit monitor (interval + ~2h slack for restart timing,
+clock drift) so a single missed tick doesn't false-alarm.
+
 ### Manual trigger
 
-For ops testing without waiting 24h for the next scheduled drift
-audit, hit the manual endpoint as a logged-in user:
+For ops testing without waiting up to 6h for the next scheduled
+drift audit, hit the manual endpoint as a logged-in user:
 
 ```bash
 curl -sf -X POST https://mindblown.example.com/api/maps/sync/audit-drift \

--- a/packages/server/src/__tests__/driftAuditInterval.test.ts
+++ b/packages/server/src/__tests__/driftAuditInterval.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for `resolveDriftAuditIntervalMs` (closes #72).
+ *
+ * The helper resolves the drift-audit cadence from an optional
+ * `DRIFT_AUDIT_INTERVAL_MS` env-var string. Five invariants:
+ *
+ *   1. Unset (undefined)                 → default 6h, no warn
+ *   2. Valid integer ≥ MIN (e.g. 6h)     → used as-is, no warn
+ *   3. Below MIN (e.g. 60_000 = 1 min)   → fall back to default + warn
+ *   4. Non-numeric / NaN (e.g. "6h")     → fall back to default + warn
+ *   5. Zero                              → fall back to default + warn
+ *
+ * The min-interval guard is critical: without it, an env-var typo
+ * could turn setInterval into a busy-loop hammering the GitHub API
+ * across every opted-in map (see deploy/README.md "Tuning the
+ * drift-audit cadence" for the rationale).
+ *
+ * The helper is a pure function exported from `index.ts` purely so
+ * this test can verify it without booting Fastify. The production
+ * call site reads `process.env.DRIFT_AUDIT_INTERVAL_MS` directly
+ * during `main()`; we exercise the same resolution logic here by
+ * passing strings directly, which is functionally equivalent and
+ * avoids env-var teardown noise.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  DEFAULT_DRIFT_AUDIT_INTERVAL_MS,
+  MIN_DRIFT_AUDIT_INTERVAL_MS,
+  resolveDriftAuditIntervalMs,
+} from '../sync/driftAuditInterval.js';
+
+describe('resolveDriftAuditIntervalMs', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns the 6h default when the env var is unset', () => {
+    const result = resolveDriftAuditIntervalMs(undefined);
+    expect(result).toBe(DEFAULT_DRIFT_AUDIT_INTERVAL_MS);
+    expect(result).toBe(6 * 60 * 60 * 1000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses the override when the env var is a valid integer ≥ MIN', () => {
+    // 4h — above the 1h floor, below the 6h default.
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+    const result = resolveDriftAuditIntervalMs(String(fourHoursMs));
+    expect(result).toBe(fourHoursMs);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses the override at the MIN boundary exactly', () => {
+    // 1h exactly — the floor, must be accepted (≥, not >).
+    const result = resolveDriftAuditIntervalMs(
+      String(MIN_DRIFT_AUDIT_INTERVAL_MS),
+    );
+    expect(result).toBe(MIN_DRIFT_AUDIT_INTERVAL_MS);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to default and warns when the value is below MIN', () => {
+    // 1 min — well below the 1h floor.
+    const result = resolveDriftAuditIntervalMs('60000');
+    expect(result).toBe(DEFAULT_DRIFT_AUDIT_INTERVAL_MS);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnText = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warnText).toContain('DRIFT_AUDIT_INTERVAL_MS=60000');
+    expect(warnText).toContain('invalid');
+    expect(warnText).toContain(String(DEFAULT_DRIFT_AUDIT_INTERVAL_MS));
+  });
+
+  it('falls back to default and warns on a non-numeric value (NaN guard)', () => {
+    // `parseInt("6h", 10)` returns 6 — fails the MIN check, NOT NaN.
+    // But `parseInt("not-a-number", 10)` returns NaN.  Both must
+    // fall back — exercise the genuinely-NaN path here.
+    const result = resolveDriftAuditIntervalMs('not-a-number');
+    expect(result).toBe(DEFAULT_DRIFT_AUDIT_INTERVAL_MS);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnText = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warnText).toContain('DRIFT_AUDIT_INTERVAL_MS=not-a-number');
+    expect(warnText).toContain('invalid');
+  });
+
+  it('falls back to default and warns on the "6h" typo (parseInt → 6, below MIN)', () => {
+    // The classic env-var typo the min guard exists to catch.
+    const result = resolveDriftAuditIntervalMs('6h');
+    expect(result).toBe(DEFAULT_DRIFT_AUDIT_INTERVAL_MS);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnText = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warnText).toContain('DRIFT_AUDIT_INTERVAL_MS=6h');
+  });
+
+  it('falls back to default and warns when the value is zero (DDoS guard)', () => {
+    // The single most dangerous typo: `setInterval(callback, 0)` is
+    // an event-loop-rate busy loop.  Must be rejected.
+    const result = resolveDriftAuditIntervalMs('0');
+    expect(result).toBe(DEFAULT_DRIFT_AUDIT_INTERVAL_MS);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnText = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warnText).toContain('DRIFT_AUDIT_INTERVAL_MS=0');
+    expect(warnText).toContain('invalid');
+  });
+
+  it('falls back to default and warns when the value is negative', () => {
+    const result = resolveDriftAuditIntervalMs('-1');
+    expect(result).toBe(DEFAULT_DRIFT_AUDIT_INTERVAL_MS);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes a 1h minimum constant', () => {
+    // Pin the documented contract so an accidental tightening (e.g.
+    // someone drops it to 60_000 "for testing") trips a test instead
+    // of shipping silently.
+    expect(MIN_DRIFT_AUDIT_INTERVAL_MS).toBe(60 * 60 * 1000);
+  });
+
+  it('exposes a 6h default constant', () => {
+    expect(DEFAULT_DRIFT_AUDIT_INTERVAL_MS).toBe(6 * 60 * 60 * 1000);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { seedIfEmpty } from './db/seed.js';
 import { snapshotAllMaps } from './lib/releaseSnapshots.js';
 import { runAllCatchups } from './sync/githubCatchup.js';
 import { runDriftAudit } from './sync/driftAudit.js';
+import { resolveDriftAuditIntervalMs } from './sync/driftAuditInterval.js';
 import { runCanary } from './sync/canary.js';
 import { sdNotifyReady } from './sync/sdNotify.js';
 import { authRoutes } from './auth.js';
@@ -171,16 +172,26 @@ async function main(): Promise<void> {
   runCatchup();
   setInterval(runCatchup, CATCHUP_INTERVAL_MS);
 
-  // ── Daily drift audit (GitHub→MindBlown reconciliation gate) ─
+  // ── Drift audit (GitHub→MindBlown reconciliation gate) ──────────
   // The webhook + catchup pair is good at "an event happened, did we
   // apply it?", but neither alarms when the event NEVER reached us —
   // bad webhook URL on the GH side, expired install token during the
   // catchup window, an ingest exception that dropped an issue. This
-  // sweep diffs open GitHub issues against linked nodes once a day,
-  // tries to auto-backfill any drift under the per-day cap, and pushes
-  // the result to a Kuma monitor. Drift left after auto-backfill → Kuma
-  // alarms via its normal channels (Pushover, etc.).
-  const DRIFT_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+  // sweep diffs open GitHub issues against linked nodes every 6 hours
+  // (configurable via DRIFT_AUDIT_INTERVAL_MS), tries to auto-backfill
+  // any drift under the per-day cap, and pushes the result to a Kuma
+  // monitor. Drift left after auto-backfill → Kuma alarms via its
+  // normal channels (Pushover, etc.).
+  //
+  // Cadence is 6h (down from a previous 24h hardcode, closes #72) so
+  // alarm-to-detect latency shrinks from a 24h max to a 6h max. Tighter
+  // intervals (sub-1h) are rejected: at 100+ opted-in maps the GitHub
+  // API rate-limit pressure starts to matter, and the floor protects
+  // against an env-var typo like `DRIFT_AUDIT_INTERVAL_MS=0` turning
+  // setInterval into a DDoS amplifier.
+  const DRIFT_AUDIT_INTERVAL_MS = resolveDriftAuditIntervalMs(
+    process.env.DRIFT_AUDIT_INTERVAL_MS,
+  );
   const driftAuditTick = async (): Promise<void> => {
     try {
       await runDriftAudit();

--- a/packages/server/src/sync/driftAuditInterval.ts
+++ b/packages/server/src/sync/driftAuditInterval.ts
@@ -1,0 +1,51 @@
+/**
+ * Drift-audit cadence resolver (closes #72).
+ *
+ * The drift audit was previously hardcoded to a 24-hour interval in
+ * `index.ts`, so a sync incident that started in the morning could
+ * wait up to 24 hours before the operator was alarmed. We now run
+ * every 6 hours by default, with an `DRIFT_AUDIT_INTERVAL_MS` env-var
+ * override for operators to dial up/down.
+ *
+ * Lives in its own module rather than inline in `index.ts` so the
+ * unit test can verify the parse/guard/fallback rules without
+ * importing `index.ts` itself — `index.ts` calls `main()` at module
+ * load time (binds the port, runs migrations), which is unsuitable
+ * for a pure unit-test surface.
+ *
+ * Resolution rules:
+ *
+ *   1. Unset env var          → DEFAULT (6h)
+ *   2. Valid integer ≥ MIN    → used as-is
+ *   3. NaN / non-numeric      → DEFAULT, with console.warn
+ *   4. Below MIN (incl. zero) → DEFAULT, with console.warn
+ *
+ * The min-interval guard is a sanity floor: an env-var typo like
+ * `DRIFT_AUDIT_INTERVAL_MS=0` would otherwise turn `setInterval` into
+ * a busy-loop hammering the GitHub API across every opted-in map.
+ * 1 hour is well below the operational target (6 h) but high enough
+ * that even a 100-map deployment stays under GitHub's rate limit
+ * comfortably.
+ */
+
+export const DEFAULT_DRIFT_AUDIT_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const MIN_DRIFT_AUDIT_INTERVAL_MS = 60 * 60 * 1000;
+
+export function resolveDriftAuditIntervalMs(
+  raw: string | undefined,
+): number {
+  if (raw === undefined) return DEFAULT_DRIFT_AUDIT_INTERVAL_MS;
+  const parsed = parseInt(raw, 10);
+  if (
+    Number.isFinite(parsed) &&
+    parsed >= MIN_DRIFT_AUDIT_INTERVAL_MS
+  ) {
+    return parsed;
+  }
+  console.warn(
+    `[drift-audit] DRIFT_AUDIT_INTERVAL_MS=${raw} invalid (must be an ` +
+      `integer ≥ ${MIN_DRIFT_AUDIT_INTERVAL_MS} ms), falling back to ` +
+      `${DEFAULT_DRIFT_AUDIT_INTERVAL_MS} ms`,
+  );
+  return DEFAULT_DRIFT_AUDIT_INTERVAL_MS;
+}


### PR DESCRIPTION
## Summary

`DRIFT_AUDIT_INTERVAL_MS` in `packages/server/src/index.ts` was hardcoded to 24h. A drift incident that started at 09:00 could wait until 08:59 the next day before the operator was alarmed. This PR drops the default to **6 hours** and exposes it as a `DRIFT_AUDIT_INTERVAL_MS` env-var override.

- **Default cadence: 6h** (down from 24h). Alarm-to-detect latency shrinks from 24h max to 6h max.
- **Override**: `DRIFT_AUDIT_INTERVAL_MS=<ms>` in `/etc/mindblown/api.env`. Documented in `deploy/README.md` with 4h/6h/12h examples.
- **1h minimum-interval guard.** Values below 1h — including `0`, `-1`, `not-a-number`, and the classic `6h` typo (`parseInt("6h", 10) === 6`) — are rejected with a `console.warn` and the 6h default is used instead. Without this guard, a typo like `DRIFT_AUDIT_INTERVAL_MS=0` would turn `setInterval` into a busy-loop hammering the GitHub API across every opted-in map.

## Implementation

- **New module** `packages/server/src/sync/driftAuditInterval.ts` — pure `resolveDriftAuditIntervalMs(raw)` helper + `DEFAULT_*` and `MIN_*` constants. Extracted so the unit test doesn't import `index.ts` (which calls `main()` at module-load time — binds the port, runs migrations — unsuitable for unit-test surfaces).
- **`packages/server/src/index.ts`** — drops the inline `24 * 60 * 60 * 1000` constant, calls the resolver. Comment updated with the new cadence + the rationale for the floor.
- **`deploy/README.md`** — env-var entry added to the `api.env` template, new "Tuning the drift-audit cadence" subsection with 4h/6h/12h examples, Kuma down-threshold guidance updated (8h instead of 30h, with a note to bump alongside any cadence raise), references to "daily audit" / "24h" updated throughout.

## Test plan

- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w build` — clean
- [x] `pnpm -w test` — 192 server tests pass (10 new in `__tests__/driftAuditInterval.test.ts`)
- [x] New tests cover: (1) unset → default, (2) valid override ≥ MIN, (3) MIN boundary exactly, (4) below MIN → fallback + warn, (5) NaN / non-numeric → fallback + warn, (6) `"6h"` typo → fallback + warn, (7) zero → fallback + warn, (8) negative → fallback + warn, (9-10) pin-the-constant checks for `MIN` + `DEFAULT`
- [ ] Post-deploy persona test:
  1. Unset `DRIFT_AUDIT_INTERVAL_MS` → first tick fires 6h after restart.
  2. `DRIFT_AUDIT_INTERVAL_MS=21600000` (6h) → same as above (default match).
  3. `DRIFT_AUDIT_INTERVAL_MS=invalid` → `journalctl -u mindblown-api` shows the `[drift-audit] ... invalid ... falling back to 21600000 ms` warning.
  4. `DRIFT_AUDIT_INTERVAL_MS=60000` (1 min, below MIN) → same warn, 6h default used.

## Anti-punt notes

The minimum-interval guard is in place and tested. NaN, zero, "6h"-style typos, and negative values all route through the same fallback + warn path. If you bump `DRIFT_AUDIT_INTERVAL_MS` up (e.g. 12h at 100+ maps), also bump the Kuma drift-audit down-threshold to `interval + ~2h` so a single missed tick doesn't false-alarm — `deploy/README.md` calls this out explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)