### PR TITLE
feat(triage): Phase 2 — bulk actions + reopened lifecycle + filters (closes #95)

### DIFF
--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Triage review panel (#94 — Phase 1 frontend).
+ * Triage review panel (#94 Phase 1 + #95 Phase 2).
  *
  * Three sub-views (Pending / Skipped / Placed) showing AI triage
  * decisions for the current map. Operator actions per row:
@@ -9,10 +9,23 @@
  *                  optionally change decision (skip / uncertain).
  *   - Re-classify — re-run the LLM against the current map context.
  *
+ * Phase 2 (#95) adds:
+ *
+ *   - Bulk-action toolbar at the top of each sub-view: checkbox column,
+ *     select-all, and "Confirm All Selected" / "Override All Selected"
+ *     / "Re-classify All Selected" buttons. Each calls the matching
+ *     bulk-* API; the response carries per-item results so the operator
+ *     sees per-row outcomes when (for example) one row was deleted
+ *     between submit and execute.
+ *   - Confidence-range slider (0-100) above the list — server-side
+ *     filter via the GET endpoint's minConfidence/maxConfidence.
+ *   - issue-state filter (open / closed / all).
+ *   - time-window filter (24h / 7d / 30d / all). Default 7d — most
+ *     common operator triage cadence per the spec.
+ *
  * Lives alongside BlockedPanel / SprintPanel — same right-docked
- * 380px width, same close-button pattern. The map header's
- * TriageIndicator button toggles it. Phase 0's backend exposes the
- * three routes; Phase 2 adds bulk operations.
+ * 420px width, same close-button pattern. The map header's
+ * TriageIndicator button toggles it.
  *
  * Frontend tests are deferred until `@mindblown/mindmap` has a test
  * runner (see #78 follow-ups). Every interactive element carries a
@@ -24,16 +37,50 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMindmapStore } from './store.js';
 import {
   ApiError,
+  bulkConfirmTriageDecisions,
+  bulkOverrideTriageDecisions,
+  bulkReclassifyTriageDecisions,
   confirmTriageDecision,
   listTriageDecisions,
   overrideTriageDecision,
   reclassifyTriageDecision,
+  type BulkTriageItem,
   type TriageDecision,
   type TriageDecisionKind,
 } from './api.js';
 import { NodePickerModal } from './NodePickerModal.js';
 
 const PANEL_WIDTH = 420;
+type IssueStateFilter = 'all' | 'open' | 'closed';
+type TimeWindowFilter = 'all' | '24h' | '7d' | '30d';
+
+// Map the time-window dropdown to an ISO `since` value. `all` returns
+// null so we don't send the param. We compute on every render of the
+// effect (cheap, < 1 µs); keeps the dropdown values reactive.
+function timeWindowToSince(w: TimeWindowFilter): string | null {
+  if (w === 'all') return null;
+  const ms =
+    w === '24h' ? 24 * 60 * 60 * 1000 : w === '7d' ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
+  return new Date(Date.now() - ms).toISOString();
+}
+
+// Count successful items + collect first per-item error from a
+// bulk-response so we can show a single inline banner without
+// hijacking the whole panel with a modal.
+function summarizeBulk(results: BulkTriageItem[]): { ok: number; err: number; firstError: string | null } {
+  let ok = 0;
+  let err = 0;
+  let firstError: string | null = null;
+  for (const r of results) {
+    if ('error' in r) {
+      err++;
+      if (!firstError) firstError = `${r.id.slice(0, 8)}…: ${r.error.message}`;
+    } else {
+      ok++;
+    }
+  }
+  return { ok, err, firstError };
+}
 
 type SubView = 'pending' | 'placed' | 'skipped';
 
@@ -48,27 +95,62 @@ export function TriagePanel({
   const [decisions, setDecisions] = useState<TriageDecision[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
   const [busyDecisionId, setBusyDecisionId] = useState<string | null>(null);
   const [pickerForDecision, setPickerForDecision] = useState<TriageDecision | null>(null);
+  // Two picker modes:
+  //   - 'single' → single-item Place/Move (existing Phase 1 flow).
+  //   - 'bulk'   → "Override All Selected" — applies the picked parent
+  //     to every checked decisionId via bulkOverrideTriageDecisions.
+  // `pickerForDecision` is null in bulk mode (the panel uses
+  // `bulkPickerOpen` instead).
+  const [bulkPickerOpen, setBulkPickerOpen] = useState(false);
   const [refreshTick, setRefreshTick] = useState(0);
+  // Selection state — checked decision ids in the current view. Reset
+  // on view-switch and after every bulk action.
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  // Bulk-in-flight indicator so the toolbar can show a counter.
+  const [bulkBusy, setBulkBusy] = useState<null | { kind: 'confirm' | 'override' | 'reclassify'; total: number }>(null);
+
+  // Phase 2 filter state — slider + dropdowns above the list.
+  const [minConfidence, setMinConfidence] = useState(0);
+  const [maxConfidence, setMaxConfidence] = useState(100);
+  const [issueStateFilter, setIssueStateFilter] = useState<IssueStateFilter>('all');
+  const [timeWindow, setTimeWindow] = useState<TimeWindowFilter>('7d');
 
   const refresh = useCallback(() => setRefreshTick((t) => t + 1), []);
+
+  // Clear selection when the view changes or after a bulk action.
+  // Clearing on filter-change isn't necessary — filtered-out rows just
+  // stay selected silently and the next bulk action operates on the
+  // intersection of selected ∩ currently-shown.
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [view]);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    // Server-side filter for the active sub-view. Pending = unreviewed;
-    // Placed = decision=place AND (reviewed OR placedNodeId set); Skipped
-    // = decision=skip AND reviewed. We pull each view fresh because the
-    // server count is authoritative — Phase 2 will switch to a single
-    // "all decisions" pull + client-side bucketing if perf demands it.
-    const filters =
-      view === 'pending'
-        ? { reviewed: false, limit: 200 }
+    // Server-side filter for the active sub-view + Phase 2 filters.
+    //   Pending  = unreviewed
+    //   Placed   = decision=place AND reviewed
+    //   Skipped  = decision=skip AND reviewed
+    // Confidence/issueState/since are sent as separate query params
+    // (server clamps to valid ranges, silently ignores malformed).
+    const since = timeWindowToSince(timeWindow);
+    const filters = {
+      ...(view === 'pending'
+        ? { reviewed: false }
         : view === 'placed'
-          ? { decision: 'place' as TriageDecisionKind, reviewed: true, limit: 200 }
-          : { decision: 'skip' as TriageDecisionKind, reviewed: true, limit: 200 };
+          ? { decision: 'place' as TriageDecisionKind, reviewed: true }
+          : { decision: 'skip' as TriageDecisionKind, reviewed: true }),
+      limit: 200,
+      minConfidence,
+      maxConfidence,
+      ...(issueStateFilter !== 'all' ? { issueState: issueStateFilter } : {}),
+      ...(since ? { since } : {}),
+    };
     listTriageDecisions(mapId, filters)
       .then((res) => {
         if (cancelled) return;
@@ -86,7 +168,7 @@ export function TriagePanel({
     return () => {
       cancelled = true;
     };
-  }, [mapId, view, refreshTick]);
+  }, [mapId, view, refreshTick, minConfidence, maxConfidence, issueStateFilter, timeWindow]);
 
   const handleConfirm = useCallback(
     async (decision: TriageDecision) => {
@@ -161,6 +243,110 @@ export function TriagePanel({
     },
     [mapId, pickerForDecision, refresh],
   );
+
+  // ── Bulk handlers (#95 Phase 2) ───────────────────────────────
+  //
+  // All three share the same shape: pull the selected ids, hit the
+  // bulk endpoint, summarize results into an info/error banner, clear
+  // the selection, and refresh. We pass the array of ids — the server
+  // handles per-item idempotency, so a deleted-mid-batch row shows up
+  // as a per-item error in the banner instead of failing the batch.
+  const selectedArray = useMemo(() => Array.from(selectedIds), [selectedIds]);
+  const selectedDecisions = useMemo(
+    () => decisions.filter((d) => selectedIds.has(d.id)),
+    [decisions, selectedIds],
+  );
+
+  const finishBulk = useCallback((results: BulkTriageItem[], label: string) => {
+    const { ok, err, firstError } = summarizeBulk(results);
+    if (err > 0) {
+      setError(
+        `${label}: ${ok} ok / ${err} failed${firstError ? ` — ${firstError}` : ''}`,
+      );
+      setInfo(null);
+    } else {
+      setInfo(`${label}: ${ok} ok`);
+      setError(null);
+    }
+    setSelectedIds(new Set());
+    refresh();
+  }, [refresh]);
+
+  const handleBulkConfirm = useCallback(async () => {
+    if (selectedArray.length === 0) return;
+    setBulkBusy({ kind: 'confirm', total: selectedArray.length });
+    try {
+      const res = await bulkConfirmTriageDecisions(mapId, selectedArray);
+      finishBulk(res.results, `Confirm ${selectedArray.length}`);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Bulk confirm failed';
+      setError(msg);
+    } finally {
+      setBulkBusy(null);
+    }
+  }, [mapId, selectedArray, finishBulk]);
+
+  const handleBulkReclassify = useCallback(async () => {
+    if (selectedArray.length === 0) return;
+    setBulkBusy({ kind: 'reclassify', total: selectedArray.length });
+    try {
+      const res = await bulkReclassifyTriageDecisions(mapId, selectedArray);
+      finishBulk(res.results, `Re-classify ${selectedArray.length}`);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Bulk reclassify failed';
+      setError(msg);
+    } finally {
+      setBulkBusy(null);
+    }
+  }, [mapId, selectedArray, finishBulk]);
+
+  const handleBulkOverridePickParent = useCallback(
+    async (parentNodeId: string) => {
+      setBulkPickerOpen(false);
+      if (selectedArray.length === 0) return;
+      setBulkBusy({ kind: 'override', total: selectedArray.length });
+      try {
+        const res = await bulkOverrideTriageDecisions(mapId, selectedArray, parentNodeId);
+        finishBulk(res.results, `Override ${selectedArray.length}`);
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Bulk override failed';
+        setError(msg);
+      } finally {
+        setBulkBusy(null);
+      }
+    },
+    [mapId, selectedArray, finishBulk],
+  );
+
+  // "Override All Selected" is only valid when every selected row is a
+  // place decision (spec: "only valid for `place` decisions — gated
+  // client-side"). The button is disabled otherwise; the server also
+  // rejects per-item.
+  const canBulkOverride =
+    selectedDecisions.length > 0 &&
+    selectedDecisions.every((d) => d.decision === 'place');
+
+  // Select-all behavior — toggle between (select all visible) and
+  // (clear).
+  const allSelected =
+    decisions.length > 0 && decisions.every((d) => selectedIds.has(d.id));
+  const someSelected = selectedIds.size > 0 && !allSelected;
+  const toggleSelectAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(decisions.map((d) => d.id)));
+    }
+  }, [allSelected, decisions]);
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
 
   return (
     <div
@@ -239,6 +425,64 @@ export function TriagePanel({
         </TabButton>
       </div>
 
+      {/* Filter row (#95 Phase 2) — confidence slider + state + window */}
+      <FilterBar
+        minConfidence={minConfidence}
+        maxConfidence={maxConfidence}
+        onMinChange={setMinConfidence}
+        onMaxChange={setMaxConfidence}
+        issueState={issueStateFilter}
+        onIssueStateChange={setIssueStateFilter}
+        timeWindow={timeWindow}
+        onTimeWindowChange={setTimeWindow}
+      />
+
+      {/* Bulk-action toolbar (#95 Phase 2) — select-all + actions */}
+      <BulkToolbar
+        view={view}
+        totalVisible={decisions.length}
+        selectedCount={selectedIds.size}
+        allSelected={allSelected}
+        someSelected={someSelected}
+        onToggleSelectAll={toggleSelectAll}
+        canBulkOverride={canBulkOverride}
+        bulkBusy={bulkBusy}
+        onBulkConfirm={handleBulkConfirm}
+        onBulkOverride={() => setBulkPickerOpen(true)}
+        onBulkReclassify={handleBulkReclassify}
+      />
+
+      {/* Info banner (bulk success) */}
+      {info && !error && (
+        <div
+          data-testid="triage-info"
+          style={{
+            padding: '8px 16px',
+            background: '#dcfce7',
+            color: '#166534',
+            fontSize: 12,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <span style={{ flex: 1 }}>{info}</span>
+          <button
+            onClick={() => setInfo(null)}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: '#166534',
+              fontFamily: 'inherit',
+              fontSize: 12,
+            }}
+          >
+            x
+          </button>
+        </div>
+      )}
+
       {/* Error banner */}
       {error && (
         <div
@@ -291,6 +535,8 @@ export function TriagePanel({
               decision={d}
               view={view}
               busy={busyDecisionId === d.id}
+              selected={selectedIds.has(d.id)}
+              onToggleSelect={() => toggleSelect(d.id)}
               onConfirm={() => handleConfirm(d)}
               onPlace={() => setPickerForDecision(d)}
               onReclassify={() => handleReclassify(d)}
@@ -312,10 +558,11 @@ export function TriagePanel({
         }}
       >
         Pending = unreviewed AI decisions. Confirm to accept, Override
-        to reparent, Re-classify to re-run.
+        to reparent, Re-classify to re-run. Check rows + use the
+        toolbar for bulk actions.
       </div>
 
-      {/* Node picker modal */}
+      {/* Single-item node picker modal */}
       {pickerForDecision && (
         <NodePickerModal
           title={`Pick a parent for "${pickerForDecision.issueTitle}"`}
@@ -324,6 +571,240 @@ export function TriagePanel({
           onClose={() => setPickerForDecision(null)}
         />
       )}
+
+      {/* Bulk-override node picker modal */}
+      {bulkPickerOpen && (
+        <NodePickerModal
+          title={`Pick a parent for ${selectedArray.length} decision${selectedArray.length === 1 ? '' : 's'}`}
+          // Exclude every selected row's placedNodeId — picking one of
+          // them would self-loop and be rejected per-item with
+          // SELF_LOOP_BLOCKED. Better to disable up front.
+          excludeNodeIds={selectedDecisions
+            .map((d) => d.placedNodeId)
+            .filter((x): x is string => typeof x === 'string')}
+          onPick={handleBulkOverridePickParent}
+          onClose={() => setBulkPickerOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Filter bar (#95 Phase 2) ──────────────────────────────────────
+
+function FilterBar({
+  minConfidence,
+  maxConfidence,
+  onMinChange,
+  onMaxChange,
+  issueState,
+  onIssueStateChange,
+  timeWindow,
+  onTimeWindowChange,
+}: {
+  minConfidence: number;
+  maxConfidence: number;
+  onMinChange: (n: number) => void;
+  onMaxChange: (n: number) => void;
+  issueState: IssueStateFilter;
+  onIssueStateChange: (s: IssueStateFilter) => void;
+  timeWindow: TimeWindowFilter;
+  onTimeWindowChange: (w: TimeWindowFilter) => void;
+}) {
+  return (
+    <div
+      data-testid="triage-filterbar"
+      style={{
+        padding: '8px 12px',
+        borderBottom: '1px solid #e2e8f0',
+        background: '#f8fafc',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 10, color: '#64748b', minWidth: 70 }}>
+          Confidence
+        </span>
+        <input
+          data-testid="triage-filter-min-confidence"
+          type="range"
+          min={0}
+          max={100}
+          value={minConfidence}
+          onChange={(e) => {
+            const n = parseInt(e.target.value, 10);
+            // Clamp: min can't exceed max.
+            onMinChange(Math.min(n, maxConfidence));
+          }}
+          style={{ flex: 1 }}
+        />
+        <input
+          data-testid="triage-filter-max-confidence"
+          type="range"
+          min={0}
+          max={100}
+          value={maxConfidence}
+          onChange={(e) => {
+            const n = parseInt(e.target.value, 10);
+            onMaxChange(Math.max(n, minConfidence));
+          }}
+          style={{ flex: 1 }}
+        />
+        <span
+          style={{ fontSize: 10, color: '#64748b', minWidth: 48, textAlign: 'right' }}
+          data-testid="triage-filter-confidence-label"
+        >
+          {minConfidence}–{maxConfidence}
+        </span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 10, color: '#64748b', minWidth: 70 }}>State</span>
+        <select
+          data-testid="triage-filter-issue-state"
+          value={issueState}
+          onChange={(e) => onIssueStateChange(e.target.value as IssueStateFilter)}
+          style={{
+            flex: 1,
+            fontSize: 11,
+            padding: '2px 4px',
+            border: '1px solid #e2e8f0',
+            borderRadius: 4,
+            background: '#fff',
+            fontFamily: 'inherit',
+          }}
+        >
+          <option value="all">All</option>
+          <option value="open">Open</option>
+          <option value="closed">Closed</option>
+        </select>
+        <span style={{ fontSize: 10, color: '#64748b', minWidth: 40 }}>Window</span>
+        <select
+          data-testid="triage-filter-time-window"
+          value={timeWindow}
+          onChange={(e) => onTimeWindowChange(e.target.value as TimeWindowFilter)}
+          style={{
+            flex: 1,
+            fontSize: 11,
+            padding: '2px 4px',
+            border: '1px solid #e2e8f0',
+            borderRadius: 4,
+            background: '#fff',
+            fontFamily: 'inherit',
+          }}
+        >
+          <option value="24h">24 h</option>
+          <option value="7d">7 d</option>
+          <option value="30d">30 d</option>
+          <option value="all">All</option>
+        </select>
+      </div>
+    </div>
+  );
+}
+
+// ── Bulk-action toolbar (#95 Phase 2) ─────────────────────────────
+
+function BulkToolbar({
+  view,
+  totalVisible,
+  selectedCount,
+  allSelected,
+  someSelected,
+  onToggleSelectAll,
+  canBulkOverride,
+  bulkBusy,
+  onBulkConfirm,
+  onBulkOverride,
+  onBulkReclassify,
+}: {
+  view: SubView;
+  totalVisible: number;
+  selectedCount: number;
+  allSelected: boolean;
+  someSelected: boolean;
+  onToggleSelectAll: () => void;
+  canBulkOverride: boolean;
+  bulkBusy: null | { kind: 'confirm' | 'override' | 'reclassify'; total: number };
+  onBulkConfirm: () => void;
+  onBulkOverride: () => void;
+  onBulkReclassify: () => void;
+}) {
+  const noSelection = selectedCount === 0;
+  const busy = bulkBusy != null;
+  return (
+    <div
+      data-testid="triage-bulk-toolbar"
+      style={{
+        padding: '6px 10px',
+        borderBottom: '1px solid #e2e8f0',
+        background: '#f1f5f9',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        flexWrap: 'wrap',
+      }}
+    >
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          fontSize: 11,
+          color: '#475569',
+          cursor: totalVisible === 0 ? 'not-allowed' : 'pointer',
+        }}
+      >
+        <input
+          data-testid="triage-bulk-select-all"
+          type="checkbox"
+          // Tri-state visual: indeterminate when some-but-not-all are
+          // selected; React doesn't have a JSX prop for `indeterminate`
+          // so we set it via a ref callback.
+          ref={(el) => {
+            if (el) el.indeterminate = someSelected;
+          }}
+          checked={allSelected}
+          disabled={totalVisible === 0 || busy}
+          onChange={onToggleSelectAll}
+        />
+        <span data-testid="triage-bulk-selected-count">
+          {selectedCount} / {totalVisible}
+        </span>
+      </label>
+      <div style={{ flex: 1 }} />
+      {view === 'pending' && (
+        <ActionBtn
+          testId="triage-bulk-confirm"
+          label={
+            bulkBusy?.kind === 'confirm' ? `Confirming ${bulkBusy.total}…` : 'Confirm All'
+          }
+          kind="primary"
+          disabled={noSelection || busy}
+          onClick={onBulkConfirm}
+        />
+      )}
+      <ActionBtn
+        testId="triage-bulk-override"
+        label={
+          bulkBusy?.kind === 'override' ? `Moving ${bulkBusy.total}…` : 'Override All'
+        }
+        kind="default"
+        disabled={noSelection || !canBulkOverride || busy}
+        onClick={onBulkOverride}
+      />
+      <ActionBtn
+        testId="triage-bulk-reclassify"
+        label={
+          bulkBusy?.kind === 'reclassify'
+            ? `Re-classifying ${bulkBusy.total}…`
+            : 'Re-classify All'
+        }
+        kind="ghost"
+        disabled={noSelection || busy}
+        onClick={onBulkReclassify}
+      />
     </div>
   );
 }
@@ -366,6 +847,8 @@ function TriageCard({
   decision,
   view,
   busy,
+  selected,
+  onToggleSelect,
   onConfirm,
   onPlace,
   onReclassify,
@@ -375,6 +858,8 @@ function TriageCard({
   decision: TriageDecision;
   view: SubView;
   busy: boolean;
+  selected: boolean;
+  onToggleSelect: () => void;
   onConfirm: () => void;
   onPlace: () => void;
   onReclassify: () => void;
@@ -415,10 +900,20 @@ function TriageCard({
         display: 'flex',
         flexDirection: 'column',
         gap: 8,
+        background: selected ? '#eff6ff' : 'transparent',
       }}
     >
       {/* Title row */}
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <input
+          data-testid="triage-card-select"
+          type="checkbox"
+          checked={selected}
+          onChange={onToggleSelect}
+          disabled={busy}
+          style={{ marginTop: 2 }}
+          aria-label={`Select ${decision.issueTitle}`}
+        />
         <span style={{ fontSize: 12, fontWeight: 600, color: '#1e293b', flex: 1 }}>
           {decision.issueTitle}
         </span>

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -1020,6 +1020,14 @@ export interface ListTriageDecisionsFilters {
   reviewed?: boolean;
   decision?: TriageDecisionKind;
   limit?: number;
+  /** Phase 2 (#95): inclusive lower bound on confidence (0–100). */
+  minConfidence?: number;
+  /** Phase 2 (#95): inclusive upper bound on confidence (0–100). */
+  maxConfidence?: number;
+  /** Phase 2 (#95): exact-match on the GH state captured at decision time. */
+  issueState?: 'open' | 'closed';
+  /** Phase 2 (#95): only rows decided at or after this ISO timestamp. */
+  since?: string;
 }
 
 export interface ListTriageDecisionsResponse {
@@ -1036,6 +1044,10 @@ export function listTriageDecisions(
   if (filters.reviewed !== undefined) qs.set('reviewed', String(filters.reviewed));
   if (filters.decision) qs.set('decision', filters.decision);
   if (filters.limit) qs.set('limit', String(filters.limit));
+  if (filters.minConfidence !== undefined) qs.set('minConfidence', String(filters.minConfidence));
+  if (filters.maxConfidence !== undefined) qs.set('maxConfidence', String(filters.maxConfidence));
+  if (filters.issueState) qs.set('issueState', filters.issueState);
+  if (filters.since) qs.set('since', filters.since);
   const q = qs.toString();
   return request<ListTriageDecisionsResponse>(
     `/api/maps/${mapId}/triage-decisions${q ? `?${q}` : ''}`,
@@ -1116,5 +1128,76 @@ export function confirmTriageDecision(
   return request<ConfirmTriageResponse>(
     `/api/maps/${mapId}/triage-decisions/${decision.id}/confirm`,
     { method: 'POST' },
+  );
+}
+
+// ── Bulk variants (#95 Phase 2) ──────────────────────────────────
+//
+// Each variant accepts `{ decisionIds: string[] }` and returns
+// `{ mapId, results: BulkTriageItem[] }` where each item is either
+// `{ id, status, ... }` (success) or `{ id, error: { code, message } }`
+// (per-item failure). HTTP is always 200 unless the whole batch is
+// rejected (bad auth, malformed body) — a single bad row in an
+// otherwise-valid batch is reported per-item, not as a batch-level error.
+
+export interface BulkTriageItemOk {
+  id: string;
+  status: string;
+  nodeId?: string | null;
+  decision?: TriageDecisionKind;
+  confidence?: number;
+  reason?: string;
+  placedNodeId?: string | null;
+}
+
+export interface BulkTriageItemErr {
+  id: string;
+  error: { code: string; message: string };
+}
+
+export type BulkTriageItem = BulkTriageItemOk | BulkTriageItemErr;
+
+export interface BulkTriageResponse {
+  mapId: string;
+  results: BulkTriageItem[];
+}
+
+export function bulkConfirmTriageDecisions(
+  mapId: string,
+  decisionIds: string[],
+): Promise<BulkTriageResponse> {
+  return request<BulkTriageResponse>(
+    `/api/maps/${mapId}/triage-decisions/bulk-confirm`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ decisionIds }),
+    },
+  );
+}
+
+export function bulkOverrideTriageDecisions(
+  mapId: string,
+  decisionIds: string[],
+  parentNodeId: string,
+): Promise<BulkTriageResponse> {
+  return request<BulkTriageResponse>(
+    `/api/maps/${mapId}/triage-decisions/bulk-override`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ decisionIds, parentNodeId }),
+    },
+  );
+}
+
+export function bulkReclassifyTriageDecisions(
+  mapId: string,
+  decisionIds: string[],
+): Promise<BulkTriageResponse> {
+  return request<BulkTriageResponse>(
+    `/api/maps/${mapId}/triage-decisions/bulk-reclassify`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ decisionIds }),
+    },
   );
 }

--- a/packages/server/src/routes/__tests__/triage-reopen.test.ts
+++ b/packages/server/src/routes/__tests__/triage-reopen.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Tests for the issue.reopened triage-lifecycle hook (#95 Phase 2).
+ *
+ * The webhook path lives in routes/integrations.ts; the re-triage
+ * decision lives in the exported `syncTriageRowsForReopen` helper.
+ * We exercise the helper directly so we don't have to fake a full
+ * Octokit/webhook payload — the webhook handler itself is a thin
+ * `if (action === 'reopened') call(externalId)` wrapper.
+ *
+ * Three scenarios per spec:
+ *   1. Existing un-reviewed decision row + reopen → re-triage runs,
+ *      issue_state flips to 'open', decision is rewritten by Claude.
+ *   2. Operator-reviewed row + reopen → re-triage SKIPPED, but
+ *      issue_state still flips to 'open' (audit-only column tracks
+ *      current GH state regardless of decision-immutability).
+ *   3. Map's triage_enabled=false → re-triage SKIPPED, issue_state
+ *      still updated.
+ *
+ * The "no existing row" → run through standard ingest case is
+ * covered by the existing githubIngest.test.ts triage fork suite; it
+ * never hits syncTriageRowsForReopen.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { GitHubIssue } from '@mindblown/integrations';
+
+// ── In-memory state ───────────────────────────────────────────────
+
+interface TriageRow {
+  id: string;
+  mapId: string;
+  externalId: string;
+  issueTitle: string;
+  issueState: 'open' | 'closed';
+  decision: 'place' | 'skip' | 'uncertain';
+  reason: string;
+  confidence: number;
+  placedNodeId: string | null;
+  decidedAt: Date;
+  decidedBy: 'auto' | 'operator';
+  reviewed: boolean;
+  reviewedAt: Date | null;
+  reviewedBy: string | null;
+}
+
+const triageRows = new Map<string, TriageRow>();
+const mapRows = new Map<string, { id: string; triageEnabled: boolean }>();
+
+function seedRow(overrides: Partial<TriageRow> & { id: string; mapId: string; externalId: string }): TriageRow {
+  const row: TriageRow = {
+    issueTitle: 'an issue',
+    issueState: 'closed', // most tests reopen from closed
+    decision: 'uncertain',
+    reason: 'r',
+    confidence: 40,
+    placedNodeId: null,
+    decidedAt: new Date(),
+    decidedBy: 'auto',
+    reviewed: false,
+    reviewedAt: null,
+    reviewedBy: null,
+    ...overrides,
+  };
+  triageRows.set(overrides.id, row);
+  return row;
+}
+
+// ── Predicate-aware DB stub (shape mirrors triage-routes.test.ts) ─
+
+type Predicate = { __pred: true; check: (row: Record<string, unknown>) => boolean };
+function applyPred(rows: Record<string, unknown>[], pred: unknown): Record<string, unknown>[] {
+  if (!pred || typeof pred !== 'object') return rows;
+  const p = pred as { __pred?: true; check?: (row: Record<string, unknown>) => boolean };
+  if (!p.__pred || typeof p.check !== 'function') return rows;
+  return rows.filter((r) => p.check!(r));
+}
+
+function buildSelectChain() {
+  const step: { table?: string; pred?: unknown } = {};
+  const resolve = async (): Promise<Record<string, unknown>[]> => {
+    let rows: Record<string, unknown>[] = [];
+    if (step.table === 'triageDecisions') {
+      rows = [...triageRows.values()].map((r) => ({ ...r }));
+    } else if (step.table === 'maps') {
+      rows = [...mapRows.values()].map((m) => ({ ...m }));
+    }
+    return applyPred(rows, step.pred);
+  };
+  const thenable = {
+    then: (onF: (v: Record<string, unknown>[]) => unknown, onR?: (e: unknown) => unknown) =>
+      resolve().then(onF, onR),
+    catch: (onR: (e: unknown) => unknown) => resolve().catch(onR),
+    where: (pred: unknown) => {
+      step.pred = pred;
+      return thenable;
+    },
+    orderBy: () => thenable,
+    limit: () => thenable,
+  };
+  return {
+    from(table: { __name?: string }) {
+      step.table = table.__name;
+      return thenable;
+    },
+  };
+}
+
+vi.mock('../../db/connection.js', () => {
+  const db = {
+    select: () => buildSelectChain(),
+    update: (table: { __name?: string }) => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: async (pred: unknown) => {
+          if (table?.__name !== 'triageDecisions') return;
+          const p = pred as { __pred?: true; check?: (row: Record<string, unknown>) => boolean };
+          for (const row of triageRows.values()) {
+            if (p?.check?.(row as unknown as Record<string, unknown>)) {
+              Object.assign(row, vals);
+            }
+          }
+        },
+      }),
+    }),
+    insert: () => ({ values: () => ({ returning: async () => [] }) }),
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(db),
+  };
+  return { db };
+});
+
+vi.mock('../../db/schema.js', () => {
+  const col = (name: string) => ({ __col: name });
+  return {
+    maps: { __name: 'maps', id: col('id'), triageEnabled: col('triageEnabled') },
+    versions: { __name: 'versions' },
+    nodes: { __name: 'nodes', id: col('id'), externalLinks: col('externalLinks') },
+    integrations: { __name: 'integrations' },
+    triageDecisions: {
+      __name: 'triageDecisions',
+      id: col('id'),
+      mapId: col('mapId'),
+      externalId: col('externalId'),
+      issueTitle: col('issueTitle'),
+      placedNodeId: col('placedNodeId'),
+      reviewed: col('reviewed'),
+      decidedBy: col('decidedBy'),
+      issueState: col('issueState'),
+    },
+  };
+});
+
+vi.mock('drizzle-orm', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('drizzle-orm');
+  return {
+    ...actual,
+    eq: (column: { __col?: string }, value: unknown): Predicate => ({
+      __pred: true,
+      check: (row) => row[column.__col ?? ''] === value,
+    }),
+    and: (...preds: Predicate[]): Predicate => ({
+      __pred: true,
+      check: (row) => preds.every((p) => p.check(row)),
+    }),
+    sql: vi.fn(),
+  };
+});
+
+// Triage + mapContext stubs. vi.mock factories are hoisted above all
+// top-level code, so any spy they reference must also be hoisted —
+// declare via vi.hoisted, re-expose for ergonomic test assertions.
+const hoisted = vi.hoisted(() => ({
+  triageMock: vi.fn(async () => ({
+    decision: 'place' as const,
+    parentNodeId: 'epic-1',
+    reason: 'reclassified, matches Frontend',
+    confidence: 90,
+  })),
+}));
+const triageMock = hoisted.triageMock;
+vi.mock('../../sync/triage.js', () => ({ triageIssue: hoisted.triageMock }));
+
+vi.mock('../../sync/mapContext.js', () => ({
+  buildMapContext: vi.fn(async (mapId: string) => ({
+    mapId,
+    mapName: 'm',
+    mapDescription: '',
+    epics: [{ nodeId: 'epic-1', title: 'Frontend', description: 'UI' }],
+  })),
+}));
+
+// The integrations module imports a bunch of other modules at top-level
+// that we don't exercise here — stub them out so the import resolves.
+vi.mock('@mindblown/integrations', () => ({
+  createGitHubIssue: vi.fn(),
+  getGitHubIssue: vi.fn(),
+  importGitHubIssues: vi.fn(),
+  extractVersionFromMilestone: vi.fn(),
+  processWebhook: vi.fn(),
+  verifyWebhookSignature: vi.fn(),
+  mintInstallationToken: vi.fn(),
+  isGitHubAppConfigured: vi.fn(),
+}));
+vi.mock('../../sync/githubCatchup.js', () => ({ reconcileRepo: vi.fn() }));
+vi.mock('../../sync/driftAudit.js', () => ({ runDriftAudit: vi.fn() }));
+vi.mock('../../sync/webhookAuthCheck.js', () => ({ recordWebhookCall: vi.fn() }));
+vi.mock('../../auth.js', () => ({ requireAdmin: vi.fn() }));
+vi.mock('../../sync/parentEpicRollup.js', () => ({ rollupParentsForChildTitle: vi.fn() }));
+vi.mock('../../sync/githubIngest.js', () => ({
+  ingestNewIssuesForRepo: vi.fn(),
+  ensureInboxNode: vi.fn(),
+  ensureNodeForIssue: vi.fn(),
+  findNodesByExternalIds: vi.fn(),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../../db/nodes.js', () => ({
+  getNode: vi.fn(),
+  updateNode: vi.fn(),
+}));
+
+import { syncTriageRowsForReopen } from '../integrations.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+function reopenedIssue(number: number): GitHubIssue {
+  return {
+    id: number * 1000,
+    number,
+    title: 'Reopened issue',
+    body: 'now has more context',
+    state: 'open',
+    labels: [],
+    assignees: [],
+    milestone: null,
+    html_url: `https://github.com/o/r/issues/${number}`,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    closed_at: null,
+  } as GitHubIssue;
+}
+
+beforeEach(() => {
+  triageRows.clear();
+  mapRows.clear();
+  triageMock.mockClear();
+  triageMock.mockResolvedValue({
+    decision: 'place' as const,
+    parentNodeId: 'epic-1',
+    reason: 'reclassified, matches Frontend',
+    confidence: 90,
+  });
+});
+
+// ── Scenarios ─────────────────────────────────────────────────────
+
+describe('syncTriageRowsForReopen', () => {
+  it('unreviewed row on a triage-enabled map → issue_state flips, re-triage runs, decision rewritten', async () => {
+    mapRows.set('m1', { id: 'm1', triageEnabled: true });
+    seedRow({
+      id: 'tr-1',
+      mapId: 'm1',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'uncertain',
+      confidence: 30,
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+
+    await syncTriageRowsForReopen('o/r#42', reopenedIssue(42));
+
+    const row = triageRows.get('tr-1')!;
+    expect(row.issueState).toBe('open');
+    expect(triageMock).toHaveBeenCalledOnce();
+    // Mock returns place + 90.
+    expect(row.decision).toBe('place');
+    expect(row.confidence).toBe(90);
+    expect(row.decidedBy).toBe('auto');
+    expect(row.reviewed).toBe(false);
+  });
+
+  it('operator-reviewed row → issue_state still flips to open, but decision/reviewer UNCHANGED', async () => {
+    mapRows.set('m1', { id: 'm1', triageEnabled: true });
+    seedRow({
+      id: 'tr-1',
+      mapId: 'm1',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'skip',
+      reason: 'operator said no',
+      confidence: 100,
+      reviewed: true,
+      decidedBy: 'operator',
+      reviewedBy: 'u-1',
+      reviewedAt: new Date('2026-06-01'),
+    });
+
+    await syncTriageRowsForReopen('o/r#42', reopenedIssue(42));
+
+    const row = triageRows.get('tr-1')!;
+    // issue_state mirrors current GH — flips even on protected rows.
+    expect(row.issueState).toBe('open');
+    // Decision NOT rewritten — operator-protect kicked in BEFORE LLM call.
+    expect(triageMock).not.toHaveBeenCalled();
+    expect(row.decision).toBe('skip');
+    expect(row.reason).toBe('operator said no');
+    expect(row.confidence).toBe(100);
+    expect(row.reviewed).toBe(true);
+    expect(row.decidedBy).toBe('operator');
+    expect(row.reviewedBy).toBe('u-1');
+  });
+
+  it('triage_enabled=false → issue_state flips, but no re-triage', async () => {
+    mapRows.set('m1', { id: 'm1', triageEnabled: false });
+    seedRow({
+      id: 'tr-1',
+      mapId: 'm1',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'place',
+      confidence: 80,
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+
+    await syncTriageRowsForReopen('o/r#42', reopenedIssue(42));
+
+    const row = triageRows.get('tr-1')!;
+    expect(row.issueState).toBe('open');
+    expect(triageMock).not.toHaveBeenCalled();
+    // Decision untouched.
+    expect(row.decision).toBe('place');
+    expect(row.confidence).toBe(80);
+  });
+
+  it('no matching row → no-op (no throw, triageIssue not called)', async () => {
+    mapRows.set('m1', { id: 'm1', triageEnabled: true });
+    // No row seeded for o/r#999.
+    await syncTriageRowsForReopen('o/r#999', reopenedIssue(999));
+    expect(triageMock).not.toHaveBeenCalled();
+    expect(triageRows.size).toBe(0);
+  });
+
+  it('multiple maps with the same externalId → re-triage runs per-eligible-map', async () => {
+    mapRows.set('m1', { id: 'm1', triageEnabled: true });
+    mapRows.set('m2', { id: 'm2', triageEnabled: true });
+    seedRow({
+      id: 'tr-1',
+      mapId: 'm1',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'uncertain',
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+    seedRow({
+      id: 'tr-2',
+      mapId: 'm2',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'skip',
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+
+    await syncTriageRowsForReopen('o/r#42', reopenedIssue(42));
+
+    expect(triageMock).toHaveBeenCalledTimes(2);
+    expect(triageRows.get('tr-1')!.issueState).toBe('open');
+    expect(triageRows.get('tr-2')!.issueState).toBe('open');
+  });
+
+  it('non-place reclassify on a previously-placed row clears placedNodeId (orphan-cleanup)', async () => {
+    mapRows.set('m1', { id: 'm1', triageEnabled: true });
+    seedRow({
+      id: 'tr-1',
+      mapId: 'm1',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'place',
+      confidence: 80,
+      placedNodeId: 'orphan-node',
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+    triageMock.mockResolvedValueOnce({
+      decision: 'skip' as const,
+      parentNodeId: undefined,
+      reason: 'no longer relevant after reopen',
+      confidence: 92,
+    } as unknown as Awaited<ReturnType<typeof triageMock>>);
+
+    await syncTriageRowsForReopen('o/r#42', reopenedIssue(42));
+
+    const row = triageRows.get('tr-1')!;
+    expect(row.decision).toBe('skip');
+    expect(row.placedNodeId).toBeNull();
+  });
+
+  it('LLM throws on one row → continues with the next row, issue_state still flipped', async () => {
+    mapRows.set('m1', { id: 'm1', triageEnabled: true });
+    mapRows.set('m2', { id: 'm2', triageEnabled: true });
+    seedRow({
+      id: 'tr-1',
+      mapId: 'm1',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'uncertain',
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+    seedRow({
+      id: 'tr-2',
+      mapId: 'm2',
+      externalId: 'o/r#42',
+      issueState: 'closed',
+      decision: 'uncertain',
+      reviewed: false,
+      decidedBy: 'auto',
+    });
+    triageMock.mockRejectedValueOnce(new Error('LLM down'));
+
+    await syncTriageRowsForReopen('o/r#42', reopenedIssue(42));
+
+    // Both rows had issue_state flipped (that happens in the first
+    // bulk UPDATE before the per-row loop).
+    expect(triageRows.get('tr-1')!.issueState).toBe('open');
+    expect(triageRows.get('tr-2')!.issueState).toBe('open');
+    // tr-1 LLM threw, decision stays uncertain.
+    expect(triageRows.get('tr-1')!.decision).toBe('uncertain');
+    // tr-2 LLM ran (default mock returns place + 90).
+    expect(triageRows.get('tr-2')!.decision).toBe('place');
+    expect(triageMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -144,6 +144,8 @@ vi.mock('../../db/schema.js', () => {
       decision: col('decision'),
       reviewed: col('reviewed'),
       decidedAt: col('decidedAt'),
+      confidence: col('confidence'),
+      issueState: col('issueState'),
     },
   };
 });
@@ -159,6 +161,22 @@ vi.mock('drizzle-orm', async () => {
     and: (...preds: Predicate[]): Predicate => ({
       __pred: true,
       check: (row) => preds.every((p) => p.check(row)),
+    }),
+    gte: (column: { __col?: string }, value: unknown): Predicate => ({
+      __pred: true,
+      check: (row) => {
+        const v = row[column.__col ?? ''];
+        if (v instanceof Date && value instanceof Date) return v.getTime() >= value.getTime();
+        return (v as number) >= (value as number);
+      },
+    }),
+    lte: (column: { __col?: string }, value: unknown): Predicate => ({
+      __pred: true,
+      check: (row) => {
+        const v = row[column.__col ?? ''];
+        if (v instanceof Date && value instanceof Date) return v.getTime() <= value.getTime();
+        return (v as number) <= (value as number);
+      },
     }),
     desc: () => ({ __order: 'desc' }),
     sql: vi.fn(),
@@ -838,5 +856,434 @@ describe('POST .../reclassify', () => {
     // also doesn't clear the previously-placed node id, since the new
     // decision is still 'place'.
     expect(row.placedNodeId).toBe('node-still-here');
+  });
+});
+
+// ── GET filters — Phase 2 (#95) ──────────────────────────────────
+
+describe('GET /api/maps/:mapId/triage-decisions — Phase 2 filters', () => {
+  it('filters by minConfidence (inclusive)', async () => {
+    seedRow({ id: 't1', confidence: 30 });
+    seedRow({ id: 't2', confidence: 70 });
+    seedRow({ id: 't3', confidence: 95 });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions?minConfidence=70',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().total).toBe(2);
+    const ids = (res.json().decisions as Array<{ id: string }>).map((d) => d.id).sort();
+    expect(ids).toEqual(['t2', 't3']);
+  });
+
+  it('filters by maxConfidence (inclusive)', async () => {
+    seedRow({ id: 't1', confidence: 30 });
+    seedRow({ id: 't2', confidence: 70 });
+    seedRow({ id: 't3', confidence: 95 });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions?maxConfidence=70',
+    });
+    await app.close();
+    expect(res.json().total).toBe(2);
+  });
+
+  it('combines minConfidence + maxConfidence to bracket a range', async () => {
+    seedRow({ id: 't1', confidence: 30 });
+    seedRow({ id: 't2', confidence: 50 });
+    seedRow({ id: 't3', confidence: 80 });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions?minConfidence=40&maxConfidence=70',
+    });
+    await app.close();
+    expect(res.json().total).toBe(1);
+    expect((res.json().decisions as Array<{ id: string }>)[0].id).toBe('t2');
+  });
+
+  it('filters by issueState=open', async () => {
+    seedRow({ id: 't1', issueState: 'open' });
+    seedRow({ id: 't2', issueState: 'closed' });
+    seedRow({ id: 't3', issueState: 'open' });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions?issueState=open',
+    });
+    await app.close();
+    expect(res.json().total).toBe(2);
+  });
+
+  it('filters by since (decidedAt >= ISO)', async () => {
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const lastWeek = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    seedRow({ id: 't-old', decidedAt: lastWeek });
+    seedRow({ id: 't-recent', decidedAt: yesterday });
+    seedRow({ id: 't-now', decidedAt: now });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const since = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/map-1/triage-decisions?since=${encodeURIComponent(since)}`,
+    });
+    await app.close();
+    expect(res.json().total).toBe(2);
+  });
+
+  it('malformed minConfidence is silently ignored (no filter applied)', async () => {
+    seedRow({ id: 't1', confidence: 30 });
+    seedRow({ id: 't2', confidence: 70 });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions?minConfidence=banana',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().total).toBe(2);
+  });
+});
+
+// ── Bulk routes — Phase 2 (#95) ──────────────────────────────────
+
+describe('POST .../bulk-confirm', () => {
+  it('marks every supplied row reviewed=true, returns per-item ok', async () => {
+    seedRow({ id: 'a', reviewed: false, decidedBy: 'auto' });
+    seedRow({ id: 'b', reviewed: false, decidedBy: 'auto' });
+    seedRow({ id: 'c', reviewed: false, decidedBy: 'auto' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: { decisionIds: ['a', 'b', 'c'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.results).toHaveLength(3);
+    expect(body.results.every((r: { status?: string }) => r.status === 'confirmed')).toBe(true);
+    for (const id of ['a', 'b', 'c']) {
+      const row = triageRows.get(id)!;
+      expect(row.reviewed).toBe(true);
+      expect(row.decidedBy).toBe('operator');
+    }
+  });
+
+  it('1 valid + 1 missing id → response is array with one ok + one error (HTTP 200)', async () => {
+    seedRow({ id: 'a', reviewed: false, decidedBy: 'auto' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: { decisionIds: ['a', 'ghost'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const results = res.json().results as Array<{ id: string; status?: string; error?: { code: string } }>;
+    expect(results).toHaveLength(2);
+    const ok = results.find((r) => r.id === 'a')!;
+    const err = results.find((r) => r.id === 'ghost')!;
+    expect(ok.status).toBe('confirmed');
+    expect(err.error?.code).toBe('NOT_FOUND');
+    // The valid row was still committed — per-item idempotency.
+    expect(triageRows.get('a')!.reviewed).toBe(true);
+  });
+
+  it('dedupes repeated ids (UI double-tap)', async () => {
+    seedRow({ id: 'a', reviewed: false, decidedBy: 'auto' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: { decisionIds: ['a', 'a', 'a'] },
+    });
+    await app.close();
+    expect(res.json().results).toHaveLength(1);
+  });
+
+  it('400 on empty decisionIds', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: { decisionIds: [] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error?.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('400 on missing decisionIds', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: {},
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400 when batch exceeds 200', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const ids = Array.from({ length: 201 }, (_, i) => `t${i}`);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: { decisionIds: ids },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('403 for API-key auth', async () => {
+    permissionLevel = 'edit';
+    seedRow({ id: 'a' });
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: { decisionIds: ['a'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('403 for JWT with view-only', async () => {
+    permissionLevel = 'view';
+    seedRow({ id: 'a' });
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-confirm',
+      payload: { decisionIds: ['a'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST .../bulk-override', () => {
+  it('mixed `place` + `skip` rows → places are moved, skips are 400-per-item', async () => {
+    seedRow({ id: 'p1', decision: 'place', placedNodeId: 'placed-1' });
+    seedRow({ id: 's1', decision: 'skip' });
+    nodes.set('placed-1', { id: 'placed-1', mapId: 'map-1', parentId: 'epic-A' });
+    nodes.set('epic-B', { id: 'epic-B', mapId: 'map-1', parentId: 'root-1' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-override',
+      payload: { decisionIds: ['p1', 's1'], parentNodeId: 'epic-B' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const results = res.json().results as Array<{ id: string; status?: string; error?: { code: string } }>;
+    const place = results.find((r) => r.id === 'p1')!;
+    const skip = results.find((r) => r.id === 's1')!;
+    expect(place.status).toBe('moved');
+    expect(skip.error?.code).toBe('BULK_NOT_PLACE');
+    // The place row was reparented; the skip row was untouched.
+    expect(moveNodeMock).toHaveBeenCalledOnce();
+    expect(triageRows.get('p1')!.reviewed).toBe(true);
+    expect(triageRows.get('s1')!.reviewed).toBe(false);
+  });
+
+  it('SELF_LOOP_BLOCKED: parentNodeId === placedNodeId rejects per-item, moveNode not called', async () => {
+    seedRow({ id: 'p1', decision: 'place', placedNodeId: 'loop-target' });
+    nodes.set('loop-target', { id: 'loop-target', mapId: 'map-1', parentId: 'epic-A' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-override',
+      payload: { decisionIds: ['p1'], parentNodeId: 'loop-target' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const results = res.json().results as Array<{ id: string; error?: { code: string } }>;
+    expect(results[0].error?.code).toBe('SELF_LOOP_BLOCKED');
+    expect(moveNodeMock).not.toHaveBeenCalled();
+    expect(triageRows.get('p1')!.reviewed).toBe(false);
+  });
+
+  it('all rows already-placed under different parents → moves each + broadcasts per move', async () => {
+    seedRow({ id: 'p1', decision: 'place', placedNodeId: 'node-1' });
+    seedRow({ id: 'p2', decision: 'place', placedNodeId: 'node-2' });
+    nodes.set('node-1', { id: 'node-1', mapId: 'map-1', parentId: 'epic-A' });
+    nodes.set('node-2', { id: 'node-2', mapId: 'map-1', parentId: 'epic-A' });
+    nodes.set('epic-B', { id: 'epic-B', mapId: 'map-1', parentId: 'root-1' });
+    permissionLevel = 'edit';
+    const wsMod = await import('../../ws.js');
+    const broadcastMock = wsMod.broadcast as unknown as ReturnType<typeof vi.fn>;
+    broadcastMock.mockClear();
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-override',
+      payload: { decisionIds: ['p1', 'p2'], parentNodeId: 'epic-B' },
+    });
+    await app.close();
+    const results = res.json().results as Array<{ id: string; status?: string }>;
+    expect(results.every((r) => r.status === 'moved')).toBe(true);
+    expect(moveNodeMock).toHaveBeenCalledTimes(2);
+    // 2 node:moved broadcasts.
+    const movedCalls = broadcastMock.mock.calls.filter(
+      (call) => (call[1] as { type?: string }).type === 'node:moved',
+    );
+    expect(movedCalls).toHaveLength(2);
+  });
+
+  it('place rows with no placedNodeId → creates new nodes under parent', async () => {
+    seedRow({ id: 'p1', decision: 'place', placedNodeId: null, externalId: 'o/r#1', issueTitle: 'A' });
+    seedRow({ id: 'p2', decision: 'place', placedNodeId: null, externalId: 'o/r#2', issueTitle: 'B' });
+    nodes.set('epic-B', { id: 'epic-B', mapId: 'map-1', parentId: 'root-1' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-override',
+      payload: { decisionIds: ['p1', 'p2'], parentNodeId: 'epic-B' },
+    });
+    await app.close();
+    const results = res.json().results as Array<{ id: string; status?: string; nodeId?: string }>;
+    expect(results.every((r) => r.status === 'placed')).toBe(true);
+    expect(results.every((r) => r.nodeId === 'created-node')).toBe(true);
+    expect(createNodeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('400 when parentNodeId is not in this map', async () => {
+    seedRow({ id: 'p1', decision: 'place' });
+    nodes.set('outside', { id: 'outside', mapId: 'other-map', parentId: null });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-override',
+      payload: { decisionIds: ['p1'], parentNodeId: 'outside' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400 when parentNodeId is missing', async () => {
+    seedRow({ id: 'p1', decision: 'place' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-override',
+      payload: { decisionIds: ['p1'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('403 for API-key auth', async () => {
+    permissionLevel = 'edit';
+    seedRow({ id: 'p1', decision: 'place' });
+    nodes.set('epic-B', { id: 'epic-B', mapId: 'map-1', parentId: 'root-1' });
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-override',
+      payload: { decisionIds: ['p1'], parentNodeId: 'epic-B' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST .../bulk-reclassify', () => {
+  it('runs triageIssue per row and updates each in place', async () => {
+    seedRow({ id: 'a', decision: 'uncertain', confidence: 20, reviewed: true, decidedBy: 'operator' });
+    seedRow({ id: 'b', decision: 'uncertain', confidence: 30, reviewed: true, decidedBy: 'operator' });
+    seedRow({ id: 'c', decision: 'uncertain', confidence: 40, reviewed: true, decidedBy: 'operator' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-reclassify',
+      payload: { decisionIds: ['a', 'b', 'c'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(triageIssueMock).toHaveBeenCalledTimes(3);
+    const results = res.json().results as Array<{ id: string; status?: string; decision?: string }>;
+    expect(results.every((r) => r.status === 'reclassified')).toBe(true);
+    for (const id of ['a', 'b', 'c']) {
+      const row = triageRows.get(id)!;
+      // Default mock returns place + confidence 88.
+      expect(row.decision).toBe('place');
+      expect(row.confidence).toBe(88);
+      expect(row.decidedBy).toBe('auto');
+      expect(row.reviewed).toBe(false);
+    }
+  });
+
+  it('1 missing id → per-item NOT_FOUND, other rows still reclassified', async () => {
+    seedRow({ id: 'a' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-reclassify',
+      payload: { decisionIds: ['a', 'ghost'] },
+    });
+    await app.close();
+    const results = res.json().results as Array<{ id: string; status?: string; error?: { code: string } }>;
+    expect(results.find((r) => r.id === 'a')?.status).toBe('reclassified');
+    expect(results.find((r) => r.id === 'ghost')?.error?.code).toBe('NOT_FOUND');
+    expect(triageIssueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-place result clears placedNodeId on a previously-placed row', async () => {
+    triageIssueMock.mockResolvedValueOnce({
+      decision: 'skip' as const,
+      parentNodeId: undefined,
+      reason: 'no longer relevant',
+      confidence: 92,
+    } as unknown as Awaited<ReturnType<typeof triageIssueMock>>);
+    seedRow({ id: 'a', decision: 'place', placedNodeId: 'orphan' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-reclassify',
+      payload: { decisionIds: ['a'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(triageRows.get('a')!.placedNodeId).toBeNull();
+  });
+
+  it('403 for API-key auth', async () => {
+    permissionLevel = 'edit';
+    seedRow({ id: 'a' });
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-reclassify',
+      payload: { decisionIds: ['a'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { eq, and } from 'drizzle-orm';
 import { db } from '../db/connection.js';
-import { integrations, versions, nodes } from '../db/schema.js';
+import { integrations, versions, nodes, triageDecisions } from '../db/schema.js';
 import * as nodeDb from '../db/nodes.js';
 import {
   createGitHubIssue,
@@ -24,6 +24,8 @@ import {
   ensureNodeForIssue,
   findNodesByExternalIds,
 } from '../sync/githubIngest.js';
+import { triageIssue } from '../sync/triage.js';
+import { buildMapContext } from '../sync/mapContext.js';
 import type { GitHubIssue } from '@mindblown/integrations';
 import type { ExternalLink } from '@mindblown/core';
 import { broadcast } from '../ws.js';
@@ -162,6 +164,116 @@ async function findNodeByExternalId(externalId: string): Promise<string | null> 
 async function getWorkspaceIdForMap(mapId: string): Promise<string | null> {
   const [row] = await db.select({ workspaceId: maps.workspaceId }).from(maps).where(eq(maps.id, mapId));
   return row?.workspaceId ?? null;
+}
+
+// ── Triage lifecycle helper (#95 Phase 2) ─────────────────────────
+//
+// Sync existing triage_decisions rows after an `issues.reopened`
+// webhook. Two responsibilities:
+//   1. Refresh issue_state='open' on every row matching externalId,
+//      regardless of operator-reviewed state or map's triage_enabled.
+//      The column is a passive mirror of GH state, used by the UI
+//      filter; keeping it stale would degrade Phase 2's open/closed
+//      filter quality.
+//   2. For maps whose triage_enabled is still true AND whose row is
+//      NOT operator-reviewed, re-run `triageIssue` with the current
+//      map context and upsert the new decision in place.
+//      Operator-reviewed rows are immutable here — the operator
+//      explicitly hits Re-classify in the UI to override their own
+//      call (#100 Round 2 / mindblown#99 fix 2).
+//
+// Re-triage failures per-row are swallowed (warn + continue) so a
+// flaky LLM doesn't block the issue_state refresh on sibling rows.
+//
+// Exported for tests; called from the webhook handler when
+// payloadAction === 'reopened'.
+export async function syncTriageRowsForReopen(
+  externalId: string,
+  issue: GitHubIssue | undefined,
+): Promise<void> {
+  // (1) Refresh issue_state on every matching row.
+  await db
+    .update(triageDecisions)
+    .set({ issueState: 'open' })
+    .where(eq(triageDecisions.externalId, externalId));
+
+  // (2) Re-triage every (map, externalId) where the map is still
+  // triage_enabled AND the row is not operator-reviewed.
+  const candidates = await db
+    .select({
+      id: triageDecisions.id,
+      mapId: triageDecisions.mapId,
+      issueTitle: triageDecisions.issueTitle,
+      placedNodeId: triageDecisions.placedNodeId,
+      reviewed: triageDecisions.reviewed,
+      decidedBy: triageDecisions.decidedBy,
+    })
+    .from(triageDecisions)
+    .where(eq(triageDecisions.externalId, externalId));
+
+  for (const row of candidates) {
+    // Operator-reviewed guard.
+    if (row.reviewed === true && row.decidedBy === 'operator') {
+      continue;
+    }
+    // Map-level triage_enabled gate.
+    const [mapRow] = await db
+      .select({ triageEnabled: maps.triageEnabled })
+      .from(maps)
+      .where(eq(maps.id, row.mapId));
+    if (!mapRow || mapRow.triageEnabled !== true) {
+      continue;
+    }
+
+    try {
+      const mapContext = await buildMapContext(row.mapId);
+      // Prefer the webhook-supplied issue body / title (operator may
+      // have edited GH-side); fall back to the row title if the
+      // payload didn't carry one (defensive — `issues.reopened`
+      // always includes the issue object).
+      const decision = await triageIssue({
+        issue: issue ?? {
+          id: 0,
+          number: 0,
+          title: row.issueTitle,
+          body: null,
+          state: 'open',
+          labels: [],
+          assignees: [],
+          milestone: null,
+          html_url: '',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        mapContext,
+      });
+
+      // Clear placedNodeId when reclassify lands on a non-place
+      // decision and we had a placed node previously (mindblown#99
+      // fix 4 — orphan cleanup).
+      const clearPlacedNode =
+        decision.decision !== 'place' && row.placedNodeId != null;
+      await db
+        .update(triageDecisions)
+        .set({
+          decision: decision.decision,
+          reason: decision.reason,
+          confidence: decision.confidence,
+          decidedBy: 'auto',
+          decidedAt: new Date(),
+          reviewed: false,
+          reviewedAt: null,
+          reviewedBy: null,
+          ...(clearPlacedNode ? { placedNodeId: null } : {}),
+        })
+        .where(eq(triageDecisions.id, row.id));
+    } catch (err) {
+      console.warn(
+        `[triage-reopen] re-triage failed for row ${row.id} (map ${row.mapId}):`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
 }
 
 // ── Routes ────────────────────────────────────────────────────────
@@ -1061,6 +1173,70 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
             );
           }
         }
+      }
+    }
+
+    // ── Triage lifecycle: issues.reopened → re-triage (#95 Phase 2) ──
+    //
+    // Two passes per (map, externalId) where a triage_decisions row exists:
+    //   (a) Always refresh `issue_state='open'` so the row reflects the
+    //       current GH state — even if the map's triage_enabled was
+    //       flipped off between the original decision and now, AND even
+    //       when the row is operator-reviewed. issue_state is the
+    //       row-level mirror of GH state, not a triage decision itself.
+    //   (b) If the map still has triage_enabled=true AND the row is
+    //       NOT operator-reviewed (reviewed=true AND decidedBy='operator'),
+    //       re-run triageIssue and upsert the new decision in place.
+    //       Operator-reviewed rows are immutable — the operator's call
+    //       stands until they explicitly hit Re-classify. This mirrors
+    //       the precheck-tx guard in ensureNodeForIssueViaTriage
+    //       (mindblown#99 fix 2 / Ray's #100 Round 2 lost-race fix).
+    //
+    // We run this BEFORE the close/reopen state-sync block below because:
+    //   - state-sync mutates the node row (status/percentComplete); the
+    //     triage row update is independent (it's just metadata audit).
+    //   - if re-triage produces a new auto-applied node placement, the
+    //     state-sync block still handles the node-level open/close
+    //     transition on whatever node was placed.
+    //
+    // Failures here are swallowed (warn + continue) — the webhook still
+    // needs to acknowledge the underlying state-sync.
+    if (
+      event === 'issues' &&
+      issuePayload?.number != null &&
+      repoFullName &&
+      payloadAction === 'reopened'
+    ) {
+      try {
+        const externalId = `${repoFullName}#${issuePayload.number}`;
+        await syncTriageRowsForReopen(externalId, payload.issue as GitHubIssue | undefined);
+      } catch (err) {
+        console.warn(
+          '[triage-reopen] failed to refresh triage rows:',
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+    // Mirror the issue_state for `closed` events too — same audit-row
+    // contract, no re-triage needed. (The reclassify branch is
+    // reopen-only; closed events just keep the audit row in sync.)
+    if (
+      event === 'issues' &&
+      issuePayload?.number != null &&
+      repoFullName &&
+      payloadAction === 'closed'
+    ) {
+      try {
+        const externalId = `${repoFullName}#${issuePayload.number}`;
+        await db
+          .update(triageDecisions)
+          .set({ issueState: 'closed' })
+          .where(eq(triageDecisions.externalId, externalId));
+      } catch (err) {
+        console.warn(
+          '[triage-close] failed to refresh triage rows:',
+          err instanceof Error ? err.message : err,
+        );
       }
     }
 

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -1,14 +1,17 @@
 /**
- * Triage CRUD routes (#92, #93).
+ * Triage CRUD routes (#92, #93, #95).
  *
- * Four endpoints, all map-scoped, all session-JWT-gated (API-key auth
- * is rejected to match the audit-drift convention — triage exposes
+ * Endpoints, all map-scoped, all session-JWT-gated (API-key auth is
+ * rejected to match the audit-drift convention — triage exposes
  * cross-issue LLM reasoning that a leaked key shouldn't be able to fan
  * out across every workspace).
  *
  *   - GET    /api/maps/:mapId/triage-decisions
- *       Filterable list. Used by Phase 1's operator UI; for Phase 0
- *       the operator drives this via curl / MCP.
+ *       Filterable list. Used by the Phase 1+2 operator UI; for Phase 0
+ *       the operator drives this via curl / MCP. Phase 2 added the
+ *       confidence-range + issueState + since query params so the
+ *       client doesn't have to re-fetch + filter when the operator
+ *       slides the confidence slider.
  *
  *   - POST   /api/maps/:mapId/triage-decisions/:decisionId/confirm
  *       Operator confirms the existing auto-decision (Ray's review on
@@ -33,13 +36,25 @@
  *       here — reclassify just refreshes the decision; the operator
  *       follows up with `override` to apply.
  *
- * Phase 0 explicitly does NOT include any frontend; the routes are
- * here so the operator can drive Phase 0 by curl while Phase 1 builds
- * the UI on top.
+ *   - POST   /api/maps/:mapId/triage-decisions/bulk-confirm
+ *   - POST   /api/maps/:mapId/triage-decisions/bulk-override
+ *   - POST   /api/maps/:mapId/triage-decisions/bulk-reclassify
+ *       Phase 2 (#95). Bulk variants of the three actions, designed for
+ *       the 290-Fulcrum-Roadmap-orphans workflow where the operator
+ *       wants to confirm a select-all of high-confidence decisions in
+ *       a single click. Each is per-item idempotent — one row failing
+ *       (e.g. deleted between submit and execute, validation failure)
+ *       doesn't fail the batch; the response carries
+ *       `{id, status|error}` per submitted id so the client can show
+ *       per-row outcomes.
+ *
+ * Phase 0 explicitly did NOT include any frontend; Phase 1 built the
+ * single-item UI on top; Phase 2 layers bulk operations + the
+ * lifecycle/reopened webhook hook (which lives in routes/integrations).
  */
 
 import type { FastifyInstance } from 'fastify';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, gte, lte } from 'drizzle-orm';
 import { db } from '../db/connection.js';
 import { maps, nodes, triageDecisions } from '../db/schema.js';
 import * as nodeDb from '../db/nodes.js';
@@ -98,15 +113,36 @@ async function gateMapAccess(
 
 export async function triageRoutes(app: FastifyInstance): Promise<void> {
   // ── GET /api/maps/:mapId/triage-decisions ─────────────────────
-  // Filter params:
-  //   reviewed=true|false       — exact-match on the boolean column.
+  // Filter params (Phase 0 baseline + Phase 2 additions):
+  //   reviewed=true|false           — exact-match on the boolean.
   //   decision=skip|place|uncertain — exact-match.
-  //   limit=N                   — default 50, hard-capped at 200.
+  //   limit=N                       — default 50, hard-capped at 200.
+  //   minConfidence=0..100          — Phase 2; lower bound, inclusive.
+  //   maxConfidence=0..100          — Phase 2; upper bound, inclusive.
+  //   issueState=open|closed        — Phase 2; exact-match on the
+  //                                   GH state captured at decision-
+  //                                   time (refreshed by webhooks).
+  //   since=ISO8601                 — Phase 2; only rows with
+  //                                   decided_at >= since.
   // Results ordered newest decided_at first so the operator review
   // queue surfaces the latest unreviewed rows.
+  //
+  // Phase 2 (#95): the slider/time-window/state filters are exposed
+  // server-side so the bulk-workflow case (290 Fulcrum roadmap orphans
+  // → operator picks the top-confidence band) doesn't have to fetch
+  // every row then filter client-side, AND so a select-all-and-confirm
+  // operates only on the rows the operator's filter actually surfaced.
   app.get<{
     Params: { mapId: string };
-    Querystring: { reviewed?: string; decision?: string; limit?: string };
+    Querystring: {
+      reviewed?: string;
+      decision?: string;
+      limit?: string;
+      minConfidence?: string;
+      maxConfidence?: string;
+      issueState?: string;
+      since?: string;
+    };
   }>('/api/maps/:mapId/triage-decisions', async (req, reply) => {
     const gate = await gateMapAccess(req, req.params.mapId, 'view');
     if (gate) {
@@ -127,6 +163,31 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       req.query.decision === 'uncertain'
     ) {
       filters.push(eq(triageDecisions.decision, req.query.decision));
+    }
+    // Phase 2 filters — silently ignore malformed values rather than
+    // 400-erroring so a typo in the URL doesn't blank the panel; the
+    // client always re-derives params from the slider/dropdowns so
+    // there's no UI affordance for sending invalid values.
+    if (req.query.minConfidence != null) {
+      const n = parseInt(req.query.minConfidence, 10);
+      if (Number.isFinite(n)) {
+        filters.push(gte(triageDecisions.confidence, Math.max(0, Math.min(100, n))));
+      }
+    }
+    if (req.query.maxConfidence != null) {
+      const n = parseInt(req.query.maxConfidence, 10);
+      if (Number.isFinite(n)) {
+        filters.push(lte(triageDecisions.confidence, Math.max(0, Math.min(100, n))));
+      }
+    }
+    if (req.query.issueState === 'open' || req.query.issueState === 'closed') {
+      filters.push(eq(triageDecisions.issueState, req.query.issueState));
+    }
+    if (req.query.since) {
+      const t = Date.parse(req.query.since);
+      if (Number.isFinite(t)) {
+        filters.push(gte(triageDecisions.decidedAt, new Date(t)));
+      }
     }
 
     const limitRaw = req.query.limit ? parseInt(req.query.limit, 10) : 50;
@@ -604,6 +665,499 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         // references the previously-placed node (Ray's #100 nit).
         placedNodeId: clearPlacedNode ? null : (row.placedNodeId ?? null),
       });
+    },
+  );
+
+  // ── Phase 2 bulk routes (#95) ─────────────────────────────────
+  //
+  // Design notes:
+  //   - All three bulk routes accept `{ decisionIds: string[] }` and
+  //     iterate per-item. Per-item failures (404, validation, race)
+  //     don't fail the batch — the response shape is always
+  //     `{ results: [{ id, status: 'ok', ... } | { id, error: { code, message } }, ... ] }`
+  //     with HTTP 200, so the client can render per-row outcomes.
+  //   - The single-item routes above remain the source of truth for
+  //     semantics: bulk handlers call into the same DB primitives and
+  //     guards (notably the SELF_LOOP_BLOCKED check on
+  //     bulk-override). We do NOT internally re-route through HTTP —
+  //     that would double the round-trip cost and lose the per-item
+  //     error context.
+  //   - We don't wrap the batch in a single DB transaction. If one
+  //     item fails, the others have already committed; an all-or-
+  //     nothing wrapper would mean "the operator selected 30 rows,
+  //     the 27th was deleted by a concurrent operator, the other 29
+  //     successful confirms get rolled back" — much worse UX than
+  //     per-item idempotency for the bulk-confirm/orphan-cleanup use
+  //     case. Per-item failures are surfaced for the operator to
+  //     inspect.
+  //   - All three require `edit` permission (same as their single-
+  //     item counterparts) and reject API-key auth (the #69 / #100
+  //     hardening — leaked keys must not fan out across all rows).
+  //   - Body validation: `decisionIds` must be a non-empty array of
+  //     strings, hard-capped at 200 (matches the GET limit so the UI
+  //     can never assemble a bulk request larger than the page it's
+  //     looking at).
+
+  const BULK_DECISION_CAP = 200;
+
+  function validateBulkBody(
+    body: unknown,
+  ): { ok: true; ids: string[] } | { ok: false; reply: { status: number; code: string; message: string } } {
+    const b = body as { decisionIds?: unknown } | null | undefined;
+    const ids = b?.decisionIds;
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return {
+        ok: false,
+        reply: {
+          status: 400,
+          code: 'VALIDATION_ERROR',
+          message: 'decisionIds must be a non-empty array',
+        },
+      };
+    }
+    if (ids.length > BULK_DECISION_CAP) {
+      return {
+        ok: false,
+        reply: {
+          status: 400,
+          code: 'VALIDATION_ERROR',
+          message: `decisionIds is capped at ${BULK_DECISION_CAP} per request`,
+        },
+      };
+    }
+    const onlyStrings = ids.every((x) => typeof x === 'string' && x.length > 0);
+    if (!onlyStrings) {
+      return {
+        ok: false,
+        reply: {
+          status: 400,
+          code: 'VALIDATION_ERROR',
+          message: 'decisionIds must contain non-empty strings',
+        },
+      };
+    }
+    // Dedupe — silently. A double-tap in the UI shouldn't cause two
+    // confirm writes; the second would be a no-op against the new
+    // reviewed=true state but might surprise the operator with a
+    // duplicate row in `results`.
+    return { ok: true, ids: Array.from(new Set(ids as string[])) };
+  }
+
+  interface BulkItemOk {
+    id: string;
+    status: string;
+    nodeId?: string | null;
+    decision?: 'place' | 'skip' | 'uncertain';
+    confidence?: number;
+    reason?: string;
+    placedNodeId?: string | null;
+  }
+  interface BulkItemErr {
+    id: string;
+    error: { code: string; message: string };
+  }
+  type BulkItem = BulkItemOk | BulkItemErr;
+
+  // ── POST /api/maps/:mapId/triage-decisions/bulk-confirm ──────
+  // Body: { decisionIds: string[] }
+  // Per-item: marks reviewed=true, decidedBy='operator', stamps
+  // reviewedAt/By. Does NOT touch parentage. Mirrors single
+  // /confirm semantics.
+  app.post<{
+    Params: { mapId: string };
+    Body: { decisionIds?: unknown };
+  }>(
+    '/api/maps/:mapId/triage-decisions/bulk-confirm',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'edit');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+      const userId = req.userId as string;
+      const validation = validateBulkBody(req.body);
+      if (!validation.ok) {
+        return reply.status(validation.reply.status).send({
+          error: { code: validation.reply.code, message: validation.reply.message },
+        });
+      }
+
+      const results: BulkItem[] = [];
+      for (const id of validation.ids) {
+        const [row] = await db
+          .select()
+          .from(triageDecisions)
+          .where(
+            and(
+              eq(triageDecisions.id, id),
+              eq(triageDecisions.mapId, req.params.mapId),
+            ),
+          );
+        if (!row) {
+          results.push({
+            id,
+            error: {
+              code: 'NOT_FOUND',
+              message: `Triage decision ${id} not found in map ${req.params.mapId}`,
+            },
+          });
+          continue;
+        }
+        try {
+          await db
+            .update(triageDecisions)
+            .set({
+              decidedBy: 'operator',
+              reviewed: true,
+              reviewedAt: new Date(),
+              reviewedBy: userId,
+            })
+            .where(eq(triageDecisions.id, row.id));
+          results.push({
+            id,
+            status: 'confirmed',
+            nodeId: row.placedNodeId ?? null,
+          });
+        } catch (err) {
+          results.push({
+            id,
+            error: {
+              code: 'INTERNAL_ERROR',
+              message: err instanceof Error ? err.message : 'confirm failed',
+            },
+          });
+        }
+      }
+      return reply.send({ mapId: req.params.mapId, results });
+    },
+  );
+
+  // ── POST /api/maps/:mapId/triage-decisions/bulk-override ─────
+  // Body: { decisionIds: string[], parentNodeId: string }
+  //
+  // Per-item: applies the operator's chosen parent. Only valid for
+  // rows whose CURRENT decision is `place` — per-item rejects rows
+  // with `decision !== 'place'` (VALIDATION_ERROR, code
+  // BULK_NOT_PLACE) so the operator can't accidentally move a
+  // batch that mixed skips in. The single /override route accepts
+  // a decision-change inside the body; this bulk route is
+  // forced-move only, by design (the spec calls out "bulk override
+  // is only valid for place decisions — gated client-side").
+  //
+  // Honors the SELF_LOOP_BLOCKED guard from Phase 1: a row whose
+  // placedNodeId === supplied parentNodeId is rejected per-item.
+  // Validates parentNodeId is in the map ONCE up front (cheaper
+  // than re-validating per item; the operator can't shift the
+  // parent mid-batch anyway).
+  app.post<{
+    Params: { mapId: string };
+    Body: { decisionIds?: unknown; parentNodeId?: unknown };
+  }>(
+    '/api/maps/:mapId/triage-decisions/bulk-override',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'edit');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+      const userId = req.userId as string;
+      const validation = validateBulkBody(req.body);
+      if (!validation.ok) {
+        return reply.status(validation.reply.status).send({
+          error: { code: validation.reply.code, message: validation.reply.message },
+        });
+      }
+      const parentNodeId = (req.body as { parentNodeId?: unknown })?.parentNodeId;
+      if (typeof parentNodeId !== 'string' || parentNodeId.length === 0) {
+        return reply.status(400).send({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'parentNodeId is required',
+          },
+        });
+      }
+      // Up-front parent validation: must exist in this map.
+      const [parent] = await db
+        .select({ id: nodes.id, mapId: nodes.mapId })
+        .from(nodes)
+        .where(eq(nodes.id, parentNodeId));
+      if (!parent || parent.mapId !== req.params.mapId) {
+        return reply.status(400).send({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'parentNodeId must be a node in this map',
+          },
+        });
+      }
+
+      const results: BulkItem[] = [];
+      for (const id of validation.ids) {
+        const [row] = await db
+          .select()
+          .from(triageDecisions)
+          .where(
+            and(
+              eq(triageDecisions.id, id),
+              eq(triageDecisions.mapId, req.params.mapId),
+            ),
+          );
+        if (!row) {
+          results.push({
+            id,
+            error: {
+              code: 'NOT_FOUND',
+              message: `Triage decision ${id} not found in map ${req.params.mapId}`,
+            },
+          });
+          continue;
+        }
+        if (row.decision !== 'place') {
+          // Per spec: forced-move is `place`-only. A row currently
+          // marked skip/uncertain must be sent through the single
+          // /override route (which accepts decision-change), not
+          // this bulk one. The client-side gate already filters this,
+          // but defense-in-depth at the server.
+          results.push({
+            id,
+            error: {
+              code: 'BULK_NOT_PLACE',
+              message: `decision must be 'place' for bulk-override (got '${row.decision}')`,
+            },
+          });
+          continue;
+        }
+        // SELF_LOOP_BLOCKED (mirrors single /override).
+        if (row.placedNodeId && row.placedNodeId === parentNodeId) {
+          results.push({
+            id,
+            error: {
+              code: 'SELF_LOOP_BLOCKED',
+              message:
+                'parentNodeId must differ from the placed node — use /confirm to mark reviewed without reparenting',
+            },
+          });
+          continue;
+        }
+        try {
+          let nodeId: string | null = null;
+          let status: string;
+          if (row.placedNodeId) {
+            // Reparent the already-placed node.
+            const placedNodeId = row.placedNodeId as string;
+            const [placedNode] = await db
+              .select({ id: nodes.id, parentId: nodes.parentId })
+              .from(nodes)
+              .where(eq(nodes.id, placedNodeId));
+            let moved = false;
+            if (placedNode && placedNode.parentId !== parentNodeId) {
+              const movedNode = await nodeDb.moveNode(placedNodeId, parentNodeId);
+              moved = movedNode != null;
+              if (moved) {
+                broadcast(req.params.mapId, {
+                  type: 'node:moved',
+                  nodeId: placedNodeId,
+                  newParentId: parentNodeId,
+                  position: undefined,
+                });
+              }
+            }
+            await db
+              .update(triageDecisions)
+              .set({
+                decision: 'place',
+                confidence: 100,
+                decidedBy: 'operator',
+                decidedAt: new Date(),
+                reviewed: true,
+                reviewedAt: new Date(),
+                reviewedBy: userId,
+              })
+              .where(eq(triageDecisions.id, row.id));
+            nodeId = placedNodeId;
+            status = moved ? 'moved' : 'already_placed';
+          } else {
+            // Create a node under parentNodeId. Same shape as the
+            // single /override place path — single tx so a crash
+            // doesn't leave a triage row with a half-attached node.
+            const isClosed = row.issueState === 'closed';
+            const created = await db.transaction(async (tx) => {
+              const node = await nodeDb.createNode(
+                {
+                  mapId: req.params.mapId,
+                  parentId: parentNodeId,
+                  text: `#${parseIssueNumber(row.externalId)} ${row.issueTitle}`,
+                  createdBy: userId,
+                  percentComplete: isClosed ? 100 : 0,
+                  status: isClosed ? 'done' : 'todo',
+                },
+                tx,
+              );
+              const link: ExternalLink = {
+                provider: 'github',
+                externalId: row.externalId,
+                url: buildIssueUrlFromExternalId(row.externalId),
+                syncEnabled: true,
+                lastSyncedAt: new Date().toISOString(),
+              };
+              const updated = await nodeDb.updateNode(
+                node.id,
+                { externalLinks: [link] },
+                undefined,
+                tx,
+              );
+              await tx
+                .update(triageDecisions)
+                .set({
+                  decision: 'place',
+                  confidence: 100,
+                  decidedBy: 'operator',
+                  decidedAt: new Date(),
+                  placedNodeId: node.id,
+                  reviewed: true,
+                  reviewedAt: new Date(),
+                  reviewedBy: userId,
+                })
+                .where(eq(triageDecisions.id, row.id));
+              return updated ?? node;
+            });
+            if (created) {
+              broadcast(req.params.mapId, {
+                type: 'node:created',
+                node: created,
+                source: 'triage_bulk_override',
+              });
+            }
+            nodeId = created?.id ?? null;
+            status = 'placed';
+          }
+          results.push({ id, status, nodeId });
+        } catch (err) {
+          results.push({
+            id,
+            error: {
+              code: 'INTERNAL_ERROR',
+              message: err instanceof Error ? err.message : 'override failed',
+            },
+          });
+        }
+      }
+      return reply.send({ mapId: req.params.mapId, results });
+    },
+  );
+
+  // ── POST /api/maps/:mapId/triage-decisions/bulk-reclassify ───
+  // Body: { decisionIds: string[] }
+  //
+  // Per-item: re-runs `triageIssue` against the current map
+  // context and updates the row in place. Each row pays one LLM
+  // call. The client should show a per-item progress counter; the
+  // response includes per-id results so the UI can render
+  // success/error inline. Building the map context once (outside
+  // the loop) keeps the per-item cost to just the LLM call.
+  //
+  // Mirrors single /reclassify semantics: decidedBy='auto',
+  // reviewed=false, and a non-place outcome clears a previously-
+  // set placedNodeId (mindblown#99 fix 4).
+  app.post<{
+    Params: { mapId: string };
+    Body: { decisionIds?: unknown };
+  }>(
+    '/api/maps/:mapId/triage-decisions/bulk-reclassify',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'edit');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+      const validation = validateBulkBody(req.body);
+      if (!validation.ok) {
+        return reply.status(validation.reply.status).send({
+          error: { code: validation.reply.code, message: validation.reply.message },
+        });
+      }
+
+      // One map context pull serves all rows in the batch — the
+      // context is the same regardless of which row we're re-
+      // evaluating, and `buildMapContext` is the heavy call.
+      const mapContext = await buildMapContext(req.params.mapId);
+
+      const results: BulkItem[] = [];
+      for (const id of validation.ids) {
+        const [row] = await db
+          .select()
+          .from(triageDecisions)
+          .where(
+            and(
+              eq(triageDecisions.id, id),
+              eq(triageDecisions.mapId, req.params.mapId),
+            ),
+          );
+        if (!row) {
+          results.push({
+            id,
+            error: {
+              code: 'NOT_FOUND',
+              message: `Triage decision ${id} not found in map ${req.params.mapId}`,
+            },
+          });
+          continue;
+        }
+        try {
+          const issueNumber = parseIssueNumber(row.externalId) ?? 0;
+          const decision = await triageIssue({
+            issue: {
+              id: issueNumber,
+              number: issueNumber,
+              title: row.issueTitle,
+              body: null,
+              state: row.issueState === 'closed' ? 'closed' : 'open',
+              labels: [],
+              assignees: [],
+              milestone: null,
+              html_url: buildIssueUrlFromExternalId(row.externalId),
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            },
+            mapContext,
+          });
+          const clearPlacedNode =
+            decision.decision !== 'place' && row.placedNodeId != null;
+          await db
+            .update(triageDecisions)
+            .set({
+              decision: decision.decision,
+              reason: decision.reason,
+              confidence: decision.confidence,
+              decidedBy: 'auto',
+              decidedAt: new Date(),
+              reviewed: false,
+              reviewedAt: null,
+              reviewedBy: null,
+              ...(clearPlacedNode ? { placedNodeId: null } : {}),
+            })
+            .where(eq(triageDecisions.id, row.id));
+          results.push({
+            id,
+            status: 'reclassified',
+            decision: decision.decision,
+            confidence: decision.confidence,
+            reason: decision.reason,
+            placedNodeId: clearPlacedNode ? null : (row.placedNodeId ?? null),
+          });
+        } catch (err) {
+          results.push({
+            id,
+            error: {
+              code: 'INTERNAL_ERROR',
+              message: err instanceof Error ? err.message : 'reclassify failed',
+            },
+          });
+        }
+      }
+      return reply.send({ mapId: req.params.mapId, results });
     },
   );
 }


### PR DESCRIPTION
## Summary

Phase 2 of the AI Triage feature (#92 umbrella, follows #98 Phase 0 + #100 Phase 1). Makes triage usable for bulk workloads (the 290 Fulcrum CRM Roadmap orphans scenario) and adds proper lifecycle behavior (`issue.reopened` → re-triage).

### Backend bulk routes

Three new routes in `packages/server/src/routes/triage.ts`:

- `POST /api/maps/:mapId/triage-decisions/bulk-confirm` — body `{ decisionIds: string[] }`
- `POST /api/maps/:mapId/triage-decisions/bulk-override` — body `{ decisionIds: string[], parentNodeId: string }`
- `POST /api/maps/:mapId/triage-decisions/bulk-reclassify` — body `{ decisionIds: string[] }`

All three are **per-item idempotent**: a deleted/invalid row doesn't fail the batch; the response carries `{ id, status | error }` per submitted id with HTTP 200. Hard-capped at 200 ids per request (matches the GET page size). Edit permission required, API-key auth rejected (#69 hardening).

- `bulk-override` is **place-only** by design — skip/uncertain rows are rejected per-item with `BULK_NOT_PLACE` (the client gates this too). Honors the `SELF_LOOP_BLOCKED` guard from Phase 1.
- `bulk-reclassify` builds the map context once and calls `triageIssue()` per row (one LLM call each).

### GET filters (Phase 2)

Extended `GET /triage-decisions` with `minConfidence`, `maxConfidence`, `issueState`, `since` query params so the slider/state/window filters push down to the server. Malformed values silently ignored (no UI affordance for them; typo shouldn't blank the panel).

### Lifecycle: `issues.reopened` → re-triage

New exported helper `syncTriageRowsForReopen` in `routes/integrations.ts`, called from the webhook handler when `payloadAction === 'reopened'`:

1. **Always** refresh `issue_state='open'` on every matching row, even on operator-reviewed rows (audit-only column).
2. For maps with `triage_enabled=true` AND **non-operator-reviewed** rows, re-run `triageIssue` and rewrite the decision. Operator-reviewed rows (`reviewed=true AND decidedBy='operator'`) are immutable — mirrors the precheck-tx guard from mindblown#99 fix 2 and Ray's #100 Round 2 fix.

Also wires `issues.closed` → `issue_state='closed'` for the audit row.

### Frontend (`TriagePanel.tsx`)

- Checkbox column per card with tri-state select-all in toolbar. Selection clears on view-switch + after every bulk action.
- Bulk-action toolbar: Confirm All / Override All / Re-classify All with per-action busy counters. Override All is disabled unless every selected row is a place decision.
- Filter bar: dual confidence-range slider (min/max clamped to each other), open/closed/all dropdown, time-window dropdown (24h/7d/30d/all, default **7d** per spec).
- Bulk-override reuses the existing `NodePickerModal`, excluding every selected row's `placedNodeId` so the operator can't trigger `SELF_LOOP_BLOCKED` in a batch.
- Info banner separate from error banner so "Confirm 12: 12 ok" doesn't look like a failure.

### Tests

- **+25** in `packages/server/src/routes/__tests__/triage-routes.test.ts`:
  - `bulk-confirm` (8): all-ok, missing-id, dedupe, empty/missing/over-cap 400s, API-key + view-only 403s
  - `bulk-override` (7): mixed place+skip, `SELF_LOOP_BLOCKED`, multi-move broadcasts, create-new under parent, bad parent, missing parent, API-key 403
  - `bulk-reclassify` (4): happy path, missing-id, non-place clears `placedNodeId`, API-key 403
  - GET filters (6): min/max confidence, range, `issueState`, `since`, malformed silent-ignore
- **+7** in `packages/server/src/routes/__tests__/triage-reopen.test.ts` (new): unreviewed row re-triages + state flips, operator-reviewed row skips re-triage but state still flips, `triage_enabled=false` skips re-triage but state still flips, no-row no-op, multi-map fan-out, non-place clears `placedNodeId` on previously-placed row, LLM-throws-on-one-row continues with the next

Test count: **290 → 322 (32 new)**. Frontend tests deferred per #78 follow-up.

### Per-item idempotency design

Bulk operations are **not** wrapped in a single DB transaction. Rationale: if the operator selected 30 rows and the 27th was deleted by a concurrent operator, all-or-nothing would roll back the other 29 successful confirms — much worse UX than per-row idempotency for the bulk-confirm / orphan-cleanup use case. Per-item failures are surfaced for the operator to inspect (UI shows "Confirm 30: 29 ok / 1 failed — …").

## Persona acceptance test

Verifiable against `mind.project.li` after merge + deploy + flipping `triage_enabled=true` on a target map:

- [ ] With ≥3 pending decisions visible: select 2 via checkbox, click "Confirm All" → both move to the Placed/Skipped tab; no node-side effects beyond `reviewed=true`.
- [ ] Filter Pending view by confidence ≥ 80 (drag min slider) → only high-confidence items show.
- [ ] On an already-triaged issue, close in GitHub then reopen → row's `issue_state='open'`, decision re-evaluated unless operator-reviewed.
- [ ] With ≥2 placed decisions selected, click "Override All" → node-picker opens once → pick a parent → both nodes move under that parent.

## Test plan

- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w build` — clean
- [x] `pnpm -w test` — 322/322 (was 290)
- [x] `rg "bulk-confirm|bulk-override|bulk-reclassify" packages/server/src` matches in routes + tests
- [ ] Manual: smoke the new toolbar + filters on a staging map after deploy
- [ ] Manual: close + reopen a GitHub issue on a triage-enabled map, verify `issue_state` flip + re-triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)