### PR TITLE
fix(scheduler): expand parent deps BEFORE injecting sequential chains

### DIFF
--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -363,16 +363,25 @@ export function schedule(
   constraints?: Map<NodeId, ScheduleConstraint>,
   context?: ScheduleContext,
 ): ScheduledNode[] {
-  // Inject implicit FS chains for sequential parents before topo sort.
-  // If injection somehow produces a cyclic graph (defense in depth — the
-  // injection function's own cycle guard should prevent this), fall back
-  // to the original nodes so the API returns a partial schedule instead
-  // of a 500. This keeps the Gantt usable even with adversarial data.
+  // Order matters: expand parent-level deps to leaves FIRST, then inject
+  // implicit sequential FS chains. With expansion-first, the injection's
+  // hasCycle guard sees the cartesian-product edges that expansion adds
+  // (a parent-level dep becomes N×M leaf edges), so it correctly skips
+  // synthetic edges that would close cycles via the expanded leaf edges.
+  //
+  // The original order (inject → expand → sort) blinded the cycle guard
+  // to edges that only exist after expansion, and topological sort
+  // crashed downstream once expansion added the missing leg of the cycle.
+  //
+  // The try/catch is defense in depth: if a cycle still slips through
+  // (e.g. the pre-existing graph itself is cyclic), fall back to running
+  // the topo sort without sequential injection. API returns a partial
+  // schedule instead of a 500; Gantt stays usable.
   let sorted: Node[];
   let expanded: Node[];
   try {
-    const sequenced = injectSequentialDeps(nodes);
-    expanded = expandParentDependencies(sequenced);
+    expanded = expandParentDependencies(nodes);
+    expanded = injectSequentialDeps(expanded);
     sorted = topologicalSort(expanded);
   } catch (err) {
     if (err instanceof Error && /Cycle detected/.test(err.message)) {


### PR DESCRIPTION
Continues #121. Order was inject → expand → sort, leaving the cycle guard blind to expanded edges. After v0.16.1, every schedule() call hit the fallback → Gantt empty. Swap to expand → inject → sort.

Test plan:
- [x] 95/95 core tests pass
- [ ] Deploy → schedule endpoint 200 with no 'cycle detected' fallback log