### PR TITLE
feat(triage): Phase 1 — frontend triage panel + Ray fixes from #98 review (closes #94, addresses #99)

### DIFF
--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -1444,7 +1444,16 @@ export function App() {
             onFilterChange={setActiveCycleFilter}
             onOpenPanel={() => {
               setSprintPanelOpen(!sprintPanelOpen);
-              if (!sprintPanelOpen) setBlockedPanelOpen(false);
+              if (!sprintPanelOpen) {
+                setBlockedPanelOpen(false);
+                // Mutual-exclusion fix from Ray's #100 review: the
+                // Blocked + Triage handlers below close Sprint when
+                // they open, but Sprint wasn't symmetrically closing
+                // Triage. Result: the Triage indicator stayed
+                // highlighted while Sprint rendered (panel precedence
+                // chain at the right-dock favours Sprint).
+                setTriagePanelOpen(false);
+              }
             }}
             panelOpen={sprintPanelOpen}
           />

--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -9,6 +9,8 @@ import { ListView } from './ListView.js';
 import { CalendarView } from './CalendarView.js';
 import { SprintPanel } from './SprintPanel.js';
 import { BlockedPanel } from './BlockedPanel.js';
+import { TriagePanel } from './TriagePanel.js';
+import { listTriageDecisions } from './api.js';
 import { CommandPalette } from './CommandPalette.js';
 import { QuickAdd } from './QuickAdd.js';
 import { HillChart } from './HillChart.js';
@@ -635,6 +637,65 @@ function BlockedIndicator({
   );
 }
 
+// ── Triage Indicator (#94) ────────────────────────────────────
+
+function TriageIndicator({
+  count,
+  panelOpen,
+  onOpenPanel,
+}: {
+  count: number;
+  panelOpen: boolean;
+  onOpenPanel: () => void;
+}) {
+  const hasPending = count > 0;
+  const fg = panelOpen ? '#1d4ed8' : hasPending ? '#1d4ed8' : '#64748b';
+  const bg = panelOpen ? '#dbeafe' : '#fff';
+  const border = panelOpen ? '#93c5fd' : hasPending ? '#bfdbfe' : '#e2e8f0';
+  return (
+    <button
+      data-testid="triage-indicator"
+      onClick={onOpenPanel}
+      title={hasPending ? `${count} triage decision(s) pending review` : 'Triage'}
+      style={{
+        padding: '3px 10px',
+        borderRadius: 4,
+        border: `1px solid ${border}`,
+        fontSize: 11,
+        fontWeight: 600,
+        fontFamily: 'inherit',
+        cursor: 'pointer',
+        background: bg,
+        color: fg,
+        transition: 'all 0.15s',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+      }}
+    >
+      <span>🧭</span>
+      <span>Triage</span>
+      {hasPending && (
+        <span
+          data-testid="triage-indicator-count"
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            background: panelOpen ? '#1d4ed8' : '#bfdbfe',
+            color: panelOpen ? '#fff' : '#1d4ed8',
+            padding: '0 5px',
+            borderRadius: 8,
+            minWidth: 14,
+            textAlign: 'center',
+          }}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
 // ── Sprint Indicator ──────────────────────────────────────────
 
 function SprintIndicator({
@@ -877,6 +938,8 @@ export function App() {
 
   const [sprintPanelOpen, setSprintPanelOpen] = useState(false);
   const [blockedPanelOpen, setBlockedPanelOpen] = useState(false);
+  const [triagePanelOpen, setTriagePanelOpen] = useState(false);
+  const [triagePendingCount, setTriagePendingCount] = useState(0);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [importExportOpen, setImportExportOpen] = useState(false);
@@ -897,6 +960,38 @@ export function App() {
   useEffect(() => {
     checkAuth().finally(() => setAuthChecked(true));
   }, [checkAuth]);
+
+  // Poll the pending-triage count for the active map. Cheap (one
+  // SELECT, server-side-filtered), used by the TriageIndicator badge.
+  // The panel itself does its own pull when opened — this is just for
+  // the always-visible counter. We re-poll when the panel closes so
+  // the badge reflects post-action state. 60s heartbeat covers the
+  // "operator-on-GitHub-edits-an-issue" path; for the real-time path
+  // Phase 1 follow-up will wire a `triage:decision_*` broadcast.
+  useEffect(() => {
+    if (!currentMapId) {
+      setTriagePendingCount(0);
+      return;
+    }
+    let cancelled = false;
+    const tick = () => {
+      listTriageDecisions(currentMapId, { reviewed: false, limit: 200 })
+        .then((res) => {
+          if (cancelled) return;
+          setTriagePendingCount(res.total);
+        })
+        .catch(() => {
+          // Triage may not be opted in for this map — silently zero out.
+          if (!cancelled) setTriagePendingCount(0);
+        });
+    };
+    tick();
+    const interval = window.setInterval(tick, 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [currentMapId, triagePanelOpen]);
 
   // Handle GitHub OAuth callback redirect (?gh=connected or ?gh=error)
   useEffect(() => {
@@ -1362,7 +1457,25 @@ export function App() {
             panelOpen={blockedPanelOpen}
             onOpenPanel={() => {
               setBlockedPanelOpen(!blockedPanelOpen);
-              if (!blockedPanelOpen) setSprintPanelOpen(false);
+              if (!blockedPanelOpen) {
+                setSprintPanelOpen(false);
+                setTriagePanelOpen(false);
+              }
+            }}
+          />
+
+          <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
+
+          {/* Triage indicator (#94) */}
+          <TriageIndicator
+            count={triagePendingCount}
+            panelOpen={triagePanelOpen}
+            onOpenPanel={() => {
+              setTriagePanelOpen(!triagePanelOpen);
+              if (!triagePanelOpen) {
+                setSprintPanelOpen(false);
+                setBlockedPanelOpen(false);
+              }
             }}
           />
 
@@ -1735,6 +1848,11 @@ export function App() {
           <BlockedPanel onClose={() => setBlockedPanelOpen(false)} />
         ) : sprintPanelOpen ? (
           <SprintPanel onClose={() => setSprintPanelOpen(false)} />
+        ) : triagePanelOpen && currentMapId ? (
+          <TriagePanel
+            mapId={currentMapId}
+            onClose={() => setTriagePanelOpen(false)}
+          />
         ) : (
           <PropertyPanel />
         )}

--- a/packages/mindmap/src/NodePickerModal.tsx
+++ b/packages/mindmap/src/NodePickerModal.tsx
@@ -1,0 +1,372 @@
+/**
+ * Node picker modal (#94 — Phase 1 frontend).
+ *
+ * Renders the current map as a collapsible tree with a search box so
+ * an operator can pick a parent node for a triage Override / Move.
+ *
+ * Reused by TriagePanel; designed to be cheap to drop in elsewhere
+ * (Phase 2 bulk-action review will reuse this).
+ *
+ * The tree is built off `useMindmapStore` state (already in memory)
+ * rather than a separate `/api/maps/:id` round-trip — same nodes
+ * the mindmap is already rendering.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import type { Node } from '@mindblown/core';
+import { useMindmapStore } from './store.js';
+
+interface TreeRow {
+  node: Node;
+  depth: number;
+  matches: boolean;
+  visible: boolean;
+  hasChildren: boolean;
+  expanded: boolean;
+}
+
+export function NodePickerModal({
+  mapId: _mapId,
+  title,
+  excludeNodeIds = [],
+  onPick,
+  onClose,
+}: {
+  mapId: string;
+  title: string;
+  excludeNodeIds?: string[];
+  onPick: (nodeId: string) => void;
+  onClose: () => void;
+}) {
+  const nodes = useMindmapStore((s) => s.nodes);
+  const rootNodeId = useMindmapStore((s) => s.rootNodeId);
+  const [search, setSearch] = useState('');
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    // Expand the root + its direct children by default — that's the
+    // "epic shelf" most overrides target.
+    const initial = new Set<string>();
+    if (rootNodeId) {
+      initial.add(rootNodeId);
+      const root = nodes[rootNodeId];
+      if (root) {
+        for (const childId of root.childrenIds) initial.add(childId);
+      }
+    }
+    return initial;
+  });
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const excludeSet = useMemo(() => new Set(excludeNodeIds), [excludeNodeIds]);
+
+  const rows = useMemo(() => {
+    if (!rootNodeId) return [] as TreeRow[];
+    const term = search.trim().toLowerCase();
+    const out: TreeRow[] = [];
+
+    // First pass: which nodeIds match the search term (case-insensitive
+    // substring on text). Empty term = everything matches.
+    const matchSet = new Set<string>();
+    if (term === '') {
+      for (const id of Object.keys(nodes)) matchSet.add(id);
+    } else {
+      for (const id of Object.keys(nodes)) {
+        const n = nodes[id];
+        if (n && n.text.toLowerCase().includes(term)) matchSet.add(id);
+      }
+    }
+
+    // Second pass: walk the tree depth-first, only descending past a
+    // node when (a) it or one of its descendants matched. Build a row
+    // per visited node. When searching, auto-expand any ancestor of a
+    // match so the matching row is visible. We do this by collecting
+    // the ancestor chain of each matching node up-front.
+    const forceExpand = new Set<string>();
+    if (term !== '') {
+      const parentOf: Record<string, string | null> = {};
+      for (const id of Object.keys(nodes)) {
+        parentOf[id] = nodes[id]?.parentId ?? null;
+      }
+      for (const matchId of matchSet) {
+        let cur: string | null = parentOf[matchId] ?? null;
+        while (cur && !forceExpand.has(cur)) {
+          forceExpand.add(cur);
+          cur = parentOf[cur] ?? null;
+        }
+      }
+    }
+
+    const containsMatch = (nodeId: string, memo: Map<string, boolean>): boolean => {
+      const cached = memo.get(nodeId);
+      if (cached !== undefined) return cached;
+      const n = nodes[nodeId];
+      if (!n) {
+        memo.set(nodeId, false);
+        return false;
+      }
+      if (matchSet.has(nodeId)) {
+        memo.set(nodeId, true);
+        return true;
+      }
+      for (const childId of n.childrenIds) {
+        if (containsMatch(childId, memo)) {
+          memo.set(nodeId, true);
+          return true;
+        }
+      }
+      memo.set(nodeId, false);
+      return false;
+    };
+    const matchMemo = new Map<string, boolean>();
+
+    const walk = (nodeId: string, depth: number): void => {
+      const node = nodes[nodeId];
+      if (!node) return;
+      const hasChildren = node.childrenIds.length > 0;
+      // Visibility: when searching, only show nodes that match OR
+      // ancestors of a match. When not searching, show everything.
+      const visible = term === '' || matchSet.has(nodeId) || containsMatch(nodeId, matchMemo);
+      const isExpanded = expanded.has(nodeId) || forceExpand.has(nodeId);
+      if (visible) {
+        out.push({
+          node,
+          depth,
+          matches: matchSet.has(nodeId),
+          visible,
+          hasChildren,
+          expanded: isExpanded,
+        });
+      }
+      if (isExpanded && hasChildren) {
+        for (const childId of node.childrenIds) walk(childId, depth + 1);
+      }
+    };
+
+    walk(rootNodeId, 0);
+    return out;
+  }, [nodes, rootNodeId, search, expanded]);
+
+  const toggleExpand = useCallback((nodeId: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) next.delete(nodeId);
+      else next.add(nodeId);
+      return next;
+    });
+  }, []);
+
+  const handlePick = useCallback(() => {
+    if (selectedNodeId) onPick(selectedNodeId);
+  }, [selectedNodeId, onPick]);
+
+  return (
+    <div
+      data-testid="node-picker-modal"
+      role="dialog"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(15, 23, 42, 0.4)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: 520,
+          maxHeight: '80vh',
+          background: '#fff',
+          borderRadius: 8,
+          boxShadow: '0 10px 40px rgba(0, 0, 0, 0.2)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: '12px 16px',
+            borderBottom: '1px solid #e2e8f0',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <span style={{ fontSize: 14, fontWeight: 700, color: '#1e293b', flex: 1 }}>
+            {title}
+          </span>
+          <button
+            data-testid="node-picker-close"
+            onClick={onClose}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '4px',
+              color: '#94a3b8',
+              fontSize: 16,
+              fontFamily: 'inherit',
+              lineHeight: 1,
+            }}
+            title="Close"
+          >
+            x
+          </button>
+        </div>
+
+        {/* Search */}
+        <div style={{ padding: '8px 16px', borderBottom: '1px solid #f1f5f9' }}>
+          <input
+            data-testid="node-picker-search"
+            type="text"
+            placeholder="Search nodes…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+            style={{
+              width: '100%',
+              padding: '6px 10px',
+              border: '1px solid #e2e8f0',
+              borderRadius: 4,
+              fontSize: 13,
+              fontFamily: 'inherit',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        {/* Tree */}
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 200 }} data-testid="node-picker-tree">
+          {rows.length === 0 ? (
+            <div style={{ padding: 20, textAlign: 'center', color: '#94a3b8', fontSize: 13 }}>
+              No matching nodes.
+            </div>
+          ) : (
+            rows.map((row) => {
+              const isExcluded = excludeSet.has(row.node.id);
+              const isSelected = selectedNodeId === row.node.id;
+              return (
+                <div
+                  key={row.node.id}
+                  data-testid="node-picker-row"
+                  data-node-id={row.node.id}
+                  onClick={() => {
+                    if (!isExcluded) setSelectedNodeId(row.node.id);
+                  }}
+                  onDoubleClick={() => {
+                    if (!isExcluded) {
+                      setSelectedNodeId(row.node.id);
+                      onPick(row.node.id);
+                    }
+                  }}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '4px 8px',
+                    paddingLeft: 8 + row.depth * 16,
+                    borderBottom: '1px solid #f8fafc',
+                    background: isSelected ? '#eff6ff' : 'transparent',
+                    cursor: isExcluded ? 'not-allowed' : 'pointer',
+                    opacity: isExcluded ? 0.4 : 1,
+                    fontSize: 12,
+                  }}
+                >
+                  <button
+                    data-testid="node-picker-expand"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (row.hasChildren) toggleExpand(row.node.id);
+                    }}
+                    style={{
+                      width: 16,
+                      height: 16,
+                      border: 'none',
+                      background: 'none',
+                      cursor: row.hasChildren ? 'pointer' : 'default',
+                      padding: 0,
+                      color: row.hasChildren ? '#64748b' : 'transparent',
+                      fontSize: 10,
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    {row.hasChildren ? (row.expanded ? '▾' : '▸') : '·'}
+                  </button>
+                  <span
+                    style={{
+                      flex: 1,
+                      color: row.matches ? '#1e293b' : '#475569',
+                      fontWeight: row.matches && search ? 600 : 400,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {row.node.text}
+                  </span>
+                  {isExcluded && (
+                    <span style={{ fontSize: 10, color: '#94a3b8' }}>(current)</span>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: '10px 16px',
+            borderTop: '1px solid #e2e8f0',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            background: '#f8fafc',
+          }}
+        >
+          <span style={{ flex: 1, fontSize: 11, color: '#64748b' }}>
+            Double-click a node, or select and Pick.
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              padding: '5px 12px',
+              borderRadius: 4,
+              border: '1px solid #e2e8f0',
+              background: '#fff',
+              color: '#475569',
+              cursor: 'pointer',
+              fontSize: 12,
+              fontFamily: 'inherit',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="node-picker-pick"
+            onClick={handlePick}
+            disabled={!selectedNodeId}
+            style={{
+              padding: '5px 12px',
+              borderRadius: 4,
+              border: '1px solid #3b82f6',
+              background: selectedNodeId ? '#3b82f6' : '#cbd5e1',
+              color: '#fff',
+              cursor: selectedNodeId ? 'pointer' : 'not-allowed',
+              fontSize: 12,
+              fontWeight: 600,
+              fontFamily: 'inherit',
+            }}
+          >
+            Pick
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/mindmap/src/NodePickerModal.tsx
+++ b/packages/mindmap/src/NodePickerModal.tsx
@@ -26,18 +26,22 @@ interface TreeRow {
 }
 
 export function NodePickerModal({
-  mapId: _mapId,
   title,
   excludeNodeIds = [],
   onPick,
   onClose,
 }: {
-  mapId: string;
   title: string;
   excludeNodeIds?: string[];
   onPick: (nodeId: string) => void;
   onClose: () => void;
 }) {
+  // The picker reads nodes from the in-memory mindmap store (already
+  // populated with the active map's tree). A `mapId` prop used to be
+  // accepted but never read — dropping it per Ray's #100 nit. Phase 2
+  // bulk-action reuse will still target the current map; if a future
+  // caller needs cross-map picking, re-add `mapId` and wire it through
+  // a dedicated lookup.
   const nodes = useMindmapStore((s) => s.nodes);
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
   const [search, setSearch] = useState('');
@@ -310,7 +314,9 @@ export function NodePickerModal({
                     {row.node.text}
                   </span>
                   {isExcluded && (
-                    <span style={{ fontSize: 10, color: '#94a3b8' }}>(current)</span>
+                    <span style={{ fontSize: 10, color: '#94a3b8' }}>
+                      (placed node)
+                    </span>
                   )}
                 </div>
               );

--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -318,7 +318,6 @@ export function TriagePanel({
       {/* Node picker modal */}
       {pickerForDecision && (
         <NodePickerModal
-          mapId={mapId}
           title={`Pick a parent for "${pickerForDecision.issueTitle}"`}
           excludeNodeIds={pickerForDecision.placedNodeId ? [pickerForDecision.placedNodeId] : []}
           onPick={handlePickParent}

--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -1,0 +1,661 @@
+/**
+ * Triage review panel (#94 — Phase 1 frontend).
+ *
+ * Three sub-views (Pending / Skipped / Placed) showing AI triage
+ * decisions for the current map. Operator actions per row:
+ *
+ *   - Confirm    — mark the row reviewed, keep the auto decision.
+ *   - Override   — pick a different parent via the node-picker modal,
+ *                  optionally change decision (skip / uncertain).
+ *   - Re-classify — re-run the LLM against the current map context.
+ *
+ * Lives alongside BlockedPanel / SprintPanel — same right-docked
+ * 380px width, same close-button pattern. The map header's
+ * TriageIndicator button toggles it. Phase 0's backend exposes the
+ * three routes; Phase 2 adds bulk operations.
+ *
+ * Frontend tests are deferred until `@mindblown/mindmap` has a test
+ * runner (see #78 follow-ups). Every interactive element carries a
+ * `data-testid` so a future pass can target them without re-writing
+ * the markup.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMindmapStore } from './store.js';
+import {
+  ApiError,
+  confirmTriageDecision,
+  listTriageDecisions,
+  overrideTriageDecision,
+  reclassifyTriageDecision,
+  type TriageDecision,
+  type TriageDecisionKind,
+} from './api.js';
+import { NodePickerModal } from './NodePickerModal.js';
+
+const PANEL_WIDTH = 420;
+
+type SubView = 'pending' | 'placed' | 'skipped';
+
+export function TriagePanel({
+  mapId,
+  onClose,
+}: {
+  mapId: string;
+  onClose: () => void;
+}) {
+  const [view, setView] = useState<SubView>('pending');
+  const [decisions, setDecisions] = useState<TriageDecision[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyDecisionId, setBusyDecisionId] = useState<string | null>(null);
+  const [pickerForDecision, setPickerForDecision] = useState<TriageDecision | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  const refresh = useCallback(() => setRefreshTick((t) => t + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    // Server-side filter for the active sub-view. Pending = unreviewed;
+    // Placed = decision=place AND (reviewed OR placedNodeId set); Skipped
+    // = decision=skip AND reviewed. We pull each view fresh because the
+    // server count is authoritative — Phase 2 will switch to a single
+    // "all decisions" pull + client-side bucketing if perf demands it.
+    const filters =
+      view === 'pending'
+        ? { reviewed: false, limit: 200 }
+        : view === 'placed'
+          ? { decision: 'place' as TriageDecisionKind, reviewed: true, limit: 200 }
+          : { decision: 'skip' as TriageDecisionKind, reviewed: true, limit: 200 };
+    listTriageDecisions(mapId, filters)
+      .then((res) => {
+        if (cancelled) return;
+        setDecisions(res.decisions);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const msg = err instanceof ApiError ? err.message : 'Failed to load triage decisions';
+        setError(msg);
+        setDecisions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mapId, view, refreshTick]);
+
+  const handleConfirm = useCallback(
+    async (decision: TriageDecision) => {
+      setBusyDecisionId(decision.id);
+      try {
+        await confirmTriageDecision(mapId, decision);
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Confirm failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, refresh],
+  );
+
+  const handleReclassify = useCallback(
+    async (decision: TriageDecision) => {
+      setBusyDecisionId(decision.id);
+      try {
+        await reclassifyTriageDecision(mapId, decision.id);
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Re-classify failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, refresh],
+  );
+
+  const handleSkipOrUncertain = useCallback(
+    async (decision: TriageDecision, newDecision: 'skip' | 'uncertain') => {
+      setBusyDecisionId(decision.id);
+      try {
+        await overrideTriageDecision(mapId, decision.id, {
+          decision: newDecision,
+          reason: decision.reason,
+        });
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Override failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, refresh],
+  );
+
+  const handlePickParent = useCallback(
+    async (parentNodeId: string) => {
+      const decision = pickerForDecision;
+      if (!decision) return;
+      setPickerForDecision(null);
+      setBusyDecisionId(decision.id);
+      try {
+        await overrideTriageDecision(mapId, decision.id, {
+          decision: 'place',
+          parentNodeId,
+          reason: decision.reason,
+        });
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Place failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, pickerForDecision, refresh],
+  );
+
+  return (
+    <div
+      data-testid="triage-panel"
+      style={{
+        width: PANEL_WIDTH,
+        height: '100%',
+        borderLeft: '1px solid #e2e8f0',
+        background: '#ffffff',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid #e2e8f0',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <span style={{ fontSize: 16 }}>🧭</span>
+        <span style={{ fontSize: 14, fontWeight: 700, color: '#1e293b', flex: 1 }}>
+          Triage
+        </span>
+        <button
+          data-testid="triage-panel-close"
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px',
+            color: '#94a3b8',
+            fontSize: 16,
+            fontFamily: 'inherit',
+            lineHeight: 1,
+          }}
+          title="Close"
+        >
+          x
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div
+        style={{
+          display: 'flex',
+          borderBottom: '1px solid #e2e8f0',
+          background: '#f8fafc',
+        }}
+      >
+        <TabButton
+          testId="triage-tab-pending"
+          active={view === 'pending'}
+          onClick={() => setView('pending')}
+        >
+          Pending review
+        </TabButton>
+        <TabButton
+          testId="triage-tab-placed"
+          active={view === 'placed'}
+          onClick={() => setView('placed')}
+        >
+          Placed
+        </TabButton>
+        <TabButton
+          testId="triage-tab-skipped"
+          active={view === 'skipped'}
+          onClick={() => setView('skipped')}
+        >
+          Skipped
+        </TabButton>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          data-testid="triage-error"
+          style={{
+            padding: '8px 16px',
+            background: '#fee2e2',
+            color: '#991b1b',
+            fontSize: 12,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <span style={{ flex: 1 }}>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: '#991b1b',
+              fontFamily: 'inherit',
+              fontSize: 12,
+            }}
+          >
+            x
+          </button>
+        </div>
+      )}
+
+      {/* Body */}
+      <div style={{ flex: 1, overflowY: 'auto' }} data-testid="triage-body">
+        {loading ? (
+          <div style={{ padding: 20, textAlign: 'center', color: '#94a3b8', fontSize: 13 }}>
+            Loading…
+          </div>
+        ) : decisions.length === 0 ? (
+          <div style={{ padding: 20, textAlign: 'center', color: '#94a3b8', fontSize: 13 }}>
+            {view === 'pending'
+              ? 'Nothing to review. 🎉'
+              : view === 'placed'
+                ? 'No placed decisions yet.'
+                : 'No skipped issues yet.'}
+          </div>
+        ) : (
+          decisions.map((d) => (
+            <TriageCard
+              key={d.id}
+              decision={d}
+              view={view}
+              busy={busyDecisionId === d.id}
+              onConfirm={() => handleConfirm(d)}
+              onPlace={() => setPickerForDecision(d)}
+              onReclassify={() => handleReclassify(d)}
+              onSkip={() => handleSkipOrUncertain(d, 'skip')}
+              onUncertain={() => handleSkipOrUncertain(d, 'uncertain')}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Footer hint */}
+      <div
+        style={{
+          padding: '10px 16px',
+          borderTop: '1px solid #f1f5f9',
+          fontSize: 10,
+          color: '#94a3b8',
+          background: '#f8fafc',
+        }}
+      >
+        Pending = unreviewed AI decisions. Confirm to accept, Override
+        to reparent, Re-classify to re-run.
+      </div>
+
+      {/* Node picker modal */}
+      {pickerForDecision && (
+        <NodePickerModal
+          mapId={mapId}
+          title={`Pick a parent for "${pickerForDecision.issueTitle}"`}
+          excludeNodeIds={pickerForDecision.placedNodeId ? [pickerForDecision.placedNodeId] : []}
+          onPick={handlePickParent}
+          onClose={() => setPickerForDecision(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+  testId,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  testId: string;
+}) {
+  return (
+    <button
+      data-testid={testId}
+      onClick={onClick}
+      style={{
+        flex: 1,
+        padding: '10px 12px',
+        border: 'none',
+        background: active ? '#fff' : 'transparent',
+        borderBottom: active ? '2px solid #3b82f6' : '2px solid transparent',
+        cursor: 'pointer',
+        fontSize: 12,
+        fontWeight: 600,
+        color: active ? '#1e293b' : '#64748b',
+        fontFamily: 'inherit',
+        transition: 'all 0.1s',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TriageCard({
+  decision,
+  view,
+  busy,
+  onConfirm,
+  onPlace,
+  onReclassify,
+  onSkip,
+  onUncertain,
+}: {
+  decision: TriageDecision;
+  view: SubView;
+  busy: boolean;
+  onConfirm: () => void;
+  onPlace: () => void;
+  onReclassify: () => void;
+  onSkip: () => void;
+  onUncertain: () => void;
+}) {
+  const selectNode = useMindmapStore((s) => s.selectNode);
+  const setFocusNode = useMindmapStore((s) => s.setFocusNode);
+  const issueUrl = useMemo(() => buildIssueUrl(decision.externalId), [decision.externalId]);
+  const colors = decisionColors(decision.decision);
+
+  const jumpToPlacedNode = () => {
+    if (!decision.placedNodeId) return;
+    selectNode(decision.placedNodeId);
+    setFocusNode(decision.placedNodeId);
+  };
+
+  // The set of available actions depends on the current decision.
+  //   - pending view, decision=place (low-confidence): Confirm (which
+  //     requires picking a parent — wire to Override instead),
+  //     Override, Re-classify, Skip.
+  //   - pending view, decision=skip: Confirm (mark reviewed), Override
+  //     (Place), Re-classify, Uncertain.
+  //   - pending view, decision=uncertain: Override (Place), Skip,
+  //     Re-classify.
+  //   - placed view: jump to node, Override (move), Re-classify.
+  //   - skipped view: Override (Place), Re-classify.
+  const canConfirm =
+    view === 'pending' && (decision.decision !== 'place' || decision.placedNodeId != null);
+
+  return (
+    <div
+      data-testid="triage-card"
+      data-decision-id={decision.id}
+      style={{
+        padding: 12,
+        borderBottom: '1px solid #f1f5f9',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      {/* Title row */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: '#1e293b', flex: 1 }}>
+          {decision.issueTitle}
+        </span>
+        <span
+          data-testid="triage-card-decision"
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            padding: '2px 8px',
+            borderRadius: 10,
+            background: colors.bg,
+            color: colors.fg,
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {decision.decision}
+        </span>
+      </div>
+
+      {/* External link + meta */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11 }}>
+        <a
+          href={issueUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="triage-card-issue-link"
+          style={{ color: '#3b82f6', textDecoration: 'none' }}
+        >
+          {decision.externalId}
+        </a>
+        <span style={{ color: '#cbd5e1' }}>•</span>
+        <span style={{ color: '#64748b' }} data-testid="triage-card-decided-by">
+          {decision.decidedBy === 'auto' ? 'Claude' : 'Operator'}
+        </span>
+        <span style={{ color: '#cbd5e1' }}>•</span>
+        <span style={{ color: '#94a3b8', fontSize: 10 }}>
+          {formatTimeAgo(decision.decidedAt)}
+        </span>
+      </div>
+
+      {/* Confidence bar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 10, color: '#64748b', minWidth: 50 }}>
+          Confidence
+        </span>
+        <div
+          style={{
+            flex: 1,
+            height: 6,
+            borderRadius: 3,
+            background: '#e2e8f0',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            data-testid="triage-card-confidence"
+            style={{
+              width: `${Math.max(0, Math.min(100, decision.confidence))}%`,
+              height: '100%',
+              background: confidenceColor(decision.confidence),
+              transition: 'width 0.2s',
+            }}
+          />
+        </div>
+        <span style={{ fontSize: 10, color: '#64748b', minWidth: 28, textAlign: 'right' }}>
+          {decision.confidence}
+        </span>
+      </div>
+
+      {/* Reason */}
+      <div
+        data-testid="triage-card-reason"
+        style={{
+          fontSize: 11,
+          color: '#475569',
+          lineHeight: 1.4,
+          padding: 8,
+          background: '#f8fafc',
+          borderRadius: 4,
+          border: '1px solid #f1f5f9',
+        }}
+      >
+        {decision.reason}
+      </div>
+
+      {/* Placed-node link (placed view only) */}
+      {view === 'placed' && decision.placedNodeId && (
+        <button
+          data-testid="triage-card-jump-to-node"
+          onClick={jumpToPlacedNode}
+          style={{
+            background: 'none',
+            border: '1px dashed #cbd5e1',
+            borderRadius: 4,
+            padding: '4px 8px',
+            cursor: 'pointer',
+            color: '#475569',
+            fontSize: 11,
+            fontFamily: 'inherit',
+            textAlign: 'left',
+          }}
+        >
+          → Jump to placed node
+        </button>
+      )}
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {canConfirm && (
+          <ActionBtn
+            testId="triage-card-confirm"
+            label="Confirm"
+            kind="primary"
+            disabled={busy}
+            onClick={onConfirm}
+          />
+        )}
+        <ActionBtn
+          testId="triage-card-override-place"
+          label={decision.placedNodeId ? 'Move…' : 'Place…'}
+          kind="default"
+          disabled={busy}
+          onClick={onPlace}
+        />
+        {decision.decision !== 'skip' && (
+          <ActionBtn
+            testId="triage-card-skip"
+            label="Skip"
+            kind="default"
+            disabled={busy}
+            onClick={onSkip}
+          />
+        )}
+        {decision.decision !== 'uncertain' && view === 'pending' && (
+          <ActionBtn
+            testId="triage-card-uncertain"
+            label="Defer"
+            kind="default"
+            disabled={busy}
+            onClick={onUncertain}
+          />
+        )}
+        <ActionBtn
+          testId="triage-card-reclassify"
+          label={busy ? '…' : 'Re-classify'}
+          kind="ghost"
+          disabled={busy}
+          onClick={onReclassify}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ActionBtn({
+  label,
+  kind,
+  disabled,
+  onClick,
+  testId,
+}: {
+  label: string;
+  kind: 'primary' | 'default' | 'ghost';
+  disabled?: boolean;
+  onClick: () => void;
+  testId: string;
+}) {
+  const styles =
+    kind === 'primary'
+      ? { background: '#3b82f6', color: '#fff', border: '1px solid #3b82f6' }
+      : kind === 'ghost'
+        ? { background: 'transparent', color: '#64748b', border: '1px solid transparent' }
+        : { background: '#fff', color: '#475569', border: '1px solid #e2e8f0' };
+  return (
+    <button
+      data-testid={testId}
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        ...styles,
+        padding: '4px 10px',
+        borderRadius: 4,
+        fontSize: 11,
+        fontWeight: 600,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.5 : 1,
+        fontFamily: 'inherit',
+        transition: 'all 0.1s',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function decisionColors(decision: TriageDecisionKind): { bg: string; fg: string } {
+  switch (decision) {
+    case 'place':
+      return { bg: '#dcfce7', fg: '#166534' };
+    case 'skip':
+      return { bg: '#fef3c7', fg: '#854d0e' };
+    case 'uncertain':
+    default:
+      return { bg: '#e2e8f0', fg: '#475569' };
+  }
+}
+
+function confidenceColor(c: number): string {
+  if (c >= 75) return '#10b981';
+  if (c >= 50) return '#3b82f6';
+  if (c >= 25) return '#f59e0b';
+  return '#ef4444';
+}
+
+function buildIssueUrl(externalId: string): string {
+  const idx = externalId.lastIndexOf('#');
+  if (idx < 0) return '#';
+  const ownerRepo = externalId.slice(0, idx);
+  const number = externalId.slice(idx + 1);
+  return `https://github.com/${ownerRepo}/issues/${number}`;
+}
+
+function formatTimeAgo(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '';
+  const deltaMs = Date.now() - t;
+  const sec = Math.floor(deltaMs / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -1074,6 +1074,13 @@ export interface ReclassifyTriageResponse {
   confidence: number;
   reason: string;
   parentNodeId: string | null;
+  /**
+   * The (potentially-just-nulled) placedNodeId after reclassify. When
+   * a previously-placed row reclassifies to skip/uncertain, the server
+   * nulls this; surfacing it here saves the client a refetch.
+   * (#100 Round 2 nit from Ray.)
+   */
+  placedNodeId: string | null;
 }
 
 export function reclassifyTriageDecision(
@@ -1086,19 +1093,28 @@ export function reclassifyTriageDecision(
   );
 }
 
+export interface ConfirmTriageResponse {
+  decisionId: string;
+  status: 'confirmed';
+  nodeId: string | null;
+}
+
 /**
- * Confirm a triage decision (mark reviewed). We model this as an
- * override that keeps the existing decision/reason — the route stamps
- * decidedBy='operator' + reviewed=true regardless of whether anything
- * else changed.
+ * Confirm a triage decision (mark reviewed). Hits the dedicated
+ * `/confirm` route — does NOT send a `parentNodeId`. The original
+ * implementation routed through `overrideTriageDecision` with
+ * `parentNodeId: decision.placedNodeId`, which fell through the
+ * override's already-placed branch and self-loop'd the node
+ * (`moveNode(placedNodeId, placedNodeId)`). Ray flagged this on the
+ * #100 review — splitting into a dedicated route makes the misuse
+ * impossible at the API boundary.
  */
 export function confirmTriageDecision(
   mapId: string,
   decision: TriageDecision,
-): Promise<OverrideTriageResponse> {
-  return overrideTriageDecision(mapId, decision.id, {
-    decision: decision.decision,
-    parentNodeId: decision.placedNodeId ?? undefined,
-    reason: decision.reason,
-  });
+): Promise<ConfirmTriageResponse> {
+  return request<ConfirmTriageResponse>(
+    `/api/maps/${mapId}/triage-decisions/${decision.id}/confirm`,
+    { method: 'POST' },
+  );
 }

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -990,3 +990,115 @@ export async function* aiChat(
     throw err;
   }
 }
+
+// ── Triage decisions (#92, #93, #94) ─────────────────────────────
+//
+// Mirrors the server-side `triage_decisions` table. Operator drives
+// review via three actions: confirm (mark reviewed), override (pick
+// a different placement), and reclassify (re-run the LLM).
+
+export type TriageDecisionKind = 'place' | 'skip' | 'uncertain';
+
+export interface TriageDecision {
+  id: string;
+  mapId: string;
+  externalId: string; // "owner/repo#NNN"
+  issueTitle: string;
+  issueState: 'open' | 'closed';
+  decision: TriageDecisionKind;
+  reason: string;
+  confidence: number; // 0-100
+  placedNodeId: string | null;
+  decidedAt: string;
+  decidedBy: 'auto' | 'operator';
+  reviewed: boolean;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+}
+
+export interface ListTriageDecisionsFilters {
+  reviewed?: boolean;
+  decision?: TriageDecisionKind;
+  limit?: number;
+}
+
+export interface ListTriageDecisionsResponse {
+  mapId: string;
+  total: number;
+  decisions: TriageDecision[];
+}
+
+export function listTriageDecisions(
+  mapId: string,
+  filters: ListTriageDecisionsFilters = {},
+): Promise<ListTriageDecisionsResponse> {
+  const qs = new URLSearchParams();
+  if (filters.reviewed !== undefined) qs.set('reviewed', String(filters.reviewed));
+  if (filters.decision) qs.set('decision', filters.decision);
+  if (filters.limit) qs.set('limit', String(filters.limit));
+  const q = qs.toString();
+  return request<ListTriageDecisionsResponse>(
+    `/api/maps/${mapId}/triage-decisions${q ? `?${q}` : ''}`,
+  );
+}
+
+export interface OverrideTriageBody {
+  decision: TriageDecisionKind;
+  parentNodeId?: string;
+  reason?: string;
+}
+
+export interface OverrideTriageResponse {
+  decisionId: string;
+  status: 'placed' | 'moved' | 'already_placed' | 'skip' | 'uncertain';
+  nodeId: string | null;
+}
+
+export function overrideTriageDecision(
+  mapId: string,
+  decisionId: string,
+  body: OverrideTriageBody,
+): Promise<OverrideTriageResponse> {
+  return request<OverrideTriageResponse>(
+    `/api/maps/${mapId}/triage-decisions/${decisionId}/override`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+export interface ReclassifyTriageResponse {
+  decisionId: string;
+  decision: TriageDecisionKind;
+  confidence: number;
+  reason: string;
+  parentNodeId: string | null;
+}
+
+export function reclassifyTriageDecision(
+  mapId: string,
+  decisionId: string,
+): Promise<ReclassifyTriageResponse> {
+  return request<ReclassifyTriageResponse>(
+    `/api/maps/${mapId}/triage-decisions/${decisionId}/reclassify`,
+    { method: 'POST' },
+  );
+}
+
+/**
+ * Confirm a triage decision (mark reviewed). We model this as an
+ * override that keeps the existing decision/reason — the route stamps
+ * decidedBy='operator' + reviewed=true regardless of whether anything
+ * else changed.
+ */
+export function confirmTriageDecision(
+  mapId: string,
+  decision: TriageDecision,
+): Promise<OverrideTriageResponse> {
+  return overrideTriageDecision(mapId, decision.id, {
+    decision: decision.decision,
+    parentNodeId: decision.placedNodeId ?? undefined,
+    reason: decision.reason,
+  });
+}

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -510,6 +510,36 @@ describe('POST .../override', () => {
     expect(row.reviewed).toBe(true);
   });
 
+  // #100 Round 2 — defense-in-depth at the override route. The
+  // dedicated /confirm route is the primary fix; this assertion
+  // guarantees the override route ALSO rejects the malformed input so
+  // a future caller (curl, MCP, alt UI) can't re-trigger the self-loop
+  // by sending parentNodeId === placedNodeId.
+  it('place + parentNodeId === placedNodeId → 400 SELF_LOOP_BLOCKED, moveNode NOT called', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      placedNodeId: 'placed-node',
+    });
+    nodes.set('placed-node', { id: 'placed-node', mapId: 'map-1', parentId: 'epic-A' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/override',
+      payload: { decision: 'place', parentNodeId: 'placed-node' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error?.code).toBe('SELF_LOOP_BLOCKED');
+    expect(moveNodeMock).not.toHaveBeenCalled();
+    expect(createNodeMock).not.toHaveBeenCalled();
+    // Row was NOT marked reviewed by the rejected request.
+    const row = triageRows.get('tr-1')!;
+    expect(row.reviewed).toBe(false);
+    expect(row.decidedBy).toBe('auto');
+  });
+
   it('place when placedNodeId already exists → does not double-create', async () => {
     seedRow({
       id: 'tr-1',
@@ -599,6 +629,114 @@ describe('POST .../override', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().status).toBe('already_placed');
     expect(moveNodeMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /confirm ────────────────────────────────────────────────
+
+// #100 Round 2 — dedicated confirm route. The original frontend wired
+// Confirm through /override with parentNodeId=placedNodeId, which fell
+// through the already-placed branch and self-loop'd the node. The
+// dedicated route accepts no body parameters and never touches
+// parentage.
+describe('POST .../confirm', () => {
+  it('marks reviewed=true, decidedBy=operator without touching placedNodeId or parentage', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      placedNodeId: 'placed-node',
+      reviewed: false,
+      decidedBy: 'auto',
+      confidence: 88,
+      reason: 'matches Frontend',
+    });
+    nodes.set('placed-node', { id: 'placed-node', mapId: 'map-1', parentId: 'epic-A' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/confirm',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('confirmed');
+    expect(res.json().nodeId).toBe('placed-node');
+    // moveNode + createNode were NEVER reachable — confirm doesn't even
+    // look at node tables. The self-loop bug is structurally impossible.
+    expect(moveNodeMock).not.toHaveBeenCalled();
+    expect(createNodeMock).not.toHaveBeenCalled();
+    const row = triageRows.get('tr-1')!;
+    expect(row.reviewed).toBe(true);
+    expect(row.decidedBy).toBe('operator');
+    // Decision/reason/confidence untouched (confirm = "accept as-is").
+    expect(row.decision).toBe('place');
+    expect(row.reason).toBe('matches Frontend');
+    expect(row.confidence).toBe(88);
+    // placedNodeId is intact — confirm never nulls it.
+    expect(row.placedNodeId).toBe('placed-node');
+    // The placed node's parent is intact at the dbState level too — no
+    // self-loop write happened. (We can't observe the node from the
+    // mock's update path because the confirm route never calls
+    // nodes.update; this assertion documents intent.)
+    expect(nodes.get('placed-node')!.parentId).toBe('epic-A');
+  });
+
+  it('works on a skip row too — confirm just marks reviewed, no parentNodeId required', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'skip',
+      placedNodeId: null,
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/confirm',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().nodeId).toBeNull();
+    const row = triageRows.get('tr-1')!;
+    expect(row.reviewed).toBe(true);
+    expect(row.decidedBy).toBe('operator');
+    expect(row.decision).toBe('skip');
+  });
+
+  it('404 when the row does not exist', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/missing/confirm',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('403 for API-key auth', async () => {
+    permissionLevel = 'edit';
+    seedRow({ id: 'tr-1' });
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/confirm',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('403 for JWT with view-only', async () => {
+    permissionLevel = 'view';
+    seedRow({ id: 'tr-1' });
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/confirm',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
   });
 });
 

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -181,6 +181,11 @@ const mocks = vi.hoisted(() => ({
     mapId: 'map-1',
     parentId: 'epic-1',
   })),
+  moveNodeMock: vi.fn(async (nodeId: string, newParentId: string) => ({
+    id: nodeId,
+    mapId: 'map-1',
+    parentId: newParentId,
+  })),
   triageIssueMock: vi.fn(async () => ({
     decision: 'place' as const,
     parentNodeId: 'epic-1',
@@ -190,10 +195,12 @@ const mocks = vi.hoisted(() => ({
 }));
 const createNodeMock = mocks.createNodeMock;
 const updateNodeMock = mocks.updateNodeMock;
+const moveNodeMock = mocks.moveNodeMock;
 const triageIssueMock = mocks.triageIssueMock;
 vi.mock('../../db/nodes.js', () => ({
   createNode: mocks.createNodeMock,
   updateNode: mocks.updateNodeMock,
+  moveNode: mocks.moveNodeMock,
 }));
 
 // Permission stub — the test toggles `permissionLevel` to drive the gate.
@@ -242,6 +249,7 @@ beforeEach(() => {
   permissionLevel = 'edit';
   createNodeMock.mockClear();
   updateNodeMock.mockClear();
+  moveNodeMock.mockClear();
   triageIssueMock.mockClear();
 });
 
@@ -522,6 +530,76 @@ describe('POST .../override', () => {
     expect(res.json().nodeId).toBe('existing-node');
     expect(createNodeMock).not.toHaveBeenCalled();
   });
+
+  // mindblown#99 fix 3 — override of an already-placed node with a
+  // different parentNodeId must call moveNode + broadcast node:moved,
+  // not silently drop the reparent.
+  it('place + already-placed + new parentNodeId → calls moveNode and broadcasts', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      placedNodeId: 'placed-node',
+    });
+    // Both old + new parents are in this map.
+    nodes.set('epic-A', { id: 'epic-A', mapId: 'map-1', parentId: 'root-1' });
+    nodes.set('epic-B', { id: 'epic-B', mapId: 'map-1', parentId: 'root-1' });
+    // The placed node currently lives under epic-A.
+    nodes.set('placed-node', { id: 'placed-node', mapId: 'map-1', parentId: 'epic-A' });
+    permissionLevel = 'edit';
+
+    const wsMod = await import('../../ws.js');
+    const broadcastMock = wsMod.broadcast as unknown as ReturnType<typeof vi.fn>;
+    broadcastMock.mockClear();
+
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/override',
+      payload: { decision: 'place', parentNodeId: 'epic-B' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('moved');
+    expect(res.json().nodeId).toBe('placed-node');
+    expect(moveNodeMock).toHaveBeenCalledOnce();
+    expect(moveNodeMock.mock.calls[0][0]).toBe('placed-node');
+    expect(moveNodeMock.mock.calls[0][1]).toBe('epic-B');
+    expect(createNodeMock).not.toHaveBeenCalled();
+    // node:moved broadcast carries the new parent so any open UI updates.
+    expect(broadcastMock).toHaveBeenCalledWith(
+      'map-1',
+      expect.objectContaining({
+        type: 'node:moved',
+        nodeId: 'placed-node',
+        newParentId: 'epic-B',
+      }),
+    );
+    // Row was marked reviewed + operator-decided.
+    const row = triageRows.get('tr-1')!;
+    expect(row.decidedBy).toBe('operator');
+    expect(row.reviewed).toBe(true);
+  });
+
+  it('place + already-placed + SAME parent → no move, status=already_placed', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      placedNodeId: 'placed-node',
+    });
+    nodes.set('epic-A', { id: 'epic-A', mapId: 'map-1', parentId: 'root-1' });
+    nodes.set('placed-node', { id: 'placed-node', mapId: 'map-1', parentId: 'epic-A' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/override',
+      payload: { decision: 'place', parentNodeId: 'epic-A' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('already_placed');
+    expect(moveNodeMock).not.toHaveBeenCalled();
+  });
 });
 
 // ── POST /reclassify ─────────────────────────────────────────────
@@ -564,5 +642,63 @@ describe('POST .../reclassify', () => {
     });
     await app.close();
     expect(res.statusCode).toBe(404);
+  });
+
+  // mindblown#99 fix 4 — when reclassify produces a non-place decision
+  // on a row that had placed a node before, the row must clear
+  // `placedNodeId` so it stops referencing an orphan. The node itself
+  // is intentionally NOT deleted (operator removes via the UI).
+  it('reclassify → skip clears placedNodeId on a previously-placed row', async () => {
+    triageIssueMock.mockResolvedValueOnce({
+      decision: 'skip' as const,
+      parentNodeId: undefined,
+      reason: 'no longer relevant',
+      confidence: 92,
+    } as unknown as Awaited<ReturnType<typeof triageIssueMock>>);
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      placedNodeId: 'orphan-node',
+      confidence: 80,
+      reviewed: true,
+      decidedBy: 'operator',
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/reclassify',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().decision).toBe('skip');
+    const row = triageRows.get('tr-1')!;
+    expect(row.decision).toBe('skip');
+    expect(row.placedNodeId).toBeNull();
+    expect(row.reviewed).toBe(false);
+    expect(row.decidedBy).toBe('auto');
+  });
+
+  it('reclassify → place keeps placedNodeId (only non-place clears it)', async () => {
+    // Default triageIssueMock returns decision='place' with parentNodeId='epic-1'.
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      placedNodeId: 'node-still-here',
+      confidence: 50,
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/reclassify',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const row = triageRows.get('tr-1')!;
+    // Reclassify doesn't auto-apply (no node created here) — but it
+    // also doesn't clear the previously-placed node id, since the new
+    // decision is still 'place'.
+    expect(row.placedNodeId).toBe('node-still-here');
   });
 });

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -1,7 +1,7 @@
 /**
  * Triage CRUD routes (#92, #93).
  *
- * Three endpoints, all map-scoped, all session-JWT-gated (API-key auth
+ * Four endpoints, all map-scoped, all session-JWT-gated (API-key auth
  * is rejected to match the audit-drift convention — triage exposes
  * cross-issue LLM reasoning that a leaked key shouldn't be able to fan
  * out across every workspace).
@@ -10,10 +10,22 @@
  *       Filterable list. Used by Phase 1's operator UI; for Phase 0
  *       the operator drives this via curl / MCP.
  *
+ *   - POST   /api/maps/:mapId/triage-decisions/:decisionId/confirm
+ *       Operator confirms the existing auto-decision (Ray's review on
+ *       #100 — split out from override to keep node parentage out of
+ *       the confirm flow). Marks the row reviewed=true + decidedBy=
+ *       'operator'. Does NOT touch node parentage. No parentNodeId
+ *       parameter. The dedicated route exists so the frontend cannot
+ *       accidentally pass `parentNodeId === placedNodeId` (which used
+ *       to flow through the override route's already-placed branch
+ *       and self-loop the node — #100 Round 2 fix).
+ *
  *   - POST   /api/maps/:mapId/triage-decisions/:decisionId/override
  *       Operator overrides the auto-decision. If the new decision is
- *       `place`, creates the node under the supplied parentNodeId.
- *       Marks the row reviewed + flips decidedBy to `operator`.
+ *       `place`, creates the node under the supplied parentNodeId
+ *       (or, when a node was already placed, calls `moveNode` to
+ *       reparent it). Marks the row reviewed + flips decidedBy to
+ *       `operator`.
  *
  *   - POST   /api/maps/:mapId/triage-decisions/:decisionId/reclassify
  *       Re-runs `triageIssue()` against the current map context, then
@@ -136,6 +148,76 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
+  // ── POST /api/maps/:mapId/triage-decisions/:decisionId/confirm ──
+  // Body: ignored (no parameters).
+  //
+  // Effect: mark the row reviewed=true, reviewedAt=now(),
+  // reviewedBy=req.userId, decidedBy='operator'. Does NOT touch node
+  // parentage, does NOT take a parentNodeId, does NOT mutate the
+  // decision/reason/confidence fields. The operator is saying "yes,
+  // accept what's already there" — same auth gate as override (edit).
+  //
+  // Why a separate route: Ray's #100 Round 2 review caught the
+  // frontend's `confirmTriageDecision` calling /override with
+  // `parentNodeId: decision.placedNodeId`. The override route's
+  // already-placed branch compared `placedNode.parentId !==
+  // submittedParent`, which is always true (a node isn't its own
+  // parent), so `moveNode(placedNodeId, placedNodeId)` ran — turning
+  // the node into its own parent. Splitting confirm into its own
+  // route closes that off at the API boundary: there is no
+  // parentNodeId parameter to misuse.
+  app.post<{
+    Params: { mapId: string; decisionId: string };
+  }>(
+    '/api/maps/:mapId/triage-decisions/:decisionId/confirm',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'edit');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+      const userId = req.userId as string; // gate guarantees set
+
+      const [row] = await db
+        .select()
+        .from(triageDecisions)
+        .where(
+          and(
+            eq(triageDecisions.id, req.params.decisionId),
+            eq(triageDecisions.mapId, req.params.mapId),
+          ),
+        );
+      if (!row) {
+        return reply.status(404).send({
+          error: {
+            code: 'NOT_FOUND',
+            message: `Triage decision ${req.params.decisionId} not found in map ${req.params.mapId}`,
+          },
+        });
+      }
+
+      // Stamp reviewed + operator. Intentionally NOT touching
+      // placedNodeId, decision, reason, or confidence — confirm means
+      // "accept the existing record as-is."
+      await db
+        .update(triageDecisions)
+        .set({
+          decidedBy: 'operator',
+          reviewed: true,
+          reviewedAt: new Date(),
+          reviewedBy: userId,
+        })
+        .where(eq(triageDecisions.id, row.id));
+
+      return reply.send({
+        decisionId: row.id,
+        status: 'confirmed',
+        nodeId: row.placedNodeId ?? null,
+      });
+    },
+  );
+
   // ── POST /api/maps/:mapId/triage-decisions/:decisionId/override ──
   // Body: { decision: 'place'|'skip'|'uncertain', parentNodeId?: uuid,
   //         reason: string }
@@ -205,6 +287,30 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           error: {
             code: 'NOT_FOUND',
             message: `Triage decision ${req.params.decisionId} not found in map ${req.params.mapId}`,
+          },
+        });
+      }
+
+      // Defense-in-depth: even with the dedicated /confirm route in
+      // place, reject parentNodeId === placedNodeId at the server.
+      // The earlier bug (#100 Round 2) had the frontend's confirm flow
+      // calling override with `parentNodeId: decision.placedNodeId`,
+      // which fell through to the already-placed branch below and
+      // called `moveNode(placedNodeId, placedNodeId)` — a self-loop
+      // that orphaned the node under itself. The frontend fix routes
+      // confirms through /confirm now, but rejecting self-loops at the
+      // override route prevents a future caller (curl, MCP, alt UI)
+      // from re-triggering the same corruption.
+      if (
+        decision === 'place' &&
+        row.placedNodeId &&
+        body.parentNodeId === row.placedNodeId
+      ) {
+        return reply.status(400).send({
+          error: {
+            code: 'SELF_LOOP_BLOCKED',
+            message:
+              'parentNodeId must differ from the placed node — use /confirm to mark reviewed without reparenting',
           },
         });
       }
@@ -433,7 +539,19 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       // Synthesize a minimal GitHubIssue from what we have on the row.
       // The triage prompt mostly leans on title + state + map context,
       // so an empty body is acceptable degradation here.
-      const issueNumber = parseIssueNumber(row.externalId) ?? 0;
+      //
+      // Nit from Ray's #100 review: parseIssueNumber returning null
+      // collapses to 0, which is indistinguishable from a real #0.
+      // We log a warning so an operator chasing a `#0 <title>` in the
+      // UI can grep server logs for the malformed externalId rather
+      // than wondering whether GitHub ever issued a #0.
+      const parsedNumber = parseIssueNumber(row.externalId);
+      if (parsedNumber == null) {
+        console.warn(
+          `[triage] reclassify: could not parse issue number from externalId=${JSON.stringify(row.externalId)} on decision ${row.id} (map ${req.params.mapId}); falling back to 0`,
+        );
+      }
+      const issueNumber = parsedNumber ?? 0;
       const decision = await triageIssue({
         issue: {
           id: issueNumber,
@@ -481,6 +599,10 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         confidence: decision.confidence,
         reason: decision.reason,
         parentNodeId: decision.parentNodeId ?? null,
+        // Surface the (potentially-just-nulled) placedNodeId so the
+        // client doesn't need a refetch to learn the row no longer
+        // references the previously-placed node (Ray's #100 nit).
+        placedNodeId: clearPlacedNode ? null : (row.placedNodeId ?? null),
       });
     },
   );

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -210,9 +210,61 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       }
 
       // If the operator wants a place but a node was already created
-      // by a prior auto-apply, short-circuit — we don't want to create
-      // a duplicate. Surface the existing node id.
+      // by a prior auto-apply, we DON'T create a second node — but if
+      // the submitted parentNodeId differs from where the node sits
+      // today, we DO call `moveNode` so the operator's intent isn't
+      // silently dropped (mindblown#99 fix 3). The previous behaviour
+      // returned the old node-id and let the operator wonder why
+      // their click didn't reparent.
       if (decision === 'place' && row.placedNodeId) {
+        // The operator MAY supply a parentNodeId that's a no-op (it
+        // matches the current parent). That's fine; moveNode is a
+        // safe identity in that case but we still don't bother
+        // calling it if parents already match.
+        const placedNodeId = row.placedNodeId as string;
+        const submittedParent = body.parentNodeId as string;
+
+        // Validate the submitted parent is in this map (same gate as
+        // the create-path below).
+        const [parent] = await db
+          .select({ id: nodes.id, mapId: nodes.mapId })
+          .from(nodes)
+          .where(eq(nodes.id, submittedParent));
+        if (!parent || parent.mapId !== req.params.mapId) {
+          return reply.status(400).send({
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'parentNodeId must be a node in this map',
+            },
+          });
+        }
+
+        // Look up the placed node's current parent so we know whether
+        // we need to move it.
+        const [placedNode] = await db
+          .select({ id: nodes.id, parentId: nodes.parentId })
+          .from(nodes)
+          .where(eq(nodes.id, placedNodeId));
+
+        let moved = false;
+        if (placedNode && placedNode.parentId !== submittedParent) {
+          // moveNode runs outside the tx that updates the decision
+          // row — it has its own internal write fan-out (children
+          // ordering on both old + new parent, parentId on the node
+          // itself) that doesn't share the route's outer tx. The
+          // payoff is the operator's reparent intent is honored.
+          const movedNode = await nodeDb.moveNode(placedNodeId, submittedParent);
+          moved = movedNode != null;
+          if (moved) {
+            broadcast(req.params.mapId, {
+              type: 'node:moved',
+              nodeId: placedNodeId,
+              newParentId: submittedParent,
+              position: undefined,
+            });
+          }
+        }
+
         await db
           .update(triageDecisions)
           .set({
@@ -228,8 +280,8 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           .where(eq(triageDecisions.id, row.id));
         return reply.send({
           decisionId: row.id,
-          status: 'already_placed',
-          nodeId: row.placedNodeId,
+          status: moved ? 'moved' : 'already_placed',
+          nodeId: placedNodeId,
         });
       }
 
@@ -399,6 +451,15 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         mapContext,
       });
 
+      // mindblown#99 fix 4: when reclassify produces a non-place
+      // decision and the row had a previous `placedNodeId`, the row
+      // is internally inconsistent ("decision says skip, but here's a
+      // node we placed earlier"). Clear placedNodeId so the row stops
+      // referencing the orphan. The original node is intentionally
+      // NOT auto-deleted on reclassify (Ray's spec: "operator can
+      // delete via UI") — only the decision-row reference is dropped.
+      const clearPlacedNode = decision.decision !== 'place' && row.placedNodeId != null;
+
       await db
         .update(triageDecisions)
         .set({
@@ -410,6 +471,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           reviewed: false,
           reviewedAt: null,
           reviewedBy: null,
+          ...(clearPlacedNode ? { placedNodeId: null } : {}),
         })
         .where(eq(triageDecisions.id, row.id));
 

--- a/packages/server/src/sync/__tests__/githubIngest.test.ts
+++ b/packages/server/src/sync/__tests__/githubIngest.test.ts
@@ -1092,6 +1092,174 @@ describe('ensureNodeForIssue — triage fork', () => {
     expect(dbState.triageDecisions.size).toBe(0);
   });
 
+  // mindblown#99 fix 2 — `issues.edited` (or any re-triage trigger)
+  // must NOT wipe `reviewed=true, decidedBy='operator'`. The fix
+  // short-circuits BEFORE the LLM call, so we also assert the triage
+  // mock was never invoked.
+  it('operator-reviewed row: re-triage short-circuits, NO LLM call, row unchanged', async () => {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    // Seed an existing operator-reviewed decision row.
+    dbState.triageDecisions.set('curated', {
+      id: 'curated',
+      mapId: 'm1',
+      externalId: 'owner/repo#200',
+      issueTitle: 'My carefully-curated decision',
+      issueState: 'open',
+      decision: 'skip',
+      reason: 'operator says no',
+      confidence: 100,
+      placedNodeId: null,
+      decidedAt: new Date('2026-01-01T00:00:00Z'),
+      decidedBy: 'operator',
+      reviewed: true,
+      reviewedAt: new Date('2026-01-01T00:00:00Z'),
+      reviewedBy: 'u1',
+    });
+    // Whatever the LLM would have said — if we call it, the test fails.
+    triageMockResponse = {
+      decision: 'place',
+      parentNodeId: 'epic-1',
+      reason: 'fresh take',
+      confidence: 90,
+    };
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', issue(200, { title: 'edited title' }), ctx);
+
+    // We treat operator-reviewed `skip` as the live answer.
+    expect(result.status).toBe('triaged_skip');
+    // LLM was NOT called — the precheck short-circuited.
+    expect(triageMockCalls.length).toBe(0);
+    // The decision row is untouched (still operator-reviewed, still skip).
+    const curated = dbState.triageDecisions.get('curated')!;
+    expect(curated.decision).toBe('skip');
+    expect(curated.decidedBy).toBe('operator');
+    expect(curated.reviewed).toBe(true);
+    expect(curated.reason).toBe('operator says no');
+    // No node was created.
+    expect(createNodeCalls.length).toBe(0);
+  });
+
+  it('operator-reviewed place row: re-triage returns the placed node, NO LLM call', async () => {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    // The placed node is what an operator put under epic-1.
+    dbState.nodes.set('curated-node', {
+      id: 'curated-node',
+      mapId: 'm1',
+      parentId: 'epic-1',
+      externalLinks: [], // Note: no externalLink (legacy migration scenario)
+    });
+    dbState.triageDecisions.set('curated', {
+      id: 'curated',
+      mapId: 'm1',
+      externalId: 'owner/repo#201',
+      issueTitle: 'op-placed',
+      issueState: 'open',
+      decision: 'place',
+      reason: 'operator chose epic-1',
+      confidence: 100,
+      placedNodeId: 'curated-node',
+      decidedAt: new Date(),
+      decidedBy: 'operator',
+      reviewed: true,
+      reviewedAt: new Date(),
+      reviewedBy: 'u1',
+    });
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'never',
+      confidence: 90,
+    };
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', issue(201), ctx);
+
+    expect(result.status).toBe('created');
+    expect(result.nodeId).toBe('curated-node');
+    expect(triageMockCalls.length).toBe(0);
+    expect(createNodeCalls.length).toBe(0);
+  });
+
+  // mindblown#99 fix 1 — race safety in the triage path. Two parallel
+  // calls on a triage_enabled map serialize on the advisory lock; the
+  // second observes the first's just-committed node and short-circuits
+  // to skipped_exists. Exactly one node + one triage_decisions row.
+  it('race safety in triage path: parallel calls create exactly one node + one decision row', async () => {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    triageMockResponse = {
+      decision: 'place',
+      parentNodeId: 'epic-1',
+      reason: 'matches Frontend',
+      confidence: 90,
+    };
+
+    const [a, b] = await Promise.all([
+      ensureNodeForIssue('m1', 'inbox-1', issue(202), ctx),
+      ensureNodeForIssue('m1', 'inbox-1', issue(202), ctx),
+    ]);
+
+    const statuses = [a.status, b.status].sort();
+    expect(statuses).toEqual(['created', 'skipped_exists']);
+    // Exactly one create across the two calls.
+    expect(createNodeCalls.length).toBe(1);
+    // The triage path took the advisory lock at least twice (once per
+    // call — actually four times because the path takes the lock for
+    // both the precheck tx AND the upsert tx). Either way, the lock
+    // infra was exercised, not bypassed.
+    expect(advisoryLocksTaken.length).toBeGreaterThanOrEqual(2);
+    // Exactly one triage_decisions row materialised across the two calls.
+    expect(dbState.triageDecisions.size).toBe(1);
+  });
+
+  // mindblown#99 fix 5 — when the caller passes triageEnabled in opts,
+  // the function MUST NOT issue an extra `SELECT maps.triage_enabled`
+  // per issue. We can't easily count SELECTs against the maps table
+  // from the mock infra, but we CAN assert the fast-path behaviour
+  // works: a map with NO entry in dbState.maps but explicit
+  // triageEnabled=true in opts should still hit the triage fork.
+  it('opts.triageEnabled overrides the per-issue maps SELECT', async () => {
+    // Note: dbState.maps does NOT contain m1 — so the fallback SELECT
+    // would return no row, and triageEnabled would be false. Passing
+    // it via opts must override that.
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    triageMockResponse = {
+      decision: 'place',
+      parentNodeId: 'epic-1',
+      reason: 'matches',
+      confidence: 90,
+    };
+
+    const result = await ensureNodeForIssue(
+      'm1',
+      'inbox-1',
+      issue(300, { title: 'fast-path' }),
+      ctx,
+      { triageEnabled: true },
+    );
+
+    expect(result.status).toBe('created');
+    expect(result.triage?.decision).toBe('place');
+    // The triage path was entered — proves opts.triageEnabled won
+    // without us populating dbState.maps.
+    expect(triageMockCalls.length).toBe(1);
+  });
+
   it('triage_enabled=true + place high-confidence with invalid parent UUID → downgrades to uncertain', async () => {
     dbState.maps.set('m1', {
       rootNodeId: 'root-1',

--- a/packages/server/src/sync/__tests__/githubIngest.test.ts
+++ b/packages/server/src/sync/__tests__/githubIngest.test.ts
@@ -386,6 +386,14 @@ let triageMockResponse: {
   confidence: number;
 } = { decision: 'uncertain', reason: 'default-mock', confidence: 0 };
 const triageMockCalls: Array<{ issueNumber: number; mapId: string }> = [];
+/**
+ * Optional async hook that runs INSIDE the triage mock, before it
+ * returns its mocked decision. Used by the lost-race operator-protect
+ * test to mutate `dbState.triageDecisions` mid-call — simulating an
+ * operator hitting Confirm during the LLM window between the precheck
+ * tx and the upsert tx.
+ */
+let triageMockMidCallHook: (() => Promise<void>) | null = null;
 
 vi.mock('../triage.js', () => ({
   triageIssue: vi.fn(async (input: { issue: { number: number }; mapContext: { mapId: string } }) => {
@@ -393,6 +401,9 @@ vi.mock('../triage.js', () => ({
       issueNumber: input.issue.number,
       mapId: input.mapContext.mapId,
     });
+    if (triageMockMidCallHook) {
+      await triageMockMidCallHook();
+    }
     return { ...triageMockResponse };
   }),
   TRIAGE_AUTO_APPLY_CONFIDENCE: 75,
@@ -571,6 +582,7 @@ function resetState() {
   getNodeMock.mockReset();
   updateNodeThrowOnNthCall = null;
   updateNodeMockShouldThrow = null;
+  triageMockMidCallHook = null;
 }
 
 beforeEach(() => {
@@ -1187,6 +1199,78 @@ describe('ensureNodeForIssue — triage fork', () => {
     expect(result.status).toBe('created');
     expect(result.nodeId).toBe('curated-node');
     expect(triageMockCalls.length).toBe(0);
+    expect(createNodeCalls.length).toBe(0);
+  });
+
+  // #100 Round 2 — lost-race operator-protect. The precheck tx checks
+  // "operator-reviewed row exists" but the upsert tx (previously) only
+  // re-checked "node exists." If an operator marks the row reviewed
+  // during the LLM-call window, the upsert's SET clause wipes the
+  // operator decision. The fix mirrors the operator-reviewed precheck
+  // INSIDE the upsert tx and short-circuits if it fires.
+  it('lost-race operator-protect: operator marks reviewed mid-LLM, upsert does NOT overwrite', async () => {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    // Seed an existing auto-decided row (operator hasn't reviewed yet).
+    // The precheck tx will see this as "proceed" and pay for the LLM.
+    dbState.triageDecisions.set('pending', {
+      id: 'pending',
+      mapId: 'm1',
+      externalId: 'owner/repo#250',
+      issueTitle: 'a candidate',
+      issueState: 'open',
+      decision: 'uncertain',
+      reason: 'auto unsure',
+      confidence: 40,
+      placedNodeId: null,
+      decidedAt: new Date('2026-01-01T00:00:00Z'),
+      decidedBy: 'auto',
+      reviewed: false,
+      reviewedAt: null,
+      reviewedBy: null,
+    });
+    // The LLM call returns "place" — without the fix, the upsert would
+    // happily clobber the operator's decision below.
+    triageMockResponse = {
+      decision: 'place',
+      parentNodeId: 'epic-1',
+      reason: 'fresh take from the model',
+      confidence: 92,
+    };
+    // Simulate an operator hitting Confirm DURING the LLM call window:
+    // mutate the existing decision row to reviewed=true,
+    // decidedBy='operator', decision='skip'. This is what the operator
+    // would have written.
+    triageMockMidCallHook = async () => {
+      const row = dbState.triageDecisions.get('pending')!;
+      row.reviewed = true;
+      row.decidedBy = 'operator';
+      row.decision = 'skip';
+      row.reason = 'operator vetoed';
+      row.reviewedAt = new Date('2026-01-02T00:00:00Z');
+      row.reviewedBy = 'u1';
+    };
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', issue(250), ctx);
+
+    // The LLM was called (cost already sunk before the operator click)
+    expect(triageMockCalls.length).toBe(1);
+    // ...but the upsert tx detected the operator-reviewed flip and
+    // returned the operator's decision instead of overwriting it.
+    expect(result.status).toBe('triaged_skip');
+    // Decision row is operator's, NOT auto.
+    const row = dbState.triageDecisions.get('pending')!;
+    expect(row.decision).toBe('skip');
+    expect(row.decidedBy).toBe('operator');
+    expect(row.reviewed).toBe(true);
+    expect(row.reason).toBe('operator vetoed');
+    expect(row.confidence).toBe(40); // un-clobbered
+    // No node was created (operator said skip).
     expect(createNodeCalls.length).toBe(0);
   });
 

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -553,7 +553,14 @@ async function ensureNodeForIssueViaTriage(
         node: Awaited<ReturnType<typeof nodeDb.getNode>>;
       }
     | { kind: 'decision_only'; decisionId: string }
-    | { kind: 'lost_race'; nodeId: string };
+    | { kind: 'lost_race'; nodeId: string }
+    | {
+        kind: 'operator_reviewed_late';
+        decisionId: string;
+        nodeId: string | null;
+        decision: TriageDecision['decision'];
+        confidence: number;
+      };
 
   const result: TxResult = await db.transaction(async (tx) => {
     await takeIngestLock(tx, externalId);
@@ -565,6 +572,49 @@ async function ensureNodeForIssueViaTriage(
     const existingNodeId = await findNodeInMapByExternalId(tx, mapId, externalId);
     if (existingNodeId) {
       return { kind: 'lost_race', nodeId: existingNodeId };
+    }
+
+    // Mirror the operator-reviewed precheck inside this tx (Ray's
+    // #100 Round 2 fix — lost-race operator-protect). The precheck tx
+    // above checks "node exists" AND "operator-reviewed row exists",
+    // but during the LLM-call window between Tx A and Tx B an
+    // operator can mark a row reviewed=true, decidedBy='operator'.
+    // Without this re-check, the upsert's SET clause below would
+    // overwrite that decision back to auto + unreviewed, wiping the
+    // operator's curation. The cost is one extra index lookup —
+    // cheaper than a wasted LLM round-trip, cheaper than losing the
+    // operator decision. We re-fetch (don't reuse the precheck row)
+    // because the precheck tx is long-since closed; the visibility
+    // we need is "what's committed NOW," and the advisory lock above
+    // means no other ingest tx can stomp before we exit this block.
+    const [existingDecisionInUpsertTx] = await tx
+      .select({
+        id: triageDecisions.id,
+        reviewed: triageDecisions.reviewed,
+        decidedBy: triageDecisions.decidedBy,
+        decision: triageDecisions.decision,
+        confidence: triageDecisions.confidence,
+        placedNodeId: triageDecisions.placedNodeId,
+      })
+      .from(triageDecisions)
+      .where(
+        and(
+          eq(triageDecisions.mapId, mapId),
+          eq(triageDecisions.externalId, externalId),
+        ),
+      );
+    if (
+      existingDecisionInUpsertTx &&
+      existingDecisionInUpsertTx.reviewed === true &&
+      existingDecisionInUpsertTx.decidedBy === 'operator'
+    ) {
+      return {
+        kind: 'operator_reviewed_late',
+        decisionId: existingDecisionInUpsertTx.id as string,
+        nodeId: (existingDecisionInUpsertTx.placedNodeId as string | null) ?? null,
+        decision: existingDecisionInUpsertTx.decision as TriageDecision['decision'],
+        confidence: existingDecisionInUpsertTx.confidence as number,
+      };
     }
 
     // Upsert the decision row. ON CONFLICT updates the existing row in
@@ -653,6 +703,45 @@ async function ensureNodeForIssueViaTriage(
     // winner persisted both the node AND its own decision row, so
     // returning skipped_exists is the safe outcome.
     return { status: 'skipped_exists', nodeId: result.nodeId, mapId };
+  }
+
+  if (result.kind === 'operator_reviewed_late') {
+    // Ray's #100 Round 2 fix — an operator marked the row reviewed
+    // during the LLM-call window between the precheck tx and the
+    // upsert tx. We did pay for the LLM call (sunk cost — the wider
+    // fix is to also short-circuit upstream once the lock can't
+    // observe the change, but that's a bigger rework), but the
+    // operator's decision wins. Mirror the precheck's mapping of
+    // operator_reviewed → matching IngestResult so downstream
+    // consumers see the operator's call, not the (now-discarded)
+    // LLM call.
+    if (result.decision === 'place' && result.nodeId) {
+      return {
+        status: 'created',
+        nodeId: result.nodeId,
+        mapId,
+        triage: {
+          decisionId: result.decisionId,
+          decision: result.decision,
+          confidence: result.confidence,
+        },
+      };
+    }
+    const lateStatus: IngestResult['status'] =
+      result.decision === 'skip'
+        ? 'triaged_skip'
+        : result.decision === 'uncertain'
+          ? 'triaged_uncertain'
+          : 'triaged_low_confidence';
+    return {
+      status: lateStatus,
+      mapId,
+      triage: {
+        decisionId: result.decisionId,
+        decision: result.decision,
+        confidence: result.confidence,
+      },
+    };
   }
 
   if (result.kind === 'auto_placed') {

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -94,10 +94,15 @@ export interface IngestResult {
  * The `createdBy` here is the map's creator — used as the attribution
  * for nodes ingested for that map. Each map gets its own inbox node, so
  * the same issue can land in two maps if both opt in.
+ *
+ * `triageEnabled` is carried alongside so `ensureNodeForIssue` doesn't
+ * need to re-SELECT `maps.triage_enabled` per issue — for a 200-issue
+ * backfill that's 200 round-trips saved.
  */
 export interface MapTarget {
   mapId: string;
   createdBy: string;
+  triageEnabled: boolean;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -201,11 +206,13 @@ export async function findIngestTargetMaps(
 ): Promise<MapTarget[]> {
   const targets = new Map<string, MapTarget>();
 
-  // (1) App-bound maps with the flag on.
+  // (1) App-bound maps with the flag on. We pull triageEnabled in the
+  // same SELECT so callers don't have to re-query it per issue.
   const appMaps = await db
     .select({
       id: maps.id,
       createdBy: maps.createdBy,
+      triageEnabled: maps.triageEnabled,
     })
     .from(maps)
     .where(
@@ -216,7 +223,11 @@ export async function findIngestTargetMaps(
       ),
     );
   for (const m of appMaps) {
-    targets.set(m.id, { mapId: m.id, createdBy: m.createdBy as string });
+    targets.set(m.id, {
+      mapId: m.id,
+      createdBy: m.createdBy as string,
+      triageEnabled: m.triageEnabled === true,
+    });
   }
 
   // (2) PAT integrations whose (owner, repo) matches → every map in
@@ -229,7 +240,11 @@ export async function findIngestTargetMaps(
     const cfg = integ.config as { owner?: string; repo?: string } | null;
     if (cfg?.owner !== owner || cfg?.repo !== repo) continue;
     const wsMaps = await db
-      .select({ id: maps.id, createdBy: maps.createdBy })
+      .select({
+        id: maps.id,
+        createdBy: maps.createdBy,
+        triageEnabled: maps.triageEnabled,
+      })
       .from(maps)
       .where(
         and(
@@ -239,7 +254,11 @@ export async function findIngestTargetMaps(
       );
     for (const m of wsMaps) {
       if (targets.has(m.id)) continue;
-      targets.set(m.id, { mapId: m.id, createdBy: m.createdBy as string });
+      targets.set(m.id, {
+        mapId: m.id,
+        createdBy: m.createdBy as string,
+        triageEnabled: m.triageEnabled === true,
+      });
     }
   }
 
@@ -331,6 +350,15 @@ export interface EnsureNodeOpts {
    * is ever lost.
    */
   allowClosedWithinDays?: number;
+  /**
+   * Whether the map has triage opted in. When provided, the caller
+   * already knows the value (e.g. it was loaded as part of
+   * `findIngestTargetMaps`) and `ensureNodeForIssue` skips the
+   * per-issue `SELECT maps.triage_enabled` round-trip. When omitted
+   * (legacy callers / explicit single-map paths like backfill), the
+   * function falls back to reading the column itself.
+   */
+  triageEnabled?: boolean;
 }
 
 // ── Triage-mode ingest helper ────────────────────────────────────
@@ -376,19 +404,111 @@ async function ensureNodeForIssueViaTriage(
   ctx: IngestContext,
   externalId: string,
 ): Promise<IngestResult> {
-  // Precheck before the LLM call — a node may already exist if the
-  // issue was previously ingested (toggled off → on, or the operator
-  // already added it manually). No need to spend tokens re-triaging
-  // something we've already placed.
-  const existing = await db
-    .select({ id: nodes.id, externalLinks: nodes.externalLinks })
-    .from(nodes)
-    .where(eq(nodes.mapId, mapId));
-  for (const row of existing) {
-    const links = (row.externalLinks as ExternalLink[]) ?? [];
-    if (links.some((l) => l.provider === 'github' && l.externalId === externalId)) {
-      return { status: 'skipped_exists', nodeId: row.id, mapId };
+  // ── Race-safety prelude (mindblown#99 fix 1) ────────────────────
+  // We do *two* things inside a transaction BEFORE paying for an LLM
+  // call:
+  //   a) `pg_advisory_xact_lock` keyed on the externalId, so two
+  //      concurrent webhook deliveries for the same issue serialize.
+  //   b) The existence precheck — both for "a node already references
+  //      this externalId" (operator added it manually, or an earlier
+  //      ingest landed it) AND for "an existing triage_decisions row
+  //      is operator-reviewed" (mindblown#99 fix 2 — never re-triage
+  //      an operator-curated row).
+  //
+  // If either precheck wins, we return early WITHOUT calling the LLM.
+  // That's the fast path; it also means the second of two racing
+  // webhook deliveries doesn't pay tokens. The fact-checks are also
+  // run inside the tx (sharing the lock) so a concurrent winner that
+  // commits in between sees its row visible from this tx as well.
+  type PrecheckResult =
+    | { kind: 'exists'; nodeId: string }
+    | { kind: 'operator_reviewed'; decisionId: string; nodeId: string | null;
+        decision: TriageDecision['decision']; confidence: number }
+    | { kind: 'proceed' };
+  const precheck: PrecheckResult = await db.transaction(async (tx) => {
+    await takeIngestLock(tx, externalId);
+
+    // (a) Node-existence precheck — uses the same tx-scoped helper as
+    // the non-triage path so it sees a concurrent winner's just-
+    // committed externalLink.
+    const existingNodeId = await findNodeInMapByExternalId(tx, mapId, externalId);
+    if (existingNodeId) {
+      return { kind: 'exists', nodeId: existingNodeId };
     }
+
+    // (b) Operator-reviewed precheck. Once an operator has reviewed a
+    // triage decision, automatic re-triage doesn't overwrite it —
+    // explicit reclassify from the UI is required. This contract
+    // closes the regression where `issues.edited` webhook fired by an
+    // edit on GitHub would wipe a careful operator decision back to
+    // `reviewed=false, decidedBy='auto'` (mindblown#99 fix 2).
+    const [existingDecision] = await tx
+      .select({
+        id: triageDecisions.id,
+        reviewed: triageDecisions.reviewed,
+        decidedBy: triageDecisions.decidedBy,
+        decision: triageDecisions.decision,
+        confidence: triageDecisions.confidence,
+        placedNodeId: triageDecisions.placedNodeId,
+      })
+      .from(triageDecisions)
+      .where(
+        and(
+          eq(triageDecisions.mapId, mapId),
+          eq(triageDecisions.externalId, externalId),
+        ),
+      );
+    if (
+      existingDecision &&
+      existingDecision.reviewed === true &&
+      existingDecision.decidedBy === 'operator'
+    ) {
+      return {
+        kind: 'operator_reviewed',
+        decisionId: existingDecision.id as string,
+        nodeId: (existingDecision.placedNodeId as string | null) ?? null,
+        decision: existingDecision.decision as TriageDecision['decision'],
+        confidence: existingDecision.confidence as number,
+      };
+    }
+    return { kind: 'proceed' };
+  });
+
+  if (precheck.kind === 'exists') {
+    return { status: 'skipped_exists', nodeId: precheck.nodeId, mapId };
+  }
+  if (precheck.kind === 'operator_reviewed') {
+    // Treat operator-reviewed rows as authoritative. Map the persisted
+    // decision back to the appropriate IngestResult shape so callers
+    // (catchup / webhook) see the same status code as if Claude had
+    // just produced the same decision — minus the LLM call.
+    if (precheck.decision === 'place' && precheck.nodeId) {
+      return {
+        status: 'created',
+        nodeId: precheck.nodeId,
+        mapId,
+        triage: {
+          decisionId: precheck.decisionId,
+          decision: precheck.decision,
+          confidence: precheck.confidence,
+        },
+      };
+    }
+    const status: IngestResult['status'] =
+      precheck.decision === 'skip'
+        ? 'triaged_skip'
+        : precheck.decision === 'uncertain'
+          ? 'triaged_uncertain'
+          : 'triaged_low_confidence';
+    return {
+      status,
+      mapId,
+      triage: {
+        decisionId: precheck.decisionId,
+        decision: precheck.decision,
+        confidence: precheck.confidence,
+      },
+    };
   }
 
   // Build the map-context summary and call the LLM. `buildMapContext`
@@ -419,9 +539,12 @@ async function ensureNodeForIssueViaTriage(
     decision.parentNodeId != null;
 
   // Persist the decision first, then (if auto-apply) create the node
-  // and update placed_node_id. We do this in a single tx so a crash
-  // between the insert and the update can't leave a "place" row with
-  // no node.
+  // and update placed_node_id. We do this in a single tx (and re-take
+  // the advisory lock on the externalId for the duration of this tx)
+  // so a crash between the insert and the update can't leave a
+  // "place" row with no node, AND so a concurrent racing webhook
+  // delivery (rare since we already serialized on the precheck tx
+  // above) still serializes on this one.
   type TxResult =
     | {
         kind: 'auto_placed';
@@ -429,12 +552,30 @@ async function ensureNodeForIssueViaTriage(
         nodeId: string;
         node: Awaited<ReturnType<typeof nodeDb.getNode>>;
       }
-    | { kind: 'decision_only'; decisionId: string };
+    | { kind: 'decision_only'; decisionId: string }
+    | { kind: 'lost_race'; nodeId: string };
 
   const result: TxResult = await db.transaction(async (tx) => {
+    await takeIngestLock(tx, externalId);
+
+    // Re-run the node-existence precheck inside this tx, in case a
+    // concurrent worker landed a node between the precheck tx above
+    // and this tx (window during which the lock was released).
+    // Cheap insurance; the happy path returns immediately.
+    const existingNodeId = await findNodeInMapByExternalId(tx, mapId, externalId);
+    if (existingNodeId) {
+      return { kind: 'lost_race', nodeId: existingNodeId };
+    }
+
     // Upsert the decision row. ON CONFLICT updates the existing row in
     // place so re-triage (operator hits `POST .../reclassify`) doesn't
     // accumulate duplicates.
+    //
+    // The operator-reviewed precheck above already short-circuits when
+    // existingDecision.reviewed=true && decidedBy='operator', so by the
+    // time we reach this upsert we know the row (if any) is either
+    // auto-decided or operator-touched-but-not-reviewed. The SET clause
+    // therefore overwrites the auto fields freely.
     const [decisionRow] = await tx
       .insert(triageDecisions)
       .values({
@@ -504,6 +645,15 @@ async function ensureNodeForIssueViaTriage(
       node: updated ?? created,
     };
   });
+
+  if (result.kind === 'lost_race') {
+    // A concurrent worker landed the node between our precheck tx and
+    // the upsert tx (rare; happens only if we lost the lock window).
+    // No tokens wasted — we already paid above, but the concurrent
+    // winner persisted both the node AND its own decision row, so
+    // returning skipped_exists is the safe outcome.
+    return { status: 'skipped_exists', nodeId: result.nodeId, mapId };
+  }
 
   if (result.kind === 'auto_placed') {
     broadcast(mapId, {
@@ -586,11 +736,23 @@ export async function ensureNodeForIssue(
   //
   // Maps with `triage_enabled = false` fall through to the existing
   // flat-under-inbox path with zero behavioural change.
-  const [mapRow] = await db
-    .select({ triageEnabled: maps.triageEnabled })
-    .from(maps)
-    .where(eq(maps.id, mapId));
-  if (mapRow?.triageEnabled) {
+  //
+  // Perf: when the caller already knows the flag (the multi-map fan-out
+  // does, via `findIngestTargetMaps`), it passes it in opts so we skip
+  // the per-issue `SELECT maps.triage_enabled` round-trip. The backfill
+  // helper and any legacy direct caller omits the opt and we fall back
+  // to reading the column.
+  let triageEnabled: boolean;
+  if (typeof opts.triageEnabled === 'boolean') {
+    triageEnabled = opts.triageEnabled;
+  } else {
+    const [mapRow] = await db
+      .select({ triageEnabled: maps.triageEnabled })
+      .from(maps)
+      .where(eq(maps.id, mapId));
+    triageEnabled = mapRow?.triageEnabled === true;
+  }
+  if (triageEnabled) {
     return ensureNodeForIssueViaTriage(mapId, issue, ctx, externalId);
   }
 
@@ -747,7 +909,7 @@ export async function ingestNewIssuesForRepo(
           inboxId,
           issue,
           { owner: target.owner, repo: target.repo, createdBy: t.createdBy },
-          opts,
+          { ...opts, triageEnabled: t.triageEnabled },
         );
         if (result.status === 'created') {
           summary.created++;
@@ -851,12 +1013,14 @@ export async function backfillMap(
       githubInstallationId: maps.githubInstallationId,
       githubRepoOwner: maps.githubRepoOwner,
       githubRepoName: maps.githubRepoName,
+      triageEnabled: maps.triageEnabled,
     })
     .from(maps)
     .where(eq(maps.id, mapId));
   if (!mapRow) {
     throw new Error(`backfillMap: map ${mapId} not found`);
   }
+  const triageEnabled = mapRow.triageEnabled === true;
 
   // Resolve owner/repo + token. App-binding first, then workspace PAT.
   // This mirrors `getGitHubContextForMap` in routes/integrations.ts —
@@ -937,7 +1101,7 @@ export async function backfillMap(
         inboxId,
         item.issue,
         { owner, repo, createdBy },
-        { allowClosedWithinDays },
+        { allowClosedWithinDays, triageEnabled },
       );
       if (result.status === 'created') imported++;
     } catch (err) {


### PR DESCRIPTION
## Summary

- **Phase 1 frontend (closes #94)**: right-docked TriagePanel with three sub-views (Pending / Placed / Skipped), per-decision cards (Confirm / Override / Re-classify), node-picker modal for Override, TriageIndicator badge in the map header.
- **Five Ray follow-ups folded in (addresses #99)**: race + tx-scoped existence check in triage path, no-wipe of operator-reviewed rows, override honors submitted parentNodeId via `moveNode`, reclassify clears `placedNodeId` on non-place decisions, and `MapTarget.triageEnabled` removes the per-issue `SELECT maps.triage_enabled` round-trip.

**Three of the five Ray fixes (1, 2, 3) MUST land before `triage_enabled = true` can be set on any real map** — they fix race conditions, state-wipe bugs, and silent-drop bugs in the Phase 0 backend that affect any opt-in user.

## Folded Ray follow-ups (from #99)

| # | Fix | Location |
|---|---|---|
| 1 | Race + tx-scoped existence check + LLM short-circuit on lost-race | `packages/server/src/sync/githubIngest.ts:373-547` |
| 2 | Don't wipe operator-reviewed rows; short-circuit before LLM | `packages/server/src/sync/githubIngest.ts:402-466` |
| 3 | Override honors submitted parentNodeId via `moveNode` + `node:moved` broadcast | `packages/server/src/routes/triage.ts:212-285` |
| 4 | Clear `placedNodeId` on non-place reclassify | `packages/server/src/routes/triage.ts:455-475` |
| 5 | `MapTarget.triageEnabled` + `opts.triageEnabled` fast-path | `packages/server/src/sync/githubIngest.ts:97-105`, `205-265`, `334-345`, `745-754` |

Each fix has a dedicated test covering the corrected behaviour (8 new tests total).

## Frontend (Phase 1)

- `packages/mindmap/src/TriagePanel.tsx` — sub-views with server-side filters, per-card actions
- `packages/mindmap/src/NodePickerModal.tsx` — collapsible tree picker with substring search, ancestors auto-expand on match
- `packages/mindmap/src/App.tsx` — new `TriageIndicator` button + pending-count polling + panel toggle wired with Sprint/Blocked
- `packages/mindmap/src/api.ts` — `listTriageDecisions` / `overrideTriageDecision` / `reclassifyTriageDecision` / `confirmTriageDecision`

Frontend tests deferred until `@mindblown/mindmap` has a runner (per #78 follow-ups); `data-testid` attributes are in place.

## Round 2 fixes (Ray's review)

Ray flagged one data-integrity bug + two should-fix items + a few nits on the first round. Round 2 commit: `51a0002`.

### Data-integrity bug — Confirm self-loop'd the placed node

The frontend's `confirmTriageDecision` was wired through `overrideTriageDecision` with `parentNodeId: decision.placedNodeId`. The override route's already-placed branch compared `placedNode.parentId !== submittedParent` — since `submittedParent === placedNodeId`, that diff was always true (a node is not its own parent), so the server called `moveNode(placedNodeId, placedNodeId)`. Result: the node became its own parent, was removed from its real parent's `childrenOrder`, and was orphaned with `parentId = self`. Data corruption on the most natural user action in the new UI.

**Fix (Option A from the review):** dedicated `POST /api/maps/:mapId/triage-decisions/:decisionId/confirm` route. It accepts no body parameters, only marks `reviewed=true, reviewedAt=NOW(), reviewedBy=<userId>, decidedBy='operator'`, and never touches node parentage. Same `edit` auth gate as override. The frontend's `confirmTriageDecision` now hits the new route. The misuse is structurally impossible at the API boundary.

**Defense-in-depth:** the `/override` route also rejects `parentNodeId === placedNodeId` with `400 SELF_LOOP_BLOCKED` so curl / MCP / alt UI can't reintroduce the same corruption.

### Lost-race operator-reviewed re-check (should-fix 1)

`packages/server/src/sync/githubIngest.ts` had a tx-scoped operator-reviewed precheck in Tx A, but Tx B (the upsert) only re-checked node existence. If an operator marked a row `reviewed=true, decidedBy='operator'` during the LLM-call window between Tx A and Tx B, Tx B's `onConflictDoUpdate.set` clause wiped it. Fix: mirror the operator-reviewed `SELECT` inside Tx B and short-circuit to a new `operator_reviewed_late` branch (returns the operator's decision, matches the precheck's `IngestResult` mapping). One extra index lookup; the alternative was lost operator curation.

### Sprint indicator mutual-exclusion (should-fix 2)

`packages/mindmap/src/App.tsx:1446-1448` — Sprint open closed Blocked but not Triage. Result: the Triage indicator stayed highlighted while Sprint panel rendered (precedence chain at 1847-1858 favours Sprint). Fix: `setTriagePanelOpen(false)` added to the Sprint handler so all three (Sprint / Blocked / Triage) are mutually exclusive.

### Nits

- `NodePickerModal.tsx` — "(current)" label changed to "(placed node)" to reflect what's actually excluded.
- `NodePickerModal.tsx` — dead `mapId: _mapId` prop removed (plus the matching pass-through in `TriagePanel.tsx`).
- `routes/triage.ts` — `parseIssueNumber` null branch now logs a `console.warn` so an operator chasing a `#0 <title>` in the UI can grep server logs for the malformed externalId.
- `routes/triage.ts` — reclassify response shape gains `placedNodeId` (the just-nulled value if non-place); saves the client a refetch.

### Round 2 tests (+7)

- `POST .../confirm`: marks reviewed without touching placedNodeId/parentage; works on skip rows; 404 missing; 403 API-key; 403 view-only (5 tests).
- `POST .../override`: `parentNodeId === placedNodeId` → 400 `SELF_LOOP_BLOCKED`, moveNode not called, row unchanged (1 test, defense-in-depth).
- `ensureNodeForIssueViaTriage`: operator marks row reviewed mid-LLM call, upsert tx detects the flip and returns the operator's decision instead of overwriting it (1 test).

## Test plan

- [x] `pnpm -w typecheck` clean
- [x] `pnpm -w build` clean
- [x] `pnpm -w test` — 290 passed (was 283; +7 Round 2 tests on top of Round 1's +8)
- [x] `rg "takeIngestLock" packages/server/src/sync/githubIngest.ts` shows 3 sites (2 in triage, 1 in non-triage)
- [x] `rg "triage_enabled" packages/server/src` — per-issue SELECT only as a fallback when `opts.triageEnabled` is omitted
- [ ] Manual persona test (post-merge): opt a test map into triage via SQL, open a GitHub issue, watch decision appear in Pending; click Confirm → assert it hits `/confirm` (not `/override`) AND the placed node's parent is unchanged; click Override → pick a new parent → decision moves to Placed; reclassify to skip clears placedNodeId; edit the GH issue body → operator-reviewed decisions are NOT wiped (Fix 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
