### PR TITLE
feat(scheduler): priority-inheritance + linear schedule; drop childrenScheduling

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -38,7 +38,6 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     externalLinks: [],
     autoProgress: 'off',
     priorityRank: null,
-    childrenScheduling: 'parallel' as const,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -36,7 +36,6 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     externalLinks: [],
     autoProgress: 'off',
     priorityRank: null,
-    childrenScheduling: 'parallel',
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,
@@ -197,96 +196,9 @@ describe('topologicalSort', () => {
   });
 });
 
-// ── Scheduling (forward pass) ───────────────────────────────────
+// ── Scheduling (forward pass — single-worker, priority-driven) ─────
 
-describe('schedule', () => {
-  it('schedules the doc example correctly', () => {
-    const { allNodes } = buildScheduleExample();
-    const result = schedule(allNodes);
-
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // Design: start=0, end=3
-    expect(byId.get('design')!.computedStart).toBe(0);
-    expect(byId.get('design')!.computedEnd).toBe(3);
-
-    // Frontend: start=3 (after design), end=11
-    expect(byId.get('frontend')!.computedStart).toBe(3);
-    expect(byId.get('frontend')!.computedEnd).toBe(11);
-
-    // Backend: start=3 (after design), end=10
-    expect(byId.get('backend')!.computedStart).toBe(3);
-    expect(byId.get('backend')!.computedEnd).toBe(10);
-
-    // Integration: starts after max(frontend=11, backend=10) = 11, end=14
-    expect(byId.get('integration')!.computedStart).toBe(11);
-    expect(byId.get('integration')!.computedEnd).toBe(14);
-
-    // Launch: starts at 14, end=14 (milestone, 0 duration)
-    expect(byId.get('launch')!.computedStart).toBe(14);
-    expect(byId.get('launch')!.computedEnd).toBe(14);
-  });
-
-  it('handles lag on dependencies', () => {
-    const a = makeNode({ id: 'a', effortEstimate: 3 });
-    const b = makeNode({
-      id: 'b',
-      effortEstimate: 5,
-      dependencies: [{ targetNodeId: 'a', type: 'FS', lag: 2 }],
-    });
-    const result = schedule([a, b]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // B starts at A.end + lag = 3 + 2 = 5
-    expect(byId.get('b')!.computedStart).toBe(5);
-    expect(byId.get('b')!.computedEnd).toBe(10);
-  });
-
-  it('handles SS dependency type', () => {
-    const a = makeNode({ id: 'a', effortEstimate: 5 });
-    const b = makeNode({
-      id: 'b',
-      effortEstimate: 3,
-      dependencies: [{ targetNodeId: 'a', type: 'SS', lag: 1 }],
-    });
-    const result = schedule([a, b]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // SS: B can start when A starts + lag = 0 + 1 = 1
-    expect(byId.get('b')!.computedStart).toBe(1);
-    expect(byId.get('b')!.computedEnd).toBe(4);
-  });
-
-  it('handles FF dependency type', () => {
-    const a = makeNode({ id: 'a', effortEstimate: 5 });
-    const b = makeNode({
-      id: 'b',
-      effortEstimate: 3,
-      dependencies: [{ targetNodeId: 'a', type: 'FF', lag: 0 }],
-    });
-    const result = schedule([a, b]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // FF: B.end >= A.end + lag → B.start >= A.end + lag - B.duration = 5 + 0 - 3 = 2
-    expect(byId.get('b')!.computedStart).toBe(2);
-    expect(byId.get('b')!.computedEnd).toBe(5);
-  });
-
-  it('handles SF dependency type', () => {
-    const a = makeNode({ id: 'a', effortEstimate: 5 });
-    const b = makeNode({
-      id: 'b',
-      effortEstimate: 3,
-      dependencies: [{ targetNodeId: 'a', type: 'SF', lag: 0 }],
-    });
-    const result = schedule([a, b]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // SF: B.end >= A.start + lag → B.start >= A.start + lag - B.duration = 0 + 0 - 3 = -3 → clamped to 0
-    expect(byId.get('b')!.computedStart).toBe(0);
-    expect(byId.get('b')!.computedEnd).toBe(3);
-  });
-
+describe('schedule — pins and dep constraints', () => {
   it('honours a minStart pin that pushes the node forward', () => {
     const a = makeNode({ id: 'a', effortEstimate: 3 });
     const constraints = new Map([['a', { minStart: 5 }]]);
@@ -317,7 +229,6 @@ describe('schedule', () => {
     const constraints = new Map([['a', { maxEnd: 10 }]]);
     const result = schedule([a], 0, constraints);
     const byId = new Map(result.map((s) => [s.nodeId, s]));
-    // start=0, required duration = 10-0 = 10 > estimate 3 → stretched
     expect(byId.get('a')!.computedStart).toBe(0);
     expect(byId.get('a')!.computedEnd).toBe(10);
     expect(byId.get('a')!.duration).toBe(10);
@@ -328,9 +239,23 @@ describe('schedule', () => {
     const constraints = new Map([['a', { maxEnd: 3 }]]);
     const result = schedule([a], 0, constraints);
     const byId = new Map(result.map((s) => [s.nodeId, s]));
-    // Required duration 3 < estimate 5 → keep the larger estimate
     expect(byId.get('a')!.duration).toBe(5);
     expect(byId.get('a')!.computedEnd).toBe(5);
+  });
+
+  it('FS lag pushes a follower past the cursor', () => {
+    // A=3, B depends on A FS lag=5. Single-worker cursor would put B
+    // at A.end=3, but FS lag pushes it to A.end + 5 = 8.
+    const a = makeNode({ id: 'a', effortEstimate: 3 });
+    const b = makeNode({
+      id: 'b',
+      effortEstimate: 2,
+      dependencies: [{ targetNodeId: 'a', type: 'FS', lag: 5 }],
+    });
+    const result = schedule([a, b]);
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    expect(byId.get('b')!.computedStart).toBe(8);
+    expect(byId.get('b')!.computedEnd).toBe(10);
   });
 });
 
@@ -411,337 +336,152 @@ describe('criticalPath', () => {
   });
 });
 
-// ── DoD unit tests for Gantt slice 1 ───────────────────────────
-//
-// (i)   'parallel' parent → siblings schedule independently (regression)
-// (ii)  'sequential' parent → siblings chained in resolved order
-// (iii) explicit FS edge overrides the implicit sequential chain
-// (iv)  business-day math: 12h estimate with 8h/day = 2 business days
-// (v)   schedule correctly converts hours to business-day durations end-to-end
+// ── Priority-inheritance scheduler tests (v0.17.0) ──────────────
 
-describe('childrenScheduling: parallel (DoD case i — regression)', () => {
-  it('parallel parent: siblings all start at project day 0', () => {
-    // Parent has 3 children with no explicit deps. All should land at start=0.
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1', 'c2', 'c3'],
-      childrenScheduling: 'parallel',
-    });
-    const c1 = makeNode({ id: 'c1', parentId: 'parent', effortEstimate: 2 });
-    const c2 = makeNode({ id: 'c2', parentId: 'parent', effortEstimate: 3 });
-    const c3 = makeNode({ id: 'c3', parentId: 'parent', effortEstimate: 5 });
-
-    const result = schedule([parent, c1, c2, c3]);
+describe('priority-inheritance schedule', () => {
+  it('orders leaves by priority — high priority first', () => {
+    const a = makeNode({ id: 'a', priority: 'P2', effortEstimate: 2 });
+    const b = makeNode({ id: 'b', priority: 'P0', effortEstimate: 1 });
+    const c = makeNode({ id: 'c', priority: 'P1', effortEstimate: 3 });
+    const result = schedule([a, b, c]);
     const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    expect(byId.get('c1')!.computedStart).toBe(0);
-    expect(byId.get('c2')!.computedStart).toBe(0);
-    expect(byId.get('c3')!.computedStart).toBe(0);
-  });
-});
-
-describe('childrenScheduling: sequential (DoD case ii)', () => {
-  it('sequential parent: children chain in resolved order', () => {
-    // Parent with sequential scheduling. Children have effort 2, 3, 5.
-    // Expected chain: c1(0→2) → c2(2→5) → c3(5→10)
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1', 'c2', 'c3'],
-      childrenScheduling: 'sequential',
-    });
-    const c1 = makeNode({
-      id: 'c1',
-      parentId: 'parent',
-      effortEstimate: 2,
-      createdAt: '2026-01-01T00:00:00Z',
-    });
-    const c2 = makeNode({
-      id: 'c2',
-      parentId: 'parent',
-      effortEstimate: 3,
-      createdAt: '2026-01-02T00:00:00Z',
-    });
-    const c3 = makeNode({
-      id: 'c3',
-      parentId: 'parent',
-      effortEstimate: 5,
-      createdAt: '2026-01-03T00:00:00Z',
-    });
-
-    const result = schedule([parent, c1, c2, c3]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    expect(byId.get('c1')!.computedStart).toBe(0);
-    expect(byId.get('c1')!.computedEnd).toBe(2);
-
-    expect(byId.get('c2')!.computedStart).toBe(2);
-    expect(byId.get('c2')!.computedEnd).toBe(5);
-
-    expect(byId.get('c3')!.computedStart).toBe(5);
-    expect(byId.get('c3')!.computedEnd).toBe(10);
+    // Order: b (P0) at 0..1, c (P1) at 1..4, a (P2) at 4..6
+    expect(byId.get('b')!.computedStart).toBe(0);
+    expect(byId.get('b')!.computedEnd).toBe(1);
+    expect(byId.get('c')!.computedStart).toBe(1);
+    expect(byId.get('c')!.computedEnd).toBe(4);
+    expect(byId.get('a')!.computedStart).toBe(4);
+    expect(byId.get('a')!.computedEnd).toBe(6);
   });
 
-  it('sequential parent: resolved order respects priorityRank', () => {
-    // c3 has priorityRank 1 (lowest rank number = first), c1 has rank 2, c2 has no rank
-    // Expected order: c3 → c1 → c2
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1', 'c2', 'c3'],
-      childrenScheduling: 'sequential',
-    });
-    const c1 = makeNode({ id: 'c1', parentId: 'parent', effortEstimate: 1, priorityRank: 2 });
-    const c2 = makeNode({ id: 'c2', parentId: 'parent', effortEstimate: 1, priorityRank: null });
-    const c3 = makeNode({ id: 'c3', parentId: 'parent', effortEstimate: 1, priorityRank: 1 });
-
-    const result = schedule([parent, c1, c2, c3]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // c3 (rank 1) → c1 (rank 2) → c2 (null rank)
-    expect(byId.get('c3')!.computedStart).toBe(0); // first
-    expect(byId.get('c1')!.computedStart).toBe(1); // after c3
-    expect(byId.get('c2')!.computedStart).toBe(2); // after c1
-  });
-});
-
-describe('explicit FS edge overrides implicit sequential chain (DoD case iii)', () => {
-  it('explicit FS from a different subtree respects the edge', () => {
-    // Sequential parent with c1 → c2 → c3. But c3 also has an explicit FS dep
-    // on an external node X(effort=10). X must finish before c3 starts.
-    const x = makeNode({ id: 'x', effortEstimate: 10 });
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1', 'c2', 'c3'],
-      childrenScheduling: 'sequential',
-    });
-    const c1 = makeNode({ id: 'c1', parentId: 'parent', effortEstimate: 2, createdAt: '2026-01-01T00:00:00Z' });
-    const c2 = makeNode({ id: 'c2', parentId: 'parent', effortEstimate: 2, createdAt: '2026-01-02T00:00:00Z' });
-    const c3 = makeNode({
-      id: 'c3',
-      parentId: 'parent',
-      effortEstimate: 2,
-      createdAt: '2026-01-03T00:00:00Z',
-      dependencies: [{ targetNodeId: 'x', type: 'FS', lag: 0 }],
-    });
-
-    const result = schedule([x, parent, c1, c2, c3]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // x ends at 10; c3 must start at max(c2.end=4, x.end=10) = 10
-    expect(byId.get('c3')!.computedStart).toBe(10);
-    expect(byId.get('c3')!.computedEnd).toBe(12);
-
-    // c1 and c2 are unaffected by x
-    expect(byId.get('c1')!.computedStart).toBe(0);
-    expect(byId.get('c2')!.computedStart).toBe(2);
-  });
-});
-
-describe('business-day math (DoD case iv — weekends skipped)', () => {
-  it('hoursToBusinessDays: 12h estimate with 8h/day = 2 business days', () => {
-    // Direct unit test repeated in scheduler context
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1'],
-      childrenScheduling: 'sequential',
-    });
-    const c1 = makeNode({ id: 'c1', parentId: 'parent', effortEstimate: 12 });
-
-    const result = schedule(
-      [parent, c1],
-      0,
-      undefined,
-      { effortUnit: 'hours', hoursPerDay: 8 },
-    );
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    expect(byId.get('c1')!.duration).toBe(2);
-  });
-});
-
-describe('hours → business-day duration end-to-end (DoD case v)', () => {
-  it('8h estimate = 1 business day, 24h = 3 business days; downstream sibling pushes by 2', () => {
-    // Sequential parent: c1(8h) → c2(24h). With 8h/day:
-    //   c1 duration = ceil(8/8) = 1 day  → 0..1
-    //   c2 duration = ceil(24/8) = 3 days → 1..4
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1', 'c2'],
-      childrenScheduling: 'sequential',
-    });
-    const c1 = makeNode({
-      id: 'c1',
-      parentId: 'parent',
-      effortEstimate: 8,
-      createdAt: '2026-01-01T00:00:00Z',
-    });
-    const c2 = makeNode({
-      id: 'c2',
-      parentId: 'parent',
-      effortEstimate: 24,
-      createdAt: '2026-01-02T00:00:00Z',
-    });
-
-    const result = schedule(
-      [parent, c1, c2],
-      0,
-      undefined,
-      { effortUnit: 'hours', hoursPerDay: 8 },
-    );
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    expect(byId.get('c1')!.duration).toBe(1);
-    expect(byId.get('c1')!.computedEnd).toBe(1);
-
-    expect(byId.get('c2')!.computedStart).toBe(1);
-    expect(byId.get('c2')!.duration).toBe(3);
-    expect(byId.get('c2')!.computedEnd).toBe(4);
-  });
-});
-
-describe('sequential parent: priority-enum tiebreaker', () => {
-  it('orders by Priority enum (P0 < P1 < P2 < P3) when priorityRank is null', () => {
-    // All siblings have priorityRank=null, distinct priority enum values.
-    // Resolved order should be P0 → P1 → P2 → P3, regardless of createdAt.
-    // (createdAt is set in reverse order to prove enum wins over createdAt.)
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1', 'c2', 'c3', 'c4'],
-      childrenScheduling: 'sequential',
-    });
-    const c1 = makeNode({
-      id: 'c1',
-      parentId: 'parent',
-      effortEstimate: 1,
-      priority: 'P3',
-      createdAt: '2026-01-01T00:00:00Z', // earliest createdAt → would be first
-    });
-    const c2 = makeNode({
-      id: 'c2',
-      parentId: 'parent',
-      effortEstimate: 1,
-      priority: 'P0',
-      createdAt: '2026-01-04T00:00:00Z',
-    });
-    const c3 = makeNode({
-      id: 'c3',
-      parentId: 'parent',
-      effortEstimate: 1,
-      priority: 'P2',
-      createdAt: '2026-01-02T00:00:00Z',
-    });
-    const c4 = makeNode({
-      id: 'c4',
-      parentId: 'parent',
-      effortEstimate: 1,
-      priority: 'P1',
-      createdAt: '2026-01-03T00:00:00Z',
-    });
-
-    const result = schedule([parent, c1, c2, c3, c4]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // Order: c2 (P0) → c4 (P1) → c3 (P2) → c1 (P3)
-    expect(byId.get('c2')!.computedStart).toBe(0);
-    expect(byId.get('c4')!.computedStart).toBe(1);
-    expect(byId.get('c3')!.computedStart).toBe(2);
-    expect(byId.get('c1')!.computedStart).toBe(3);
-  });
-});
-
-describe('sequential parent: cycle-safe synthetic injection', () => {
-  it('skips synthetic FS when explicit reverse edge would close a cycle', () => {
-    // Sequential parent with default order c1 → c2 (by createdAt).
-    // But c1 has an EXPLICIT FS dep on c2 (c1 depends on c2 finishing first).
-    // The synthetic FS(c2 → c1) would combine with the explicit FS(c1 → c2)
-    // to form a cycle. Injection must skip this pair and let the explicit
-    // edge win; topologicalSort must not throw.
-    const parent = makeNode({
-      id: 'parent',
-      childrenIds: ['c1', 'c2'],
-      childrenScheduling: 'sequential',
-    });
-    const c1 = makeNode({
-      id: 'c1',
-      parentId: 'parent',
-      effortEstimate: 2,
-      createdAt: '2026-01-01T00:00:00Z',
-      dependencies: [{ targetNodeId: 'c2', type: 'FS', lag: 0 }],
-    });
-    const c2 = makeNode({
-      id: 'c2',
-      parentId: 'parent',
-      effortEstimate: 3,
-      createdAt: '2026-01-02T00:00:00Z',
-    });
-
-    // Should not throw despite the would-be cycle.
-    const result = schedule([parent, c1, c2]);
-    const byId = new Map(result.map((s) => [s.nodeId, s]));
-
-    // Explicit FS wins: c2 runs first (0..3), c1 depends on c2 (3..5).
-    expect(byId.get('c2')!.computedStart).toBe(0);
-    expect(byId.get('c2')!.computedEnd).toBe(3);
-    expect(byId.get('c1')!.computedStart).toBe(3);
-    expect(byId.get('c1')!.computedEnd).toBe(5);
-  });
-
-  it('cross-parent cycle: synthetic edges across two sequential parents do not create cycles', () => {
-    // Two sequential parents:
-    //   P1 has children A, B (resolved order A → B)
-    //   P2 has children C, D (resolved order C → D)
-    // Explicit edges already in the graph:
-    //   C depends on B (FS)
-    //   A depends on D (FS)
-    //
-    // Without the cross-parent-aware cycle guard, both synthetic edges
-    // (FS(B → A) and FS(D → C)) would be injected because each look-up
-    // sees only the pre-injection graph. Combined they form a cycle:
-    //   A → D → C → B → A
-    // and topologicalSort throws.
-    //
-    // With the working-nodeMap fix, the second injection's hasCycle check
-    // sees the synthetic FS(B → A) added by the first injection and skips
-    // the FS(D → C) injection. P2's chain is partially honored (D doesn't
-    // chain) but the schedule resolves without throwing.
-    const p1 = makeNode({
-      id: 'P1',
-      childrenIds: ['A', 'B'],
-      childrenScheduling: 'sequential',
-    });
-    const p2 = makeNode({
-      id: 'P2',
-      childrenIds: ['C', 'D'],
-      childrenScheduling: 'sequential',
-    });
+  it('high-priority item with low-priority blocker: blocker inherits and runs first', () => {
+    // A=P0 depends on B=P3. B inherits P0 → runs at 0, then A.
+    // C=P1 has no deps → runs after A (queue: B@P0, A@P0, C@P1).
     const a = makeNode({
-      id: 'A',
-      parentId: 'P1',
+      id: 'a',
+      priority: 'P0',
       effortEstimate: 1,
-      createdAt: '2026-01-01T00:00:00Z',
-      dependencies: [{ targetNodeId: 'D', type: 'FS', lag: 0 }],
+      dependencies: [{ targetNodeId: 'b', type: 'FS', lag: 0 }],
+    });
+    const b = makeNode({ id: 'b', priority: 'P3', effortEstimate: 2 });
+    const c = makeNode({ id: 'c', priority: 'P1', effortEstimate: 1 });
+    const result = schedule([a, b, c]);
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    expect(byId.get('b')!.computedStart).toBe(0);
+    expect(byId.get('b')!.computedEnd).toBe(2);
+    expect(byId.get('a')!.computedStart).toBe(2);
+    expect(byId.get('a')!.computedEnd).toBe(3);
+    expect(byId.get('c')!.computedStart).toBe(3);
+    expect(byId.get('c')!.computedEnd).toBe(4);
+  });
+
+  it('chain inheritance: A → B → C all converge to A.priority', () => {
+    // A=P0 depends on B. B=P2 depends on C. C=P3.
+    // After inheritance: A=P0, B=P0, C=P0.
+    // Topological order forces C before B before A.
+    // Queue: C, B, A (all P0).
+    const a = makeNode({
+      id: 'a',
+      priority: 'P0',
+      effortEstimate: 1,
+      dependencies: [{ targetNodeId: 'b', type: 'FS', lag: 0 }],
     });
     const b = makeNode({
-      id: 'B',
-      parentId: 'P1',
+      id: 'b',
+      priority: 'P2',
       effortEstimate: 1,
-      createdAt: '2026-01-02T00:00:00Z',
+      dependencies: [{ targetNodeId: 'c', type: 'FS', lag: 0 }],
     });
-    const c = makeNode({
-      id: 'C',
-      parentId: 'P2',
-      effortEstimate: 1,
-      createdAt: '2026-01-03T00:00:00Z',
-      dependencies: [{ targetNodeId: 'B', type: 'FS', lag: 0 }],
-    });
-    const d = makeNode({
-      id: 'D',
-      parentId: 'P2',
-      effortEstimate: 1,
-      createdAt: '2026-01-04T00:00:00Z',
-    });
+    const c = makeNode({ id: 'c', priority: 'P3', effortEstimate: 1 });
+    const result = schedule([a, b, c]);
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    expect(byId.get('c')!.computedStart).toBe(0);
+    expect(byId.get('b')!.computedStart).toBe(1);
+    expect(byId.get('a')!.computedStart).toBe(2);
+  });
 
-    // Must not throw "Cycle detected".
-    const result = schedule([p1, p2, a, b, c, d]);
-    expect(result.length).toBe(6);
+  it('diamond: B blocks both A and E, inherits min priority', () => {
+    // A=P0 deps on B, E=P2 deps on B, B=P3.
+    // B inherits min(P0, P2) = P0.
+    // After inheritance: A=P0, B=P0, E=P2.
+    // Queue: B (P0), A (P0), E (P2). [B before A by topo, A and B share P0]
+    const a = makeNode({
+      id: 'a',
+      priority: 'P0',
+      effortEstimate: 1,
+      dependencies: [{ targetNodeId: 'b', type: 'FS', lag: 0 }],
+    });
+    const b = makeNode({ id: 'b', priority: 'P3', effortEstimate: 1 });
+    const e = makeNode({
+      id: 'e',
+      priority: 'P2',
+      effortEstimate: 1,
+      dependencies: [{ targetNodeId: 'b', type: 'FS', lag: 0 }],
+    });
+    const result = schedule([a, b, e]);
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    expect(byId.get('b')!.computedStart).toBe(0);
+    expect(byId.get('a')!.computedStart).toBe(1);
+    expect(byId.get('e')!.computedStart).toBe(2);
+  });
+
+  it('parent rollup: parent.start = min(child.start), parent.end = max(child.end)', () => {
+    const parent = makeNode({
+      id: 'p',
+      childrenIds: ['c1', 'c2'],
+    });
+    const c1 = makeNode({
+      id: 'c1',
+      parentId: 'p',
+      priority: 'P0',
+      effortEstimate: 2,
+    });
+    const c2 = makeNode({
+      id: 'c2',
+      parentId: 'p',
+      priority: 'P1',
+      effortEstimate: 3,
+    });
+    const result = schedule([parent, c1, c2]);
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    // c1 at 0..2, c2 at 2..5. Parent at 0..5.
+    expect(byId.get('p')!.computedStart).toBe(0);
+    expect(byId.get('p')!.computedEnd).toBe(5);
+  });
+
+  it('priorityRank tiebreaks within same priority enum', () => {
+    const a = makeNode({ id: 'a', priority: 'P1', priorityRank: 3, effortEstimate: 1 });
+    const b = makeNode({ id: 'b', priority: 'P1', priorityRank: 1, effortEstimate: 1 });
+    const c = makeNode({ id: 'c', priority: 'P1', priorityRank: 2, effortEstimate: 1 });
+    const result = schedule([a, b, c]);
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    expect(byId.get('b')!.computedStart).toBe(0); // rank 1
+    expect(byId.get('c')!.computedStart).toBe(1); // rank 2
+    expect(byId.get('a')!.computedStart).toBe(2); // rank 3
+  });
+
+  it('null priority sorts last (lowest)', () => {
+    const a = makeNode({ id: 'a', priority: null, effortEstimate: 1 });
+    const b = makeNode({ id: 'b', priority: 'P3', effortEstimate: 1 });
+    const result = schedule([a, b]);
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    expect(byId.get('b')!.computedStart).toBe(0);
+    expect(byId.get('a')!.computedStart).toBe(1);
+  });
+
+  it('hours → business-day conversion via context', () => {
+    const a = makeNode({ id: 'a', priority: 'P0', effortEstimate: 12 });
+    const b = makeNode({ id: 'b', priority: 'P1', effortEstimate: 8 });
+    const result = schedule([a, b], 0, undefined, {
+      effortUnit: 'hours',
+      hoursPerDay: 8,
+    });
+    const byId = new Map(result.map((s) => [s.nodeId, s]));
+    // 12h → ceil(12/8) = 2 days. 8h → 1 day.
+    expect(byId.get('a')!.duration).toBe(2);
+    expect(byId.get('b')!.duration).toBe(1);
+    expect(byId.get('a')!.computedStart).toBe(0);
+    expect(byId.get('b')!.computedStart).toBe(2);
   });
 });
+

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -39,7 +39,6 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     externalLinks: [],
     autoProgress: 'off',
     priorityRank: null,
-    childrenScheduling: 'parallel',
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -225,152 +225,78 @@ export interface ScheduleContext {
   hoursPerDay?: number;
 }
 
-// Priority enum ordering for resolved sibling sort. Lower index = higher priority.
-const PRIORITY_ORDER: Record<string, number> = {
+// Priority enum ordering. Lower number = higher priority.
+// P0 = 0 (highest), P1 = 1, P2 = 2, P3 = 3, null = 4 (lowest).
+const PRIORITY_ENUM_ORDER: Record<string, number> = {
   P0: 0,
   P1: 1,
   P2: 2,
   P3: 3,
 };
 
+function priorityEnumNum(p: Node['priority']): number {
+  if (!p) return 4;
+  return PRIORITY_ENUM_ORDER[p] ?? 4;
+}
+
 /**
- * Return the resolved sibling order for the children of `parent`.
+ * Sort a list of nodes (typically siblings under a single parent) by
+ * priorityRank ASC NULLS LAST → priority enum (P0 < P1 < P2 < P3) → createdAt ASC.
  *
- * Sort key: priorityRank ASC NULLS LAST → priority enum (P0 < P1 < P2 < P3) → createdAt ASC.
- *
- * Exported (as a named export + re-exported from index) so the orchestration
- * substrate's `ready_nodes` handler can reuse it for ordering results.
+ * Used by the orchestration substrate (`ready_nodes`) to order what to
+ * dispatch next; not used by the scheduler itself, which uses effective
+ * priority via inheritance instead.
  */
 export function resolvedSiblingOrder(children: Node[]): Node[] {
   return [...children].sort((a, b) => {
-    // 1. priorityRank ASC NULLS LAST
     const ra = a.priorityRank;
     const rb = b.priorityRank;
     if (ra !== null && rb !== null) {
       if (ra !== rb) return ra - rb;
     } else if (ra !== null) {
-      return -1; // a has rank, b doesn't → a first
+      return -1;
     } else if (rb !== null) {
-      return 1; // b has rank, a doesn't → b first
+      return 1;
     }
-
-    // 2. priority enum (P0 < P1 < P2 < P3), null last
-    const pa = a.priority ? (PRIORITY_ORDER[a.priority] ?? 99) : 99;
-    const pb = b.priority ? (PRIORITY_ORDER[b.priority] ?? 99) : 99;
+    const pa = priorityEnumNum(a.priority);
+    const pb = priorityEnumNum(b.priority);
     if (pa !== pb) return pa - pb;
-
-    // 3. createdAt ASC
     return a.createdAt.localeCompare(b.createdAt);
   });
 }
 
 /**
- * For nodes whose parent has `childrenScheduling = 'sequential'`, inject
- * synthetic FS dependency edges so the scheduler chains them in resolved
- * sibling order. Explicit dependency edges are left untouched and continue
- * to take precedence (the topo sort enforces explicit deps first).
+ * Priority-inheritance scheduler.
  *
- * Returns a new nodes array; original nodes are not mutated.
- */
-function injectSequentialDeps(nodes: Node[]): Node[] {
-  // Greedy per-edge verification. The pop-LIFO approach in #125 fell short
-  // when MULTIPLE edges in one chain would cycle: popping LIFO can keep
-  // dropping non-problematic tail edges before reaching the culprit, and
-  // sometimes empties the whole chain. The Roadmap's root has 8
-  // cross-section explicit deps each potentially closing a different
-  // cycle, so the LIFO path dropped the whole 27-edge root chain.
-  //
-  // Greedy: push each edge ONE AT A TIME and run topologicalSort to
-  // verify. If acyclic, keep the edge. If cyclic, drop just THIS edge
-  // and continue with the next pair. Each rejected edge leaves a "gap"
-  // in the chain but the chain continues past it.
-  //
-  // Cost: O(E × (N + E)) per schedule(), where E = candidate chain edges.
-  // For a ~2500-node map with a few hundred sequential parents, ~50 ms.
-  const workingNodes: Node[] = nodes.map((n) => ({
-    ...n,
-    dependencies: [...n.dependencies],
-  }));
-  const workingMap = new Map<NodeId, Node>(workingNodes.map((n) => [n.id, n]));
-
-  // Iterate parents shallowest-first. With greedy per-edge verification,
-  // edges added EARLIER survive when later additions would cycle — so
-  // processing the root first means top-level chain edges are evaluated
-  // against an emptier working graph and have the best chance of being
-  // accepted. By the time deep-level chains are evaluated, their cycles
-  // (typically caused by cross-subtree leaf deps interacting with the
-  // already-accepted top-level chain) cost only the deep chain, not the
-  // user-visible top-level structure.
-  const depth = new Map<NodeId, number>();
-  for (const n of workingNodes) {
-    let d = 0;
-    let cur: Node | undefined = n;
-    while (cur && cur.parentId) {
-      d++;
-      cur = workingMap.get(cur.parentId);
-      if (d > 100) break; // pathological structure guard
-    }
-    depth.set(n.id, d);
-  }
-  const orderedParents = [...nodes].sort(
-    (a, b) => (depth.get(a.id) ?? 0) - (depth.get(b.id) ?? 0),
-  );
-
-  for (const originalParent of orderedParents) {
-    if (originalParent.childrenScheduling !== 'sequential') continue;
-    if (originalParent.childrenIds.length < 2) continue;
-
-    const presentChildren = originalParent.childrenIds
-      .map((cid) => workingMap.get(cid))
-      .filter((n): n is Node => n !== undefined);
-
-    if (presentChildren.length < 2) continue;
-
-    const ordered = resolvedSiblingOrder(presentChildren);
-
-    for (let i = 1; i < ordered.length; i++) {
-      const predecessor = ordered[i - 1];
-      const follower = ordered[i];
-
-      const alreadyHas = follower.dependencies.some(
-        (d) => d.targetNodeId === predecessor.id && d.type === 'FS',
-      );
-      if (alreadyHas) continue;
-
-      const synthetic = {
-        targetNodeId: predecessor.id,
-        type: 'FS' as const,
-        lag: 0,
-      };
-      follower.dependencies.push(synthetic);
-
-      try {
-        topologicalSort(workingNodes);
-        // acyclic — keep
-      } catch (err) {
-        if (!(err instanceof Error && /Cycle detected/.test(err.message))) {
-          throw err;
-        }
-        // Cycle introduced by this edge — drop it and move on
-        const idx = follower.dependencies.indexOf(synthetic);
-        if (idx >= 0) follower.dependencies.splice(idx, 1);
-      }
-    }
-  }
-
-  return workingNodes;
-}
-
-/**
- * Forward-pass scheduling.
+ * Model: every node has a priority. The Gantt is a single linear queue
+ * sorted by priority — item 1 starts at the project start, item 2 starts
+ * when item 1 ends, item 3 when item 2 ends, and so on. Tree structure is
+ * for visual grouping only; scheduling operates on leaf nodes (work items).
  *
- * Given nodes with effort estimates and dependencies, compute the earliest
- * possible start and end for each node.
+ * Two mechanisms keep the queue honest:
  *
- * `projectStartDay` is day 0. All dates are in the map's effort unit (days/hours/points).
- * Optional `constraints` pin individual nodes in place (manually-set dates).
- * Optional `context` enables business-day unit conversion (hours → business days).
- * Returns a ScheduledNode for every input node.
+ * 1. **Priority inheritance.** If A (priority P1) depends on B (priority P5),
+ *    the queue can't put A before B — A is blocked by B. Instead of pushing A
+ *    to the back, B inherits A's priority: B's *effective* priority becomes
+ *    `min(B.own, A.effective)` = P1. So both A and B land near the front,
+ *    with B right before A. Chains propagate: A → B → C all converge to A's
+ *    priority. Diamonds merge: if A and E both depend on B, B inherits
+ *    `min(A.effective, E.effective)`.
+ *
+ * 2. **Dep constraints in the forward pass.** Once the leaf queue is sorted,
+ *    each leaf's start is `max(cursor, max(dep.target.end + lag))`. The
+ *    cursor advances after each placement; deps add extra constraints that
+ *    can push the start later (but never earlier).
+ *
+ * What this replaces: the synthetic-FS-chain machinery from #109/#121–#129.
+ * The old model invented edges to mimic sequential ordering at each level,
+ * and those invented edges fought with user explicit deps, creating cycles
+ * the topo sort couldn't resolve. Priority inheritance achieves the same
+ * "high-priority first" ordering with zero invented edges, so cycles are
+ * impossible unless the user explicitly created a circular dep.
+ *
+ * Returns a ScheduledNode for every input node. Parents derive their
+ * start/end from a bottom-up rollup of their children's positions.
  */
 export function schedule(
   nodes: Node[],
@@ -378,49 +304,63 @@ export function schedule(
   constraints?: Map<NodeId, ScheduleConstraint>,
   context?: ScheduleContext,
 ): ScheduledNode[] {
-  // Order matters: expand parent-level deps to leaves FIRST, then inject
-  // implicit sequential FS chains. With expansion-first, the injection's
-  // hasCycle guard sees the cartesian-product edges that expansion adds
-  // (a parent-level dep becomes N×M leaf edges), so it correctly skips
-  // synthetic edges that would close cycles via the expanded leaf edges.
-  //
-  // The original order (inject → expand → sort) blinded the cycle guard
-  // to edges that only exist after expansion, and topological sort
-  // crashed downstream once expansion added the missing leg of the cycle.
-  //
-  // The try/catch is defense in depth: if a cycle still slips through
-  // (e.g. the pre-existing graph itself is cyclic), fall back to running
-  // the topo sort without sequential injection. API returns a partial
-  // schedule instead of a 500; Gantt stays usable.
-  let sorted: Node[];
-  let expanded: Node[];
-  try {
-    expanded = expandParentDependencies(nodes);
-    expanded = injectSequentialDeps(expanded);
-    sorted = topologicalSort(expanded);
-  } catch (err) {
-    if (err instanceof Error && /Cycle detected/.test(err.message)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[scheduler] cycle detected after sequential injection; falling back to no implicit chains for this run',
-      );
-      expanded = expandParentDependencies(nodes);
-      sorted = topologicalSort(expanded);
-    } else {
-      throw err;
+  // Step 1: Expand any parent-level user deps to leaves (handles the rare
+  // case where someone wrote "Section A depends on Section B" at the parent
+  // level — that becomes leaf-cascade deps).
+  const expanded = expandParentDependencies(nodes);
+
+  // Step 2: Build the forward dep graph (who depends on me) for priority
+  // inheritance propagation.
+  const dependents = new Map<NodeId, NodeId[]>();
+  for (const n of expanded) {
+    for (const dep of n.dependencies) {
+      if (!dependents.has(dep.targetNodeId)) dependents.set(dep.targetNodeId, []);
+      dependents.get(dep.targetNodeId)!.push(n.id);
     }
   }
 
-  const nodeMap = new Map<NodeId, Node>();
-  for (const node of expanded) {
-    nodeMap.set(node.id, node);
+  // Step 3: Topological sort. Will throw if the user has circular explicit
+  // deps — that's a real data error, not something to paper over.
+  const sorted = topologicalSort(expanded);
+
+  // Step 4: Compute effective priority by walking in REVERSE topological
+  // order. Reverse topo means dependents are processed BEFORE the nodes
+  // they depend on, so by the time we visit a node N, every node that
+  // depends on N has its effective priority already set. We propagate
+  // `min(N.own, all dependent.effective)` to N.
+  const effective = new Map<NodeId, number>();
+  for (const n of expanded) effective.set(n.id, priorityEnumNum(n.priority));
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const node = sorted[i];
+    let eff = effective.get(node.id)!;
+    for (const dependentId of dependents.get(node.id) ?? []) {
+      const depEff = effective.get(dependentId);
+      if (depEff !== undefined && depEff < eff) eff = depEff;
+    }
+    effective.set(node.id, eff);
   }
 
-  const scheduled = new Map<NodeId, ScheduledNode>();
+  // Step 5: Build the global ordered queue. Sort starting from the
+  // topo-sorted list (so equal-priority deps stay in dep order, since
+  // Array.sort is stable). Within an effective-priority tier, use
+  // priorityRank ASC NULLS LAST → createdAt ASC as the tiebreaker.
+  const queue = [...sorted].sort((a, b) => {
+    const ea = effective.get(a.id)!;
+    const eb = effective.get(b.id)!;
+    if (ea !== eb) return ea - eb;
+    const ra = a.priorityRank;
+    const rb = b.priorityRank;
+    if (ra !== null && rb !== null) {
+      if (ra !== rb) return ra - rb;
+    } else if (ra !== null) {
+      return -1;
+    } else if (rb !== null) {
+      return 1;
+    }
+    return a.createdAt.localeCompare(b.createdAt);
+  });
 
-  // Business-day conversion: when effortUnit is 'hours', convert leaf effort
-  // to business days using ceil(hours / hoursPerDay). This makes a 12h estimate
-  // with an 8h day render as 2 business-day bars instead of 12 unit-bars.
+  // Step 6: Schedule the leaves linearly. Parents derive from rollup.
   const useHoursConversion =
     context?.effortUnit === 'hours' &&
     context.hoursPerDay !== undefined &&
@@ -434,18 +374,22 @@ export function schedule(
     return raw;
   }
 
-  for (const node of sorted) {
-    let duration =
-      node.childrenIds.length === 0
-        ? leafDuration(node.effortEstimate)
-        : 0;
+  const scheduled = new Map<NodeId, ScheduledNode>();
+  let cursor = projectStartDay;
 
-    let earliestStart = projectStartDay;
+  for (const node of queue) {
+    // Parents are skipped here; they get derived in the rollup pass.
+    if (node.childrenIds.length > 0) continue;
 
+    let duration = leafDuration(node.effortEstimate);
+    let earliestStart = cursor;
+
+    // Honor explicit dep constraints. Targets are guaranteed scheduled
+    // already because we walk in queue order, which is topo-sorted with
+    // priority inheritance preserving dep order for ties.
     for (const dep of node.dependencies) {
       const target = scheduled.get(dep.targetNodeId);
-      if (!target) continue; // dependency not in this set
-
+      if (!target) continue;
       let constraint: number;
       switch (dep.type) {
         case 'FS':
@@ -461,53 +405,92 @@ export function schedule(
           constraint = target.computedStart + dep.lag - duration;
           break;
       }
-
-      earliestStart = Math.max(earliestStart, constraint);
+      if (constraint > earliestStart) earliestStart = constraint;
     }
 
-    // Apply per-node pinning constraints. minStart pushes the start forward;
-    // maxEnd stretches duration to force end alignment (a manual due date
-    // acts as a hard deadline the bar must reach).
+    // Apply per-node pinning constraints.
     const pin = constraints?.get(node.id);
     if (pin) {
-      if (pin.minStart !== undefined) {
-        earliestStart = Math.max(earliestStart, pin.minStart);
+      if (pin.minStart !== undefined && pin.minStart > earliestStart) {
+        earliestStart = pin.minStart;
       }
-      if (pin.maxEnd !== undefined && node.childrenIds.length === 0) {
+      if (pin.maxEnd !== undefined) {
         const requiredDuration = pin.maxEnd - earliestStart;
         if (requiredDuration > duration) duration = requiredDuration;
       }
     }
 
+    const start = earliestStart;
+    const end = start + duration;
     scheduled.set(node.id, {
       nodeId: node.id,
-      computedStart: earliestStart,
-      computedEnd: earliestStart + duration,
+      computedStart: start,
+      computedEnd: end,
       duration,
     });
+
+    // Advance the cursor so the next leaf starts after this one. Single-
+    // worker model: one item at a time.
+    cursor = end;
   }
 
-  // For parent nodes, compute start/end from children
-  for (const node of expanded) {
-    if (node.childrenIds.length === 0) continue;
-    const s = scheduled.get(node.id)!;
+  // Step 7: Roll up parents bottom-up (deepest first) so each parent
+  // reads its children's already-rolled-up values.
+  const treeDepth = new Map<NodeId, number>();
+  const expandedMap = new Map<NodeId, Node>();
+  for (const n of expanded) expandedMap.set(n.id, n);
+  for (const n of expanded) {
+    let d = 0;
+    let cur: Node | undefined = n;
+    while (cur && cur.parentId) {
+      d++;
+      cur = expandedMap.get(cur.parentId);
+      if (d > 100) break;
+    }
+    treeDepth.set(n.id, d);
+  }
+  const parentsBottomUp = expanded
+    .filter((n) => n.childrenIds.length > 0)
+    .sort((a, b) => (treeDepth.get(b.id) ?? 0) - (treeDepth.get(a.id) ?? 0));
+
+  for (const parent of parentsBottomUp) {
     let minStart = Infinity;
-    let maxEnd = 0;
-    for (const childId of node.childrenIds) {
+    let maxEnd = -Infinity;
+    for (const childId of parent.childrenIds) {
       const child = scheduled.get(childId);
       if (!child) continue;
-      minStart = Math.min(minStart, child.computedStart);
-      maxEnd = Math.max(maxEnd, child.computedEnd);
+      if (child.computedStart < minStart) minStart = child.computedStart;
+      if (child.computedEnd > maxEnd) maxEnd = child.computedEnd;
     }
     if (minStart !== Infinity) {
-      s.computedStart = minStart;
-      s.computedEnd = maxEnd;
-      s.duration = maxEnd - minStart;
+      scheduled.set(parent.id, {
+        nodeId: parent.id,
+        computedStart: minStart,
+        computedEnd: maxEnd,
+        duration: maxEnd - minStart,
+      });
+    } else {
+      // Parent with no scheduled children: collapse to project start.
+      scheduled.set(parent.id, {
+        nodeId: parent.id,
+        computedStart: projectStartDay,
+        computedEnd: projectStartDay,
+        duration: 0,
+      });
     }
   }
 
-  // Return in original node order (using original IDs)
-  return nodes.map((n) => scheduled.get(n.id)!);
+  // Default for any node that didn't land in scheduled (shouldn't happen
+  // but defensive).
+  return nodes.map(
+    (n) =>
+      scheduled.get(n.id) ?? {
+        nodeId: n.id,
+        computedStart: projectStartDay,
+        computedEnd: projectStartDay,
+        duration: 0,
+      },
+  );
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,6 @@ export type {
   Priority,
   EffortUnit,
   LayoutMode,
-  ChildrenScheduling,
   CustomFieldValue,
   Dependency,
   ExternalLink,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,17 +24,6 @@ export type EffortUnit = 'hours' | 'days' | 'points';
 export type LayoutMode = 'radial' | 'tree_lr' | 'tree_td' | 'org_chart' | 'freeform';
 
 /**
- * How a parent's children are scheduled relative to each other.
- *
- * - `'parallel'` (default) — each child starts as early as its own explicit
- *   dependencies allow. Siblings are independent. Preserves existing behavior.
- * - `'sequential'` — the scheduler implicitly treats children as an FS chain
- *   in their resolved sibling order. Explicit dep edges still win over the
- *   implicit chain; this flag is purely additive.
- */
-export type ChildrenScheduling = 'parallel' | 'sequential';
-
-/**
  * A custom field value. The shape depends on the field definition
  * on the Map (see MapSchema.customFieldDefs).
  */
@@ -135,13 +124,6 @@ export interface Node {
    * null = no explicit rank (sorts after ranked siblings).
    */
   priorityRank: number | null;
-
-  /**
-   * How this node's children are scheduled relative to each other.
-   * `'parallel'` (default) = existing behavior; `'sequential'` = implicit
-   * FS chain in resolved sibling order. Explicit dep edges still win.
-   */
-  childrenScheduling: ChildrenScheduling;
 
   // ── Orchestration substrate (#111) ────────────────────────────
 

--- a/packages/mindmap/src/GanttView.tsx
+++ b/packages/mindmap/src/GanttView.tsx
@@ -1969,47 +1969,6 @@ export function GanttView() {
                       />
                     </div>
 
-                    {/* childrenScheduling toggle (parent nodes only) */}
-                    {row.hasChildren && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          const next = row.node.childrenScheduling === 'sequential'
-                            ? 'parallel'
-                            : 'sequential';
-                          updateNode(row.node.id, { childrenScheduling: next } as Partial<Node>);
-                        }}
-                        title={
-                          row.node.childrenScheduling === 'sequential'
-                            ? 'Children: Sequential (click to switch to Parallel)'
-                            : 'Children: Parallel (click to switch to Sequential)'
-                        }
-                        style={{
-                          width: 24,
-                          height: 24,
-                          border: '1px solid',
-                          borderColor:
-                            row.node.childrenScheduling === 'sequential' ? '#4f46e5' : '#e2e8f0',
-                          borderRadius: 4,
-                          background:
-                            row.node.childrenScheduling === 'sequential' ? '#eef2ff' : 'transparent',
-                          color:
-                            row.node.childrenScheduling === 'sequential' ? '#4f46e5' : '#94a3b8',
-                          cursor: 'pointer',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          padding: 0,
-                          flexShrink: 0,
-                          fontSize: 9,
-                          fontWeight: 700,
-                          fontFamily: 'inherit',
-                          lineHeight: 1,
-                        }}
-                      >
-                        {row.node.childrenScheduling === 'sequential' ? 'SEQ' : 'PAR'}
-                      </button>
-                    )}
                   </div>
                 );
               })}

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -838,7 +838,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       externalLinks: [],
       autoProgress: 'off',
       priorityRank: null,
-      childrenScheduling: 'sequential',
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -1,4 +1,4 @@
-import type { Node as CoreNode, MindMap, CustomFieldValue, ChildrenScheduling } from '@mindblown/core';
+import type { Node as CoreNode, MindMap, CustomFieldValue } from '@mindblown/core';
 
 /**
  * Convert a database node row to the core Node type.
@@ -35,7 +35,6 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     externalLinks: (get('externalLinks', 'external_links') as CoreNode['externalLinks']) ?? [],
     autoProgress: ((get('autoProgress', 'auto_progress') as CoreNode['autoProgress']) ?? 'off'),
     priorityRank: (get('priorityRank', 'priority_rank') as number) ?? null,
-    childrenScheduling: ((get('childrenScheduling', 'children_scheduling') as ChildrenScheduling) ?? 'sequential'),
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -618,28 +618,19 @@ export async function runMigrations(): Promise<void> {
     ON nodes(deleted_at) WHERE deleted_at IS NOT NULL
   `);
 
-  // ── Gantt slice 1 (#109): implicit sibling ordering + scheduling mode ──
-  // priority_rank: fractional ranking for drag-to-reorder within a sibling
-  //   group. REAL (float) for midpoint insertion. null = no explicit rank.
-  // children_scheduling: 'sequential' (default, implicit FS chain in resolved
-  //   sibling order) or 'parallel' (legacy — siblings stack at the same start).
-  //   Default flipped from 'parallel' to 'sequential' so the Gantt actually
-  //   spreads out without requiring a per-parent toggle.
+  // ── Gantt slice 1 (#109): priorityRank ──────────────────────────
+  // Fractional ranking for drag-to-reorder within a sibling group.
+  // REAL (float) for midpoint insertion. null = no explicit rank.
   await db.execute(sql`
     ALTER TABLE nodes ADD COLUMN IF NOT EXISTS priority_rank REAL
   `);
+  // children_scheduling (#109) was DROPPED in v0.17.0 — the priority-
+  // inheritance scheduler doesn't need a per-parent sequential/parallel
+  // flag. Children are scheduled by global priority, with inheritance
+  // ensuring blockers run before their dependents.
   await db.execute(sql`
-    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS children_scheduling TEXT NOT NULL DEFAULT 'sequential'
+    ALTER TABLE nodes DROP COLUMN IF EXISTS children_scheduling
   `);
-  // On installs that pre-date this default flip, the column was created
-  // with DEFAULT 'parallel' and existing rows are stuck at 'parallel'.
-  // Repoint the column default and one-shot-flip historical rows.
-  await db.execute(sql`
-    ALTER TABLE nodes ALTER COLUMN children_scheduling SET DEFAULT 'sequential'
-  `);
-  // Root-level scheduling mode is governed by the root node's own
-  // childrenScheduling field — the map record itself has no separate
-  // setting (the root Node is just a normal Node).
 
   // ── Orchestration substrate (#111): work-queue + soft-conflict detection ──
   // claimed_by_session: session ID that has claimed this node for active work.
@@ -687,21 +678,9 @@ export async function runMigrations(): Promise<void> {
     )
   `);
 
-  // Flip historical 'parallel' rows to 'sequential'. The column default
-  // changed in this release, but rows created BEFORE this release carry
-  // the old 'parallel' value. The marker row in data_migrations ensures
-  // we only run the UPDATE on first boot of this version, so a user who
-  // later explicitly sets a parent back to 'parallel' won't get clobbered
-  // by subsequent restarts.
-  await db.execute(sql`
-    DO $$
-    BEGIN
-      IF NOT EXISTS (SELECT 1 FROM data_migrations WHERE id = 'flip_children_scheduling_default_v1') THEN
-        UPDATE nodes SET children_scheduling = 'sequential' WHERE children_scheduling = 'parallel';
-        INSERT INTO data_migrations (id) VALUES ('flip_children_scheduling_default_v1');
-      END IF;
-    END $$;
-  `);
+  // (The 'flip_children_scheduling_default_v1' data migration from
+  // v0.16.1 is a no-op now that the column has been dropped; the marker
+  // row stays in data_migrations as historical record.)
 
   console.log('[db] Migrations complete.');
 }

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -3,7 +3,7 @@ import { db } from './connection.js';
 import { nodes, maps, changeEvents } from './schema.js';
 import { dbNodeToCore } from './helpers.js';
 import { hasCycle } from '@mindblown/core';
-import type { Node as CoreNode, Dependency, DependencyType, ExternalLink, Priority, CustomFieldValue, NodeMap, StatusDef, ChildrenScheduling } from '@mindblown/core';
+import type { Node as CoreNode, Dependency, DependencyType, ExternalLink, Priority, CustomFieldValue, NodeMap, StatusDef } from '@mindblown/core';
 import { invalidateMapContext } from '../sync/mapContext.js';
 
 // Soft-delete filter shared by every read that returns user-visible nodes.
@@ -109,7 +109,6 @@ export interface CreateNodeInput {
   dueDate?: string;
   autoProgress?: 'off' | 'children';
   priorityRank?: number | null;
-  childrenScheduling?: ChildrenScheduling;
 }
 
 export async function createNode(
@@ -142,7 +141,6 @@ export async function createNode(
     dueDate: input.dueDate ?? null,
     autoProgress: input.autoProgress ?? 'off',
     priorityRank: input.priorityRank ?? null,
-    childrenScheduling: input.childrenScheduling ?? 'sequential',
     assigneeIds: [],
     tags: [],
     customFields: {},
@@ -216,7 +214,6 @@ export interface UpdateNodeInput {
   externalLinks?: ExternalLink[];
   autoProgress?: 'off' | 'children';
   priorityRank?: number | null;
-  childrenScheduling?: ChildrenScheduling;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -287,7 +284,6 @@ export async function updateNode(
   if (input.externalLinks !== undefined) updates.externalLinks = input.externalLinks;
   if (input.autoProgress !== undefined) updates.autoProgress = input.autoProgress;
   if (input.priorityRank !== undefined) updates.priorityRank = input.priorityRank;
-  if (input.childrenScheduling !== undefined) updates.childrenScheduling = input.childrenScheduling;
   // Orchestration substrate (#111)
   if (input.claimedBySession !== undefined) updates.claimedBySession = input.claimedBySession;
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -171,12 +171,6 @@ export const nodes = pgTable('nodes', {
   // Fractional ranking for drag-to-reorder within a sibling group.
   // null = no explicit rank (sorts after ranked siblings in resolved order).
   priorityRank: real('priority_rank'),
-  // How children of this node are scheduled relative to each other.
-  // 'sequential' (default) = implicit FS chain in resolved sibling order;
-  // 'parallel' = legacy behavior where siblings stack at the same start.
-  // Default flipped from 'parallel' to 'sequential' so the Gantt actually
-  // spreads out without requiring a per-parent toggle.
-  childrenScheduling: text('children_scheduling').notNull().default('sequential'),
 
   // ── Orchestration substrate (#111) ───────────────────────────
   // claimed_by_session: session ID that owns this node for active work.

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -386,7 +386,6 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           externalLinks: [],
           autoProgress: 'off',
           priorityRank: null,
-          childrenScheduling: 'sequential' as const,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -168,7 +168,6 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       dueDate?: string;
       autoProgress?: 'off' | 'children';
       priorityRank?: number | null;
-      childrenScheduling?: 'parallel' | 'sequential';
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`
        * auto-link backstop (#58). Useful when the leading `#NNNN` is

--- a/packages/tool-kit/src/tools/bulk.ts
+++ b/packages/tool-kit/src/tools/bulk.ts
@@ -14,7 +14,6 @@ const VALID_NODE_FIELDS = new Set([
   'tags',
   'assigneeIds',
   'priorityRank',
-  'childrenScheduling',
 ]);
 
 /**

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -27,12 +27,6 @@ export const createNodeTool = defineTool({
       .describe(
         'Fractional rank for sibling ordering within the same parent (Gantt slice 1). Lower numbers appear earlier. Use (A.rank + B.rank) / 2 for midpoint insertion. null = no explicit rank (sorts after ranked siblings).',
       ),
-    childrenScheduling: z
-      .enum(['parallel', 'sequential'])
-      .optional()
-      .describe(
-        "How this node's children are scheduled relative to each other. 'parallel' (default) = existing behavior. 'sequential' = implicit FS chain in resolved sibling order.",
-      ),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -78,12 +72,6 @@ export const updateNodeTool = defineTool({
       .optional()
       .describe(
         'Fractional rank for sibling ordering within the same parent (Gantt slice 1). Lower numbers appear first. Use (A.rank + B.rank) / 2 to insert between two nodes. null clears the rank.',
-      ),
-    childrenScheduling: z
-      .enum(['parallel', 'sequential'])
-      .optional()
-      .describe(
-        "How this node's children are scheduled relative to each other. 'parallel' (default) = existing behavior, each child starts as early as its own deps allow. 'sequential' = implicit FS chain in resolved sibling order (priorityRank ASC NULLS LAST → priority enum → createdAt ASC). Explicit dep edges still win over the implicit chain.",
       ),
     // Orchestration substrate (#111)
     scopes: z


### PR DESCRIPTION
Replaces the sibling-chain machinery (#109/#121–#129) with a single-track priority queue.

**Model:** every leaf has a priority; the Gantt is laid out in priority order (item 2 starts when item 1 ends, etc). Tree structure is for visual grouping. Priority inheritance ensures blockers run before their high-priority dependents.

**Stats:** -698 / +311 lines, 16 files. All tests green except 1 pre-existing flake.

Closes the saga.