### PR TITLE
feat(scheduler): nodes.completedAt + hide-done toggle

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -38,6 +38,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     externalLinks: [],
     autoProgress: 'off',
     priorityRank: null,
+    completedAt: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -36,6 +36,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     externalLinks: [],
     autoProgress: 'off',
     priorityRank: null,
+    completedAt: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -39,6 +39,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     externalLinks: [],
     autoProgress: 'off',
     priorityRank: null,
+    completedAt: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -294,6 +294,11 @@ export function resolvedSiblingOrder(children: Node[]): Node[] {
  *    produce different timelines depending on assumed parallelism, but
  *    the plan itself never changes.
  *
+ * 4. **Done leaves keep their close date.** When the optional
+ *    `completedAtByNodeId` map carries an entry for a done leaf, the bar
+ *    ENDS at that scheduler-unit offset (real close date), with effort
+ *    as width. Without an entry, falls back to ending at `todayDay`.
+ *
  * What this replaces: the synthetic-FS-chain machinery from #109/#121–#129.
  * The old model invented edges to mimic sequential ordering at each level,
  * and those invented edges fought with user explicit deps, creating cycles
@@ -311,6 +316,7 @@ export function schedule(
   context?: ScheduleContext,
   workerCount: number = 1,
   todayDay: number = projectStartDay,
+  completedAtByNodeId?: Map<NodeId, number>,
 ): ScheduledNode[] {
   // Step 1: Expand any parent-level user deps to leaves (handles the rare
   // case where someone wrote "Section A depends on Section B" at the parent
@@ -411,10 +417,13 @@ export function schedule(
     const isDone = (node.percentComplete ?? 0) >= 100;
     if (isDone) {
       const doneDuration = leafDuration(node.effortEstimate);
+      // Position the bar so it ENDS at the node's actual close date if we
+      // have one, otherwise fall back to ending at today. Width = effort.
+      const endAt = completedAtByNodeId?.get(node.id) ?? todayDay;
       scheduled.set(node.id, {
         nodeId: node.id,
-        computedStart: todayDay - doneDuration,
-        computedEnd: todayDay,
+        computedStart: endAt - doneDuration,
+        computedEnd: endAt,
         duration: doneDuration,
       });
       doneMarkers.add(node.id);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -125,6 +125,15 @@ export interface Node {
    */
   priorityRank: number | null;
 
+  /**
+   * ISO 8601 timestamp of when this node was marked done. Set when status
+   * transitions into a 'done' workflow category OR percentComplete hits 100;
+   * cleared when either un-dones. Used by the Gantt scheduler to position
+   * done bars at their actual close date in the past.
+   * null = either not done, or done before the column existed (no history).
+   */
+  completedAt: string | null;
+
   // ── Orchestration substrate (#111) ────────────────────────────
 
   /**

--- a/packages/mindmap/src/GanttView.tsx
+++ b/packages/mindmap/src/GanttView.tsx
@@ -281,6 +281,16 @@ export function GanttView() {
   const [workersInput, setWorkersInput] = useState<number>(1);
   const [savingWorkers, setSavingWorkers] = useState(false);
   const [showBehindOnly, setShowBehindOnly] = useState(false);
+  // Hide done items from the Gantt — persisted per-user in localStorage so
+  // the choice survives page refresh and tab switches.
+  const [hideDone, setHideDone] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem('mindblown_gantt_hide_done') === '1';
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('mindblown_gantt_hide_done', hideDone ? '1' : '0');
+  }, [hideDone]);
   const [taskListWidth, setTaskListWidth] = useState<number>(() => {
     const raw = typeof window !== 'undefined' ? window.localStorage.getItem(TASK_WIDTH_STORAGE_KEY) : null;
     const n = raw ? parseInt(raw, 10) : NaN;
@@ -459,6 +469,11 @@ export function GanttView() {
         for (const cid of node.childrenIds) walk(cid, depth);
         return;
       }
+      // Hide done items — both done leaves AND parents whose subtree is
+      // entirely done (percentComplete >= 100 propagates via rollup).
+      if (hideDone && (node.percentComplete ?? 0) >= 100) {
+        return;
+      }
       const hasChildren = node.childrenIds.length > 0;
       const isExpanded = !collapsedSet.has(nodeId);
       result.push({
@@ -480,6 +495,7 @@ export function GanttView() {
     activeVersionFilter,
     activeCycleFilter,
     showBehindOnly,
+    hideDone,
     computed,
   ]);
 
@@ -1074,6 +1090,30 @@ export function GanttView() {
             ✓ {savedFlash}
           </span>
         )}
+
+        {/* Hide done toggle */}
+        <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
+        <button
+          onClick={() => setHideDone((v) => !v)}
+          title={
+            hideDone
+              ? 'Showing only active work. Click to include done items.'
+              : 'Showing all rows. Click to hide done items.'
+          }
+          style={{
+            padding: '3px 10px',
+            borderRadius: 4,
+            border: '1px solid #e2e8f0',
+            fontSize: 11,
+            fontWeight: 600,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+            background: hideDone ? '#4f46e5' : '#fff',
+            color: hideDone ? '#fff' : '#475569',
+          }}
+        >
+          {hideDone ? 'Hide done ✓' : 'Hide done'}
+        </button>
 
         {/* Baseline selector */}
         {baselines.length > 0 && (

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -838,6 +838,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       externalLinks: [],
       autoProgress: 'off',
       priorityRank: null,
+    completedAt: null,
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -35,6 +35,9 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     externalLinks: (get('externalLinks', 'external_links') as CoreNode['externalLinks']) ?? [],
     autoProgress: ((get('autoProgress', 'auto_progress') as CoreNode['autoProgress']) ?? 'off'),
     priorityRank: (get('priorityRank', 'priority_rank') as number) ?? null,
+    completedAt: (get('completedAt', 'completed_at') instanceof Date
+      ? (get('completedAt', 'completed_at') as Date).toISOString()
+      : (get('completedAt', 'completed_at') as string)) ?? null,
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -690,5 +690,42 @@ export async function runMigrations(): Promise<void> {
   // v0.16.1 is a no-op now that the column has been dropped; the marker
   // row stays in data_migrations as historical record.)
 
+  // ── nodes.completed_at (v0.17.6) ───────────────────────────────
+  // Timestamp of when a node was marked done. Written by updateNode on
+  // status→done category or percentComplete→100 transitions; cleared on
+  // un-done. Used by the Gantt to position done bars at real close dates.
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ
+  `);
+
+  // One-shot backfill: for every currently-done node without a
+  // completedAt, derive a best-effort timestamp from history. Priority:
+  //   1. Latest change_event where field_name in ('status','percentComplete')
+  //   2. Fallback: the node's updated_at
+  // Items completed before the change_events table started getting
+  // populated (or by bulk imports that bypass updateNode) land at
+  // updated_at — imperfect but past, which is the point.
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM data_migrations WHERE id = 'backfill_completed_at_v1') THEN
+        UPDATE nodes n
+        SET completed_at = COALESCE(
+          (
+            SELECT MAX(ce.created_at) FROM change_events ce
+            WHERE ce.node_id = n.id
+              AND ce.event_type = 'node.field_changed'
+              AND ce.field_name IN ('status', 'percentComplete')
+          ),
+          n.updated_at
+        )
+        WHERE n.percent_complete >= 100
+          AND n.completed_at IS NULL
+          AND n.deleted_at IS NULL;
+        INSERT INTO data_migrations (id) VALUES ('backfill_completed_at_v1');
+      END IF;
+    END $$;
+  `);
+
   console.log('[db] Migrations complete.');
 }

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -109,6 +109,7 @@ export interface CreateNodeInput {
   dueDate?: string;
   autoProgress?: 'off' | 'children';
   priorityRank?: number | null;
+  completedAt?: string | null;
 }
 
 export async function createNode(
@@ -141,6 +142,7 @@ export async function createNode(
     dueDate: input.dueDate ?? null,
     autoProgress: input.autoProgress ?? 'off',
     priorityRank: input.priorityRank ?? null,
+    completedAt: input.completedAt ? new Date(input.completedAt) : null,
     assigneeIds: [],
     tags: [],
     customFields: {},
@@ -214,6 +216,7 @@ export interface UpdateNodeInput {
   externalLinks?: ExternalLink[];
   autoProgress?: 'off' | 'children';
   priorityRank?: number | null;
+  completedAt?: string | null;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -289,14 +292,18 @@ export async function updateNode(
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;
   if (input.scopes !== undefined) updates.scopes = input.scopes;
 
-  // Auto-release claim when status transitions to a 'done' category (#111).
-  // We only need to act when `input.status` is being set AND neither
-  // `claimedBySession` nor `claimedAt` is already being cleared by the
-  // same call (to avoid clobbering explicit claim manipulation).
-  if (input.status !== undefined && input.status !== null
-      && input.claimedBySession === undefined && input.claimedAt === undefined) {
-    // Resolve the map's status workflow to check whether the target status
-    // maps to the 'done' category. We need the node's mapId for this.
+  // Auto-release claim when status transitions to a 'done' category (#111)
+  // + write completedAt timestamp for the Gantt scheduler (v0.17.6).
+  // Both behaviors hinge on the same workflow lookup, so we do them
+  // together. We only act when the caller doesn't already manipulate
+  // those fields explicitly in this same call.
+  const statusChanging = input.status !== undefined;
+  const pctChanging = input.percentComplete !== undefined;
+  const completedAtTouched = input.completedAt !== undefined;
+  const claimTouched =
+    input.claimedBySession !== undefined || input.claimedAt !== undefined;
+
+  if ((statusChanging || pctChanging) && (!claimTouched || !completedAtTouched)) {
     const [nodeForMap] = await handle
       .select({ mapId: nodes.mapId })
       .from(nodes)
@@ -307,14 +314,47 @@ export async function updateNode(
         .from(maps)
         .where(eq(maps.id, nodeForMap.mapId as string));
       const workflow = ((mapRow?.statusWorkflow as StatusDef[]) ?? []);
-      const targetDef = workflow.find(
-        (s) => s.id === input.status || s.name.toLowerCase() === (input.status as string).toLowerCase(),
-      );
-      if (targetDef?.category === 'done') {
+
+      // Resolve whether the post-update node is "done":
+      //   - status (if changing) → check its category in the workflow
+      //   - percentComplete >= 100 (if changing) → done
+      let movingToDone = false;
+      let movingFromDone = false;
+      if (statusChanging && input.status !== null) {
+        const targetDef = workflow.find(
+          (s) =>
+            s.id === input.status ||
+            s.name.toLowerCase() === (input.status as string).toLowerCase(),
+        );
+        if (targetDef?.category === 'done') movingToDone = true;
+        else movingFromDone = true;
+      } else if (statusChanging && input.status === null) {
+        // Status cleared → no longer done.
+        movingFromDone = true;
+      }
+      if (pctChanging && input.percentComplete !== null && input.percentComplete !== undefined) {
+        if (input.percentComplete >= 100) movingToDone = true;
+        else movingFromDone = true;
+      } else if (pctChanging && input.percentComplete === null) {
+        movingFromDone = true;
+      }
+
+      if (movingToDone && !claimTouched) {
         updates.claimedBySession = null;
         updates.claimedAt = null;
       }
+      if (movingToDone && !completedAtTouched) {
+        updates.completedAt = new Date();
+      } else if (movingFromDone && !completedAtTouched && !movingToDone) {
+        // Transitioning OUT of done with no overriding move-to-done in
+        // the same call → clear the timestamp.
+        updates.completedAt = null;
+      }
     }
+  }
+
+  if (input.completedAt !== undefined) {
+    updates.completedAt = input.completedAt ? new Date(input.completedAt) : null;
   }
 
   // Conditional update: when expectedRevision is provided, the WHERE clause

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -180,6 +180,13 @@ export const nodes = pgTable('nodes', {
   // null = no explicit rank (sorts after ranked siblings in resolved order).
   priorityRank: real('priority_rank'),
 
+  // ── Completion timestamp (v0.17.6) ────────────────────────────
+  // Set when status transitions into a 'done' workflow category OR
+  // percentComplete hits 100; cleared when either un-dones. Used by
+  // the Gantt to position done bars at their actual close date in
+  // the past instead of piling them on the today line.
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+
   // ── Orchestration substrate (#111) ───────────────────────────
   // claimed_by_session: session ID that owns this node for active work.
   //   null = unclaimed / available.

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -387,6 +387,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           externalLinks: [],
           autoProgress: 'off',
           priorityRank: null,
+          completedAt: null,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,
@@ -534,7 +535,19 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     todayDate.setUTCHours(0, 0, 0, 0);
     const todayDay = toDayOffset(todayDate.toISOString().slice(0, 10));
 
-    const scheduled = schedule(scopedNodes, 0, constraints, undefined, effectiveWorkers, todayDay);
+    // Build per-node completedAt offsets so done bars sit at their actual
+    // close dates instead of all piling on `todayDay`. Backfill populated
+    // these via the migration; new completions write them on each status
+    // transition. Nodes without a completedAt fall back to today in the
+    // scheduler.
+    const completedAtByNodeId = new Map<NodeId, number>();
+    for (const n of scopedNodes) {
+      if (n.completedAt) {
+        completedAtByNodeId.set(n.id, toDayOffset(n.completedAt.slice(0, 10)));
+      }
+    }
+
+    const scheduled = schedule(scopedNodes, 0, constraints, undefined, effectiveWorkers, todayDay, completedAtByNodeId);
     const cp = criticalPath(scopedNodes);
 
     return reply.send({


### PR DESCRIPTION
Adds nodes.completedAt column with backfill from change_events; scheduler now positions done bars at their actual close dates instead of piling on today. Plus a Hide-done toolbar toggle for users who want the future-only view.