### PR TITLE
feat(triage): persist + surface suggested parent for place decisions

### DIFF
--- a/packages/mindmap/src/NodePickerModal.tsx
+++ b/packages/mindmap/src/NodePickerModal.tsx
@@ -12,7 +12,7 @@
  * the mindmap is already rendering.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Node } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 
@@ -28,11 +28,21 @@ interface TreeRow {
 export function NodePickerModal({
   title,
   excludeNodeIds = [],
+  initialSelectedNodeId = null,
   onPick,
   onClose,
 }: {
   title: string;
   excludeNodeIds?: string[];
+  /**
+   * Pre-selected node when the picker opens. Used by the triage Override
+   * flow on low-confidence places to pre-pick the LLM's suggested epic.
+   * The node is selected (highlighted), all its ancestors are expanded
+   * so the row is visible, and the row scrolls into view. If the node
+   * isn't in the current tree (deleted or never existed), the prop is
+   * silently ignored and the picker opens with no selection.
+   */
+  initialSelectedNodeId?: string | null;
   onPick: (nodeId: string) => void;
   onClose: () => void;
 }) {
@@ -47,7 +57,9 @@ export function NodePickerModal({
   const [search, setSearch] = useState('');
   const [expanded, setExpanded] = useState<Set<string>>(() => {
     // Expand the root + its direct children by default — that's the
-    // "epic shelf" most overrides target.
+    // "epic shelf" most overrides target. When an initial selection is
+    // provided AND it's a node we know about, also expand every
+    // ancestor so the pre-selected row is visible without scrolling.
     const initial = new Set<string>();
     if (rootNodeId) {
       initial.add(rootNodeId);
@@ -56,9 +68,37 @@ export function NodePickerModal({
         for (const childId of root.childrenIds) initial.add(childId);
       }
     }
+    if (initialSelectedNodeId && nodes[initialSelectedNodeId]) {
+      let cur: string | null | undefined = nodes[initialSelectedNodeId]?.parentId ?? null;
+      while (cur) {
+        initial.add(cur);
+        cur = nodes[cur]?.parentId ?? null;
+      }
+    }
     return initial;
   });
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(() => {
+    // Only honor the initial selection if the node is actually in the
+    // tree. A suggestion that points at a deleted node is silently
+    // ignored — the badge in TriagePanel renders a "(no longer exists)"
+    // affordance for that case; the picker opens unselected.
+    if (initialSelectedNodeId && nodes[initialSelectedNodeId]) {
+      return initialSelectedNodeId;
+    }
+    return null;
+  });
+  const selectedRowRef = useRef<HTMLDivElement | null>(null);
+
+  // Scroll the pre-selected row into view once the tree has rendered.
+  // We only fire on the first mount (or the first time the selection
+  // becomes resolvable) — subsequent clicks shouldn't yank the scroll
+  // position.
+  useEffect(() => {
+    if (selectedRowRef.current) {
+      selectedRowRef.current.scrollIntoView({ block: 'center', behavior: 'auto' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const excludeSet = useMemo(() => new Set(excludeNodeIds), [excludeNodeIds]);
 
@@ -259,6 +299,7 @@ export function NodePickerModal({
                   key={row.node.id}
                   data-testid="node-picker-row"
                   data-node-id={row.node.id}
+                  ref={isSelected ? selectedRowRef : undefined}
                   onClick={() => {
                     if (!isExcluded) setSelectedNodeId(row.node.id);
                   }}

--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -601,6 +601,15 @@ export function TriagePanel({
         <NodePickerModal
           title={`Pick a parent for "${pickerForDecision.issueTitle}"`}
           excludeNodeIds={pickerForDecision.placedNodeId ? [pickerForDecision.placedNodeId] : []}
+          // Pre-select the LLM's suggested parent when the operator
+          // opens Override on a place decision. The suggestion column
+          // is set on every auto-triage call (high- and low-confidence
+          // alike), so the operator confirms with one click instead of
+          // re-deriving the suggestion from the `reason` text. If the
+          // suggested node was deleted, NodePickerModal silently drops
+          // the pre-selection and opens unselected — the "(no longer
+          // exists)" badge on the card surfaces that to the operator.
+          initialSelectedNodeId={pickerForDecision.suggestedParentNodeId}
           onPick={handlePickParent}
           onClose={() => setPickerForDecision(null)}
         />
@@ -1055,6 +1064,25 @@ function TriageCard({
         {decision.reason}
       </div>
 
+      {/* Suggested-parent badge (place decisions only). The column is
+          set on every LLM call regardless of confidence, so a
+          low-confidence place that didn't auto-apply still surfaces
+          the suggestion here — operator clicks the badge to open the
+          Override picker pre-selected on that epic. Hidden on skipped
+          / uncertain (the suggestion is meaningless there).
+
+          When the suggested node was deleted between triage time and
+          now, we render "(no longer exists)" in muted style so the
+          operator knows to re-classify instead of confirming a stale
+          suggestion. */}
+      {decision.decision === 'place' && decision.suggestedParentNodeId && (
+        <SuggestedParentBadge
+          suggestedParentNodeId={decision.suggestedParentNodeId}
+          onClick={onPlace}
+          disabled={busy}
+        />
+      )}
+
       {/* Placed-node link (placed view only) */}
       {view === 'placed' && decision.placedNodeId && (
         <button
@@ -1121,6 +1149,78 @@ function TriageCard({
         />
       </div>
     </div>
+  );
+}
+
+// ── Suggested-parent badge ───────────────────────────────────────
+//
+// Renders under the reason on `place` decisions whose row has a
+// `suggested_parent_node_id` set. The badge text is the suggested
+// node's `text` (looked up in the in-memory store, same way the
+// NodePickerModal resolves names) — falling back to a muted "(no
+// longer exists)" affordance when the suggestion points at a
+// deleted node.
+//
+// Clicking the badge invokes the same handler as the Place/Move
+// button. That handler opens the NodePickerModal, which receives
+// the suggestion via `initialSelectedNodeId` and pre-highlights it
+// — so the operator can confirm with one click or pick a different
+// epic. We deliberately don't add a separate "Place with suggested"
+// shortcut: pre-selection + confirm IS the one-click flow, and an
+// extra button would split the operator's attention between two
+// near-identical affordances.
+
+function SuggestedParentBadge({
+  suggestedParentNodeId,
+  onClick,
+  disabled,
+}: {
+  suggestedParentNodeId: string;
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  const nodes = useMindmapStore((s) => s.nodes);
+  const suggested = nodes[suggestedParentNodeId];
+  const stale = !suggested;
+  const label = stale
+    ? `${suggestedParentNodeId.slice(0, 8)}… (no longer exists)`
+    : suggested.text;
+  return (
+    <button
+      data-testid="triage-card-suggested-parent"
+      data-suggested-parent-node-id={suggestedParentNodeId}
+      data-suggested-stale={stale ? 'true' : 'false'}
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '4px 8px',
+        borderRadius: 4,
+        border: '1px dashed #cbd5e1',
+        background: 'transparent',
+        color: stale ? '#94a3b8' : '#475569',
+        fontStyle: stale ? 'italic' : 'normal',
+        fontSize: 11,
+        fontFamily: 'inherit',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
+        textAlign: 'left',
+      }}
+      title={
+        stale
+          ? 'Claude suggested a parent that no longer exists in this map — re-classify or pick a different one.'
+          : 'Claude suggested this parent. Click to open the picker pre-selected here.'
+      }
+    >
+      <span style={{ color: '#94a3b8', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+        Suggested:
+      </span>
+      <span style={{ flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        {label}
+      </span>
+    </button>
   );
 }
 

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -1108,6 +1108,18 @@ export interface TriageDecision {
   reason: string;
   confidence: number; // 0-100
   placedNodeId: string | null;
+  /**
+   * The LLM's most recent suggested parent (for `place` decisions).
+   * Distinct from `placedNodeId` — the suggestion is the LLM's pick;
+   * `placedNodeId` is set only when a node was actually created. On
+   * low-confidence places, the suggestion is what the Override modal
+   * pre-selects.
+   *
+   * Operator overrides do NOT update this field — it always reflects
+   * the latest LLM suggestion, so the audit history can show "Claude
+   * suggested X, operator chose Y".
+   */
+  suggestedParentNodeId: string | null;
   decidedAt: string;
   decidedBy: 'auto' | 'operator';
   reviewed: boolean;
@@ -1192,6 +1204,12 @@ export interface ReclassifyTriageResponse {
    * (#100 Round 2 nit from Ray.)
    */
   placedNodeId: string | null;
+  /**
+   * The LLM's newly-suggested parent. Always reflects what was just
+   * written to the row's `suggestedParentNodeId` column — null on
+   * skip/uncertain, the suggested epic UUID on place.
+   */
+  suggestedParentNodeId: string | null;
 }
 
 export function reclassifyTriageDecision(
@@ -1247,6 +1265,12 @@ export interface BulkTriageItemOk {
   confidence?: number;
   reason?: string;
   placedNodeId?: string | null;
+  /**
+   * Populated by bulk-reclassify per-item results — mirrors the
+   * single-reclassify response shape so the UI can pre-select the
+   * new LLM suggestion in the Override modal without a refetch.
+   */
+  suggestedParentNodeId?: string | null;
 }
 
 export interface BulkTriageItemErr {

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -553,6 +553,21 @@ export async function runMigrations(): Promise<void> {
     ON triage_decisions(map_id) WHERE reviewed = false
   `);
 
+  // ── suggested_parent_node_id (#TBD) ───────────────────────────
+  // The LLM's most recent suggested parent for `place` decisions —
+  // distinct from `placed_node_id` (which is set only when a node was
+  // actually created). On low-confidence places the operator must
+  // review; without this column the suggestion is only embedded in the
+  // `reason` text and the Override modal opens with empty selection.
+  // FK-less on purpose (mirrors placed_node_id) — when the suggested
+  // node is later deleted, the row stays and the UI shows a "stale
+  // suggestion" badge. Operator overrides do NOT update this column;
+  // it always reflects the latest LLM suggestion so the audit history
+  // can show "Claude suggested X, operator chose Y".
+  await db.execute(sql`
+    ALTER TABLE triage_decisions ADD COLUMN IF NOT EXISTS suggested_parent_node_id UUID
+  `);
+
   // ── Phase 3 (#96) — opt-in GitHub label write-back per map ────
   // When true, finalized triage decisions write `triage:placed` /
   // `triage:skipped` labels back to the source GitHub issue. Default

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -362,6 +362,20 @@ export const triageDecisions = pgTable('triage_decisions', {
   reason: text('reason').notNull(),
   confidence: integer('confidence').notNull(), // 0-100
   placedNodeId: uuid('placed_node_id'),
+  // Suggested parent from the LLM's most recent triage call. Set on every
+  // `place` decision (regardless of auto-apply). Distinct from
+  // placed_node_id: this carries the LLM's suggestion; placed_node_id
+  // carries where the node was actually created (auto-applied or
+  // operator-placed). Lets the Override modal pre-select the LLM's
+  // suggested epic on low-confidence places, instead of asking the
+  // operator to guess from the `reason` text. FK-less (matches
+  // placed_node_id convention) — when the suggested node is later
+  // deleted, the decision row stays around and the UI shows
+  // "Suggested: <id> (no longer exists)" rather than cascading.
+  // Operator overrides do NOT update this field — the column always
+  // reflects the latest LLM suggestion, so the audit history can show
+  // "Claude suggested X, operator chose Y".
+  suggestedParentNodeId: uuid('suggested_parent_node_id'),
   decidedAt: timestamp('decided_at', { withTimezone: true }).notNull().defaultNow(),
   decidedBy: text('decided_by').notNull(), // 'auto' | 'operator'
   reviewed: boolean('reviewed').notNull().default(false),

--- a/packages/server/src/routes/__tests__/triage-reopen.test.ts
+++ b/packages/server/src/routes/__tests__/triage-reopen.test.ts
@@ -36,6 +36,7 @@ interface TriageRow {
   reason: string;
   confidence: number;
   placedNodeId: string | null;
+  suggestedParentNodeId: string | null;
   decidedAt: Date;
   decidedBy: 'auto' | 'operator';
   reviewed: boolean;
@@ -54,6 +55,7 @@ function seedRow(overrides: Partial<TriageRow> & { id: string; mapId: string; ex
     reason: 'r',
     confidence: 40,
     placedNodeId: null,
+    suggestedParentNodeId: null,
     decidedAt: new Date(),
     decidedBy: 'auto',
     reviewed: false,
@@ -141,6 +143,7 @@ vi.mock('../../db/schema.js', () => {
       externalId: col('externalId'),
       issueTitle: col('issueTitle'),
       placedNodeId: col('placedNodeId'),
+      suggestedParentNodeId: col('suggestedParentNodeId'),
       reviewed: col('reviewed'),
       decidedBy: col('decidedBy'),
       issueState: col('issueState'),

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -26,6 +26,7 @@ interface TriageRow {
   reason: string;
   confidence: number;
   placedNodeId: string | null;
+  suggestedParentNodeId: string | null;
   decidedAt: Date;
   decidedBy: 'auto' | 'operator';
   reviewed: boolean;
@@ -68,6 +69,7 @@ function seedRow(overrides: Partial<TriageRow> = {}): TriageRow {
     reason: 'unsure',
     confidence: 40,
     placedNodeId: null,
+    suggestedParentNodeId: null,
     decidedAt: new Date(),
     decidedBy: 'auto',
     reviewed: false,
@@ -207,6 +209,7 @@ vi.mock('../../db/schema.js', () => {
       decidedAt: col('decidedAt'),
       confidence: col('confidence'),
       issueState: col('issueState'),
+      suggestedParentNodeId: col('suggestedParentNodeId'),
     },
     // Phase 3 (#96) — recordTriageHistory inserts into this table from
     // every mutation route. The route tests don't assert on the history
@@ -486,6 +489,41 @@ describe('GET /api/maps/:mapId/triage-decisions', () => {
     expect(decisions.every((d) => d === 'skip')).toBe(true);
   });
 
+  // ── suggested_parent_node_id surfacing ──────────────────────
+  // The column is populated by every LLM-driven write (auto-ingest +
+  // reclassify), distinct from placedNodeId which only flips on
+  // actual node creation. The GET list response must surface it so
+  // the Override modal can pre-select the suggestion.
+  it('returns suggestedParentNodeId on each row', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      confidence: 60, // low-confidence — no auto-apply, placedNodeId null
+      placedNodeId: null,
+      suggestedParentNodeId: 'epic-suggested',
+    });
+    seedRow({
+      id: 'tr-2',
+      decision: 'skip',
+      suggestedParentNodeId: null,
+    });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const decisions = res.json().decisions as Array<{
+      id: string;
+      suggestedParentNodeId: string | null;
+    }>;
+    const byId = Object.fromEntries(decisions.map((d) => [d.id, d.suggestedParentNodeId]));
+    expect(byId['tr-1']).toBe('epic-suggested');
+    expect(byId['tr-2']).toBeNull();
+  });
+
   it('honors limit and caps at 200', async () => {
     for (let i = 0; i < 10; i++) seedRow({ id: `t${i}` });
     permissionLevel = 'view';
@@ -737,6 +775,70 @@ describe('POST .../override', () => {
     expect(res.json().status).toBe('already_placed');
     expect(moveNodeMock).not.toHaveBeenCalled();
   });
+
+  // suggested_parent_node_id semantic: the column always reflects the
+  // latest LLM suggestion, NEVER the operator's pick. So an override
+  // that lands a place under parentNodeId=X leaves the original LLM
+  // suggestion untouched — that way the audit history shows "Claude
+  // suggested Y, operator chose X." Without this guard, the override
+  // route would silently rewrite the suggestion to whatever the
+  // operator clicked, erasing the audit signal.
+  it('place override does NOT overwrite suggestedParentNodeId (operator pick ≠ LLM suggestion)', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      confidence: 60,
+      placedNodeId: null,
+      // LLM suggested epic-X with low confidence.
+      suggestedParentNodeId: 'epic-X',
+    });
+    nodes.set('epic-Y', { id: 'epic-Y', mapId: 'map-1', parentId: 'root-1' });
+    permissionLevel = 'edit';
+
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/override',
+      // Operator picks epic-Y — different from the LLM's epic-X.
+      payload: {
+        decision: 'place',
+        parentNodeId: 'epic-Y',
+        reason: 'better fit',
+      },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const row = triageRows.get('tr-1')!;
+    // placedNodeId stamped to the newly-created node (operator pick).
+    expect(row.placedNodeId).toBe('created-node');
+    // But the LLM suggestion column is INTACT — the audit history can
+    // still surface "Claude suggested epic-X, operator chose epic-Y."
+    expect(row.suggestedParentNodeId).toBe('epic-X');
+  });
+
+  // Mirror the same invariant for the skip/uncertain override branch —
+  // a place row that the operator skips must keep the suggestion intact
+  // (it's still the most recent LLM call's output).
+  it('skip override does NOT overwrite suggestedParentNodeId', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      confidence: 60,
+      suggestedParentNodeId: 'epic-X',
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/override',
+      payload: { decision: 'skip', reason: 'not for us' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const row = triageRows.get('tr-1')!;
+    expect(row.decision).toBe('skip');
+    expect(row.suggestedParentNodeId).toBe('epic-X');
+  });
 });
 
 // ── POST /confirm ────────────────────────────────────────────────
@@ -945,6 +1047,58 @@ describe('POST .../reclassify', () => {
     // also doesn't clear the previously-placed node id, since the new
     // decision is still 'place'.
     expect(row.placedNodeId).toBe('node-still-here');
+  });
+
+  // Counterpart to the override-doesn't-touch-suggestion tests above.
+  // Reclassify is the LLM speaking; the suggested-parent column MUST
+  // refresh on every reclassify so a stale suggestion can't linger
+  // past a re-run.
+  it('reclassify → place refreshes suggestedParentNodeId from LLM output', async () => {
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      confidence: 50,
+      // Stale suggestion from an earlier LLM call.
+      suggestedParentNodeId: 'epic-stale',
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/reclassify',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    // Default triageIssueMock returns parentNodeId='epic-1' on place.
+    expect(res.json().suggestedParentNodeId).toBe('epic-1');
+    const row = triageRows.get('tr-1')!;
+    expect(row.suggestedParentNodeId).toBe('epic-1');
+  });
+
+  it('reclassify → skip nulls suggestedParentNodeId', async () => {
+    triageIssueMock.mockResolvedValueOnce({
+      decision: 'skip' as const,
+      parentNodeId: undefined,
+      reason: 'no longer relevant',
+      confidence: 92,
+    } as unknown as Awaited<ReturnType<typeof triageIssueMock>>);
+    seedRow({
+      id: 'tr-1',
+      decision: 'place',
+      confidence: 50,
+      suggestedParentNodeId: 'epic-was-suggested',
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/reclassify',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().suggestedParentNodeId).toBeNull();
+    const row = triageRows.get('tr-1')!;
+    expect(row.suggestedParentNodeId).toBeNull();
   });
 });
 

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -260,12 +260,19 @@ export async function syncTriageRowsForReopen(
       // fix 4 — orphan cleanup).
       const clearPlacedNode =
         decision.decision !== 'place' && row.placedNodeId != null;
+      // The reopen-driven re-triage is an LLM call — refresh the
+      // suggested-parent column with the new pick (null on
+      // skip/uncertain). Operator overrides never touch this field;
+      // every LLM-driven write does.
+      const newSuggestedParentNodeId =
+        decision.decision === 'place' ? (decision.parentNodeId ?? null) : null;
       await db
         .update(triageDecisions)
         .set({
           decision: decision.decision,
           reason: decision.reason,
           confidence: decision.confidence,
+          suggestedParentNodeId: newSuggestedParentNodeId,
           decidedBy: 'auto',
           decidedAt: new Date(),
           reviewed: false,

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -820,6 +820,12 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       // NOT auto-deleted on reclassify (Ray's spec: "operator can
       // delete via UI") — only the decision-row reference is dropped.
       const clearPlacedNode = decision.decision !== 'place' && row.placedNodeId != null;
+      // Reclassify is an LLM call — refresh the suggested-parent
+      // column with the new pick (null on skip/uncertain). This is
+      // what the Override modal pre-selects when the operator opens
+      // it for a low-confidence place.
+      const newSuggestedParentNodeId =
+        decision.decision === 'place' ? (decision.parentNodeId ?? null) : null;
 
       await db
         .update(triageDecisions)
@@ -827,6 +833,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           decision: decision.decision,
           reason: decision.reason,
           confidence: decision.confidence,
+          suggestedParentNodeId: newSuggestedParentNodeId,
           decidedBy: 'auto',
           decidedAt: new Date(),
           reviewed: false,
@@ -880,6 +887,10 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         // client doesn't need a refetch to learn the row no longer
         // references the previously-placed node (Ray's #100 nit).
         placedNodeId: clearPlacedNode ? null : (row.placedNodeId ?? null),
+        // Suggested parent reflects the LLM's new pick — surfaced so
+        // the operator's next Override modal can pre-select it without
+        // a refetch. Always matches what was just written to the row.
+        suggestedParentNodeId: newSuggestedParentNodeId,
       });
     },
   );
@@ -975,6 +986,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
     confidence?: number;
     reason?: string;
     placedNodeId?: string | null;
+    suggestedParentNodeId?: string | null;
   }
   interface BulkItemErr {
     id: string;
@@ -1476,12 +1488,20 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           });
           const clearPlacedNode =
             decision.decision !== 'place' && row.placedNodeId != null;
+          // Mirror single /reclassify: refresh the LLM's suggested
+          // parent on every bulk re-classify call. Operator overrides
+          // never touch this column; every LLM-driven write does.
+          const newSuggestedParentNodeId =
+            decision.decision === 'place'
+              ? (decision.parentNodeId ?? null)
+              : null;
           await db
             .update(triageDecisions)
             .set({
               decision: decision.decision,
               reason: decision.reason,
               confidence: decision.confidence,
+              suggestedParentNodeId: newSuggestedParentNodeId,
               decidedBy: 'auto',
               decidedAt: new Date(),
               reviewed: false,
@@ -1521,6 +1541,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
             confidence: decision.confidence,
             reason: decision.reason,
             placedNodeId: clearPlacedNode ? null : (row.placedNodeId ?? null),
+            suggestedParentNodeId: newSuggestedParentNodeId,
           });
         } catch (err) {
           results.push({

--- a/packages/server/src/scripts/backfill-suggested-parent.ts
+++ b/packages/server/src/scripts/backfill-suggested-parent.ts
@@ -1,0 +1,235 @@
+/**
+ * One-off backfill: populate `suggested_parent_node_id` on existing
+ * low-confidence `place` triage rows whose `placed_node_id IS NULL`.
+ *
+ * Why this exists
+ * ---------------
+ * The `suggested_parent_node_id` column was added to `triage_decisions`
+ * AFTER several rounds of auto-triage had already run. Rows written
+ * before the column existed have `suggested_parent_node_id = NULL`,
+ * which means the new Override-modal pre-selection has nothing to
+ * latch onto for the exact rows the feature targets (low-confidence
+ * places that the operator must review).
+ *
+ * The fix is to re-run `triageIssue` once per affected row, with the
+ * row's stored title + state as input, and write the LLM's suggested
+ * parent into the new column. The existing `/reclassify` route does
+ * exactly this — we reach into it via the same `triageIssue` helper
+ * rather than HTTP-bouncing through Fastify, so the script can be
+ * run from a one-shot container without standing up the API server.
+ *
+ * Scope
+ * -----
+ * Only touches rows where:
+ *   - `decision = 'place'`
+ *   - `placed_node_id IS NULL` (low-confidence — auto-apply didn't fire)
+ *   - `suggested_parent_node_id IS NULL` (not already backfilled)
+ *   - the parent map is `triage_enabled = true`
+ *
+ * For each affected row, runs one LLM call. The current MindBlown
+ * self-map (df1d3294-09a1-4d08-9099-0899b76efaed) has 5 such rows so
+ * the cost is ~5 cents on Opus. This script is idempotent — running
+ * twice is a no-op because the second pass finds no rows matching
+ * the `suggested_parent_node_id IS NULL` filter.
+ *
+ * Run as
+ * ------
+ *   DATABASE_URL=... ANTHROPIC_API_KEY=... \
+ *     tsx packages/server/src/scripts/backfill-suggested-parent.ts
+ *
+ * Or with an explicit map filter:
+ *   tsx packages/server/src/scripts/backfill-suggested-parent.ts \
+ *     --map-id df1d3294-09a1-4d08-9099-0899b76efaed
+ *
+ * Not invoked automatically. The schema migration is idempotent and
+ * runs every startup; the backfill is gated to one-off manual run so
+ * a server restart can't spam the LLM.
+ */
+
+import { and, eq, isNull } from 'drizzle-orm';
+import { db, pool } from '../db/connection.js';
+import { maps, triageDecisions } from '../db/schema.js';
+import { buildMapContext } from '../sync/mapContext.js';
+import { triageIssue } from '../sync/triage.js';
+
+function parseIssueNumber(externalId: string): number {
+  const idx = externalId.lastIndexOf('#');
+  if (idx < 0) return 0;
+  const n = parseInt(externalId.slice(idx + 1), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function buildIssueUrlFromExternalId(externalId: string): string {
+  const idx = externalId.lastIndexOf('#');
+  if (idx < 0) return '';
+  const ownerRepo = externalId.slice(0, idx);
+  const number = externalId.slice(idx + 1);
+  return `https://github.com/${ownerRepo}/issues/${number}`;
+}
+
+interface BackfillRow {
+  id: string;
+  mapId: string;
+  externalId: string;
+  issueTitle: string;
+  issueState: string;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const mapIdFlagIdx = args.indexOf('--map-id');
+  const targetMapId =
+    mapIdFlagIdx >= 0 && args[mapIdFlagIdx + 1] ? args[mapIdFlagIdx + 1] : null;
+
+  const dryRun = args.includes('--dry-run');
+
+  console.log('[backfill] starting suggested_parent_node_id retro-fill');
+  if (targetMapId) console.log(`[backfill]   filter: map_id=${targetMapId}`);
+  if (dryRun) console.log('[backfill]   DRY RUN — no writes, no LLM calls');
+
+  // Find every row that needs backfilling. Strict filter set: place
+  // decision, no placed node, no existing suggestion. We DON'T touch
+  // skip/uncertain rows (suggestion is irrelevant) or already-placed
+  // rows (auto-apply already happened — suggestion ≠ placed but the
+  // operator's view of "what to do next" is satisfied without it).
+  const filters = [
+    eq(triageDecisions.decision, 'place'),
+    isNull(triageDecisions.placedNodeId),
+    isNull(triageDecisions.suggestedParentNodeId),
+  ];
+  if (targetMapId) {
+    filters.push(eq(triageDecisions.mapId, targetMapId));
+  }
+  const rows: BackfillRow[] = await db
+    .select({
+      id: triageDecisions.id,
+      mapId: triageDecisions.mapId,
+      externalId: triageDecisions.externalId,
+      issueTitle: triageDecisions.issueTitle,
+      issueState: triageDecisions.issueState,
+    })
+    .from(triageDecisions)
+    .where(and(...filters));
+
+  console.log(`[backfill] found ${rows.length} candidate row(s)`);
+
+  // Group by mapId so we build mapContext once per map, not once per row.
+  // Same optimisation the bulk-reclassify route uses. For one map with
+  // 5 rows this saves 4 buildMapContext calls (a few ms each, but cleaner).
+  const rowsByMap = new Map<string, BackfillRow[]>();
+  for (const row of rows) {
+    const existing = rowsByMap.get(row.mapId) ?? [];
+    existing.push(row);
+    rowsByMap.set(row.mapId, existing);
+  }
+
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const [mapId, mapRows] of rowsByMap) {
+    // Per-map gate: only backfill if the map still has triage_enabled.
+    // A map that disabled triage between the auto-call and the
+    // backfill shouldn't get fresh LLM calls — the operator opted out.
+    const [m] = await db
+      .select({ triageEnabled: maps.triageEnabled })
+      .from(maps)
+      .where(eq(maps.id, mapId));
+    if (!m || m.triageEnabled !== true) {
+      console.warn(
+        `[backfill] skipping map ${mapId}: triage_enabled=${m?.triageEnabled} (need true)`,
+      );
+      skipped += mapRows.length;
+      continue;
+    }
+
+    let mapContext;
+    try {
+      mapContext = await buildMapContext(mapId);
+    } catch (err) {
+      console.error(
+        `[backfill] failed to build context for map ${mapId}:`,
+        err instanceof Error ? err.message : err,
+      );
+      errors += mapRows.length;
+      continue;
+    }
+
+    for (const row of mapRows) {
+      try {
+        if (dryRun) {
+          console.log(
+            `[backfill] DRY: would re-triage ${row.externalId} (decision ${row.id})`,
+          );
+          skipped++;
+          continue;
+        }
+
+        const issueNumber = parseIssueNumber(row.externalId);
+        const decision = await triageIssue({
+          issue: {
+            id: issueNumber,
+            number: issueNumber,
+            title: row.issueTitle,
+            body: null,
+            state: row.issueState === 'closed' ? 'closed' : 'open',
+            labels: [],
+            assignees: [],
+            milestone: null,
+            html_url: buildIssueUrlFromExternalId(row.externalId),
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+          mapContext,
+        });
+
+        // Always write the new suggestion (null on skip/uncertain),
+        // because the row is by definition a stale low-confidence
+        // place — if the new LLM call decides skip, we want the
+        // suggestion column to reflect that. We do NOT rewrite
+        // `decision` / `confidence` / `placedNodeId` here, because
+        // this is a column-backfill, not a reclassify. The operator's
+        // review queue still shows the original auto-decision; the
+        // only thing that changes is the badge surfaces a usable
+        // pre-selection.
+        const newSuggestedParentNodeId =
+          decision.decision === 'place' ? (decision.parentNodeId ?? null) : null;
+
+        await db
+          .update(triageDecisions)
+          .set({ suggestedParentNodeId: newSuggestedParentNodeId })
+          .where(eq(triageDecisions.id, row.id));
+
+        if (newSuggestedParentNodeId) {
+          console.log(
+            `[backfill]   ${row.externalId}: suggested ${newSuggestedParentNodeId}`,
+          );
+          updated++;
+        } else {
+          console.log(
+            `[backfill]   ${row.externalId}: new decision is ${decision.decision}, no parent suggestion`,
+          );
+          // Still counts as updated — we wrote NULL deliberately.
+          updated++;
+        }
+      } catch (err) {
+        console.error(
+          `[backfill] ${row.externalId}: failed —`,
+          err instanceof Error ? err.message : err,
+        );
+        errors++;
+      }
+    }
+  }
+
+  console.log(
+    `[backfill] done: ${updated} updated / ${skipped} skipped / ${errors} errors`,
+  );
+  await pool.end();
+  process.exit(errors > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('[backfill] fatal:', err);
+  process.exit(1);
+});

--- a/packages/server/src/sync/__tests__/githubIngest.test.ts
+++ b/packages/server/src/sync/__tests__/githubIngest.test.ts
@@ -1005,6 +1005,11 @@ describe('ensureNodeForIssue — triage fork', () => {
     });
     // placed_node_id was stamped after the node was created.
     expect(rows[0].placedNodeId).toBeDefined();
+    // suggested_parent_node_id mirrors the LLM's pick — set on every
+    // place decision, regardless of confidence / auto-apply outcome.
+    // Same column the Override modal later pre-selects from on
+    // low-confidence places.
+    expect(rows[0].suggestedParentNodeId).toBe('epic-1');
   });
 
   it('triage_enabled=true + place LOW-confidence → triage row persisted, NO node created', async () => {
@@ -1036,6 +1041,12 @@ describe('ensureNodeForIssue — triage fork', () => {
     });
     // placed_node_id is null since no node was created.
     expect(rows[0].placedNodeId).toBeNull();
+    // BUT suggested_parent_node_id IS populated — that's the entire
+    // point of the column: the Override modal needs the LLM's pick
+    // for low-confidence places even when auto-apply was blocked.
+    // Without this assertion the gap that motivated the column
+    // wouldn't be regression-tested.
+    expect(rows[0].suggestedParentNodeId).toBe('epic-1');
   });
 
   it('triage_enabled=true + skip → triage row persisted, no node created', async () => {

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -658,6 +658,16 @@ async function ensureNodeForIssueViaTriage(
     // time we reach this upsert we know the row (if any) is either
     // auto-decided or operator-touched-but-not-reviewed. The SET clause
     // therefore overwrites the auto fields freely.
+    // Capture the LLM's suggested parent for both branches of the
+    // upsert. Always reflects the latest auto-triage call: a `place`
+    // decision carries the suggested epic, a `skip`/`uncertain` decision
+    // carries null. The column is intentionally distinct from
+    // placed_node_id (which only flips when a node is actually created)
+    // so the Override modal can pre-select the LLM's pick on
+    // low-confidence places.
+    const suggestedParentNodeId =
+      decision.decision === 'place' ? (decision.parentNodeId ?? null) : null;
+
     const [decisionRow] = await tx
       .insert(triageDecisions)
       .values({
@@ -669,6 +679,7 @@ async function ensureNodeForIssueViaTriage(
         reason: decision.reason,
         confidence: decision.confidence,
         placedNodeId: null,
+        suggestedParentNodeId,
         decidedBy: 'auto',
         reviewed: false,
       })
@@ -684,6 +695,7 @@ async function ensureNodeForIssueViaTriage(
           // re-triages — placed_node_id stays whatever it was unless
           // the new decision is also auto-apply, in which case the
           // INSERT-branch fields below run.
+          suggestedParentNodeId,
           decidedAt: new Date(),
           decidedBy: 'auto',
           reviewed: false,


### PR DESCRIPTION
## Motivation

The Override modal on low-confidence `place` triage decisions previously opened with empty selection. The LLM's suggested epic was only readable in the `reason` prose, not machine-readable — operators had to re-derive the suggestion every time they reviewed a row.

## Summary

- New `suggested_parent_node_id` UUID column on `triage_decisions`, written by every LLM-driven path (auto-ingest, reopen re-triage, single + bulk reclassify).
- Frontend Override modal pre-selects the suggested epic via a new `initialSelectedNodeId` prop on `NodePickerModal`. One-click confirm if the suggestion is right; pick a different one otherwise.
- New "Suggested: <epic title>" badge under the reason on every place decision card. Click → opens the picker pre-selected. Stale-suggestion case (node deleted) renders "(no longer exists)" in muted italics.
- Retro-fill script for the 5 existing low-confidence place rows on the MindBlown self-map. Idempotent, manual run only — not part of the migration so a server restart can't spam the LLM.

## Semantic decision

`suggested_parent_node_id` always reflects the **latest LLM suggestion**. Operator overrides update `placed_node_id` (where the operator chose to put the node) but do NOT touch `suggested_parent_node_id`. This way the audit history can show "Claude suggested X, operator chose Y" — the two columns intentionally diverge. Two tests assert the invariant: a place override and a skip override both leave the suggestion intact; only reclassify (an LLM call) refreshes it.

## Schema

```sql
ALTER TABLE triage_decisions ADD COLUMN IF NOT EXISTS suggested_parent_node_id UUID;
```

Nullable, no FK (matches the `placed_node_id` convention) — when the suggested node is later deleted, the row stays around and the UI shows the stale-suggestion affordance instead of cascading.

## Retro-fill

After deploy, run once:

```bash
DATABASE_URL=... ANTHROPIC_API_KEY=... \
  tsx packages/server/src/scripts/backfill-suggested-parent.ts \
  --map-id df1d3294-09a1-4d08-9099-0899b76efaed
```

Scopes to rows where `decision='place' AND placed_node_id IS NULL AND suggested_parent_node_id IS NULL` on triage-enabled maps. ~5 cents on Opus for the 5 affected rows. Idempotent.

`--dry-run` lists candidates without writes/LLM calls. Without `--map-id`, runs across every triage-enabled map.

## Test plan

- [x] `pnpm -w typecheck` clean
- [x] `pnpm -w build` clean
- [x] `pnpm -w test` — 395 passes (up from 390), all server suites green
- [ ] Deploy + run the retro-fill against the self-map (5 rows updated)
- [ ] Manual: open Triage tab on `df1d3294-09a1-4d08-9099-0899b76efaed`, observe "Suggested: <epic>" badge on low-confidence places; click Override; confirm picker opens with that epic pre-selected
- [ ] Audit history: a reclassify that changes the suggestion shows previous + new `suggested_parent_node_id` in `triage_decision_history`

## Files touched (7 layers)

1. **Schema** — `packages/server/src/db/schema.ts:364`
2. **Migration** — `packages/server/src/db/migrate.ts:556`
3. **Persistence** — `packages/server/src/sync/githubIngest.ts:660` (auto-ingest), `packages/server/src/routes/integrations.ts:264` (reopen), `packages/server/src/routes/triage.ts:825` (single reclassify), `packages/server/src/routes/triage.ts:1483` (bulk reclassify). Override paths intentionally untouched per the semantic decision above.
4. **API response** — `packages/server/src/routes/triage.ts:880` (single reclassify), `packages/server/src/routes/triage.ts:1540` (bulk reclassify per-item)
5. **Frontend type** — `packages/mindmap/src/api.ts:1110`
6. **UI badge** — `packages/mindmap/src/TriagePanel.tsx:1057` (`SuggestedParentBadge` component)
7. **Picker pre-select** — `packages/mindmap/src/NodePickerModal.tsx:28` (new `initialSelectedNodeId` prop), `packages/mindmap/src/TriagePanel.tsx:608` (wire-up)

Plus retro-fill at `packages/server/src/scripts/backfill-suggested-parent.ts` and +5 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)