### PR TITLE
feat(triage): Phase 3 — MCP tools + audit history + GitHub label writeback (closes #96)

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -723,3 +723,94 @@ export function aiStandup(mapId: string, sinceHours?: number): Promise<AiStandup
     body: JSON.stringify({ mapId, sinceHours }),
   });
 }
+
+// ── Triage (#96 Phase 3) ──────────────────────────────────────
+
+export type TriageDecisionKindApi = 'place' | 'skip' | 'uncertain';
+
+export interface TriageDecisionRowApi {
+  id: string;
+  mapId: string;
+  externalId: string;
+  issueTitle: string;
+  issueState: 'open' | 'closed';
+  decision: TriageDecisionKindApi;
+  reason: string;
+  confidence: number;
+  placedNodeId: string | null;
+  decidedAt: string;
+  decidedBy: 'auto' | 'operator';
+  reviewed: boolean;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+}
+
+export interface TriageListFiltersApi {
+  reviewed?: boolean;
+  decision?: TriageDecisionKindApi;
+  minConfidence?: number;
+  maxConfidence?: number;
+  issueState?: 'open' | 'closed';
+  since?: string;
+  limit?: number;
+}
+
+export interface TriageActionResultApi {
+  decisionId: string;
+  status: string;
+  nodeId?: string | null;
+  decision?: TriageDecisionKindApi;
+  confidence?: number;
+  reason?: string;
+  parentNodeId?: string | null;
+  placedNodeId?: string | null;
+}
+
+export function listTriageDecisions(
+  mapId: string,
+  filters: TriageListFiltersApi,
+): Promise<{ mapId: string; total: number; decisions: TriageDecisionRowApi[] }> {
+  const params = new URLSearchParams();
+  if (filters.reviewed != null) params.set('reviewed', String(filters.reviewed));
+  if (filters.decision) params.set('decision', filters.decision);
+  if (filters.minConfidence != null) params.set('minConfidence', String(filters.minConfidence));
+  if (filters.maxConfidence != null) params.set('maxConfidence', String(filters.maxConfidence));
+  if (filters.issueState) params.set('issueState', filters.issueState);
+  if (filters.since) params.set('since', filters.since);
+  if (filters.limit != null) params.set('limit', String(filters.limit));
+  const qs = params.toString();
+  return request<{ mapId: string; total: number; decisions: TriageDecisionRowApi[] }>(
+    `/api/maps/${mapId}/triage-decisions${qs ? `?${qs}` : ''}`,
+  );
+}
+
+export function overrideTriage(
+  mapId: string,
+  decisionId: string,
+  body: { decision: TriageDecisionKindApi; parentNodeId?: string; reason?: string },
+): Promise<TriageActionResultApi> {
+  return request<TriageActionResultApi>(
+    `/api/maps/${mapId}/triage-decisions/${decisionId}/override`,
+    { method: 'POST', body: JSON.stringify(body) },
+  );
+}
+
+export function reclassifyTriage(
+  mapId: string,
+  decisionId: string,
+): Promise<TriageActionResultApi> {
+  return request<TriageActionResultApi>(
+    `/api/maps/${mapId}/triage-decisions/${decisionId}/reclassify`,
+    { method: 'POST' },
+  );
+}
+
+export function confirmTriage(
+  mapId: string,
+  decisionId: string,
+): Promise<TriageActionResultApi> {
+  return request<TriageActionResultApi>(
+    `/api/maps/${mapId}/triage-decisions/${decisionId}/confirm`,
+    { method: 'POST' },
+  );
+}

--- a/packages/mcp/src/backend.ts
+++ b/packages/mcp/src/backend.ts
@@ -16,4 +16,9 @@ export const httpBackend: ToolBackend = {
   updateNode: (mapId, nodeId, fields) => api.updateNode(mapId, nodeId, fields),
   deleteNode: (mapId, nodeId) => api.deleteNode(mapId, nodeId),
   moveNode: (mapId, nodeId, newParentId, position) => api.moveNode(mapId, nodeId, newParentId, position),
+  // ── Triage (#96 Phase 3) ────────────────────────────────────────
+  listTriageDecisions: (mapId, filters) => api.listTriageDecisions(mapId, filters),
+  overrideTriage: (mapId, decisionId, body) => api.overrideTriage(mapId, decisionId, body),
+  reclassifyTriage: (mapId, decisionId) => api.reclassifyTriage(mapId, decisionId),
+  confirmTriage: (mapId, decisionId) => api.confirmTriage(mapId, decisionId),
 };

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -184,5 +184,33 @@ export function createChatBackend(userId: string): ToolBackend {
       broadcast(mapId, { type: 'node:moved', nodeId, newParentId });
       return toNodeWithComputed(moved, undefined);
     },
+
+    // ── Triage (#96 Phase 3) ────────────────────────────────────
+    // The in-app chat backend doesn't expose the triage surface — the
+    // routes enforce a session-JWT-only gate (API-key auth is 403'd) for
+    // blast-radius reasons (#69 / #100), which doesn't map cleanly to the
+    // chat's in-process backend. Operators use the MCP HTTP backend
+    // (Eve, claude code) for triage; the chat refuses the same call with
+    // a clear directive rather than half-applying it.
+    async listTriageDecisions(_mapId, _filters) {
+      throw new Error(
+        'list_triage_decisions is not available through the in-app chat — call it via the MCP HTTP endpoint.',
+      );
+    },
+    async overrideTriage(_mapId, _decisionId, _body) {
+      throw new Error(
+        'override_triage is not available through the in-app chat — call it via the MCP HTTP endpoint.',
+      );
+    },
+    async reclassifyTriage(_mapId, _decisionId) {
+      throw new Error(
+        'reclassify_triage is not available through the in-app chat — call it via the MCP HTTP endpoint.',
+      );
+    },
+    async confirmTriage(_mapId, _decisionId) {
+      throw new Error(
+        'confirm_triage is not available through the in-app chat — call it via the MCP HTTP endpoint.',
+      );
+    },
   };
 }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -553,6 +553,46 @@ export async function runMigrations(): Promise<void> {
     ON triage_decisions(map_id) WHERE reviewed = false
   `);
 
+  // ── Phase 3 (#96) — opt-in GitHub label write-back per map ────
+  // When true, finalized triage decisions write `triage:placed` /
+  // `triage:skipped` labels back to the source GitHub issue. Default
+  // false so existing maps don't suddenly mutate their bound repos.
+  await db.execute(sql`
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS triage_label_writeback BOOLEAN NOT NULL DEFAULT false
+  `);
+
+  // ── Phase 3 (#96) — triage decision history (audit log) ───────
+  // Append-only history of every mutation on a triage_decisions row.
+  // ON DELETE CASCADE: when a decision row is removed (cascade from
+  // map delete, manual cleanup), its history rides along.
+  // changed_by is TEXT (not a users FK) so the 'auto' sentinel doesn't
+  // need a synthetic user row, and so dropping an operator user
+  // doesn't truncate their audit trail.
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS triage_decision_history (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      decision_id UUID NOT NULL REFERENCES triage_decisions(id) ON DELETE CASCADE,
+      changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      changed_by TEXT NOT NULL,
+      change_type TEXT NOT NULL,
+      previous_decision TEXT,
+      new_decision TEXT NOT NULL,
+      previous_confidence INTEGER,
+      new_confidence INTEGER,
+      previous_parent_node_id UUID,
+      new_parent_node_id UUID,
+      reason TEXT
+    )
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS triage_decision_history_decision_idx
+    ON triage_decision_history(decision_id)
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS triage_decision_history_changed_at_idx
+    ON triage_decision_history(changed_at DESC)
+  `);
+
   // ── Drop Milestone entity (collapsed into Version) ────────────
   // Historical: milestones were a first-class entity and nodes carried
   // both milestone_id and an is_milestone boolean checkpoint flag.

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -106,6 +106,13 @@ export const maps = pgTable('maps', {
   // suggested parent. Default false → ingest behaves exactly like
   // before (flat under the GitHub Inbox).
   triageEnabled: boolean('triage_enabled').notNull().default(false),
+  // Per-map opt-in for Phase 3 GitHub label write-back (#96). When true,
+  // finalized triage decisions write `triage:placed` / `triage:skipped`
+  // labels back to the source GitHub issue. Default false so existing
+  // maps don't suddenly mutate their bound repos. Best-effort: a label
+  // write failure never blocks the triage flow. Uncertain decisions do
+  // NOT write labels — intermediate state would just noise up GitHub.
+  triageLabelWriteback: boolean('triage_label_writeback').notNull().default(false),
 });
 
 // ── Nodes ──────────────────────────────────────────────────────────
@@ -319,6 +326,34 @@ export const triageDecisions = pgTable('triage_decisions', {
   reviewed: boolean('reviewed').notNull().default(false),
   reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
   reviewedBy: uuid('reviewed_by').references(() => users.id),
+});
+
+// ── Triage Decision History (#96, Phase 3) ────────────────────────
+// Append-only audit log for every mutation of a `triage_decisions` row.
+// Written by `recordTriageHistory()` from each call site that mutates a
+// triage row (auto-ingest, override, reclassify, confirm, reopen-sync,
+// bulk variants). Cascades on `triage_decisions` delete because the
+// decision row is the natural lifecycle anchor — if the operator deletes
+// a triage row, its history rides along.
+//
+// `changed_by` is either the literal string 'auto' (the pipeline) or a
+// stringified userId. It's text rather than a nullable users(id) FK so
+// the 'auto' sentinel doesn't need a synthetic user row, and so deleting
+// an operator user doesn't drop their audit trail.
+
+export const triageDecisionHistory = pgTable('triage_decision_history', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  decisionId: uuid('decision_id').notNull().references(() => triageDecisions.id, { onDelete: 'cascade' }),
+  changedAt: timestamp('changed_at', { withTimezone: true }).notNull().defaultNow(),
+  changedBy: text('changed_by').notNull(), // 'auto' | userId
+  changeType: text('change_type').notNull(), // 'created' | 'overridden' | 'reclassified' | 'confirmed' | 'state_synced'
+  previousDecision: text('previous_decision'), // null on 'created'
+  newDecision: text('new_decision').notNull(),
+  previousConfidence: integer('previous_confidence'),
+  newConfidence: integer('new_confidence'),
+  previousParentNodeId: uuid('previous_parent_node_id'),
+  newParentNodeId: uuid('new_parent_node_id'),
+  reason: text('reason'), // snapshot of the new decision's reason
 });
 
 // ── Cycles ─────────────────────────────────────────────────────────

--- a/packages/server/src/lib/githubContext.ts
+++ b/packages/server/src/lib/githubContext.ts
@@ -1,0 +1,98 @@
+/**
+ * GitHub token + repo resolution for a map.
+ *
+ * Extracted from `routes/integrations.ts` so non-route consumers (the
+ * triage label writeback in `sync/triageLabelWriteback.ts`, etc.) can
+ * resolve a token without dragging the route module — which would
+ * create a routes ↔ sync import cycle.
+ *
+ * Resolution order:
+ *   1. The map's own GitHub App installation binding (mint a fresh
+ *      installation token).
+ *   2. The workspace's legacy PAT integration row.
+ *
+ * Returns `null` when neither is configured.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import { db } from '../db/connection.js';
+import { integrations, maps } from '../db/schema.js';
+import { mintInstallationToken } from '@mindblown/integrations';
+
+export interface GitHubMapContext {
+  owner: string;
+  repo: string;
+  token: string;
+}
+
+interface GitHubConfig {
+  owner: string;
+  repo: string;
+  token: string;
+  webhookSecret?: string;
+}
+
+async function getGitHubIntegration(
+  workspaceId: string,
+): Promise<{ id: string; config: GitHubConfig } | null> {
+  const [row] = await db
+    .select()
+    .from(integrations)
+    .where(
+      and(
+        eq(integrations.workspaceId, workspaceId),
+        eq(integrations.provider, 'github'),
+      ),
+    );
+  if (!row || !row.enabled) return null;
+  return { id: row.id, config: row.config as unknown as GitHubConfig };
+}
+
+export async function getGitHubContextForMap(
+  mapId: string,
+): Promise<GitHubMapContext | null> {
+  const [map] = await db
+    .select({
+      githubInstallationId: maps.githubInstallationId,
+      githubRepoOwner: maps.githubRepoOwner,
+      githubRepoName: maps.githubRepoName,
+      workspaceId: maps.workspaceId,
+    })
+    .from(maps)
+    .where(eq(maps.id, mapId));
+
+  if (!map) return null;
+
+  // Try App installation binding first
+  if (
+    map.githubInstallationId &&
+    map.githubRepoOwner &&
+    map.githubRepoName
+  ) {
+    try {
+      const token = await mintInstallationToken(map.githubInstallationId);
+      return {
+        owner: map.githubRepoOwner,
+        repo: map.githubRepoName,
+        token,
+      };
+    } catch (err) {
+      console.warn(
+        '[github] Failed to mint installation token, falling back to PAT:',
+        err,
+      );
+    }
+  }
+
+  // Fallback: workspace PAT integration
+  const integration = await getGitHubIntegration(map.workspaceId);
+  if (integration) {
+    return {
+      owner: integration.config.owner,
+      repo: integration.config.repo,
+      token: integration.config.token,
+    };
+  }
+
+  return null;
+}

--- a/packages/server/src/routes/__tests__/triage-reopen.test.ts
+++ b/packages/server/src/routes/__tests__/triage-reopen.test.ts
@@ -145,6 +145,16 @@ vi.mock('../../db/schema.js', () => {
       decidedBy: col('decidedBy'),
       issueState: col('issueState'),
     },
+    // Phase 3 (#96) — recordTriageHistory writes into this table. The
+    // test doesn't assert on the contents but the recorder still
+    // attempts an insert, so the symbol must exist or the import
+    // resolves to undefined and drizzle throws.
+    triageDecisionHistory: {
+      __name: 'triageDecisionHistory',
+      id: col('id'),
+      decisionId: col('decisionId'),
+      changedAt: col('changedAt'),
+    },
   };
 });
 

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -35,6 +35,25 @@ interface TriageRow {
 
 const triageRows = new Map<string, TriageRow>();
 const nodes = new Map<string, { id: string; mapId: string; parentId: string | null }>();
+// Phase 3 (#96) — history insert recorder for the GET .../history route
+// test. Inserts from the mutation routes also land here so a test can
+// assert "the override route wrote a history row" without spinning up
+// the dedicated triage-history test infra.
+interface HistoryRow {
+  id: string;
+  decisionId: string;
+  changedAt: Date;
+  changedBy: string;
+  changeType: string;
+  previousDecision: string | null;
+  newDecision: string;
+  previousConfidence: number | null;
+  newConfidence: number | null;
+  previousParentNodeId: string | null;
+  newParentNodeId: string | null;
+  reason: string | null;
+}
+const historyRows = new Map<string, HistoryRow>();
 let permissionLevel: 'view' | 'edit' | 'admin' | null = 'edit';
 
 function seedRow(overrides: Partial<TriageRow> = {}): TriageRow {
@@ -71,13 +90,19 @@ function applyPred(rows: Record<string, unknown>[], pred: unknown): Record<strin
 }
 
 function buildSelectChain() {
-  const step: { table?: string; pred?: unknown; limit?: number } = {};
+  const step: { table?: string; pred?: unknown; limit?: number; ordered?: boolean } = {};
   const resolve = async (): Promise<Record<string, unknown>[]> => {
     let rows: Record<string, unknown>[] = [];
     if (step.table === 'triageDecisions') {
       rows = [...triageRows.values()].map((r) => ({ ...r }));
     } else if (step.table === 'nodes') {
       rows = [...nodes.values()].map((n) => ({ ...n }));
+    } else if (step.table === 'triageDecisionHistory') {
+      rows = [...historyRows.values()]
+        .map((r) => ({ ...r }))
+        .sort((a, b) =>
+          (b.changedAt as Date).getTime() - (a.changedAt as Date).getTime(),
+        );
     }
     const filtered = applyPred(rows, step.pred);
     return step.limit ? filtered.slice(0, step.limit) : filtered;
@@ -120,7 +145,29 @@ vi.mock('../../db/connection.js', () => {
         },
       }),
     }),
-    insert: () => ({ values: () => ({ returning: async () => [] }) }),
+    insert: (table: { __name?: string }) => ({
+      values: async (vals: Record<string, unknown>) => {
+        if (table?.__name === 'triageDecisionHistory') {
+          const id = `h${historyRows.size + 1}`;
+          historyRows.set(id, {
+            id,
+            decisionId: vals.decisionId as string,
+            changedAt: new Date(Date.now() + historyRows.size), // stable ordering
+            changedBy: vals.changedBy as string,
+            changeType: vals.changeType as string,
+            previousDecision: (vals.previousDecision as string | null) ?? null,
+            newDecision: vals.newDecision as string,
+            previousConfidence: (vals.previousConfidence as number | null) ?? null,
+            newConfidence: (vals.newConfidence as number | null) ?? null,
+            previousParentNodeId:
+              (vals.previousParentNodeId as string | null) ?? null,
+            newParentNodeId: (vals.newParentNodeId as string | null) ?? null,
+            reason: (vals.reason as string | null) ?? null,
+          });
+        }
+        return { returning: async () => [] };
+      },
+    }),
     transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(db),
   };
   return { db };
@@ -146,6 +193,16 @@ vi.mock('../../db/schema.js', () => {
       decidedAt: col('decidedAt'),
       confidence: col('confidence'),
       issueState: col('issueState'),
+    },
+    // Phase 3 (#96) — recordTriageHistory inserts into this table from
+    // every mutation route. The route tests don't assert on the history
+    // rows (covered separately in triage-history.test.ts), but the symbol
+    // must exist on the mock or drizzle throws on import resolution.
+    triageDecisionHistory: {
+      __name: 'triageDecisionHistory',
+      id: col('id'),
+      decisionId: col('decisionId'),
+      changedAt: col('changedAt'),
     },
   };
 });
@@ -264,6 +321,7 @@ async function buildApp(authSource: 'jwt' | 'api-key' | 'none'): Promise<Fastify
 beforeEach(() => {
   triageRows.clear();
   nodes.clear();
+  historyRows.clear();
   permissionLevel = 'edit';
   createNodeMock.mockClear();
   updateNodeMock.mockClear();
@@ -1285,5 +1343,102 @@ describe('POST .../bulk-reclassify', () => {
     });
     await app.close();
     expect(res.statusCode).toBe(403);
+  });
+});
+
+// ── GET .../history (Phase 3 #96) ────────────────────────────────
+
+describe('GET .../triage-decisions/:decisionId/history', () => {
+  it('returns history rows newest-first for the supplied decision', async () => {
+    seedRow({ id: 'tr-1' });
+    nodes.set('epic-1', { id: 'epic-1', mapId: 'map-1', parentId: 'root-1' });
+    permissionLevel = 'edit';
+
+    // Seed three mutations on the same decision (confirm → confirm again
+    // → override) by issuing real route calls so the history-write path
+    // matches production.
+    const app = await buildApp('jwt');
+    await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/confirm',
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/confirm',
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/override',
+      payload: { decision: 'place', parentNodeId: 'epic-1', reason: 'I know better' },
+    });
+
+    permissionLevel = 'view';
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/tr-1/history',
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { total: number; history: Array<{ changeType: string }> };
+    expect(body.total).toBe(3);
+    // The recorder writes them in insert order; the route sorts desc
+    // by changedAt. With our deterministic timestamps the override is
+    // last-written → first-returned.
+    expect(body.history[0].changeType).toBe('overridden');
+  });
+
+  it('404 when the decision is not in this map (cross-map id leak guard)', async () => {
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/ghost/history',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error?.code).toBe('NOT_FOUND');
+  });
+
+  it('403 for API-key auth (same gate as other triage reads)', async () => {
+    seedRow({ id: 'tr-1' });
+    permissionLevel = 'admin';
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/tr-1/history',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error?.code).toBe('FORBIDDEN');
+  });
+
+  it("403 for a JWT session without view permission", async () => {
+    seedRow({ id: 'tr-1' });
+    permissionLevel = null;
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/tr-1/history',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns empty history for a row that has never been mutated through the routes', async () => {
+    // History rows are written by the mutation routes / ingest path.
+    // A bare seeded row (no mutations through this app instance) has
+    // no rows in the history table — the route returns total=0 cleanly.
+    seedRow({ id: 'tr-1' });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/tr-1/history',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().total).toBe(0);
+    expect(res.json().history).toEqual([]);
   });
 });

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -26,10 +26,15 @@ import {
 } from '../sync/githubIngest.js';
 import { triageIssue } from '../sync/triage.js';
 import { buildMapContext } from '../sync/mapContext.js';
+import { recordTriageHistory } from '../sync/triageHistory.js';
 import type { GitHubIssue } from '@mindblown/integrations';
 import type { ExternalLink } from '@mindblown/core';
 import { broadcast } from '../ws.js';
 import { maps } from '../db/schema.js';
+import {
+  getGitHubContextForMap as getGitHubContextForMapImpl,
+  type GitHubMapContext as GitHubMapContextImpl,
+} from '../lib/githubContext.js';
 
 // ── Helper: find integration config for a workspace (legacy PAT) ──
 
@@ -51,43 +56,14 @@ async function getGitHubIntegration(workspaceId: string): Promise<{ id: string; 
 }
 
 // ── Helper: resolve GitHub token + repo for a map ─────────────────
-// Tries the map's own GitHub App binding first, falls back to the
-// workspace PAT integration.
+// Canonical impl lives in `lib/githubContext.ts` so non-route consumers
+// (the Phase 3 triage label writeback in `sync/triageLabelWriteback.ts`)
+// can import it without creating a routes ↔ sync cycle. The named
+// exports below are kept for back-compat with `routes/nodes.ts` and any
+// other site that already imports them from this file.
 
-export interface GitHubMapContext {
-  owner: string;
-  repo: string;
-  token: string;
-}
-
-export async function getGitHubContextForMap(mapId: string): Promise<GitHubMapContext | null> {
-  const [map] = await db.select({
-    githubInstallationId: maps.githubInstallationId,
-    githubRepoOwner: maps.githubRepoOwner,
-    githubRepoName: maps.githubRepoName,
-    workspaceId: maps.workspaceId,
-  }).from(maps).where(eq(maps.id, mapId));
-
-  if (!map) return null;
-
-  // Try App installation binding first
-  if (map.githubInstallationId && map.githubRepoOwner && map.githubRepoName) {
-    try {
-      const token = await mintInstallationToken(map.githubInstallationId);
-      return { owner: map.githubRepoOwner, repo: map.githubRepoName, token };
-    } catch (err) {
-      console.warn('[github] Failed to mint installation token, falling back to PAT:', err);
-    }
-  }
-
-  // Fallback: workspace PAT integration
-  const integration = await getGitHubIntegration(map.workspaceId);
-  if (integration) {
-    return { owner: integration.config.owner, repo: integration.config.repo, token: integration.config.token };
-  }
-
-  return null;
-}
+export type GitHubMapContext = GitHubMapContextImpl;
+export const getGitHubContextForMap = getGitHubContextForMapImpl;
 
 /**
  * Resolve a GitHub token + repo for a given `owner/repo`, scanning every
@@ -191,15 +167,11 @@ export async function syncTriageRowsForReopen(
   externalId: string,
   issue: GitHubIssue | undefined,
 ): Promise<void> {
-  // (1) Refresh issue_state on every matching row.
-  await db
-    .update(triageDecisions)
-    .set({ issueState: 'open' })
-    .where(eq(triageDecisions.externalId, externalId));
-
-  // (2) Re-triage every (map, externalId) where the map is still
-  // triage_enabled AND the row is not operator-reviewed.
-  const candidates = await db
+  // Snapshot every row matching this externalId BEFORE we update — we
+  // need the prior decision/confidence/placedNode for the history rows
+  // we'll write for the issue_state refresh, AND for any subsequent
+  // re-triage. One select reused for both passes.
+  const matchingRows = await db
     .select({
       id: triageDecisions.id,
       mapId: triageDecisions.mapId,
@@ -207,9 +179,39 @@ export async function syncTriageRowsForReopen(
       placedNodeId: triageDecisions.placedNodeId,
       reviewed: triageDecisions.reviewed,
       decidedBy: triageDecisions.decidedBy,
+      decision: triageDecisions.decision,
+      confidence: triageDecisions.confidence,
+      reason: triageDecisions.reason,
     })
     .from(triageDecisions)
     .where(eq(triageDecisions.externalId, externalId));
+
+  // (1) Refresh issue_state on every matching row.
+  await db
+    .update(triageDecisions)
+    .set({ issueState: 'open' })
+    .where(eq(triageDecisions.externalId, externalId));
+
+  // Phase 3 audit log — one 'state_synced' row per touched decision.
+  // Decision/confidence/parent don't change here, so previous_ == new_.
+  for (const row of matchingRows) {
+    await recordTriageHistory({
+      decisionId: row.id,
+      changedBy: 'auto',
+      changeType: 'state_synced',
+      previousDecision: row.decision,
+      newDecision: row.decision,
+      previousConfidence: row.confidence,
+      newConfidence: row.confidence,
+      previousParentNodeId: row.placedNodeId ?? null,
+      newParentNodeId: row.placedNodeId ?? null,
+      reason: row.reason,
+    });
+  }
+
+  // (2) Re-triage every (map, externalId) where the map is still
+  // triage_enabled AND the row is not operator-reviewed.
+  const candidates = matchingRows;
 
   for (const row of candidates) {
     // Operator-reviewed guard.
@@ -267,6 +269,25 @@ export async function syncTriageRowsForReopen(
           ...(clearPlacedNode ? { placedNodeId: null } : {}),
         })
         .where(eq(triageDecisions.id, row.id));
+      // Phase 3 audit log — re-triage on reopen is recorded as 'auto'
+      // since the LLM produced the new call.
+      const reopenNewParent = clearPlacedNode
+        ? null
+        : decision.decision === 'place'
+          ? (decision.parentNodeId ?? row.placedNodeId ?? null)
+          : (row.placedNodeId ?? null);
+      await recordTriageHistory({
+        decisionId: row.id,
+        changedBy: 'auto',
+        changeType: 'reclassified',
+        previousDecision: row.decision,
+        newDecision: decision.decision,
+        previousConfidence: row.confidence,
+        newConfidence: decision.confidence,
+        previousParentNodeId: row.placedNodeId ?? null,
+        newParentNodeId: reopenNewParent,
+        reason: decision.reason,
+      });
     } catch (err) {
       console.warn(
         `[triage-reopen] re-triage failed for row ${row.id} (map ${row.mapId}):`,

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -56,12 +56,14 @@
 import type { FastifyInstance } from 'fastify';
 import { and, desc, eq, gte, lte } from 'drizzle-orm';
 import { db } from '../db/connection.js';
-import { maps, nodes, triageDecisions } from '../db/schema.js';
+import { maps, nodes, triageDecisions, triageDecisionHistory } from '../db/schema.js';
 import * as nodeDb from '../db/nodes.js';
 import * as permDb from '../db/permissions.js';
 import { broadcast } from '../ws.js';
 import { buildMapContext } from '../sync/mapContext.js';
 import { triageIssue } from '../sync/triage.js';
+import { recordTriageHistory } from '../sync/triageHistory.js';
+import { applyTriageLabel } from '../sync/triageLabelWriteback.js';
 import type { ExternalLink } from '@mindblown/core';
 
 // ── Auth helpers ──────────────────────────────────────────────────
@@ -209,6 +211,63 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
+  // ── GET /api/maps/:mapId/triage-decisions/:decisionId/history ─
+  // Phase 3 (#96). Returns the append-only audit log for a single
+  // decision, ordered newest-first. Auth mirrors the single-decision
+  // list route: session JWT + 'view' permission (API-key auth 403s,
+  // same blast-radius reasoning as the rest of triage).
+  //
+  // The history rows are written by `recordTriageHistory` from every
+  // mutation site (override, reclassify, confirm, ingest auto-apply,
+  // reopened-state sync, bulk variants). On `triage_decisions` delete
+  // the history rows cascade away.
+  app.get<{
+    Params: { mapId: string; decisionId: string };
+  }>(
+    '/api/maps/:mapId/triage-decisions/:decisionId/history',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'view');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+
+      // Confirm the decision exists in this map before returning rows
+      // — prevents cross-map information leakage if a future operator
+      // pastes a decisionId from another tenant into the URL.
+      const [row] = await db
+        .select({ id: triageDecisions.id })
+        .from(triageDecisions)
+        .where(
+          and(
+            eq(triageDecisions.id, req.params.decisionId),
+            eq(triageDecisions.mapId, req.params.mapId),
+          ),
+        );
+      if (!row) {
+        return reply.status(404).send({
+          error: {
+            code: 'NOT_FOUND',
+            message: `Triage decision ${req.params.decisionId} not found in map ${req.params.mapId}`,
+          },
+        });
+      }
+
+      const rows = await db
+        .select()
+        .from(triageDecisionHistory)
+        .where(eq(triageDecisionHistory.decisionId, req.params.decisionId))
+        .orderBy(desc(triageDecisionHistory.changedAt));
+
+      return reply.send({
+        decisionId: req.params.decisionId,
+        total: rows.length,
+        history: rows,
+      });
+    },
+  );
+
   // ── POST /api/maps/:mapId/triage-decisions/:decisionId/confirm ──
   // Body: ignored (no parameters).
   //
@@ -270,6 +329,31 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           reviewedBy: userId,
         })
         .where(eq(triageDecisions.id, row.id));
+
+      // Phase 3 audit log — confirm doesn't change the decision so
+      // previous_/new_ fields all reflect the same values; the row
+      // documents WHO confirmed and WHEN.
+      await recordTriageHistory({
+        decisionId: row.id,
+        changedBy: userId,
+        changeType: 'confirmed',
+        previousDecision: row.decision,
+        newDecision: row.decision,
+        previousConfidence: row.confidence,
+        newConfidence: row.confidence,
+        previousParentNodeId: row.placedNodeId ?? null,
+        newParentNodeId: row.placedNodeId ?? null,
+        reason: row.reason,
+      });
+
+      // Phase 3 opt-in label writeback — fire-and-forget, best-effort
+      // (helper internally checks the per-map flag and silently no-ops
+      // on uncertain / disabled / GH errors).
+      await applyTriageLabel({
+        mapId: req.params.mapId,
+        externalId: row.externalId,
+        decision: row.decision as 'place' | 'skip' | 'uncertain',
+      });
 
       return reply.send({
         decisionId: row.id,
@@ -445,6 +529,25 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
             reviewedBy: userId,
           })
           .where(eq(triageDecisions.id, row.id));
+
+        await recordTriageHistory({
+          decisionId: row.id,
+          changedBy: userId,
+          changeType: 'overridden',
+          previousDecision: row.decision,
+          newDecision: 'place',
+          previousConfidence: row.confidence,
+          newConfidence: 100,
+          previousParentNodeId: row.placedNodeId ?? null,
+          newParentNodeId: submittedParent,
+          reason: body.reason ?? row.reason,
+        });
+        await applyTriageLabel({
+          mapId: req.params.mapId,
+          externalId: row.externalId,
+          decision: 'place',
+        });
+
         return reply.send({
           decisionId: row.id,
           status: moved ? 'moved' : 'already_placed',
@@ -545,6 +648,28 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           source: 'triage_override',
         });
       }
+
+      // Phase 3 audit log — record the override with full before/after
+      // snapshots. For 'place' the new parent is the freshly-created
+      // node; for skip/uncertain we leave parent null on both sides.
+      await recordTriageHistory({
+        decisionId: row.id,
+        changedBy: userId,
+        changeType: 'overridden',
+        previousDecision: row.decision,
+        newDecision: decision,
+        previousConfidence: row.confidence,
+        newConfidence: 100,
+        previousParentNodeId: row.placedNodeId ?? null,
+        newParentNodeId:
+          decision === 'place' ? (createdNodeId ?? null) : null,
+        reason: body.reason ?? row.reason,
+      });
+      await applyTriageLabel({
+        mapId: req.params.mapId,
+        externalId: row.externalId,
+        decision,
+      });
 
       return reply.send({
         decisionId: row.id,
@@ -653,6 +778,37 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           ...(clearPlacedNode ? { placedNodeId: null } : {}),
         })
         .where(eq(triageDecisions.id, row.id));
+
+      // Phase 3 audit log — reclassify is recorded as 'auto' since the
+      // LLM is the actor here, even though an operator triggered the
+      // re-run. Mirroring decidedBy/decidedAt semantics on the row.
+      const newParent = clearPlacedNode
+        ? null
+        : decision.decision === 'place'
+          ? (decision.parentNodeId ?? row.placedNodeId ?? null)
+          : (row.placedNodeId ?? null);
+      await recordTriageHistory({
+        decisionId: row.id,
+        changedBy: 'auto',
+        changeType: 'reclassified',
+        previousDecision: row.decision,
+        newDecision: decision.decision,
+        previousConfidence: row.confidence,
+        newConfidence: decision.confidence,
+        previousParentNodeId: row.placedNodeId ?? null,
+        newParentNodeId: newParent,
+        reason: decision.reason,
+      });
+      // Phase 3 label writeback: reclassify resets reviewed=false, so
+      // the new decision is auto and intermediate. We still write the
+      // label (the spec calls out reclassify-to-skip should flip the
+      // label) — uncertain decisions are silently no-op'd inside
+      // applyTriageLabel.
+      await applyTriageLabel({
+        mapId: req.params.mapId,
+        externalId: row.externalId,
+        decision: decision.decision,
+      });
 
       return reply.send({
         decisionId: row.id,
@@ -814,6 +970,23 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
               reviewedBy: userId,
             })
             .where(eq(triageDecisions.id, row.id));
+          await recordTriageHistory({
+            decisionId: row.id,
+            changedBy: userId,
+            changeType: 'confirmed',
+            previousDecision: row.decision,
+            newDecision: row.decision,
+            previousConfidence: row.confidence,
+            newConfidence: row.confidence,
+            previousParentNodeId: row.placedNodeId ?? null,
+            newParentNodeId: row.placedNodeId ?? null,
+            reason: row.reason,
+          });
+          await applyTriageLabel({
+            mapId: req.params.mapId,
+            externalId: row.externalId,
+            decision: row.decision as 'place' | 'skip' | 'uncertain',
+          });
           results.push({
             id,
             status: 'confirmed',
@@ -975,6 +1148,23 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
                 reviewedBy: userId,
               })
               .where(eq(triageDecisions.id, row.id));
+            await recordTriageHistory({
+              decisionId: row.id,
+              changedBy: userId,
+              changeType: 'overridden',
+              previousDecision: row.decision,
+              newDecision: 'place',
+              previousConfidence: row.confidence,
+              newConfidence: 100,
+              previousParentNodeId: row.placedNodeId ?? null,
+              newParentNodeId: parentNodeId,
+              reason: row.reason,
+            });
+            await applyTriageLabel({
+              mapId: req.params.mapId,
+              externalId: row.externalId,
+              decision: 'place',
+            });
             nodeId = placedNodeId;
             status = moved ? 'moved' : 'already_placed';
           } else {
@@ -1031,6 +1221,23 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
             }
             nodeId = created?.id ?? null;
             status = 'placed';
+            await recordTriageHistory({
+              decisionId: row.id,
+              changedBy: userId,
+              changeType: 'overridden',
+              previousDecision: row.decision,
+              newDecision: 'place',
+              previousConfidence: row.confidence,
+              newConfidence: 100,
+              previousParentNodeId: row.placedNodeId ?? null,
+              newParentNodeId: nodeId,
+              reason: row.reason,
+            });
+            await applyTriageLabel({
+              mapId: req.params.mapId,
+              externalId: row.externalId,
+              decision: 'place',
+            });
           }
           results.push({ id, status, nodeId });
         } catch (err) {
@@ -1139,6 +1346,28 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
               ...(clearPlacedNode ? { placedNodeId: null } : {}),
             })
             .where(eq(triageDecisions.id, row.id));
+          const newParent = clearPlacedNode
+            ? null
+            : decision.decision === 'place'
+              ? (decision.parentNodeId ?? row.placedNodeId ?? null)
+              : (row.placedNodeId ?? null);
+          await recordTriageHistory({
+            decisionId: row.id,
+            changedBy: 'auto',
+            changeType: 'reclassified',
+            previousDecision: row.decision,
+            newDecision: decision.decision,
+            previousConfidence: row.confidence,
+            newConfidence: decision.confidence,
+            previousParentNodeId: row.placedNodeId ?? null,
+            newParentNodeId: newParent,
+            reason: decision.reason,
+          });
+          await applyTriageLabel({
+            mapId: req.params.mapId,
+            externalId: row.externalId,
+            decision: decision.decision,
+          });
           results.push({
             id,
             status: 'reclassified',

--- a/packages/server/src/sync/__tests__/triage-history.test.ts
+++ b/packages/server/src/sync/__tests__/triage-history.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for the Phase 3 (#96) triage history recorder.
+ *
+ * Covers:
+ *   - Every mutation through `recordTriageHistory` writes a row with the
+ *     expected before/after snapshot fields.
+ *   - A multi-mutation sequence (created → overridden → reclassified)
+ *     produces ordered history rows that round-trip the decision
+ *     trajectory.
+ *   - Write failures inside the recorder are swallowed (the caller
+ *     mustn't see a thrown error from history bookkeeping).
+ *
+ * The DELETE-cascades-to-history invariant lives at the SQL layer — it's
+ * enforced by the FK constraint in `db/schema.ts` (ON DELETE CASCADE).
+ * We don't reach for a real Postgres instance here; the cascade test
+ * lives in the migrate-level integration suite (the schema itself
+ * declares the constraint, and the migration SQL mirrors it).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Shared insert recorder ───────────────────────────────────────
+
+interface HistoryRow {
+  decisionId: string;
+  changedBy: string;
+  changeType: string;
+  previousDecision: string | null;
+  newDecision: string;
+  previousConfidence: number | null;
+  newConfidence: number | null;
+  previousParentNodeId: string | null;
+  newParentNodeId: string | null;
+  reason: string | null;
+  insertedAt: number; // ordering helper for assertions
+}
+
+const insertedHistory: HistoryRow[] = [];
+let shouldFailInsert = false;
+
+vi.mock('../../db/connection.js', () => {
+  const db = {
+    insert: (table: { __name?: string }) => ({
+      values: async (vals: Record<string, unknown>) => {
+        if (shouldFailInsert) {
+          throw new Error('simulated db failure');
+        }
+        if (table?.__name === 'triageDecisionHistory') {
+          insertedHistory.push({
+            decisionId: vals.decisionId as string,
+            changedBy: vals.changedBy as string,
+            changeType: vals.changeType as string,
+            previousDecision: (vals.previousDecision as string | null) ?? null,
+            newDecision: vals.newDecision as string,
+            previousConfidence: (vals.previousConfidence as number | null) ?? null,
+            newConfidence: (vals.newConfidence as number | null) ?? null,
+            previousParentNodeId:
+              (vals.previousParentNodeId as string | null) ?? null,
+            newParentNodeId: (vals.newParentNodeId as string | null) ?? null,
+            reason: (vals.reason as string | null) ?? null,
+            insertedAt: insertedHistory.length,
+          });
+        }
+      },
+    }),
+  };
+  return { db };
+});
+
+vi.mock('../../db/schema.js', () => ({
+  triageDecisionHistory: { __name: 'triageDecisionHistory' },
+}));
+
+import { recordTriageHistory } from '../triageHistory.js';
+
+beforeEach(() => {
+  insertedHistory.length = 0;
+  shouldFailInsert = false;
+});
+
+// ── recordTriageHistory ──────────────────────────────────────────
+
+describe('recordTriageHistory — single mutation', () => {
+  it("writes a 'created' row with previous=null", async () => {
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'auto',
+      changeType: 'created',
+      previousDecision: null,
+      newDecision: 'place',
+      previousConfidence: null,
+      newConfidence: 88,
+      previousParentNodeId: null,
+      newParentNodeId: 'epic-1',
+      reason: 'matches Frontend',
+    });
+    expect(insertedHistory).toHaveLength(1);
+    expect(insertedHistory[0]).toMatchObject({
+      decisionId: 'd1',
+      changedBy: 'auto',
+      changeType: 'created',
+      previousDecision: null,
+      newDecision: 'place',
+      previousConfidence: null,
+      newConfidence: 88,
+      previousParentNodeId: null,
+      newParentNodeId: 'epic-1',
+      reason: 'matches Frontend',
+    });
+  });
+
+  it("writes an 'overridden' row with before/after deltas captured", async () => {
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'user-7',
+      changeType: 'overridden',
+      previousDecision: 'uncertain',
+      newDecision: 'place',
+      previousConfidence: 40,
+      newConfidence: 100,
+      previousParentNodeId: null,
+      newParentNodeId: 'epic-1',
+      reason: 'operator: I know better',
+    });
+    expect(insertedHistory[0]).toMatchObject({
+      changeType: 'overridden',
+      previousDecision: 'uncertain',
+      newDecision: 'place',
+      previousConfidence: 40,
+      newConfidence: 100,
+      changedBy: 'user-7',
+    });
+  });
+
+  it("writes a 'reclassified' row with auto changedBy", async () => {
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'auto',
+      changeType: 'reclassified',
+      previousDecision: 'place',
+      newDecision: 'skip',
+      previousConfidence: 80,
+      newConfidence: 92,
+      previousParentNodeId: 'epic-1',
+      newParentNodeId: null,
+      reason: 'no longer relevant after map refactor',
+    });
+    expect(insertedHistory[0]).toMatchObject({
+      changeType: 'reclassified',
+      changedBy: 'auto',
+      previousDecision: 'place',
+      newDecision: 'skip',
+      previousParentNodeId: 'epic-1',
+      newParentNodeId: null,
+    });
+  });
+
+  it("writes a 'confirmed' row where previous_/new_ are identical", async () => {
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'user-7',
+      changeType: 'confirmed',
+      previousDecision: 'place',
+      newDecision: 'place',
+      previousConfidence: 88,
+      newConfidence: 88,
+      previousParentNodeId: 'epic-1',
+      newParentNodeId: 'epic-1',
+      reason: 'accept LLM call as-is',
+    });
+    expect(insertedHistory[0].changeType).toBe('confirmed');
+    expect(insertedHistory[0].previousDecision).toBe(insertedHistory[0].newDecision);
+    expect(insertedHistory[0].previousParentNodeId).toBe(
+      insertedHistory[0].newParentNodeId,
+    );
+  });
+
+  it("writes a 'state_synced' row for GH issue_state refresh on reopen", async () => {
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'auto',
+      changeType: 'state_synced',
+      previousDecision: 'place',
+      newDecision: 'place',
+      previousConfidence: 88,
+      newConfidence: 88,
+      previousParentNodeId: 'epic-1',
+      newParentNodeId: 'epic-1',
+      reason: 'matches Frontend',
+    });
+    expect(insertedHistory[0].changeType).toBe('state_synced');
+    expect(insertedHistory[0].changedBy).toBe('auto');
+  });
+});
+
+// ── Multi-mutation sequence ──────────────────────────────────────
+
+describe('recordTriageHistory — sequenced trajectory', () => {
+  it('multiple mutations land in chronological order, decisionId stable', async () => {
+    // Simulate: auto-created → operator-overridden → auto-reclassified
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'auto',
+      changeType: 'created',
+      previousDecision: null,
+      newDecision: 'uncertain',
+      previousConfidence: null,
+      newConfidence: 40,
+      previousParentNodeId: null,
+      newParentNodeId: null,
+      reason: 'LLM unsure',
+    });
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'user-7',
+      changeType: 'overridden',
+      previousDecision: 'uncertain',
+      newDecision: 'place',
+      previousConfidence: 40,
+      newConfidence: 100,
+      previousParentNodeId: null,
+      newParentNodeId: 'epic-1',
+      reason: 'operator force-placed',
+    });
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'auto',
+      changeType: 'reclassified',
+      previousDecision: 'place',
+      newDecision: 'skip',
+      previousConfidence: 100,
+      newConfidence: 88,
+      previousParentNodeId: 'epic-1',
+      newParentNodeId: null,
+      reason: 'map refactor — no longer fits',
+    });
+
+    expect(insertedHistory).toHaveLength(3);
+    expect(insertedHistory.map((r) => r.changeType)).toEqual([
+      'created',
+      'overridden',
+      'reclassified',
+    ]);
+    // Each row's previous_ matches the prior row's new_ — round-trips the
+    // decision trajectory.
+    expect(insertedHistory[1].previousDecision).toBe(insertedHistory[0].newDecision);
+    expect(insertedHistory[2].previousDecision).toBe(insertedHistory[1].newDecision);
+    expect(insertedHistory[1].previousParentNodeId).toBe(
+      insertedHistory[0].newParentNodeId,
+    );
+    expect(insertedHistory[2].previousParentNodeId).toBe(
+      insertedHistory[1].newParentNodeId,
+    );
+    // All three rows share the same decisionId — history is per-row.
+    expect(new Set(insertedHistory.map((r) => r.decisionId))).toEqual(
+      new Set(['d1']),
+    );
+  });
+
+  it('mutations on two different decisions stay segregated by decisionId', async () => {
+    await recordTriageHistory({
+      decisionId: 'd1',
+      changedBy: 'auto',
+      changeType: 'created',
+      previousDecision: null,
+      newDecision: 'place',
+      previousConfidence: null,
+      newConfidence: 88,
+      previousParentNodeId: null,
+      newParentNodeId: 'epic-1',
+      reason: 'r1',
+    });
+    await recordTriageHistory({
+      decisionId: 'd2',
+      changedBy: 'auto',
+      changeType: 'created',
+      previousDecision: null,
+      newDecision: 'skip',
+      previousConfidence: null,
+      newConfidence: 92,
+      previousParentNodeId: null,
+      newParentNodeId: null,
+      reason: 'r2',
+    });
+    expect(insertedHistory).toHaveLength(2);
+    const d1Rows = insertedHistory.filter((r) => r.decisionId === 'd1');
+    const d2Rows = insertedHistory.filter((r) => r.decisionId === 'd2');
+    expect(d1Rows).toHaveLength(1);
+    expect(d2Rows).toHaveLength(1);
+    expect(d1Rows[0].newDecision).toBe('place');
+    expect(d2Rows[0].newDecision).toBe('skip');
+  });
+});
+
+// ── Failure modes ────────────────────────────────────────────────
+
+describe('recordTriageHistory — failure isolation', () => {
+  it('a DB throw inside the recorder is swallowed (no rethrow)', async () => {
+    shouldFailInsert = true;
+    // The whole point of best-effort audit logging is that a write
+    // failure here can't take down the surrounding mutation. The test
+    // proves the helper doesn't propagate.
+    await expect(
+      recordTriageHistory({
+        decisionId: 'd1',
+        changedBy: 'auto',
+        changeType: 'created',
+        previousDecision: null,
+        newDecision: 'place',
+        previousConfidence: null,
+        newConfidence: 88,
+        previousParentNodeId: null,
+        newParentNodeId: 'epic-1',
+        reason: 'r1',
+      }),
+    ).resolves.toBeUndefined();
+    expect(insertedHistory).toHaveLength(0);
+  });
+});

--- a/packages/server/src/sync/__tests__/triage-label-writeback.test.ts
+++ b/packages/server/src/sync/__tests__/triage-label-writeback.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the Phase 3 (#96) optional GitHub label write-back.
+ *
+ * Covers:
+ *   - `triage_label_writeback=false` (default) → no GH API call.
+ *   - `triage_label_writeback=true` + place → `triage:placed` POSTed,
+ *     `triage:skipped` DELETEd (best-effort 404 ignored).
+ *   - place ↔ skip flip swaps the labels.
+ *   - decision='uncertain' → no GH API call even with writeback enabled
+ *     (intermediate-state suppression).
+ *   - GH 422 (label doesn't exist) → flow completes, only a warn is logged.
+ *   - GH 500 → flow completes (best-effort, never throws to caller).
+ *   - Malformed externalId → silent skip, no GH call.
+ *   - Map without GH context → silent skip, no GH call.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+let labelWritebackEnabled = false;
+let mapExists = true;
+let ghContext: { owner: string; repo: string; token: string } | null = {
+  owner: 'octocat',
+  repo: 'demo',
+  token: 't_test',
+};
+
+vi.mock('../../db/connection.js', () => {
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: async () => {
+          if (!mapExists) return [];
+          return [{ writeback: labelWritebackEnabled }];
+        },
+      }),
+    }),
+  };
+  return { db };
+});
+
+vi.mock('../../db/schema.js', () => ({
+  maps: {
+    __name: 'maps',
+    id: { __col: 'id' },
+    triageLabelWriteback: { __col: 'triageLabelWriteback' },
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ __pred: true, col, val }),
+}));
+
+vi.mock('../../lib/githubContext.js', () => ({
+  getGitHubContextForMap: async () => ghContext,
+}));
+
+vi.mock('@mindblown/integrations', () => ({
+  GitHubApiError: class GitHubApiError extends Error {
+    status: number;
+    body: string;
+    constructor(status: number, body: string) {
+      super(`GitHub API ${status}: ${body}`);
+      this.name = 'GitHubApiError';
+      this.status = status;
+      this.body = body;
+    }
+  },
+}));
+
+import { applyTriageLabel } from '../triageLabelWriteback.js';
+
+// Build a fetch-impl shim the tests can wire into `applyTriageLabel`
+// so we never touch real network and can assert request shape.
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  body: string | undefined;
+}
+
+function fetchShim(
+  responseByPattern: Array<{ urlContains: string; method: string; status: number; body?: string }>,
+): { calls: RecordedCall[]; impl: Parameters<typeof applyTriageLabel>[0]['fetchImpl'] } {
+  const calls: RecordedCall[] = [];
+  const impl: NonNullable<Parameters<typeof applyTriageLabel>[0]['fetchImpl']> = async (
+    url,
+    init,
+  ) => {
+    calls.push({ url, method: init.method, body: init.body });
+    const match = responseByPattern.find(
+      (r) => url.includes(r.urlContains) && r.method === init.method,
+    );
+    const status = match?.status ?? 200;
+    const body = match?.body ?? '{}';
+    return {
+      status,
+      text: async () => body,
+    };
+  };
+  return { calls, impl };
+}
+
+beforeEach(() => {
+  labelWritebackEnabled = false;
+  mapExists = true;
+  ghContext = { owner: 'octocat', repo: 'demo', token: 't_test' };
+});
+
+// ── Disabled paths ───────────────────────────────────────────────
+
+describe('applyTriageLabel — gated off', () => {
+  it('writeback disabled → no GH API call', async () => {
+    labelWritebackEnabled = false;
+    const shim = fetchShim([]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'place',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(0);
+  });
+
+  it("decision='uncertain' → no GH API call even when writeback is enabled", async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'uncertain',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(0);
+  });
+
+  it('map row missing → silent skip, no GH call', async () => {
+    labelWritebackEnabled = true;
+    mapExists = false;
+    const shim = fetchShim([]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'place',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(0);
+  });
+
+  it('malformed externalId → silent skip, no GH call', async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'not-an-external-id',
+      decision: 'place',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(0);
+  });
+
+  it('no GitHub context for map → silent skip, no GH call', async () => {
+    labelWritebackEnabled = true;
+    ghContext = null;
+    const shim = fetchShim([]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'place',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(0);
+  });
+});
+
+// ── Active paths ─────────────────────────────────────────────────
+
+describe('applyTriageLabel — active', () => {
+  it("decision='place' → POSTs triage:placed and DELETEs triage:skipped", async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels', method: 'POST', status: 200, body: '[]' },
+      { urlContains: '/labels/triage', method: 'DELETE', status: 200 },
+    ]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'place',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(2);
+    expect(shim.calls[0].method).toBe('POST');
+    expect(shim.calls[0].url).toContain('/repos/octocat/demo/issues/42/labels');
+    expect(shim.calls[0].body).toContain('triage:placed');
+    expect(shim.calls[1].method).toBe('DELETE');
+    expect(shim.calls[1].url).toContain(
+      `/repos/octocat/demo/issues/42/labels/${encodeURIComponent('triage:skipped')}`,
+    );
+  });
+
+  it("decision='skip' → POSTs triage:skipped and DELETEs triage:placed (inverse)", async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels', method: 'POST', status: 200 },
+      { urlContains: '/labels/triage', method: 'DELETE', status: 200 },
+    ]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'skip',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(2);
+    expect(shim.calls[0].body).toContain('triage:skipped');
+    expect(shim.calls[1].url).toContain(
+      `/repos/octocat/demo/issues/42/labels/${encodeURIComponent('triage:placed')}`,
+    );
+  });
+
+  it('inverse-label DELETE 404 → treated as no-op, flow continues', async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels', method: 'POST', status: 200 },
+      { urlContains: '/labels/triage', method: 'DELETE', status: 404 },
+    ]);
+    await expect(
+      applyTriageLabel({
+        mapId: 'm1',
+        externalId: 'octocat/demo#42',
+        decision: 'place',
+        fetchImpl: shim.impl,
+      }),
+    ).resolves.toBeUndefined();
+    expect(shim.calls).toHaveLength(2);
+  });
+
+  it('add-label 422 (label doesn\'t exist in repo) → still attempts remove, never throws', async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels', method: 'POST', status: 422 },
+      { urlContains: '/labels/triage', method: 'DELETE', status: 422 },
+    ]);
+    await expect(
+      applyTriageLabel({
+        mapId: 'm1',
+        externalId: 'octocat/demo#42',
+        decision: 'place',
+        fetchImpl: shim.impl,
+      }),
+    ).resolves.toBeUndefined();
+    // Both calls still attempted — best-effort, neither throws.
+    expect(shim.calls).toHaveLength(2);
+  });
+
+  it('add-label 500 (server error) → flow completes without throwing', async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels', method: 'POST', status: 500 },
+      { urlContains: '/labels/triage', method: 'DELETE', status: 500 },
+    ]);
+    await expect(
+      applyTriageLabel({
+        mapId: 'm1',
+        externalId: 'octocat/demo#42',
+        decision: 'place',
+        fetchImpl: shim.impl,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('Bearer token from the resolved GH context is sent on every request', async () => {
+    labelWritebackEnabled = true;
+    let capturedAuth: string | undefined;
+    const impl: NonNullable<Parameters<typeof applyTriageLabel>[0]['fetchImpl']> = async (
+      _url,
+      init,
+    ) => {
+      capturedAuth = (init.headers as Record<string, string>).Authorization;
+      return { status: 200, text: async () => '' };
+    };
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'place',
+      fetchImpl: impl,
+    });
+    expect(capturedAuth).toBe('Bearer t_test');
+  });
+});

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -49,6 +49,8 @@ import { integrations, maps, nodes, triageDecisions } from '../db/schema.js';
 import * as nodeDb from '../db/nodes.js';
 import { broadcast } from '../ws.js';
 import { buildMapContext } from './mapContext.js';
+import { recordTriageHistory } from './triageHistory.js';
+import { applyTriageLabel } from './triageLabelWriteback.js';
 import {
   triageIssue,
   TRIAGE_AUTO_APPLY_CONFIDENCE,
@@ -551,8 +553,13 @@ async function ensureNodeForIssueViaTriage(
         decisionId: string;
         nodeId: string;
         node: Awaited<ReturnType<typeof nodeDb.getNode>>;
+        previous: PriorDecisionSnapshot | null;
       }
-    | { kind: 'decision_only'; decisionId: string }
+    | {
+        kind: 'decision_only';
+        decisionId: string;
+        previous: PriorDecisionSnapshot | null;
+      }
     | { kind: 'lost_race'; nodeId: string }
     | {
         kind: 'operator_reviewed_late';
@@ -561,6 +568,16 @@ async function ensureNodeForIssueViaTriage(
         decision: TriageDecision['decision'];
         confidence: number;
       };
+
+  // Captured for the audit-history write (#96 Phase 3). When the upsert
+  // tx finds no existing row, previous is null → history records 'created'.
+  // Otherwise we keep the prior decision/confidence/placedNode so the
+  // history row carries a proper before/after delta.
+  interface PriorDecisionSnapshot {
+    decision: string;
+    confidence: number;
+    placedNodeId: string | null;
+  }
 
   const result: TxResult = await db.transaction(async (tx) => {
     await takeIngestLock(tx, externalId);
@@ -617,6 +634,20 @@ async function ensureNodeForIssueViaTriage(
       };
     }
 
+    // Snapshot the prior decision (if any) so the post-tx history write
+    // can record a proper before/after delta. When no row existed, the
+    // snapshot is null → history records 'created' rather than
+    // 'overridden'. Captured here while we already hold the row in memory.
+    const priorSnapshot: PriorDecisionSnapshot | null =
+      existingDecisionInUpsertTx
+        ? {
+            decision: existingDecisionInUpsertTx.decision as string,
+            confidence: existingDecisionInUpsertTx.confidence as number,
+            placedNodeId:
+              (existingDecisionInUpsertTx.placedNodeId as string | null) ?? null,
+          }
+        : null;
+
     // Upsert the decision row. ON CONFLICT updates the existing row in
     // place so re-triage (operator hits `POST .../reclassify`) doesn't
     // accumulate duplicates.
@@ -660,7 +691,11 @@ async function ensureNodeForIssueViaTriage(
       .returning({ id: triageDecisions.id });
 
     if (!shouldAutoApply || !decision.parentNodeId) {
-      return { kind: 'decision_only', decisionId: decisionRow.id };
+      return {
+        kind: 'decision_only',
+        decisionId: decisionRow.id,
+        previous: priorSnapshot,
+      };
     }
 
     // Auto-apply: create the node under the LLM-chosen parent.
@@ -693,6 +728,7 @@ async function ensureNodeForIssueViaTriage(
       decisionId: decisionRow.id,
       nodeId: created.id,
       node: updated ?? created,
+      previous: priorSnapshot,
     };
   });
 
@@ -750,6 +786,28 @@ async function ensureNodeForIssueViaTriage(
       node: result.node,
       source: 'github_ingest_triage',
     });
+    // Phase 3 (#96) audit-history record. previous=null → 'created';
+    // any prior row (auto-revisit) → 'overridden'. The helper swallows
+    // its own errors so a logging failure can't block ingest.
+    await recordTriageHistory({
+      decisionId: result.decisionId,
+      changedBy: 'auto',
+      changeType: result.previous ? 'overridden' : 'created',
+      previousDecision: result.previous?.decision ?? null,
+      newDecision: decision.decision,
+      previousConfidence: result.previous?.confidence ?? null,
+      newConfidence: decision.confidence,
+      previousParentNodeId: result.previous?.placedNodeId ?? null,
+      newParentNodeId: result.nodeId,
+      reason: decision.reason,
+    });
+    // Phase 3 (#96) opt-in label writeback. Best-effort; helper internally
+    // gates on map's writeback flag + GH token availability.
+    await applyTriageLabel({
+      mapId,
+      externalId,
+      decision: decision.decision,
+    });
     return {
       status: 'created',
       nodeId: result.nodeId,
@@ -771,6 +829,23 @@ async function ensureNodeForIssueViaTriage(
       : decision.decision === 'uncertain'
         ? 'triaged_uncertain'
         : 'triaged_low_confidence';
+  await recordTriageHistory({
+    decisionId: result.decisionId,
+    changedBy: 'auto',
+    changeType: result.previous ? 'overridden' : 'created',
+    previousDecision: result.previous?.decision ?? null,
+    newDecision: decision.decision,
+    previousConfidence: result.previous?.confidence ?? null,
+    newConfidence: decision.confidence,
+    previousParentNodeId: result.previous?.placedNodeId ?? null,
+    newParentNodeId: null,
+    reason: decision.reason,
+  });
+  await applyTriageLabel({
+    mapId,
+    externalId,
+    decision: decision.decision,
+  });
   return {
     status,
     mapId,

--- a/packages/server/src/sync/triageHistory.ts
+++ b/packages/server/src/sync/triageHistory.ts
@@ -1,0 +1,78 @@
+/**
+ * Triage decision history recorder (#96, Phase 3).
+ *
+ * Every mutation of a `triage_decisions` row writes one row to
+ * `triage_decision_history` so an operator/auditor can reconstruct what
+ * Claude or the human did to a given decision over time.
+ *
+ * The recorder is centralised here so the wire-up at each mutation site
+ * stays a one-line `await recordTriageHistory(...)`. Mutation sites:
+ *
+ *   - `ensureNodeForIssueViaTriage`  → 'created' or 'overridden' depending
+ *     on whether a prior row was present in the upsert.
+ *   - `POST .../override`            → 'overridden'.
+ *   - `POST .../reclassify`          → 'reclassified'.
+ *   - `POST .../confirm`             → 'confirmed'.
+ *   - `syncTriageRowsForReopen`      → 'state_synced' (and 'reclassified'
+ *      when the row is re-triaged).
+ *   - Bulk variants                  → one row per item.
+ *
+ * Write failures are best-effort: the helper logs and swallows. History
+ * is an audit-trail concern; if it can't write, the actual decision flow
+ * must still succeed. (Compare: change_events follows the same pattern.)
+ */
+
+import { db } from '../db/connection.js';
+import { triageDecisionHistory } from '../db/schema.js';
+
+export type TriageChangeType =
+  | 'created'
+  | 'overridden'
+  | 'reclassified'
+  | 'confirmed'
+  | 'state_synced';
+
+export interface TriageHistoryInput {
+  decisionId: string;
+  /** 'auto' for pipeline writes, a stringified userId for operator writes. */
+  changedBy: string;
+  changeType: TriageChangeType;
+  previousDecision: string | null;
+  newDecision: string;
+  previousConfidence: number | null;
+  newConfidence: number;
+  previousParentNodeId: string | null;
+  newParentNodeId: string | null;
+  /** Snapshot of the new decision's reason text. */
+  reason: string | null;
+}
+
+/**
+ * Append a history row for a triage_decisions mutation.
+ *
+ * Best-effort: errors are logged but not rethrown so the surrounding
+ * mutation never fails on audit-write failure.
+ */
+export async function recordTriageHistory(
+  input: TriageHistoryInput,
+): Promise<void> {
+  try {
+    await db.insert(triageDecisionHistory).values({
+      decisionId: input.decisionId,
+      changedBy: input.changedBy,
+      changeType: input.changeType,
+      previousDecision: input.previousDecision,
+      newDecision: input.newDecision,
+      previousConfidence: input.previousConfidence,
+      newConfidence: input.newConfidence,
+      previousParentNodeId: input.previousParentNodeId,
+      newParentNodeId: input.newParentNodeId,
+      reason: input.reason,
+    });
+  } catch (err) {
+    console.warn(
+      `[triage-history] failed to record ${input.changeType} on decision ${input.decisionId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}

--- a/packages/server/src/sync/triageLabelWriteback.ts
+++ b/packages/server/src/sync/triageLabelWriteback.ts
@@ -1,0 +1,208 @@
+/**
+ * Optional GitHub label write-back for triage decisions (#96, Phase 3).
+ *
+ * When a map opts into `triage_label_writeback`, finalised triage
+ * decisions write a `triage:placed` or `triage:skipped` label back to
+ * the source GitHub issue:
+ *
+ *   - decision='place'     → add `triage:placed`, remove `triage:skipped`
+ *   - decision='skip'      → add `triage:skipped`, remove `triage:placed`
+ *   - decision='uncertain' → no label change (intermediate state, don't
+ *                            spam GitHub)
+ *
+ * Best-effort: a label-write failure must NEVER block the triage flow.
+ * We log + ignore. If the operator hasn't created the label in their
+ * repo, GitHub returns 422 — we treat that as a no-op and warn.
+ *
+ * We don't auto-create labels: the operator is expected to set them up
+ * in their GitHub repo first. That's a deliberate UX choice — silent
+ * label creation surprises owners of public repos.
+ *
+ * Token resolution flows through the existing `getGitHubContextForMap`
+ * helper so App installations and PAT integrations both work.
+ */
+
+import { GitHubApiError } from '@mindblown/integrations';
+import { db } from '../db/connection.js';
+import { maps } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+import { getGitHubContextForMap } from '../lib/githubContext.js';
+
+export const TRIAGE_PLACED_LABEL = 'triage:placed';
+export const TRIAGE_SKIPPED_LABEL = 'triage:skipped';
+
+export type FinalizedTriageDecision = 'place' | 'skip' | 'uncertain';
+
+interface WriteLabelOpts {
+  mapId: string;
+  externalId: string; // "owner/repo#NNN"
+  decision: FinalizedTriageDecision;
+  /**
+   * Test injection: replace the `githubFetch` HTTP call. Production
+   * callers omit this; tests pass a mock to assert request shape.
+   */
+  fetchImpl?: (
+    url: string,
+    init: { method: string; headers: Record<string, string>; body?: string },
+  ) => Promise<{ status: number; text: () => Promise<string> }>;
+}
+
+const GITHUB_API = 'https://api.github.com';
+
+function parseExternalId(
+  externalId: string,
+): { owner: string; repo: string; issueNumber: number } | null {
+  const match = externalId.match(/^(.+?)\/(.+?)#(\d+)$/);
+  if (!match) return null;
+  return {
+    owner: match[1],
+    repo: match[2],
+    issueNumber: parseInt(match[3], 10),
+  };
+}
+
+async function ghRequest(
+  url: string,
+  method: string,
+  token: string,
+  body: unknown | undefined,
+  fetchImpl: WriteLabelOpts['fetchImpl'],
+): Promise<{ status: number; bodyText: string }> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+  if (fetchImpl) {
+    const res = await fetchImpl(url, {
+      method,
+      headers,
+      body: body == null ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    return { status: res.status, bodyText: text };
+  }
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, bodyText: text };
+}
+
+/**
+ * Apply the desired triage label state to the GitHub issue. Best-effort:
+ * never throws. Callers do `await applyTriageLabel(...)` and continue
+ * regardless of outcome.
+ *
+ * The "remove the inverse label" step is also best-effort: if the inverse
+ * label isn't on the issue, GitHub returns 404 on the remove — we treat
+ * that as a no-op and don't log.
+ */
+export async function applyTriageLabel(opts: WriteLabelOpts): Promise<void> {
+  // Gate: 'uncertain' is a no-op (we don't want intermediate-state label
+  // churn on GitHub).
+  if (opts.decision === 'uncertain') return;
+
+  // Gate: map must have label writeback enabled.
+  const [mapRow] = await db
+    .select({ writeback: maps.triageLabelWriteback })
+    .from(maps)
+    .where(eq(maps.id, opts.mapId));
+  if (!mapRow || mapRow.writeback !== true) return;
+
+  const parsed = parseExternalId(opts.externalId);
+  if (!parsed) {
+    console.warn(
+      `[triage-label] could not parse externalId=${JSON.stringify(opts.externalId)} for map ${opts.mapId}; skipping label writeback`,
+    );
+    return;
+  }
+
+  const ghCtx = await getGitHubContextForMap(opts.mapId);
+  if (!ghCtx) {
+    console.warn(
+      `[triage-label] no GitHub context for map ${opts.mapId}; skipping label writeback`,
+    );
+    return;
+  }
+
+  const addLabel =
+    opts.decision === 'place' ? TRIAGE_PLACED_LABEL : TRIAGE_SKIPPED_LABEL;
+  const removeLabel =
+    opts.decision === 'place' ? TRIAGE_SKIPPED_LABEL : TRIAGE_PLACED_LABEL;
+
+  const { owner, repo, issueNumber } = parsed;
+
+  // 1) Add the new label. POST /repos/{owner}/{repo}/issues/{number}/labels
+  //    is additive — GitHub merges with existing labels rather than
+  //    replacing the set.
+  try {
+    const addUrl = `${GITHUB_API}/repos/${owner}/${repo}/issues/${issueNumber}/labels`;
+    const { status, bodyText } = await ghRequest(
+      addUrl,
+      'POST',
+      ghCtx.token,
+      { labels: [addLabel] },
+      opts.fetchImpl,
+    );
+    if (status === 422) {
+      // GitHub returns 422 when the label doesn't exist on the repo.
+      // Per spec: don't auto-create — log a warn and continue.
+      console.warn(
+        `[triage-label] label "${addLabel}" does not exist on ${owner}/${repo}; create it in your repo to enable writeback. (issue #${issueNumber})`,
+      );
+    } else if (status < 200 || status >= 300) {
+      console.warn(
+        `[triage-label] add ${addLabel} on ${owner}/${repo}#${issueNumber} returned ${status}: ${bodyText.slice(0, 200)}`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof GitHubApiError) {
+      console.warn(
+        `[triage-label] add label failed on ${owner}/${repo}#${issueNumber}: ${err.message}`,
+      );
+    } else {
+      console.warn(
+        `[triage-label] add label network error on ${owner}/${repo}#${issueNumber}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  // 2) Remove the inverse label. DELETE /labels/{name} returns 404 if
+  //    the label isn't on the issue — treat as no-op (very common).
+  try {
+    const removeUrl = `${GITHUB_API}/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(removeLabel)}`;
+    const { status, bodyText } = await ghRequest(
+      removeUrl,
+      'DELETE',
+      ghCtx.token,
+      undefined,
+      opts.fetchImpl,
+    );
+    if (status === 404) {
+      // Label wasn't on the issue — common, silent skip.
+    } else if (status === 422) {
+      // Label doesn't exist on the repo at all — silent (mirror add-side
+      // behaviour; the operator's already been warned).
+    } else if (status < 200 || status >= 300) {
+      console.warn(
+        `[triage-label] remove ${removeLabel} on ${owner}/${repo}#${issueNumber} returned ${status}: ${bodyText.slice(0, 200)}`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof GitHubApiError) {
+      console.warn(
+        `[triage-label] remove label failed on ${owner}/${repo}#${issueNumber}: ${err.message}`,
+      );
+    } else {
+      console.warn(
+        `[triage-label] remove label network error on ${owner}/${repo}#${issueNumber}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -10,6 +10,56 @@
 
 import type { MapDetail, MapSummary, NodeWithComputed } from './types.js';
 
+// ── Triage shapes (#96 Phase 3) ────────────────────────────────────
+// Mirrors the persisted `triage_decisions` row, plus the per-request
+// filter set the HTTP route accepts.
+
+export type TriageDecisionKind = 'place' | 'skip' | 'uncertain';
+
+export interface TriageDecisionRow {
+  id: string;
+  mapId: string;
+  externalId: string;
+  issueTitle: string;
+  issueState: 'open' | 'closed';
+  decision: TriageDecisionKind;
+  reason: string;
+  confidence: number;
+  placedNodeId: string | null;
+  decidedAt: string;
+  decidedBy: 'auto' | 'operator';
+  reviewed: boolean;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+}
+
+export interface TriageListFilters {
+  reviewed?: boolean;
+  decision?: TriageDecisionKind;
+  minConfidence?: number;
+  maxConfidence?: number;
+  issueState?: 'open' | 'closed';
+  since?: string;
+  limit?: number;
+}
+
+export interface TriageListResult {
+  mapId: string;
+  total: number;
+  decisions: TriageDecisionRow[];
+}
+
+export interface TriageActionResult {
+  decisionId: string;
+  status: string;
+  nodeId?: string | null;
+  decision?: TriageDecisionKind;
+  confidence?: number;
+  reason?: string;
+  parentNodeId?: string | null;
+  placedNodeId?: string | null;
+}
+
 export interface ToolBackend {
   listMaps(): Promise<MapSummary[]>;
   getMap(mapId: string): Promise<MapDetail>;
@@ -45,4 +95,18 @@ export interface ToolBackend {
     newParentId: string,
     position?: number,
   ): Promise<NodeWithComputed>;
+
+  // ── Triage (#96 Phase 3) ────────────────────────────────────────
+  listTriageDecisions(mapId: string, filters: TriageListFilters): Promise<TriageListResult>;
+  overrideTriage(
+    mapId: string,
+    decisionId: string,
+    body: {
+      decision: TriageDecisionKind;
+      parentNodeId?: string;
+      reason?: string;
+    },
+  ): Promise<TriageActionResult>;
+  reclassifyTriage(mapId: string, decisionId: string): Promise<TriageActionResult>;
+  confirmTriage(mapId: string, decisionId: string): Promise<TriageActionResult>;
 }

--- a/packages/tool-kit/src/index.ts
+++ b/packages/tool-kit/src/index.ts
@@ -1,4 +1,11 @@
 export type { ToolBackend } from './backend.js';
+export type {
+  TriageDecisionKind,
+  TriageDecisionRow,
+  TriageListFilters,
+  TriageListResult,
+  TriageActionResult,
+} from './backend.js';
 export type { ToolSpec } from './spec.js';
 export { defineTool } from './spec.js';
 export type { MapDetail, MapSummary, NodeWithComputed } from './types.js';
@@ -9,6 +16,7 @@ export { specToAnthropicTool, type AnthropicTool } from './anthropic.js';
 import { mapTools } from './tools/map.js';
 import { nodeTools } from './tools/node.js';
 import { bulkTools } from './tools/bulk.js';
-export { mapTools, nodeTools, bulkTools };
+import { triageTools } from './tools/triage.js';
+export { mapTools, nodeTools, bulkTools, triageTools };
 
-export const allTools = [...mapTools, ...nodeTools, ...bulkTools];
+export const allTools = [...mapTools, ...nodeTools, ...bulkTools, ...triageTools];

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -77,6 +77,10 @@ function makeRecordingBackend(): {
     },
     deleteNode: async () => { throw new Error('not implemented'); },
     moveNode: async () => { throw new Error('not implemented'); },
+    listTriageDecisions: async () => { throw new Error('not implemented'); },
+    overrideTriage: async () => { throw new Error('not implemented'); },
+    reclassifyTriage: async () => { throw new Error('not implemented'); },
+    confirmTriage: async () => { throw new Error('not implemented'); },
   };
   return {
     backend,

--- a/packages/tool-kit/src/tools/__tests__/triage.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/triage.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tool-kit schema/handler regression tests for the Phase 3 (#96) triage
+ * MCP tools.
+ *
+ * Coverage per tool:
+ *   - Happy path: tool calls backend with the expected arguments,
+ *     returns a human-readable message.
+ *   - Error path: backend throws → handler propagates (the MCP wrapper
+ *     in `packages/mcp` is responsible for catching, not the spec layer).
+ *   - Auth pass-through: the tool layer doesn't authenticate — the
+ *     server route does — so we assert the tool DOESN'T strip or
+ *     mutate arguments before they reach the backend.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  listTriageDecisionsTool,
+  overrideTriageTool,
+  reclassifyTriageTool,
+  confirmTriageTool,
+} from '../triage.js';
+import type {
+  ToolBackend,
+  TriageActionResult,
+  TriageDecisionRow,
+  TriageListResult,
+} from '../../backend.js';
+
+// ── Recording backend ────────────────────────────────────────────
+
+interface Recorder {
+  backend: ToolBackend;
+  lastList: { mapId: string; filters: Record<string, unknown> } | null;
+  lastOverride: {
+    mapId: string;
+    decisionId: string;
+    body: Record<string, unknown>;
+  } | null;
+  lastReclassify: { mapId: string; decisionId: string } | null;
+  lastConfirm: { mapId: string; decisionId: string } | null;
+  listResult: TriageListResult;
+  overrideResult: TriageActionResult;
+  reclassifyResult: TriageActionResult;
+  confirmResult: TriageActionResult;
+  throwOn: Partial<Record<'list' | 'override' | 'reclassify' | 'confirm', Error>>;
+}
+
+function makeRecorder(): Recorder {
+  const state: Recorder = {
+    lastList: null,
+    lastOverride: null,
+    lastReclassify: null,
+    lastConfirm: null,
+    listResult: { mapId: 'm1', total: 0, decisions: [] },
+    overrideResult: { decisionId: 'd1', status: 'placed', nodeId: 'n1' },
+    reclassifyResult: {
+      decisionId: 'd1',
+      status: 'reclassified',
+      decision: 'place',
+      confidence: 88,
+      reason: 'matches Frontend',
+    },
+    confirmResult: { decisionId: 'd1', status: 'confirmed', nodeId: 'n1' },
+    throwOn: {},
+    backend: {} as ToolBackend,
+  };
+  state.backend = {
+    listMaps: async () => { throw new Error('not used'); },
+    getMap: async () => { throw new Error('not used'); },
+    createMap: async () => { throw new Error('not used'); },
+    updateMap: async () => { throw new Error('not used'); },
+    deleteMap: async () => { throw new Error('not used'); },
+    createNode: async () => { throw new Error('not used'); },
+    updateNode: async () => { throw new Error('not used'); },
+    deleteNode: async () => { throw new Error('not used'); },
+    moveNode: async () => { throw new Error('not used'); },
+    listTriageDecisions: async (mapId, filters) => {
+      if (state.throwOn.list) throw state.throwOn.list;
+      state.lastList = { mapId, filters: filters as Record<string, unknown> };
+      return state.listResult;
+    },
+    overrideTriage: async (mapId, decisionId, body) => {
+      if (state.throwOn.override) throw state.throwOn.override;
+      state.lastOverride = {
+        mapId,
+        decisionId,
+        body: body as Record<string, unknown>,
+      };
+      return state.overrideResult;
+    },
+    reclassifyTriage: async (mapId, decisionId) => {
+      if (state.throwOn.reclassify) throw state.throwOn.reclassify;
+      state.lastReclassify = { mapId, decisionId };
+      return state.reclassifyResult;
+    },
+    confirmTriage: async (mapId, decisionId) => {
+      if (state.throwOn.confirm) throw state.throwOn.confirm;
+      state.lastConfirm = { mapId, decisionId };
+      return state.confirmResult;
+    },
+  };
+  return state;
+}
+
+function fakeDecision(overrides: Partial<TriageDecisionRow> = {}): TriageDecisionRow {
+  return {
+    id: 'd1',
+    mapId: 'm1',
+    externalId: 'o/r#42',
+    issueTitle: 'My issue',
+    issueState: 'open',
+    decision: 'uncertain',
+    reason: 'unsure',
+    confidence: 40,
+    placedNodeId: null,
+    decidedAt: new Date().toISOString(),
+    decidedBy: 'auto',
+    reviewed: false,
+    reviewedAt: null,
+    reviewedBy: null,
+    ...overrides,
+  };
+}
+
+// ── list_triage_decisions ────────────────────────────────────────
+
+describe('list_triage_decisions tool', () => {
+  it('accepts the full Phase 2 filter set in the schema', () => {
+    const schema = z.object(listTriageDecisionsTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      reviewed: false,
+      decision: 'place',
+      minConfidence: 70,
+      maxConfidence: 100,
+      issueState: 'open',
+      since: '2026-01-01T00:00:00Z',
+      limit: 50,
+    });
+    expect(parsed.reviewed).toBe(false);
+    expect(parsed.decision).toBe('place');
+    expect(parsed.minConfidence).toBe(70);
+    expect(parsed.maxConfidence).toBe(100);
+    expect(parsed.issueState).toBe('open');
+    expect(parsed.limit).toBe(50);
+  });
+
+  it('rejects out-of-range confidence', () => {
+    const schema = z.object(listTriageDecisionsTool.schema);
+    expect(() =>
+      schema.parse({ mapId: 'm1', minConfidence: -5 }),
+    ).toThrow();
+    expect(() =>
+      schema.parse({ mapId: 'm1', maxConfidence: 200 }),
+    ).toThrow();
+  });
+
+  it('rejects an out-of-range limit', () => {
+    const schema = z.object(listTriageDecisionsTool.schema);
+    expect(() => schema.parse({ mapId: 'm1', limit: 0 })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', limit: 250 })).toThrow();
+  });
+
+  it('happy path: forwards filters to the backend and renders the result', async () => {
+    const rec = makeRecorder();
+    rec.listResult = {
+      mapId: 'm1',
+      total: 2,
+      decisions: [
+        fakeDecision({ id: 't1', decision: 'place', confidence: 92, reviewed: false }),
+        fakeDecision({ id: 't2', decision: 'skip', confidence: 70, reviewed: true, decidedBy: 'operator' }),
+      ],
+    };
+    const out = await listTriageDecisionsTool.handler(rec.backend, {
+      mapId: 'm1',
+      reviewed: false,
+      minConfidence: 70,
+    } as never);
+    expect(rec.lastList).toEqual({
+      mapId: 'm1',
+      filters: {
+        reviewed: false,
+        decision: undefined,
+        minConfidence: 70,
+        maxConfidence: undefined,
+        issueState: undefined,
+        since: undefined,
+        limit: undefined,
+      },
+    });
+    expect(out).toContain('Found 2 triage decision(s) in map m1');
+    expect(out).toContain('t1');
+    expect(out).toContain('t2');
+  });
+
+  it('reports zero results in a human-readable way (no thrown error)', async () => {
+    const rec = makeRecorder();
+    const out = await listTriageDecisionsTool.handler(rec.backend, {
+      mapId: 'empty-map',
+    } as never);
+    expect(out).toContain('No triage decisions found in map empty-map');
+  });
+
+  it('error path: backend throw propagates (MCP wrapper catches)', async () => {
+    const rec = makeRecorder();
+    rec.throwOn.list = new Error('API Error (403): forbidden');
+    await expect(
+      listTriageDecisionsTool.handler(rec.backend, { mapId: 'm1' } as never),
+    ).rejects.toThrow('API Error (403)');
+  });
+});
+
+// ── override_triage ──────────────────────────────────────────────
+
+describe('override_triage tool', () => {
+  it('accepts decision=place with parentNodeId in the schema', () => {
+    const schema = z.object(overrideTriageTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      decisionId: 'd1',
+      decision: 'place',
+      parentNodeId: 'epic-1',
+      reason: 'I know better',
+    });
+    expect(parsed.decision).toBe('place');
+    expect(parsed.parentNodeId).toBe('epic-1');
+  });
+
+  it('rejects unknown decision values', () => {
+    const schema = z.object(overrideTriageTool.schema);
+    expect(() =>
+      schema.parse({ mapId: 'm1', decisionId: 'd1', decision: 'maybe' }),
+    ).toThrow();
+  });
+
+  it('happy path: forwards decision/parent/reason to the backend', async () => {
+    const rec = makeRecorder();
+    const out = await overrideTriageTool.handler(rec.backend, {
+      mapId: 'm1',
+      decisionId: 'd1',
+      decision: 'place',
+      parentNodeId: 'epic-1',
+      reason: 'I know better',
+    } as never);
+    expect(rec.lastOverride).toEqual({
+      mapId: 'm1',
+      decisionId: 'd1',
+      body: { decision: 'place', parentNodeId: 'epic-1', reason: 'I know better' },
+    });
+    expect(out).toContain('Override applied on decision d1');
+    expect(out).toContain('nodeId=n1');
+  });
+
+  it('auth pass-through: schema doesn\'t strip parentNodeId on a place decision', () => {
+    // Defense: a future cleanup that drops "optional" fields client-side
+    // would silently break the server's place-requires-parent gate. Pin
+    // that parentNodeId rides through the parsed schema verbatim.
+    const schema = z.object(overrideTriageTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      decisionId: 'd1',
+      decision: 'place',
+      parentNodeId: 'epic-1',
+    });
+    expect(Object.keys(parsed)).toContain('parentNodeId');
+    expect(parsed.parentNodeId).toBe('epic-1');
+  });
+
+  it('error path: backend SELF_LOOP_BLOCKED throw surfaces verbatim', async () => {
+    const rec = makeRecorder();
+    rec.throwOn.override = new Error(
+      'API Error (400): parentNodeId must differ from the placed node',
+    );
+    await expect(
+      overrideTriageTool.handler(rec.backend, {
+        mapId: 'm1',
+        decisionId: 'd1',
+        decision: 'place',
+        parentNodeId: 'self',
+      } as never),
+    ).rejects.toThrow(/parentNodeId must differ/);
+  });
+});
+
+// ── reclassify_triage ────────────────────────────────────────────
+
+describe('reclassify_triage tool', () => {
+  it('schema requires mapId + decisionId, nothing else', () => {
+    const schema = z.object(reclassifyTriageTool.schema);
+    expect(() => schema.parse({})).toThrow();
+    expect(() => schema.parse({ mapId: 'm1' })).toThrow();
+    const parsed = schema.parse({ mapId: 'm1', decisionId: 'd1' });
+    expect(parsed.mapId).toBe('m1');
+    expect(parsed.decisionId).toBe('d1');
+  });
+
+  it('happy path: forwards to backend, renders the new decision + confidence', async () => {
+    const rec = makeRecorder();
+    const out = await reclassifyTriageTool.handler(rec.backend, {
+      mapId: 'm1',
+      decisionId: 'd1',
+    } as never);
+    expect(rec.lastReclassify).toEqual({ mapId: 'm1', decisionId: 'd1' });
+    expect(out).toContain('Reclassified d1');
+    expect(out).toContain('decision=place');
+    expect(out).toContain('88%');
+  });
+
+  it('error path: backend 404 propagates', async () => {
+    const rec = makeRecorder();
+    rec.throwOn.reclassify = new Error('API Error (404): not found');
+    await expect(
+      reclassifyTriageTool.handler(rec.backend, {
+        mapId: 'm1',
+        decisionId: 'missing',
+      } as never),
+    ).rejects.toThrow('404');
+  });
+});
+
+// ── confirm_triage ───────────────────────────────────────────────
+
+describe('confirm_triage tool', () => {
+  it('schema rejects parentNodeId (the #100 Round 2 fix — confirm has no parent input)', () => {
+    const schema = z.object(confirmTriageTool.schema);
+    // We don't enforce strictness on extra fields, but the schema
+    // intentionally has no parentNodeId field so it can't be parsed
+    // into the args object. Test: the parsed object never contains
+    // parentNodeId even if supplied.
+    const parsed = schema.parse({ mapId: 'm1', decisionId: 'd1' });
+    expect('parentNodeId' in parsed).toBe(false);
+  });
+
+  it('happy path: forwards to backend, returns a confirmation message', async () => {
+    const rec = makeRecorder();
+    const out = await confirmTriageTool.handler(rec.backend, {
+      mapId: 'm1',
+      decisionId: 'd1',
+    } as never);
+    expect(rec.lastConfirm).toEqual({ mapId: 'm1', decisionId: 'd1' });
+    expect(out).toContain('Confirmed d1');
+    expect(out).toContain('confirmed');
+  });
+
+  it('renders nodeId when present, omits when null (skip rows)', async () => {
+    const rec = makeRecorder();
+    rec.confirmResult = { decisionId: 'd1', status: 'confirmed', nodeId: null };
+    const out = await confirmTriageTool.handler(rec.backend, {
+      mapId: 'm1',
+      decisionId: 'd1',
+    } as never);
+    expect(out).not.toContain('nodeId=');
+  });
+
+  it('error path: backend 403 propagates (auth fail at the route layer)', async () => {
+    const rec = makeRecorder();
+    rec.throwOn.confirm = new Error(
+      'API Error (403): API-key auth cannot access triage endpoints',
+    );
+    await expect(
+      confirmTriageTool.handler(rec.backend, {
+        mapId: 'm1',
+        decisionId: 'd1',
+      } as never),
+    ).rejects.toThrow('API-key auth cannot access');
+  });
+});

--- a/packages/tool-kit/src/tools/triage.ts
+++ b/packages/tool-kit/src/tools/triage.ts
@@ -1,0 +1,187 @@
+/**
+ * Triage MCP tools (#96, Phase 3).
+ *
+ * Four operator-equivalent surfaces for Eve so she can drive the triage
+ * pipeline through MCP rather than touching the HTTP API directly:
+ *
+ *   - `list_triage_decisions` — paginated query with the full Phase 2
+ *     filter set (reviewed, decision, confidence range, issueState, since).
+ *   - `override_triage`       — apply an operator override; for `place`,
+ *     reparent or create the node under the supplied parentNodeId. Honors
+ *     the SELF_LOOP_BLOCKED guard from #100 by surfacing the server's
+ *     error string verbatim (the backend already rejects parentNodeId ===
+ *     placedNodeId).
+ *   - `reclassify_triage`     — re-run the LLM against the current map
+ *     context. Decision/reason/confidence are refreshed in place.
+ *   - `confirm_triage`        — mark a row reviewed without parentage
+ *     change (the dedicated #100 Round 2 path).
+ *
+ * Auth flow: tools call through the abstract `ToolBackend`. The HTTP
+ * MCP backend (`packages/mcp/src/backend.ts`) drives the standard
+ * /api/maps/:mapId/triage-decisions routes, which enforce the
+ * session-JWT-only gate from `routes/triage.ts` — API-key auth is
+ * 403'd there. So Eve's calls land with whatever auth the MCP transport
+ * carries (the HTTP MCP server mints a JWT from the user's API key
+ * at request boundary per #63/#80, which gives Eve a session-equivalent
+ * surface on triage).
+ */
+
+import { z } from 'zod';
+import { defineTool } from '../spec.js';
+import type {
+  TriageDecisionKind,
+  TriageDecisionRow,
+} from '../backend.js';
+
+// Shared decision enum used by `list_triage_decisions.decision`,
+// `override_triage.decision`, etc.
+const decisionEnum = z.enum(['place', 'skip', 'uncertain']);
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function renderDecisionLine(d: TriageDecisionRow): string {
+  const reviewed = d.reviewed ? 'reviewed' : 'pending';
+  const by = d.decidedBy;
+  const placed = d.placedNodeId ? ` placed=${d.placedNodeId}` : '';
+  return `- [${d.id}] ${d.externalId} "${d.issueTitle}" — ${d.decision} (${d.confidence}%, by=${by}, ${reviewed})${placed}\n    reason: ${d.reason}`;
+}
+
+// ── Tool: list_triage_decisions ──────────────────────────────────
+
+export const listTriageDecisionsTool = defineTool({
+  name: 'list_triage_decisions',
+  description:
+    "List AI triage decisions for a map. Returns auto + operator-decided rows with their decision (place/skip/uncertain), confidence (0-100), parent node id, and reason. Mirrors the operator UI surface so Eve can review the triage queue without leaving MCP. Filter by reviewed/decision/confidence-range/issueState/since to narrow the result set; default limit 50, max 200.",
+  schema: {
+    mapId: z.string().describe('The map ID'),
+    reviewed: z
+      .boolean()
+      .optional()
+      .describe('Filter by reviewed flag — true=human-confirmed, false=pending review'),
+    decision: decisionEnum.optional().describe('Filter by decision kind'),
+    minConfidence: z
+      .number()
+      .int()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe('Lower bound on confidence (inclusive, 0-100)'),
+    maxConfidence: z
+      .number()
+      .int()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe('Upper bound on confidence (inclusive, 0-100)'),
+    issueState: z
+      .enum(['open', 'closed'])
+      .optional()
+      .describe("Filter by GitHub issue state captured at triage time"),
+    since: z
+      .string()
+      .optional()
+      .describe('ISO 8601 — only return rows with decided_at >= this instant'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Max rows to return (default 50, hard cap 200)'),
+  },
+  handler: async (backend, { mapId, reviewed, decision, minConfidence, maxConfidence, issueState, since, limit }) => {
+    const result = await backend.listTriageDecisions(mapId, {
+      reviewed,
+      decision: decision as TriageDecisionKind | undefined,
+      minConfidence,
+      maxConfidence,
+      issueState,
+      since,
+      limit,
+    });
+    if (result.total === 0) {
+      return `No triage decisions found in map ${mapId} matching the supplied filters.`;
+    }
+    const lines = result.decisions.map(renderDecisionLine);
+    return `Found ${result.total} triage decision(s) in map ${mapId}:\n${lines.join('\n')}`;
+  },
+});
+
+// ── Tool: override_triage ────────────────────────────────────────
+
+export const overrideTriageTool = defineTool({
+  name: 'override_triage',
+  description:
+    "Override an AI triage decision. When decision='place', the row's node is created under parentNodeId (or reparented if a node already exists). When decision='skip' or 'uncertain', the row is updated but no node is created. The server rejects parentNodeId === placedNodeId with SELF_LOOP_BLOCKED — use confirm_triage instead to accept the existing decision without reparenting. Caller must have edit permission on the map; API-key auth is rejected for triage surfaces (use a session login).",
+  schema: {
+    mapId: z.string().describe('The map ID'),
+    decisionId: z.string().describe('The triage decision row ID'),
+    decision: decisionEnum.describe(
+      "The new decision. 'place' requires parentNodeId.",
+    ),
+    parentNodeId: z
+      .string()
+      .optional()
+      .describe(
+        "Required when decision='place'. Must be a node in this map. Must differ from the row's current placedNodeId (use confirm_triage instead).",
+      ),
+    reason: z
+      .string()
+      .optional()
+      .describe('Override reason — persisted verbatim in the audit log'),
+  },
+  handler: async (backend, { mapId, decisionId, decision, parentNodeId, reason }) => {
+    const result = await backend.overrideTriage(mapId, decisionId, {
+      decision: decision as TriageDecisionKind,
+      parentNodeId,
+      reason,
+    });
+    const parts: string[] = [
+      `Override applied on decision ${decisionId} → status=${result.status}`,
+    ];
+    if (result.nodeId) parts.push(`nodeId=${result.nodeId}`);
+    return parts.join(', ');
+  },
+});
+
+// ── Tool: reclassify_triage ──────────────────────────────────────
+
+export const reclassifyTriageTool = defineTool({
+  name: 'reclassify_triage',
+  description:
+    "Re-run the LLM triage against the current map context for an existing decision row. Use after the map's epic structure has changed (new top-level epics, renamed/described differently) and you want the AI to take another pass at a previously-decided row. Decision/reason/confidence are refreshed in place; decidedBy becomes 'auto' and reviewed resets to false. No node is created here — apply with override_triage afterwards if needed. Caller must have edit permission.",
+  schema: {
+    mapId: z.string().describe('The map ID'),
+    decisionId: z.string().describe('The triage decision row ID'),
+  },
+  handler: async (backend, { mapId, decisionId }) => {
+    const result = await backend.reclassifyTriage(mapId, decisionId);
+    const conf = result.confidence != null ? ` (${result.confidence}%)` : '';
+    const parent = result.parentNodeId ? `, parentNodeId=${result.parentNodeId}` : '';
+    return `Reclassified ${decisionId}: decision=${result.decision ?? 'unknown'}${conf}${parent}\nreason: ${result.reason ?? '(none)'}`;
+  },
+});
+
+// ── Tool: confirm_triage ─────────────────────────────────────────
+
+export const confirmTriageTool = defineTool({
+  name: 'confirm_triage',
+  description:
+    "Mark a triage decision row as reviewed without changing parentage. Use this when the existing auto-decision (place/skip/uncertain) is correct and you just want to accept it. Does NOT take a parentNodeId — the dedicated route prevents the #100 Round 2 self-loop where 'confirm' was previously routed through override with parentNodeId === placedNodeId. Caller must have edit permission.",
+  schema: {
+    mapId: z.string().describe('The map ID'),
+    decisionId: z.string().describe('The triage decision row ID'),
+  },
+  handler: async (backend, { mapId, decisionId }) => {
+    const result = await backend.confirmTriage(mapId, decisionId);
+    const node = result.nodeId ? ` (nodeId=${result.nodeId})` : '';
+    return `Confirmed ${decisionId} → status=${result.status}${node}`;
+  },
+});
+
+export const triageTools = [
+  listTriageDecisionsTool,
+  overrideTriageTool,
+  reclassifyTriageTool,
+  confirmTriageTool,
+];


### PR DESCRIPTION
## Summary

Phase 3 of AI Triage. Adds three additive surfaces on top of Phases 0/1/2 (#98/#100/#101):

1. **MCP tools** for Eve: `list_triage_decisions`, `override_triage`, `reclassify_triage`, `confirm_triage`. Backed by the existing `ToolBackend` abstraction; HTTP MCP calls flow through the session-JWT-gated triage routes (API-key auth is still 403'd, mirroring the rest of triage).
2. **Audit history**: new append-only `triage_decision_history` table written from every mutation site (auto-ingest, override, reclassify, confirm, bulk variants, reopened-state sync). New `GET /api/maps/:mapId/triage-decisions/:decisionId/history` endpoint. Best-effort writes — never blocks the surrounding mutation.
3. **Optional GitHub label write-back**: per-map opt-in `triage_label_writeback` flag. Finalised decisions write `triage:placed` / `triage:skipped` labels to the bound GH issue. `uncertain` decisions are silent (no intermediate-state churn); 422 (label doesn't exist on repo) → warn + skip (no auto-create). All failures swallowed.

## Persona acceptance test

Operator/Eve, against a triage-enabled map with at least one row:

1. Call `mcp__mindblown__list_triage_decisions(mapId=…, reviewed=false)` — pending rows returned with reason + confidence.
2. Call `mcp__mindblown__override_triage(decisionId=…, decision='place', parentNodeId=…)` — node moves; `GET .../history` shows the operator (`changed_by=<userId>`) as the latest entry, change_type='overridden'.
3. Enable `triage_label_writeback` on the map, run the override flow above on an issue whose repo has both `triage:placed` and `triage:skipped` labels pre-created — see `triage:placed` appear on the GitHub issue. Override the same row to `skip` — labels swap.
4. `GET /api/maps/:mapId/triage-decisions/:decisionId/history` for the row used above returns the chronological list (created → overridden → ...) newest-first.

## Surfaces touched (definition of done)

- **core types** — n/a (no `MindMap`/`Node` shape change)
- **server DB + routes** — `triage_decision_history` table, new GET history endpoint, `recordTriageHistory()` wired into 7 mutation sites, `applyTriageLabel()` wired into all finalising mutation paths, `triage_label_writeback` column on maps.
- **tool-kit MCP schema** — 4 new tool specs in `packages/tool-kit/src/tools/triage.ts`, exported through `allTools`. `ToolBackend` extended with 4 triage methods.
- **mcp HTTP backend** — `packages/mcp/src/api.ts` + `backend.ts` extended; tools register automatically via the existing `for (const spec of sharedTools)` loop in `packages/mcp/src/index.ts`.
- **mindmap frontend** — n/a (Phase 1 already has the override UI; this PR's frontend touch was intentionally deferred — operator can read history via curl / MCP).

## Audit-history schema

```sql
CREATE TABLE triage_decision_history (
  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  decision_id UUID NOT NULL REFERENCES triage_decisions(id) ON DELETE CASCADE,
  changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  changed_by TEXT NOT NULL,           -- 'auto' | userId
  change_type TEXT NOT NULL,          -- 'created' | 'overridden' | 'reclassified' | 'confirmed' | 'state_synced'
  previous_decision TEXT,
  new_decision TEXT NOT NULL,
  previous_confidence INTEGER,
  new_confidence INTEGER,
  previous_parent_node_id UUID,
  new_parent_node_id UUID,
  reason TEXT
);
```

Migration is idempotent (CREATE TABLE IF NOT EXISTS + idempotent index creation). `changed_by` is TEXT (not a `users(id)` FK) so the `'auto'` sentinel doesn't need a synthetic user row and so dropping an operator user doesn't truncate their audit trail.

## Label-writeback design

- Add label: `POST /repos/{owner}/{repo}/issues/{number}/labels { labels: [label] }` (additive — GitHub merges with existing labels).
- Remove inverse label: `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{name}` — 404 treated as no-op (label wasn't on the issue, very common).
- 422 from GitHub on add (label doesn't exist in the repo): warn + skip, don't auto-create.
- All exceptions caught + logged; the surrounding triage flow never sees a throw.
- Token resolution flows through the existing `getGitHubContextForMap()` helper (moved to `lib/githubContext.ts` to break the routes ↔ sync import cycle).

## Refactor note

`getGitHubContextForMap` moved from `routes/integrations.ts` to `lib/githubContext.ts`. A back-compat re-export is kept on `routes/integrations.ts` so existing callers (`routes/nodes.ts`) don't change. The reason: `sync/triageLabelWriteback.ts` needs to resolve a token for a map without dragging the routes layer into a sync module.

## Test plan

- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w build` — clean
- [x] `pnpm -w test` — passes (346 server + 25 tool-kit, +42 new across `triage-history.test.ts`, `triage-label-writeback.test.ts`, `triage.test.ts`, and history-route additions to `triage-routes.test.ts`)
- [x] `rg "triage_decision_history" packages/server/src` — matches schema, helper, route, migration, tests
- [x] `rg "list_triage_decisions|override_triage|reclassify_triage|confirm_triage" packages/tool-kit/src packages/mcp/src` — all four tool names present
- [ ] Post-merge: enable `triage_label_writeback` on a staging map and verify a `triage:placed` label appears on a GitHub issue after override.
- [ ] Post-merge: open the new history endpoint after running a mutation through MCP, verify chronological ordering.

Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)