### PR TITLE
fix(scheduling): flip childrenScheduling default to 'sequential'

### DIFF
--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -838,7 +838,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       externalLinks: [],
       autoProgress: 'off',
       priorityRank: null,
-      childrenScheduling: 'parallel',
+      childrenScheduling: 'sequential',
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -35,7 +35,7 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     externalLinks: (get('externalLinks', 'external_links') as CoreNode['externalLinks']) ?? [],
     autoProgress: ((get('autoProgress', 'auto_progress') as CoreNode['autoProgress']) ?? 'off'),
     priorityRank: (get('priorityRank', 'priority_rank') as number) ?? null,
-    childrenScheduling: ((get('childrenScheduling', 'children_scheduling') as ChildrenScheduling) ?? 'parallel'),
+    childrenScheduling: ((get('childrenScheduling', 'children_scheduling') as ChildrenScheduling) ?? 'sequential'),
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -621,13 +621,21 @@ export async function runMigrations(): Promise<void> {
   // ── Gantt slice 1 (#109): implicit sibling ordering + scheduling mode ──
   // priority_rank: fractional ranking for drag-to-reorder within a sibling
   //   group. REAL (float) for midpoint insertion. null = no explicit rank.
-  // children_scheduling: 'parallel' (default, existing behavior) or
-  //   'sequential' (implicit FS chain in resolved sibling order).
+  // children_scheduling: 'sequential' (default, implicit FS chain in resolved
+  //   sibling order) or 'parallel' (legacy — siblings stack at the same start).
+  //   Default flipped from 'parallel' to 'sequential' so the Gantt actually
+  //   spreads out without requiring a per-parent toggle.
   await db.execute(sql`
     ALTER TABLE nodes ADD COLUMN IF NOT EXISTS priority_rank REAL
   `);
   await db.execute(sql`
-    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS children_scheduling TEXT NOT NULL DEFAULT 'parallel'
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS children_scheduling TEXT NOT NULL DEFAULT 'sequential'
+  `);
+  // On installs that pre-date this default flip, the column was created
+  // with DEFAULT 'parallel' and existing rows are stuck at 'parallel'.
+  // Repoint the column default and one-shot-flip historical rows.
+  await db.execute(sql`
+    ALTER TABLE nodes ALTER COLUMN children_scheduling SET DEFAULT 'sequential'
   `);
   // Root-level scheduling mode is governed by the root node's own
   // childrenScheduling field — the map record itself has no separate
@@ -668,6 +676,31 @@ export async function runMigrations(): Promise<void> {
   // project without a global env-var.
   await db.execute(sql`
     ALTER TABLE maps ADD COLUMN IF NOT EXISTS stale_claim_hours REAL NOT NULL DEFAULT 4
+  `);
+
+  // ── One-shot data migrations ───────────────────────────────────
+  // Tracks data flips that should run exactly once per database.
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS data_migrations (
+      id TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  // Flip historical 'parallel' rows to 'sequential'. The column default
+  // changed in this release, but rows created BEFORE this release carry
+  // the old 'parallel' value. The marker row in data_migrations ensures
+  // we only run the UPDATE on first boot of this version, so a user who
+  // later explicitly sets a parent back to 'parallel' won't get clobbered
+  // by subsequent restarts.
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM data_migrations WHERE id = 'flip_children_scheduling_default_v1') THEN
+        UPDATE nodes SET children_scheduling = 'sequential' WHERE children_scheduling = 'parallel';
+        INSERT INTO data_migrations (id) VALUES ('flip_children_scheduling_default_v1');
+      END IF;
+    END $$;
   `);
 
   console.log('[db] Migrations complete.');

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -142,7 +142,7 @@ export async function createNode(
     dueDate: input.dueDate ?? null,
     autoProgress: input.autoProgress ?? 'off',
     priorityRank: input.priorityRank ?? null,
-    childrenScheduling: input.childrenScheduling ?? 'parallel',
+    childrenScheduling: input.childrenScheduling ?? 'sequential',
     assigneeIds: [],
     tags: [],
     customFields: {},

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -172,8 +172,11 @@ export const nodes = pgTable('nodes', {
   // null = no explicit rank (sorts after ranked siblings in resolved order).
   priorityRank: real('priority_rank'),
   // How children of this node are scheduled relative to each other.
-  // 'parallel' (default) = existing behavior; 'sequential' = implicit FS chain.
-  childrenScheduling: text('children_scheduling').notNull().default('parallel'),
+  // 'sequential' (default) = implicit FS chain in resolved sibling order;
+  // 'parallel' = legacy behavior where siblings stack at the same start.
+  // Default flipped from 'parallel' to 'sequential' so the Gantt actually
+  // spreads out without requiring a per-parent toggle.
+  childrenScheduling: text('children_scheduling').notNull().default('sequential'),
 
   // ── Orchestration substrate (#111) ───────────────────────────
   // claimed_by_session: session ID that owns this node for active work.

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -386,7 +386,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           externalLinks: [],
           autoProgress: 'off',
           priorityRank: null,
-          childrenScheduling: 'parallel' as const,
+          childrenScheduling: 'sequential' as const,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,


### PR DESCRIPTION
## Summary

Slice 1 (#109) shipped the toggle but defaulted to `'parallel'` — meaning the Gantt still stacks every child at day 0 unless someone manually flips every parent. This patch flips the production default to `'sequential'` and one-shot-migrates historical rows.

Production-code surfaces flipped:
- DB column default + Drizzle schema default
- `dbNodeToCore` fallback for null/undefined column values
- `createNode` input fallback
- `routes/maps.ts` temp-node literal
- `mindmap/store.ts` new-node literal

One-shot data migration:
- New `data_migrations` table tracks one-time data flips by ID
- On first boot of this version, runs `UPDATE nodes SET children_scheduling = 'sequential' WHERE children_scheduling = 'parallel'` inside a `DO` block guarded by the marker
- Subsequent restarts no-op so operators who later set a parent back to `'parallel'` don't get clobbered

Test fixtures (`makeNode` helpers in compute/dependencies/orchestration tests) keep `'parallel'` as their internal default — the existing scheduler test suite constructs DAGs that assume parallel sibling layout, and flipping the test default would invalidate the regression suite. Production defaults match what users see; test fixtures stay aligned with the algorithm tests they build on. Intentional divergence.

## Test results

- `@mindblown/core`: 94/94 passing
- `@mindblown/server`: 389/390 (1 pre-existing flake: `triage-routes.test.ts > peakActive ≥ 2`, unrelated)
- `@mindblown/tool-kit`: 31/31, `@mindblown/mcp`: 8/8
- Typecheck + lint + build clean

## Test plan

- [ ] After deploy, open the Roadmap map → Gantt bars spread out by parent hierarchy + estimates instead of stacking at today
- [ ] Set a parent to `childrenScheduling: 'parallel'` via MCP → its children re-stack
- [ ] Restart the API → the parallel override survives (marker prevents re-flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)