### PR TITLE
fix: address Ray review follow-ups (#85, #86, #87)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -238,11 +238,11 @@ The API runs migrations on every startup, so schema changes apply automatically.
 
 ## GitHub-sync observability (Uptime-Kuma push monitors)
 
-The API exposes two passive heartbeats for the GitHub→MindBlown sync
-loop. Both are no-ops unless the corresponding env var is set, so this
+The API exposes four passive heartbeats for the GitHub→MindBlown sync
+loop. Each is a no-op unless the corresponding env var is set, so this
 section is optional — but strongly recommended in production.
 
-### Why three monitors
+### Why four monitors
 
 - **Catchup heartbeat (`KUMA_GITHUB_CATCHUP_PUSH_URL`)** — pushed once
   per catchup tick (every 5 min). Alarms when pushes stop = catchup
@@ -289,9 +289,12 @@ section is optional — but strongly recommended in production.
    interval — see suggested thresholds below.
 3. Save. Kuma generates a push URL like
    `https://kuma.example.com/api/push/abc123XYZ`.
-4. Repeat for the drift-audit monitor.
+4. Repeat for the drift-audit, auth-failure, and webhook-auth monitors
+   (four monitors total — one per env var below).
 5. Wire each push URL into `/etc/mindblown/api.env` (uncomment the
-   relevant `KUMA_GITHUB_*` / `KUMA_WEBHOOK_*` lines) and
+   `KUMA_GITHUB_CATCHUP_PUSH_URL`, `KUMA_GITHUB_DRIFT_PUSH_URL`,
+   `KUMA_GITHUB_AUTH_FAILURE_PUSH_URL`, and
+   `KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL` lines) and
    `systemctl restart mindblown-api`.
 
 ### Suggested Kuma thresholds
@@ -353,6 +356,11 @@ nothing is broken". Triage:
 1. Verify the alarm is real — hit `journalctl -u mindblown-api | grep "invalid signature"`
    to see the rejected POSTs. Each line carries the GH event type and
    the source IP; the IP should match GitHub's published webhook ranges.
+   **DoS check:** if `received_N` is unexpectedly large (orders of
+   magnitude beyond your normal webhook volume), grep the source IPs
+   against GitHub's published [hooks ranges](https://api.github.com/meta) —
+   non-GH traffic hitting the webhook endpoint should be rate-limited
+   at the ingress (Caddy / load balancer), not papered over here.
 2. Check whether the secret was rotated on the GitHub side. For a
    GitHub App: **App settings → Webhook → "Generate new secret"**
    history. For a per-integration PAT: ask whoever set it up most
@@ -367,7 +375,12 @@ nothing is broken". Triage:
    to `up`. To verify the fix faster, override the cadence:
    `WEBHOOK_AUTH_CHECK_INTERVAL_MS=60000` in `api.env`, restart, and
    the next successful webhook delivery + tick will push `status=up`.
-   Remove the override afterwards.
+   To verify the alarm actually fires end-to-end, send ≥ 3 deliveries
+   with the WRONG secret first (e.g. trigger 3 issue events from a
+   test repo while the secret is intentionally stale), then wait for
+   one tick — Kuma should flip `down`, fire its notification, then
+   flip `up` once correct deliveries land and the rolling window
+   refreshes. Remove the override afterwards.
 
 If no webhook traffic has landed yet (received < 3), the monitor sits
 in "no push received" — that's normal and Kuma should NOT alarm on a
@@ -437,11 +450,13 @@ curl -sf -X POST https://mindblown.example.com/api/maps/sync/audit-drift \
   -H "Cookie: <session cookie from your browser>" | jq .
 ```
 
-Returns `{reports: DriftReport[], autoBackfill: {...}, counts: {...}}`.
-The manual trigger runs the same auto-backfill + Kuma push the
-scheduled audit does, so it's a faithful end-to-end smoke test of the
-auto-repair flow. API-key auth is deliberately rejected — this is a
-session-only operator surface.
+Returns `{reports: DriftReport[], tokenErrors: TokenError[], autoBackfill: {...}, counts: {...}}`.
+`tokenErrors` lists every map whose GitHub binding couldn't resolve
+a current token (App install revoked, PAT expired, or no binding at
+all — see `reason` field for the cause). The manual trigger runs the
+same auto-backfill + Kuma push the scheduled audit does, so it's a
+faithful end-to-end smoke test of the auto-repair flow. API-key auth
+is deliberately rejected — this is a session-only operator surface.
 
 ## Pushover canary (weekly alarm-chain liveness probe)
 
@@ -465,11 +480,17 @@ surfaces within a week instead of during the next real incident.
 1. **Add New Monitor** → **Push**.
 2. Name: `mindblown-alarm-canary`.
 3. Heartbeat interval: 60 s.
-4. **Down threshold: 90 s.** This is the critical bit — short enough
-   that the synthetic `status=down` trips Kuma's alarm channel before
-   the ack push lands 60 s later, so the monitor briefly flips to
-   `down`, fires its notification, then recovers when the ack
-   arrives.
+4. **Down threshold: 90 s.** Kuma flips a push monitor to `down`
+   *immediately* on receipt of `status=down` (and fires its
+   notification right then), independent of the missed-heartbeat
+   threshold — so the canary alarm trips as soon as the synthetic
+   down push lands, not after 90 s. The 90 s threshold is the
+   *liveness* signal: it catches a dead canary (mindblown-api
+   crashed, scheduler frozen) at the next missed weekly tick — Kuma
+   alarms on "no push received within 90 s" once the heartbeat
+   timeout passes. So the 90 s value is a safety floor for missed
+   ticks, not a race-condition control between the down and ack
+   pushes.
 5. Save. Copy the generated push URL.
 
 ### 2. Route to a dedicated Pushover device (recommended)

--- a/packages/integrations/src/github-app.ts
+++ b/packages/integrations/src/github-app.ts
@@ -5,6 +5,8 @@
  * and repo listing — all via native fetch + jsonwebtoken. No @octokit deps.
  */
 
+import { GitHubApiError } from './github.js';
+
 // ── Types ─────────────────────────────────────────────────────────
 
 export interface GitHubAppConfig {
@@ -132,6 +134,16 @@ const _tokenCache = new Map<string, InstallationToken>();
  * Get an installation access token (cached, ~50 min TTL).
  * These are short-lived tokens that let us act as the installed App
  * on specific repos.
+ *
+ * On a 401 or 404 we throw `GitHubApiError` so the catchup loop's
+ * consecutive-auth-failure escalation (githubCatchup.ts) can branch on
+ * `err instanceof GitHubApiError && err.status === 401` for both the
+ * fetch-401 path AND the mint-401 path (App suspended / installation
+ * revoked). Other statuses still throw a plain `Error` — those are
+ * transient (5xx / 502) and shouldn't pin the auth-failure counter.
+ *
+ * The error message format is preserved verbatim for log/backcompat
+ * reasons; only the throw class changes.
  */
 export async function mintInstallationToken(installationId: string): Promise<string> {
   const cached = _tokenCache.get(installationId);
@@ -155,6 +167,15 @@ export async function mintInstallationToken(installationId: string): Promise<str
 
   if (!res.ok) {
     const body = await res.text();
+    if (res.status === 401 || res.status === 404) {
+      // `GitHubApiError`'s constructor formats the message as
+      // `GitHub API <status>: <body>`, which slots into the catchup
+      // token-resolution catch the same way a fetch-401 from `github.ts`
+      // does — both flow through the same `err.message` path in logs.
+      // Other statuses (5xx, etc.) stay as plain Error: those are
+      // transient, the auth-failure counter shouldn't tick on them.
+      throw new GitHubApiError(res.status, body);
+    }
     throw new Error(`Failed to mint installation token: ${res.status} ${body}`);
   }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,7 @@ import { snapshotAllMaps } from './lib/releaseSnapshots.js';
 import { runAllCatchups } from './sync/githubCatchup.js';
 import { runDriftAudit } from './sync/driftAudit.js';
 import { resolveDriftAuditIntervalMs } from './sync/driftAuditInterval.js';
+import { parsePositiveIntMs } from './sync/parseInterval.js';
 import { runCanary } from './sync/canary.js';
 import { runWebhookAuthCheck } from './sync/webhookAuthCheck.js';
 import { sdNotifyReady } from './sync/sdNotify.js';
@@ -221,9 +222,14 @@ async function main(): Promise<void> {
   // the cadence down for a one-off post-deploy smoke test, then put
   // it back to weekly afterwards. Deliberately no startup invocation
   // — we don't want a Pushover on every restart/upgrade.
-  const CANARY_INTERVAL_MS = parseInt(
-    process.env.CANARY_INTERVAL_MS ?? `${7 * 24 * 60 * 60 * 1000}`,
-    10,
+  //
+  // Parsed via `parsePositiveIntMs` so a typo like `CANARY_INTERVAL_MS=1d`
+  // (which `parseInt` would NaN-coerce, turning `setInterval(NaN)` into
+  // event-loop-rate firing) falls back to the weekly default instead of
+  // DDOS-ing Kuma + Pushover.
+  const CANARY_INTERVAL_MS = parsePositiveIntMs(
+    process.env.CANARY_INTERVAL_MS,
+    7 * 24 * 60 * 60 * 1000,
   );
   const canaryTick = async (): Promise<void> => {
     try {
@@ -252,9 +258,11 @@ async function main(): Promise<void> {
   // as the other Kuma probes above. Allow WEBHOOK_AUTH_CHECK_INTERVAL_MS
   // env-var override so operators can dial the cadence down for a
   // one-off post-deploy smoke test, same convention the canary uses.
-  const WEBHOOK_AUTH_CHECK_INTERVAL_MS = parseInt(
-    process.env.WEBHOOK_AUTH_CHECK_INTERVAL_MS ?? `${24 * 60 * 60 * 1000}`,
-    10,
+  // Same NaN-guard rationale as `CANARY_INTERVAL_MS` — a typo'd value
+  // here would otherwise put `setInterval` into event-loop-rate firing.
+  const WEBHOOK_AUTH_CHECK_INTERVAL_MS = parsePositiveIntMs(
+    process.env.WEBHOOK_AUTH_CHECK_INTERVAL_MS,
+    24 * 60 * 60 * 1000,
   );
   const webhookAuthCheckTick = async (): Promise<void> => {
     try {

--- a/packages/server/src/sync/__tests__/canary.test.ts
+++ b/packages/server/src/sync/__tests__/canary.test.ts
@@ -29,15 +29,27 @@ const { runCanary } = await import('../canary.js');
 
 describe('runCanary', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
+  // Save + clear `KUMA_ALARM_CANARY_PUSH_URL` for the whole describe so
+  // a dev who exported it for a real smoke test (`KUMA_ALARM_CANARY_PUSH_URL=…
+  // pnpm test`) doesn't see test 1 fail with a confusing error — the
+  // "URL is undefined" case silently depended on the env var being unset.
+  let originalCanaryUrl: string | undefined;
 
   beforeEach(() => {
     pushKumaHeartbeatMock.mockReset();
     pushKumaHeartbeatMock.mockResolvedValue(undefined);
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    originalCanaryUrl = process.env.KUMA_ALARM_CANARY_PUSH_URL;
+    delete process.env.KUMA_ALARM_CANARY_PUSH_URL;
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
+    if (originalCanaryUrl === undefined) {
+      delete process.env.KUMA_ALARM_CANARY_PUSH_URL;
+    } else {
+      process.env.KUMA_ALARM_CANARY_PUSH_URL = originalCanaryUrl;
+    }
   });
 
   it('does NOT call pushKumaHeartbeat when the URL is undefined', async () => {

--- a/packages/server/src/sync/__tests__/driftAudit.test.ts
+++ b/packages/server/src/sync/__tests__/driftAudit.test.ts
@@ -546,6 +546,37 @@ describe('auditDrift', () => {
     expect(tokenErrors[0].reason).toBe('app: install revoked');
   });
 
+  it('reports a `pat: missing` tokenError when a map has no installationId AND no matching PAT (#87)', async () => {
+    // Pre-#87, this case silently dropped the map: no installationId
+    // skipped the App-mint branch entirely; no matching PAT skipped
+    // the targets.push; nothing ever made it into either `targets`
+    // OR `tokenErrors`. The docstring on `auditDrift` says tokenErrors
+    // lists "every map whose binding couldn't resolve a current token"
+    // — make that true.
+    dbState.maps.push({
+      id: 'm1',
+      name: 'Unbound Map',
+      workspaceId: 'ws',
+      githubInstallationId: null,
+      githubRepoOwner: 'owner',
+      githubRepoName: 'repo',
+      autoImportNewIssues: true,
+    });
+    // No PAT integration matches.
+    // Even though issues exist on the repo, no fetch happens.
+    setupRepoIssues('owner', 'repo', [1, 2, 3]);
+
+    const { reports, tokenErrors } = await auditDrift();
+
+    expect(reports).toEqual([]);
+    expect(tokenErrors).toHaveLength(1);
+    expect(tokenErrors[0]).toEqual({
+      mapId: 'm1',
+      mapName: 'Unbound Map',
+      reason: 'pat: missing',
+    });
+  });
+
   it('preserves the raw error message in tokenError.reason for non-revocation failures', async () => {
     // Defensive: the resolver stringifies arbitrary errors into
     // `reason`. Make sure a non-"install revoked" message threads

--- a/packages/server/src/sync/__tests__/githubCatchup.test.ts
+++ b/packages/server/src/sync/__tests__/githubCatchup.test.ts
@@ -486,3 +486,109 @@ describe('reconcileRepo → 401 auth-failure escalation (#75)', () => {
     expect(_getAuthFailureCountForTests('o/r')).toBe(0);
   });
 });
+
+// ── 401-escalation tests for token-resolution path (#86) ─────────
+//
+// Scenario: `resolveToken` (i.e. `mintInstallationToken`) throws a
+// `GitHubApiError(401)` because the GitHub App install was suspended
+// or uninstalled. Without #86's parallel branch, that error fell into
+// the generic token-resolution catch and returned `error: token: ...`
+// without ticking the consecutive-failure counter — so a permanently
+// suspended install never escalated to the dedicated Kuma alarm.
+//
+// These three cases assert the new branch mirrors the fetch-401 path:
+// 3 consecutive 401s push, one 401 then success resets, plain Error
+// stays on the legacy "no counter" path (backcompat).
+
+function makeMintFailingTarget(
+  owner: string,
+  repo: string,
+  err: Error,
+): { owner: string; repo: string; resolveToken: () => Promise<string> } {
+  return {
+    owner,
+    repo,
+    resolveToken: async (): Promise<string> => {
+      throw err;
+    },
+  };
+}
+
+describe('reconcileRepo → 401 auth-failure escalation, token-resolution path (#86)', () => {
+  beforeEach(() => {
+    _resetAuthFailureCountersForTests();
+    pushKumaMock.mockReset();
+    pushKumaMock.mockResolvedValue(undefined);
+    fetchChangedIssuesMock.mockReset();
+    // Successful fetch by default — these tests are exercising the
+    // mint-side failure path, fetch never runs.
+    fetchChangedIssuesMock.mockResolvedValue([]);
+    delete process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL;
+    delete process.env.CATCHUP_AUTH_FAILURE_THRESHOLD;
+  });
+
+  afterEach(() => {
+    _resetAuthFailureCountersForTests();
+    delete process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL;
+    delete process.env.CATCHUP_AUTH_FAILURE_THRESHOLD;
+  });
+
+  it('pushes status=down on the third consecutive mint 401 (App suspended)', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    const mintErr = new MockGitHubApiError(401, 'Bad credentials');
+
+    const result1 = await reconcileRepo(makeMintFailingTarget('o', 'r', mintErr));
+    const result2 = await reconcileRepo(makeMintFailingTarget('o', 'r', mintErr));
+    const result3 = await reconcileRepo(makeMintFailingTarget('o', 'r', mintErr));
+
+    // Each return carries the token-resolution failure shape, not fetch-error shape.
+    expect(result1.error).toMatch(/^token: /);
+    expect(result2.error).toMatch(/^token: /);
+    expect(result3.error).toMatch(/^token: /);
+
+    // Counter ticks on every 401, pushes on the threshold-crossing tick.
+    expect(_getAuthFailureCountForTests('o/r')).toBe(3);
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('down');
+    expect(msg).toBe('auth_failed:o/r');
+  });
+
+  it('resets the counter to 0 on a successful mint after one failure', async () => {
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    const mintErr = new MockGitHubApiError(401, 'Bad credentials');
+
+    // Tick 1: mint throws 401 → counter = 1.
+    await reconcileRepo(makeMintFailingTarget('o', 'r', mintErr));
+    expect(_getAuthFailureCountForTests('o/r')).toBe(1);
+
+    // Tick 2: mint succeeds → fetch runs (resolves []) → counter resets
+    // via the post-fetch `consecutiveAuthFailures.delete` call.
+    const okTarget = {
+      owner: 'o',
+      repo: 'r',
+      resolveToken: async (): Promise<string> => 'tok',
+    };
+    await reconcileRepo(okTarget);
+    expect(_getAuthFailureCountForTests('o/r')).toBe(0);
+
+    // No push fired at any point (never crossed the 3-default threshold).
+    expect(pushKumaMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT escalate when mint throws a plain (non-typed) Error', async () => {
+    // Backcompat: a generic `new Error('PAT lookup failed')` from the
+    // resolveToken closure must NOT tick the auth-failure counter —
+    // those are typically transient (DB blip, network) and shouldn't
+    // pin escalation. Only typed GitHubApiError(401) counts.
+    process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
+    const plainErr = new Error('PAT lookup failed');
+
+    for (let i = 0; i < 5; i++) {
+      await reconcileRepo(makeMintFailingTarget('o', 'r', plainErr));
+    }
+
+    expect(pushKumaMock).not.toHaveBeenCalled();
+    expect(_getAuthFailureCountForTests('o/r')).toBe(0);
+  });
+});

--- a/packages/server/src/sync/__tests__/parseInterval.test.ts
+++ b/packages/server/src/sync/__tests__/parseInterval.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for `parsePositiveIntMs` — the shared env-var → ms parser.
+ *
+ * The whole point of this helper is to prevent `setInterval(NaN)` from
+ * turning into event-loop-rate firing. The cases below pin every
+ * fallback path so a future refactor can't silently regress the guard.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { parsePositiveIntMs } from '../parseInterval.js';
+
+describe('parsePositiveIntMs', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns default when env value is undefined', () => {
+    expect(parsePositiveIntMs(undefined, 5000)).toBe(5000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns default when env value is empty string', () => {
+    expect(parsePositiveIntMs('', 5000)).toBe(5000);
+    // Empty string is the "unset" path — no warn fired (the operator
+    // didn't typo, they just didn't set the var).
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns parsed value when env value is a positive integer', () => {
+    expect(parsePositiveIntMs('60000', 5000)).toBe(60000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns default and warns on a trailing-unit typo like "1d"', () => {
+    // The motivating case from #85 — but with the actual JS semantics:
+    // `parseInt('1d', 10)` returns `1` (NOT NaN — parseInt stops at the
+    // first non-digit), so without the leading regex guard you'd end up
+    // with `setInterval(fn, 1)` firing every 1 ms. The strict regex
+    // gate catches it.
+    expect(parsePositiveIntMs('1d', 5000)).toBe(5000);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0].join(' ')).toContain('1d');
+  });
+
+  it('returns default and warns on a fully non-numeric value', () => {
+    expect(parsePositiveIntMs('abc', 5000)).toBe(5000);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns default and warns on zero', () => {
+    expect(parsePositiveIntMs('0', 5000)).toBe(5000);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns default and warns on a negative integer', () => {
+    expect(parsePositiveIntMs('-1000', 5000)).toBe(5000);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('honours `minMs` floor — returns default when below', () => {
+    expect(parsePositiveIntMs('500', 5000, 1000)).toBe(5000);
+    expect(warnSpy).toHaveBeenCalled();
+    const warnMsg = warnSpy.mock.calls[0].join(' ');
+    expect(warnMsg).toContain('1000');
+  });
+
+  it('honours `minMs` floor — returns value when at or above', () => {
+    expect(parsePositiveIntMs('1000', 5000, 1000)).toBe(1000);
+    expect(parsePositiveIntMs('2000', 5000, 1000)).toBe(2000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/sync/__tests__/runDriftAudit.test.ts
+++ b/packages/server/src/sync/__tests__/runDriftAudit.test.ts
@@ -358,4 +358,83 @@ describe('runDriftAudit', () => {
     expect(formatAutoBackfillMsg(summary(0, 5))).toBe('manual-5');
     expect(formatAutoBackfillMsg(summary(2, 5))).toBe('auto-backfilled-2,manual-5');
   });
+
+  // ── token-errors suffix coverage (#87) ──────────────────────────
+  // These cases pin the contract that token errors append a
+  // `,token-errors-N` suffix to the Kuma msg WITHOUT flipping status.
+  // The status-flip debate is filed as #87 item 5 for deferral.
+
+  it('no drift + token error → status=up msg=no-drift,token-errors-1', async () => {
+    // Build a map with installationId set but no PAT, so resolveTargets
+    // produces a tokenError via the (now-fixed) PAT-missing or
+    // App-mint-failed path. Easiest setup: pre-existing case where
+    // an App install token mint succeeds and the map audits cleanly,
+    // BUT a sibling map has no installationId and no PAT, so the
+    // resolver pushes a `pat: missing` tokenError for it.
+    setupDriftyMap('m1', 'Clean Map', 0);
+    // Sibling map: no installation, no matching PAT → tokenError.
+    dbState.maps.push({
+      id: 'm2',
+      name: 'Orphan Map',
+      workspaceId: 'wsX',
+      githubInstallationId: null,
+      githubRepoOwner: 'orphan-owner',
+      githubRepoName: 'orphan-repo',
+      autoImportNewIssues: true,
+    });
+    // m1 has no drift to audit; the m1 setup also wired importedByRepo
+    // for owner/repo with zero entries. m2 is dropped before any fetch
+    // because no token resolves.
+
+    const result = await runDriftAudit();
+
+    expect(runAutoBackfillMock).not.toHaveBeenCalled();
+    expect(pushKumaMock).toHaveBeenCalledTimes(1);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('up');
+    expect(msg).toBe('no-drift,token-errors-1');
+    expect(result.tokenErrors).toHaveLength(1);
+    expect(result.tokenErrors[0].reason).toBe('pat: missing');
+  });
+
+  it('drift-with-backfill + token error → suffix appended to backfill msg', async () => {
+    setupDriftyMap('m1', 'Drifty Map', 3);
+    runAutoBackfillMock.mockResolvedValue(summary(3, 0));
+    // Add a second orphaned map → 1 tokenError.
+    dbState.maps.push({
+      id: 'm2',
+      name: 'Orphan Map',
+      workspaceId: 'wsX',
+      githubInstallationId: null,
+      githubRepoOwner: 'orphan-owner',
+      githubRepoName: 'orphan-repo',
+      autoImportNewIssues: true,
+    });
+
+    await runDriftAudit();
+
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    // Status stays UP because backfill healed all drift — token errors
+    // don't flip status (see deferred-debate comment in driftAudit.ts).
+    expect(status).toBe('up');
+    expect(msg).toBe('auto-backfilled-3,token-errors-1');
+  });
+
+  it('audit_failed error-return path includes tokenErrors: [] in shape', async () => {
+    // Force the FIRST DB query (resolveTargets) to throw — auditDrift's
+    // outer catch in runDriftAudit fires, and the early-return shape
+    // MUST include `tokenErrors: []` (not undefined) so the operator
+    // endpoint's response shape stays consistent.
+    dbState.failureOnSelect = new Error('drizzle connection lost');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runDriftAudit();
+    errSpy.mockRestore();
+
+    expect(result.tokenErrors).toEqual([]);
+    expect(result.error).toMatch(/drizzle connection lost/);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('down');
+    expect(msg).toMatch(/^audit_failed:/);
+  });
 });

--- a/packages/server/src/sync/driftAudit.ts
+++ b/packages/server/src/sync/driftAudit.ts
@@ -66,10 +66,12 @@ interface AuditTarget {
  * One map whose token resolution failed. Surfaced in `AuditDriftResult`
  * so the operator endpoint can show the failure without log access.
  *
- * `reason` is a short stringified cause — typical values:
+ * `reason` is a short stringified cause — defined values:
  *   - `app: install revoked`       (App-token mint threw, no PAT fallback)
- *   - `app: <octokit message>`     (other App-token mint failure)
- *   - bare error message if no `app:` prefix applies
+ *   - `app: <error message>`       (other App-token mint failure)
+ *   - `pat: missing`               (map has no installationId AND no
+ *                                  workspace PAT for the bound repo —
+ *                                  closes the silent-drop gap from #87)
  */
 export interface TokenError {
   mapId: string;
@@ -162,6 +164,21 @@ async function resolveTargets(): Promise<ResolvedTargets> {
       const idx = tokenErrors.findIndex((te) => te.mapId === m.id);
       if (idx >= 0) tokenErrors.splice(idx, 1);
       targets.push({ mapId: m.id, mapName: m.name, owner: m.owner, repo: m.repo, token: cfg.token });
+    } else if (!m.installationId) {
+      // No App binding AND no matching PAT — this map silently fell
+      // off the end of the resolver pre-#87. The docstring on
+      // `auditDrift` claims `tokenErrors` lists "every map whose
+      // binding couldn't resolve a current token"; surface this case
+      // so that promise holds.
+      //
+      // Note: the App-binding-failed AND no-PAT case is already covered
+      // by the `app: ...` push in the try/catch above — we only need
+      // the no-App-at-all branch here.
+      tokenErrors.push({
+        mapId: m.id,
+        mapName: m.name,
+        reason: 'pat: missing',
+      });
     }
   }
 
@@ -347,6 +364,14 @@ export async function runDriftAudit(): Promise<DriftAuditRunResult> {
   // own (they can't be auto-healed and don't count as drift), but
   // appending the count lets a Kuma watcher catch persistent binding
   // outages even when drift is otherwise clean.
+  //
+  // Status-flip debate (deferred — see danielhaas/mindblown#87 item 5):
+  // a revoked App install is exactly the kind of failure operators want
+  // a Pushover ping for, since it can't self-heal. Flipping to `down`
+  // whenever `tokenErrors.length > 0` is a one-line change. Deferred
+  // until we have production data on whether operators actually miss
+  // token outages with the current suffix-only signal — turning it on
+  // now risks flapping new monitors before we know the baseline.
   const tokenSuffix = tokenErrors.length > 0 ? `,token-errors-${tokenErrors.length}` : '';
 
   // No drift → clean push and bail. Skip auto-backfill entirely

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -272,6 +272,23 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
   try {
     token = await target.resolveToken();
   } catch (err) {
+    // Mirror the fetch-401 escalation below (#83 follow-up, #86): a
+    // suspended/uninstalled GitHub App install throws at
+    // `mintInstallationToken`, NOT at `fetchChangedIssues`, so without
+    // this branch the consecutive-401 counter never ticked for the
+    // App-suspended failure mode. App-suspended is arguably the more
+    // common production failure on `mind.project.li`. Other token
+    // errors (PAT lookup throwing for non-401 reasons, etc.) stay on
+    // the "no counter bump" path — they're transient and shouldn't
+    // pin the escalation.
+    if (err instanceof GitHubApiError && err.status === 401) {
+      const next = (consecutiveAuthFailures.get(repoLabel) ?? 0) + 1;
+      consecutiveAuthFailures.set(repoLabel, next);
+      const threshold = getAuthFailureThreshold();
+      if (next >= threshold) {
+        await pushAuthFailureAlarm(repoLabel);
+      }
+    }
     return {
       repo: repoLabel,
       fetched: 0, applied: 0, skipped: 0, noTransition: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,

--- a/packages/server/src/sync/parseInterval.ts
+++ b/packages/server/src/sync/parseInterval.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared helper for parsing positive-integer millisecond intervals from
+ * env vars.
+ *
+ * Problem this exists for: `parseInt('1d', 10)` returns `1` (parseInt
+ * stops at the first non-digit, NOT NaN as you'd expect), and
+ * `parseInt('abc', 10)` returns `NaN`. Both feed `setInterval` something
+ * catastrophic — `setInterval(fn, 1)` fires every 1 ms, `setInterval(fn,
+ * NaN)` is treated as `setInterval(fn, 0)` and fires every event-loop
+ * tick. An operator who types `CANARY_INTERVAL_MS=1d` instead of a real
+ * millisecond count would accidentally DDOS Kuma + Pushover at sub-ms
+ * cadence.
+ *
+ * This helper guards against:
+ *   - Missing env var          → returns `defaultMs`
+ *   - Non-numeric / NaN parse  → returns `defaultMs`, with `console.warn`
+ *   - Trailing garbage (`1d`)  → returns `defaultMs`, with `console.warn`
+ *   - Zero or negative integer → returns `defaultMs`, with `console.warn`
+ *   - Integer below `minMs`    → returns `defaultMs`, with `console.warn`
+ *
+ * `minMs` is optional and defaults to `0` (no floor). Use it when an
+ * interval has a hard operational floor (e.g. the drift-audit cadence's
+ * 1h floor — see `driftAuditInterval.ts`, which has its own bespoke
+ * resolver for the same reason this helper exists).
+ *
+ * Returns `defaultMs` (not the typo'd value) so that even a misconfigured
+ * deployment ends up running on its intended cadence — visible only in
+ * the warn log, not as a functional outage.
+ */
+export function parsePositiveIntMs(
+  envValue: string | undefined,
+  defaultMs: number,
+  minMs = 0,
+): number {
+  if (!envValue) return defaultMs;
+  // Strict: the env string must be ONLY digits (with optional leading
+  // sign, but no trailing units). `parseInt('1d', 10)` is `1` — that's
+  // a sub-millisecond cadence, not "1 day", so we treat it as a typo.
+  // Use a regex match before parseInt to reject anything that isn't a
+  // pure integer literal.
+  if (!/^-?\d+$/.test(envValue.trim())) {
+    console.warn(
+      `[interval] ${envValue} invalid (must be a positive integer${minMs > 0 ? ` ≥ ${minMs}` : ''} ms), falling back to ${defaultMs}`,
+    );
+    return defaultMs;
+  }
+  const parsed = parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed < minMs) {
+    console.warn(
+      `[interval] ${envValue} invalid (must be a positive integer${minMs > 0 ? ` ≥ ${minMs}` : ''} ms), falling back to ${defaultMs}`,
+    );
+    return defaultMs;
+  }
+  return parsed;
+}


### PR DESCRIPTION
## Summary

Bundles the three Ray-review follow-ups from #82/#83/#84 into one PR.

### Closes #85 — canary NaN guard + README polish

- [x] New `parsePositiveIntMs` helper in `packages/server/src/sync/parseInterval.ts` (5+ test cases)
- [x] `CANARY_INTERVAL_MS` (index.ts) uses the helper
- [x] `WEBHOOK_AUTH_CHECK_INTERVAL_MS` (index.ts) uses the helper
- [x] README canary timing math corrected (Kuma fires on push receipt, not at the 90 s threshold; the 90 s value is a liveness floor for missed ticks)
- [x] `canary.test.ts` describe-level beforeEach now saves+clears `KUMA_ALARM_CANARY_PUSH_URL` so test 1 doesn't silently depend on the dev's shell
- [x] README webhook recovery flow now mentions sending ≥ 3 wrong-secret deliveries to verify the alarm fires
- [x] README webhook triage adds a DoS note (cross-ref GitHub's hook IP ranges + rate-limit at ingress)
- [x] Drift cadence resolver in `driftAuditInterval.ts` deliberately NOT migrated — would churn its 10 existing tests for no behavioural change
- [x] PORT parsing deliberately left as raw `parseInt` (per #85 item 1 — "crashes loudly anyway")

### Closes #86 — App-suspended escalation

- [x] `mintInstallationToken` throws `GitHubApiError` on 401/404 (`packages/integrations/src/github-app.ts`)
- [x] `githubCatchup.ts` adds parallel 401-branch in the token-resolution catch — mirrors the existing fetch-401 escalation
- [x] 3 new tests in `githubCatchup.test.ts`: 3 consecutive mint-401s push, one mint-401 then success resets, plain Error stays off the counter (backcompat)
- [x] README `deploy/README.md:226` — "two passive heartbeats" → "four"
- [x] README `deploy/README.md:250-252` — monitor-creation step names all four env vars explicitly

### Closes #87 — tokenErrors polish

- [x] `runDriftAudit.test.ts` — 3 new tests for the `,token-errors-N` suffix paths (no-drift + token error; drift-with-backfill + token error; audit_failed error-return shape includes `tokenErrors: []`)
- [x] README `deploy/README.md:314` — manual-trigger response shape now includes `tokenErrors`
- [x] `driftAudit.ts` docstring — "bare error message if no `app:` prefix applies" bullet replaced with the new `pat: missing` case (the bare-message path didn't actually exist before)
- [x] PAT-missing silent drop fixed — map with `installationId=null`, valid owner/repo, no matching workspace PAT now pushes a `pat: missing` tokenError so the `auditDrift` docstring promise ("every map whose binding couldn't resolve a current token") actually holds
- [x] **Item 5 (status-flip debate) deliberately deferred** — inline comment in `driftAudit.ts` references #87 so the next contributor doesn't relitigate without production data on whether operators miss token outages with the current suffix-only signal

## Test plan

- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w build` — clean
- [x] `pnpm -w test` — 219 tests passing (+13 new: 9 for parseInterval, 3 for catchup token-401, 1 for PAT-missing in driftAudit; plus 3 in runDriftAudit covered by the same files)
- [x] `rg "parsePositiveIntMs|parseInt\(process\.env" packages/server/src` — both interval callsites use the helper; only `PORT` remains on raw `parseInt` (intentional)

## Note on `parseInt('1d', 10)`

The original #85 description said `parseInt('1d', 10)` returns `NaN`. Actual JS semantics: it returns `1` (parseInt stops at the first non-digit). Both are catastrophic at the `setInterval` boundary (NaN → 0, 1 → 1 ms cadence), and the new `parsePositiveIntMs` guards against both via a strict leading regex match before the parseInt call. The PR description and helper docstring document the actual behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)