### PR TITLE
fix(scheduler): cross-parent cycle detection + cycle-fallback in schedule()

### DIFF
--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -684,4 +684,64 @@ describe('sequential parent: cycle-safe synthetic injection', () => {
     expect(byId.get('c1')!.computedStart).toBe(3);
     expect(byId.get('c1')!.computedEnd).toBe(5);
   });
+
+  it('cross-parent cycle: synthetic edges across two sequential parents do not create cycles', () => {
+    // Two sequential parents:
+    //   P1 has children A, B (resolved order A → B)
+    //   P2 has children C, D (resolved order C → D)
+    // Explicit edges already in the graph:
+    //   C depends on B (FS)
+    //   A depends on D (FS)
+    //
+    // Without the cross-parent-aware cycle guard, both synthetic edges
+    // (FS(B → A) and FS(D → C)) would be injected because each look-up
+    // sees only the pre-injection graph. Combined they form a cycle:
+    //   A → D → C → B → A
+    // and topologicalSort throws.
+    //
+    // With the working-nodeMap fix, the second injection's hasCycle check
+    // sees the synthetic FS(B → A) added by the first injection and skips
+    // the FS(D → C) injection. P2's chain is partially honored (D doesn't
+    // chain) but the schedule resolves without throwing.
+    const p1 = makeNode({
+      id: 'P1',
+      childrenIds: ['A', 'B'],
+      childrenScheduling: 'sequential',
+    });
+    const p2 = makeNode({
+      id: 'P2',
+      childrenIds: ['C', 'D'],
+      childrenScheduling: 'sequential',
+    });
+    const a = makeNode({
+      id: 'A',
+      parentId: 'P1',
+      effortEstimate: 1,
+      createdAt: '2026-01-01T00:00:00Z',
+      dependencies: [{ targetNodeId: 'D', type: 'FS', lag: 0 }],
+    });
+    const b = makeNode({
+      id: 'B',
+      parentId: 'P1',
+      effortEstimate: 1,
+      createdAt: '2026-01-02T00:00:00Z',
+    });
+    const c = makeNode({
+      id: 'C',
+      parentId: 'P2',
+      effortEstimate: 1,
+      createdAt: '2026-01-03T00:00:00Z',
+      dependencies: [{ targetNodeId: 'B', type: 'FS', lag: 0 }],
+    });
+    const d = makeNode({
+      id: 'D',
+      parentId: 'P2',
+      effortEstimate: 1,
+      createdAt: '2026-01-04T00:00:00Z',
+    });
+
+    // Must not throw "Cycle detected".
+    const result = schedule([p1, p2, a, b, c, d]);
+    expect(result.length).toBe(6);
+  });
 });

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -273,8 +273,17 @@ export function resolvedSiblingOrder(children: Node[]): Node[] {
  * Returns a new nodes array; original nodes are not mutated.
  */
 function injectSequentialDeps(nodes: Node[]): Node[] {
+  // Build a WORKING nodeMap whose dep arrays are mutable copies. As each
+  // synthetic edge is added we mutate the working node's `dependencies`,
+  // so subsequent hasCycle checks (for OTHER parents in the same pass)
+  // see the synthetic edges added by earlier parents. Without this, the
+  // cycle guard only catches cycles formed by EXISTING edges; cycles
+  // formed by combining synthetic chains from sibling parents slip
+  // through and crash topologicalSort downstream.
   const nodeMap = new Map<NodeId, Node>();
-  for (const n of nodes) nodeMap.set(n.id, n);
+  for (const n of nodes) {
+    nodeMap.set(n.id, { ...n, dependencies: [...n.dependencies] });
+  }
 
   // Map from child id → extra synthetic deps to prepend
   const extras = new Map<NodeId, Node['dependencies']>();
@@ -306,15 +315,22 @@ function injectSequentialDeps(nodes: Node[]): Node[] {
       // Skip if predecessor already (transitively) depends on follower —
       // injecting FS(follower → predecessor) would close a cycle and crash
       // topologicalSort. The user's explicit edge wins; siblings stay
-      // parallel for this pair.
+      // parallel for this pair. Uses the working nodeMap so it sees
+      // synthetic edges added by earlier parents in this same pass.
       if (hasCycle(follower.id, predecessor.id, nodeMap)) continue;
 
-      if (!extras.has(follower.id)) extras.set(follower.id, []);
-      extras.get(follower.id)!.push({
+      const synthetic = {
         targetNodeId: predecessor.id,
-        type: 'FS',
+        type: 'FS' as const,
         lag: 0,
-      });
+      };
+
+      if (!extras.has(follower.id)) extras.set(follower.id, []);
+      extras.get(follower.id)!.push(synthetic);
+
+      // CRITICAL: mutate the working nodeMap so subsequent hasCycle calls
+      // see this edge. Without this, cross-parent cycles slip through.
+      nodeMap.get(follower.id)!.dependencies.push(synthetic);
     }
   }
 
@@ -347,13 +363,29 @@ export function schedule(
   constraints?: Map<NodeId, ScheduleConstraint>,
   context?: ScheduleContext,
 ): ScheduledNode[] {
-  // Inject implicit FS chains for sequential parents before topo sort
-  const sequenced = injectSequentialDeps(nodes);
-
-  // Expand parent-node dependencies to leaf-node dependencies
-  const expanded = expandParentDependencies(sequenced);
-
-  const sorted = topologicalSort(expanded);
+  // Inject implicit FS chains for sequential parents before topo sort.
+  // If injection somehow produces a cyclic graph (defense in depth — the
+  // injection function's own cycle guard should prevent this), fall back
+  // to the original nodes so the API returns a partial schedule instead
+  // of a 500. This keeps the Gantt usable even with adversarial data.
+  let sorted: Node[];
+  let expanded: Node[];
+  try {
+    const sequenced = injectSequentialDeps(nodes);
+    expanded = expandParentDependencies(sequenced);
+    sorted = topologicalSort(expanded);
+  } catch (err) {
+    if (err instanceof Error && /Cycle detected/.test(err.message)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[scheduler] cycle detected after sequential injection; falling back to no implicit chains for this run',
+      );
+      expanded = expandParentDependencies(nodes);
+      sorted = topologicalSort(expanded);
+    } else {
+      throw err;
+    }
+  }
 
   const nodeMap = new Map<NodeId, Node>();
   for (const node of expanded) {


### PR DESCRIPTION
## Summary

Hotfix for cycles exposed by #120 (default flipped to 'sequential' on a 2487-node Roadmap). The schedule endpoint was returning HTTP 500 with 'Cycle detected in dependency graph — topological sort failed'.

Two layered fixes:

1. **injectSequentialDeps uses a working nodeMap with mutable dep arrays.** As each synthetic FS edge is added we mutate the working node's dependencies so subsequent hasCycle checks (for other parents in the same pass) see those edges. Without this, cross-parent cycles slip through because the cycle guard only saw the pre-injection graph.

2. **schedule() catches cycles and falls back to no-injection.** Defense in depth — if any cycle slips past the guard, we re-run the topo sort without sequential injection and log a warning, so the API returns a partial schedule instead of a 500.

## Test plan

- [x] New regression test 'cross-parent cycle' constructs the failing topology and asserts schedule() doesn't throw
- [ ] Deploy + verify GET /api/maps/<roadmap>/schedule returns 200 with non-empty data
- [ ] Open Roadmap in UI → Gantt renders with bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)