### PR TITLE
feat(triage): unified "Not in MindBlown" view (closes #140)

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -865,6 +865,61 @@ export function confirmTriage(
   );
 }
 
+// ── Not-in-MindBlown unified view (#140) ─────────────────────────
+
+export type NotInMindBlownKindApi =
+  | 'skipped'
+  | 'pending-skipped'
+  | 'uncertain'
+  | 'orphan';
+
+export interface NotInMindBlownItemApi {
+  kind: NotInMindBlownKindApi;
+  triageDecisionId?: string;
+  decision?: 'skip' | 'uncertain';
+  reason?: string;
+  confidence?: number;
+  decidedAt?: string;
+  externalId: string;
+  issueTitle: string;
+  issueState: 'open' | 'closed';
+  issueUrl: string;
+}
+
+export interface NotInMindBlownFiltersApi {
+  bucket?: NotInMindBlownKindApi | 'all' | 'orphans';
+  limit?: number;
+  since?: string;
+}
+
+export interface NotInMindBlownResultApi {
+  mapId: string;
+  bucket: string;
+  total: number;
+  returned: number;
+  orphansAvailable: boolean;
+  orphansError: string | null;
+  items: NotInMindBlownItemApi[];
+}
+
+export function listNotInMindBlown(
+  mapId: string,
+  filters: NotInMindBlownFiltersApi,
+): Promise<NotInMindBlownResultApi> {
+  const params = new URLSearchParams();
+  if (filters.bucket) {
+    // Server accepts both 'orphan' (singular) and 'orphans' (plural)
+    // — normalize to the canonical 'orphans' query value.
+    params.set('bucket', filters.bucket === 'orphan' ? 'orphans' : filters.bucket);
+  }
+  if (filters.limit != null) params.set('limit', String(filters.limit));
+  if (filters.since) params.set('since', filters.since);
+  const qs = params.toString();
+  return request<NotInMindBlownResultApi>(
+    `/api/maps/${mapId}/triage-decisions/not-in-mindblown${qs ? `?${qs}` : ''}`,
+  );
+}
+
 // ── Orchestration substrate (#111) ────────────────────────────
 
 export interface ReadyNodeApi {

--- a/packages/mcp/src/backend.ts
+++ b/packages/mcp/src/backend.ts
@@ -24,6 +24,8 @@ export const httpBackend: ToolBackend = {
   overrideTriage: (mapId, decisionId, body) => api.overrideTriage(mapId, decisionId, body),
   reclassifyTriage: (mapId, decisionId) => api.reclassifyTriage(mapId, decisionId),
   confirmTriage: (mapId, decisionId) => api.confirmTriage(mapId, decisionId),
+  // ── Not-in-MindBlown unified view (#140) ────────────────────────
+  listNotInMindBlown: (mapId, filters) => api.listNotInMindBlown(mapId, filters),
   // ── Orchestration substrate (#111) ──────────────────────────────
   readyNodes: (mapId, opts) => api.readyNodes(mapId, opts),
   claimNode: (mapId, nodeId, sessionId) => api.claimNode(mapId, nodeId, sessionId),

--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -41,10 +41,15 @@ import {
   bulkOverrideTriageDecisions,
   bulkReclassifyTriageDecisions,
   confirmTriageDecision,
+  importOrphanIssue,
+  listNotInMindBlown,
   listTriageDecisions,
   overrideTriageDecision,
   reclassifyTriageDecision,
+  skipOrphanIssue,
   type BulkTriageItem,
+  type NotInMindBlownBucket,
+  type NotInMindBlownItem,
   type TriageDecision,
   type TriageDecisionKind,
 } from './api.js';
@@ -82,7 +87,11 @@ function summarizeBulk(results: BulkTriageItem[]): { ok: number; err: number; fi
   return { ok, err, firstError };
 }
 
-type SubView = 'pending' | 'placed' | 'skipped';
+type SubView = 'pending' | 'placed' | 'skipped' | 'not-in-mindblown';
+
+// Sub-filter inside the "Not in MindBlown" tab. 'all' shows every bucket;
+// the others narrow to a single bucket using the server's `bucket` param.
+type NotInMindBlownFilter = 'all' | NotInMindBlownBucket;
 
 export function TriagePanel({
   mapId,
@@ -117,6 +126,24 @@ export function TriagePanel({
   const [maxConfidence, setMaxConfidence] = useState(100);
   const [issueStateFilter, setIssueStateFilter] = useState<IssueStateFilter>('all');
   const [timeWindow, setTimeWindow] = useState<TimeWindowFilter>('7d');
+
+  // ── Not-in-MindBlown tab state (#140) ─────────────────────────
+  // Lives outside the main `decisions` state because the items have a
+  // different shape (no Phase 2 triage-row fields like reviewed/
+  // confidence on orphans). The decision-row buckets (skipped/pending-
+  // skipped/uncertain) still carry a triageDecisionId so per-card
+  // actions can reuse override/reclassify/confirm against the existing
+  // server routes; orphans render a smaller action set.
+  const [notInMindBlownItems, setNotInMindBlownItems] = useState<NotInMindBlownItem[]>([]);
+  const [notInMindBlownFilter, setNotInMindBlownFilter] = useState<NotInMindBlownFilter>('all');
+  const [orphansAvailable, setOrphansAvailable] = useState(true);
+  const [orphansError, setOrphansError] = useState<string | null>(null);
+  // Picker mode tracks which not-in-mindblown card opened the modal so
+  // the pick handler knows whether to call /override (decision-row
+  // buckets) or to create+attach a node from scratch (orphan bucket).
+  // Reuses NodePickerModal; cleared after pick or cancel.
+  const [notInMindBlownPickerItem, setNotInMindBlownPickerItem] =
+    useState<NotInMindBlownItem | null>(null);
 
   const refresh = useCallback(() => setRefreshTick((t) => t + 1), []);
 
@@ -154,6 +181,11 @@ export function TriagePanel({
   }, [mapId]);
 
   useEffect(() => {
+    // The not-in-mindblown view has its own data source — let its own
+    // effect handle the fetch. Skip the legacy decision-list path here
+    // so we don't wastefully hit GET /triage-decisions when the
+    // operator is looking at the unified view.
+    if (view === 'not-in-mindblown') return;
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -194,6 +226,48 @@ export function TriagePanel({
       cancelled = true;
     };
   }, [mapId, view, refreshTick, minConfidence, maxConfidence, issueStateFilter, timeWindow]);
+
+  // Not-in-MindBlown data fetch (#140). Runs on view-switch into the new
+  // tab, sub-filter change, or refresh tick (after an action like
+  // import / mark-as-skip). We send `bucket=all` when the sub-filter is
+  // 'all' so the server returns every bucket; otherwise we narrow with
+  // the server-side filter. The time-window filter still applies to the
+  // decision-row buckets (orphans don't carry a decidedAt — they're
+  // included regardless of the time-window setting).
+  useEffect(() => {
+    if (view !== 'not-in-mindblown') return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    // No `since` here — the time-window filter doesn't apply to this
+    // tab (the FilterBar is hidden for it). Orphans don't carry a
+    // decidedAt, so a since-filter would silently exclude them and
+    // confuse the operator.
+    const bucketParam: NotInMindBlownFilter | 'orphans' =
+      notInMindBlownFilter === 'orphan' ? 'orphans' : notInMindBlownFilter;
+    listNotInMindBlown(mapId, {
+      bucket: bucketParam,
+      limit: 200,
+    })
+      .then((res) => {
+        if (cancelled) return;
+        setNotInMindBlownItems(res.items);
+        setOrphansAvailable(res.orphansAvailable);
+        setOrphansError(res.orphansError);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const msg = err instanceof ApiError ? err.message : 'Failed to load unified view';
+        setError(msg);
+        setNotInMindBlownItems([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mapId, view, refreshTick, notInMindBlownFilter]);
 
   const handleConfirm = useCallback(
     async (decision: TriageDecision) => {
@@ -267,6 +341,105 @@ export function TriagePanel({
       }
     },
     [mapId, pickerForDecision, refresh],
+  );
+
+  // ── Not-in-MindBlown action handlers (#140) ───────────────────
+  //
+  // Decision-row buckets (skipped/pending-skipped/uncertain) reuse the
+  // existing override/reclassify/confirm routes — the per-card actions
+  // dispatch by `triageDecisionId`. Orphans hit the new orphan-import /
+  // orphan-skip routes since no decision row exists yet.
+  const handleNotInMindBlownPickParent = useCallback(
+    async (parentNodeId: string) => {
+      const item = notInMindBlownPickerItem;
+      if (!item) return;
+      setNotInMindBlownPickerItem(null);
+      setBusyDecisionId(item.triageDecisionId ?? item.externalId);
+      try {
+        if (item.kind === 'orphan') {
+          await importOrphanIssue(mapId, {
+            externalId: item.externalId,
+            issueTitle: item.issueTitle,
+            issueState: item.issueState,
+            parentNodeId,
+            reason: 'Operator imported from "Not in MindBlown" view',
+          });
+        } else if (item.triageDecisionId) {
+          await overrideTriageDecision(mapId, item.triageDecisionId, {
+            decision: 'place',
+            parentNodeId,
+            reason: item.reason,
+          });
+        }
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Import failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, notInMindBlownPickerItem, refresh],
+  );
+
+  const handleOrphanSkip = useCallback(
+    async (item: NotInMindBlownItem) => {
+      if (item.kind !== 'orphan') return;
+      setBusyDecisionId(item.externalId);
+      try {
+        await skipOrphanIssue(mapId, {
+          externalId: item.externalId,
+          issueTitle: item.issueTitle,
+          issueState: item.issueState,
+          reason: 'Operator marked orphan as skip from "Not in MindBlown" view',
+        });
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Mark as skip failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, refresh],
+  );
+
+  const handleNotInMindBlownReclassify = useCallback(
+    async (item: NotInMindBlownItem) => {
+      if (!item.triageDecisionId) return;
+      setBusyDecisionId(item.triageDecisionId);
+      try {
+        await reclassifyTriageDecision(mapId, item.triageDecisionId);
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Re-classify failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, refresh],
+  );
+
+  const handleNotInMindBlownConfirmSkip = useCallback(
+    async (item: NotInMindBlownItem) => {
+      if (!item.triageDecisionId) return;
+      setBusyDecisionId(item.triageDecisionId);
+      try {
+        // Reconstruct a minimal TriageDecision-shape so confirmTriageDecision
+        // can hit the dedicated /confirm route (which takes only the id).
+        await confirmTriageDecision(mapId, {
+          id: item.triageDecisionId,
+        } as TriageDecision);
+        refresh();
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : 'Confirm failed';
+        setError(msg);
+      } finally {
+        setBusyDecisionId(null);
+      }
+    },
+    [mapId, refresh],
   );
 
   // ── Bulk handlers (#95 Phase 2) ───────────────────────────────
@@ -457,34 +630,51 @@ export function TriagePanel({
         >
           Skipped
         </TabButton>
+        <TabButton
+          testId="triage-tab-not-in-mindblown"
+          active={view === 'not-in-mindblown'}
+          onClick={() => setView('not-in-mindblown')}
+        >
+          Not in MindBlown
+        </TabButton>
       </div>
 
-      {/* Filter row (#95 Phase 2) — confidence slider + state + window */}
-      <FilterBar
-        minConfidence={minConfidence}
-        maxConfidence={maxConfidence}
-        onMinChange={setMinConfidence}
-        onMaxChange={setMaxConfidence}
-        issueState={issueStateFilter}
-        onIssueStateChange={setIssueStateFilter}
-        timeWindow={timeWindow}
-        onTimeWindowChange={setTimeWindow}
-      />
+      {/* Filter row (#95 Phase 2) — confidence slider + state + window.
+          Hidden on the "Not in MindBlown" tab: confidence/state filters
+          don't apply to orphans (no decision row), and the time window
+          would silently exclude orphans (no decided_at). That view has
+          its own sub-filter pills instead. */}
+      {view !== 'not-in-mindblown' && (
+        <FilterBar
+          minConfidence={minConfidence}
+          maxConfidence={maxConfidence}
+          onMinChange={setMinConfidence}
+          onMaxChange={setMaxConfidence}
+          issueState={issueStateFilter}
+          onIssueStateChange={setIssueStateFilter}
+          timeWindow={timeWindow}
+          onTimeWindowChange={setTimeWindow}
+        />
+      )}
 
-      {/* Bulk-action toolbar (#95 Phase 2) — select-all + actions */}
-      <BulkToolbar
-        view={view}
-        totalVisible={decisions.length}
-        selectedCount={selectedIds.size}
-        allSelected={allSelected}
-        someSelected={someSelected}
-        onToggleSelectAll={toggleSelectAll}
-        canBulkOverride={canBulkOverride}
-        bulkBusy={bulkBusy}
-        onBulkConfirm={handleBulkConfirm}
-        onBulkOverride={() => setBulkPickerOpen(true)}
-        onBulkReclassify={handleBulkReclassify}
-      />
+      {/* Bulk-action toolbar (#95 Phase 2) — select-all + actions.
+          Hidden on the unified "Not in MindBlown" tab (#140); that view
+          has its own per-card actions and no selection model. */}
+      {view !== 'not-in-mindblown' && (
+        <BulkToolbar
+          view={view}
+          totalVisible={decisions.length}
+          selectedCount={selectedIds.size}
+          allSelected={allSelected}
+          someSelected={someSelected}
+          onToggleSelectAll={toggleSelectAll}
+          canBulkOverride={canBulkOverride}
+          bulkBusy={bulkBusy}
+          onBulkConfirm={handleBulkConfirm}
+          onBulkOverride={() => setBulkPickerOpen(true)}
+          onBulkReclassify={handleBulkReclassify}
+        />
+      )}
 
       {/* Info banner (bulk success) */}
       {info && !error && (
@@ -550,7 +740,21 @@ export function TriagePanel({
 
       {/* Body */}
       <div style={{ flex: 1, overflowY: 'auto' }} data-testid="triage-body">
-        {loading ? (
+        {view === 'not-in-mindblown' ? (
+          <NotInMindBlownView
+            loading={loading}
+            items={notInMindBlownItems}
+            filter={notInMindBlownFilter}
+            onFilterChange={setNotInMindBlownFilter}
+            orphansAvailable={orphansAvailable}
+            orphansError={orphansError}
+            busyKey={busyDecisionId}
+            onImport={(item) => setNotInMindBlownPickerItem(item)}
+            onOrphanSkip={handleOrphanSkip}
+            onReclassify={handleNotInMindBlownReclassify}
+            onConfirmSkip={handleNotInMindBlownConfirmSkip}
+          />
+        ) : loading ? (
           <div style={{ padding: 20, textAlign: 'center', color: '#94a3b8', fontSize: 13 }}>
             Loading…
           </div>
@@ -567,7 +771,7 @@ export function TriagePanel({
             <TriageCard
               key={d.id}
               decision={d}
-              view={view}
+              view={view as 'pending' | 'placed' | 'skipped'}
               busy={busyDecisionId === d.id}
               selected={selectedIds.has(d.id)}
               onToggleSelect={() => toggleSelect(d.id)}
@@ -627,6 +831,18 @@ export function TriagePanel({
             .filter((x): x is string => typeof x === 'string')}
           onPick={handleBulkOverridePickParent}
           onClose={() => setBulkPickerOpen(false)}
+        />
+      )}
+
+      {/* Not-in-MindBlown picker modal (#140) — for both orphan
+          imports and decision-row → place overrides from the unified
+          view. */}
+      {notInMindBlownPickerItem && (
+        <NodePickerModal
+          title={`Import "${notInMindBlownPickerItem.issueTitle}" — pick a parent`}
+          excludeNodeIds={[]}
+          onPick={handleNotInMindBlownPickParent}
+          onClose={() => setNotInMindBlownPickerItem(null)}
         />
       )}
     </div>
@@ -762,7 +978,11 @@ function BulkToolbar({
   onBulkOverride,
   onBulkReclassify,
 }: {
-  view: SubView;
+  // The "Not in MindBlown" tab has its own card component and no
+  // selection model — BulkToolbar is hidden in that view at the call
+  // site. Narrow the type so a future regression that re-introduces
+  // bulk actions there surfaces as a type error.
+  view: 'pending' | 'placed' | 'skipped';
   totalVisible: number;
   selectedCount: number;
   allSelected: boolean;
@@ -919,7 +1139,12 @@ function TriageCard({
   onUncertain,
 }: {
   decision: TriageDecision;
-  view: SubView;
+  // The legacy three-bucket TriageCard never renders inside the
+  // 'not-in-mindblown' tab — that tab has its own card component
+  // (NotInMindBlownCard) that handles orphans + decision-row buckets
+  // with the unified shape. Narrow the type so a stray case here
+  // surfaces at the compile step.
+  view: 'pending' | 'placed' | 'skipped';
   busy: boolean;
   selected: boolean;
   onToggleSelect: () => void;
@@ -1306,4 +1531,316 @@ function formatTimeAgo(iso: string): string {
   if (hr < 24) return `${hr}h ago`;
   const day = Math.floor(hr / 24);
   return `${day}d ago`;
+}
+
+// ── Not-in-MindBlown view (#140) ──────────────────────────────────
+//
+// Renders the unified "tickets that aren't on the roadmap" surface:
+// sub-filter buttons (All / Skipped / Pending / Uncertain / Orphans)
+// at the top, plus a vertical list of per-card items. Each card shows
+// the issue link + state, the bucket badge, and a small action set
+// matched to the bucket:
+//
+//   - skipped / uncertain → Import to MindBlown + Re-classify
+//   - pending-skipped     → Import + Confirm skip + Re-classify
+//   - orphan              → Import + Mark as skip (no decision row exists)
+//
+// When the orphan branch is unavailable (no GitHub integration, or the
+// import call failed) we still render the decision-row items and show
+// an inline notice explaining the missing bucket. The notice is muted
+// rather than red — the operator can still triage the rest.
+
+function NotInMindBlownView({
+  loading,
+  items,
+  filter,
+  onFilterChange,
+  orphansAvailable,
+  orphansError,
+  busyKey,
+  onImport,
+  onOrphanSkip,
+  onReclassify,
+  onConfirmSkip,
+}: {
+  loading: boolean;
+  items: NotInMindBlownItem[];
+  filter: NotInMindBlownFilter;
+  onFilterChange: (f: NotInMindBlownFilter) => void;
+  orphansAvailable: boolean;
+  orphansError: string | null;
+  busyKey: string | null;
+  onImport: (item: NotInMindBlownItem) => void;
+  onOrphanSkip: (item: NotInMindBlownItem) => void;
+  onReclassify: (item: NotInMindBlownItem) => void;
+  onConfirmSkip: (item: NotInMindBlownItem) => void;
+}) {
+  const filterButtons: Array<{ key: NotInMindBlownFilter; label: string; testId: string }> = [
+    { key: 'all', label: 'All', testId: 'not-in-mindblown-filter-all' },
+    { key: 'skipped', label: 'Skipped', testId: 'not-in-mindblown-filter-skipped' },
+    { key: 'pending-skipped', label: 'Pending', testId: 'not-in-mindblown-filter-pending-skipped' },
+    { key: 'uncertain', label: 'Uncertain', testId: 'not-in-mindblown-filter-uncertain' },
+    { key: 'orphan', label: 'Orphans', testId: 'not-in-mindblown-filter-orphan' },
+  ];
+  return (
+    <div data-testid="not-in-mindblown-view">
+      {/* Sub-filter pills */}
+      <div
+        data-testid="not-in-mindblown-filter-bar"
+        style={{
+          padding: '8px 10px',
+          borderBottom: '1px solid #f1f5f9',
+          background: '#f8fafc',
+          display: 'flex',
+          gap: 4,
+          flexWrap: 'wrap',
+        }}
+      >
+        {filterButtons.map((b) => (
+          <button
+            key={b.key}
+            data-testid={b.testId}
+            onClick={() => onFilterChange(b.key)}
+            style={{
+              padding: '3px 10px',
+              borderRadius: 12,
+              border: '1px solid #e2e8f0',
+              background: filter === b.key ? '#3b82f6' : '#fff',
+              color: filter === b.key ? '#fff' : '#475569',
+              fontSize: 11,
+              fontWeight: 600,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            {b.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Orphan-unavailable notice */}
+      {!orphansAvailable && (filter === 'all' || filter === 'orphan') && (
+        <div
+          data-testid="not-in-mindblown-orphans-notice"
+          style={{
+            padding: '8px 12px',
+            background: '#fef3c7',
+            color: '#92400e',
+            fontSize: 11,
+            borderBottom: '1px solid #fde68a',
+          }}
+        >
+          Orphan bucket unavailable: {orphansError ?? 'GitHub fetch failed'}
+        </div>
+      )}
+
+      {/* Body */}
+      {loading ? (
+        <div style={{ padding: 20, textAlign: 'center', color: '#94a3b8', fontSize: 13 }}>
+          Loading…
+        </div>
+      ) : items.length === 0 ? (
+        <div
+          data-testid="not-in-mindblown-empty"
+          style={{ padding: 20, textAlign: 'center', color: '#94a3b8', fontSize: 13 }}
+        >
+          Nothing matches the current filter.
+        </div>
+      ) : (
+        items.map((item) => (
+          <NotInMindBlownCard
+            key={
+              item.triageDecisionId ?? `orphan:${item.externalId}`
+            }
+            item={item}
+            busy={busyKey === (item.triageDecisionId ?? item.externalId)}
+            onImport={() => onImport(item)}
+            onOrphanSkip={() => onOrphanSkip(item)}
+            onReclassify={() => onReclassify(item)}
+            onConfirmSkip={() => onConfirmSkip(item)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function NotInMindBlownCard({
+  item,
+  busy,
+  onImport,
+  onOrphanSkip,
+  onReclassify,
+  onConfirmSkip,
+}: {
+  item: NotInMindBlownItem;
+  busy: boolean;
+  onImport: () => void;
+  onOrphanSkip: () => void;
+  onReclassify: () => void;
+  onConfirmSkip: () => void;
+}) {
+  const bucketBadge = (() => {
+    switch (item.kind) {
+      case 'skipped':
+        return { label: 'Skipped', bg: '#fef3c7', fg: '#854d0e' };
+      case 'pending-skipped':
+        return { label: 'Pending', bg: '#fef9c3', fg: '#854d0e' };
+      case 'uncertain':
+        return { label: 'Uncertain', bg: '#e2e8f0', fg: '#475569' };
+      case 'orphan':
+      default:
+        return { label: 'Orphan', bg: '#dbeafe', fg: '#1e40af' };
+    }
+  })();
+  const stateBadge =
+    item.issueState === 'closed'
+      ? { label: 'closed', bg: '#fee2e2', fg: '#991b1b' }
+      : { label: 'open', bg: '#dcfce7', fg: '#166534' };
+  return (
+    <div
+      data-testid="not-in-mindblown-card"
+      data-kind={item.kind}
+      data-external-id={item.externalId}
+      style={{
+        padding: 12,
+        borderBottom: '1px solid #f1f5f9',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      {/* Title row */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: '#1e293b', flex: 1 }}>
+          {item.issueTitle}
+        </span>
+        <span
+          data-testid="not-in-mindblown-card-bucket"
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            padding: '2px 8px',
+            borderRadius: 10,
+            background: bucketBadge.bg,
+            color: bucketBadge.fg,
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {bucketBadge.label}
+        </span>
+      </div>
+
+      {/* External link + state */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11 }}>
+        <a
+          href={item.issueUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="not-in-mindblown-card-link"
+          style={{ color: '#3b82f6', textDecoration: 'none' }}
+        >
+          {item.externalId}
+        </a>
+        <span
+          data-testid="not-in-mindblown-card-state"
+          style={{
+            fontSize: 9,
+            padding: '1px 6px',
+            borderRadius: 8,
+            background: stateBadge.bg,
+            color: stateBadge.fg,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+          }}
+        >
+          {stateBadge.label}
+        </span>
+        {item.decidedAt && (
+          <>
+            <span style={{ color: '#cbd5e1' }}>•</span>
+            <span style={{ color: '#94a3b8', fontSize: 10 }}>
+              {formatTimeAgo(item.decidedAt)}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Decision detail or orphan placeholder */}
+      {item.kind === 'orphan' ? (
+        <div
+          data-testid="not-in-mindblown-card-orphan-marker"
+          style={{
+            fontSize: 11,
+            color: '#64748b',
+            fontStyle: 'italic',
+            padding: 6,
+            background: '#f8fafc',
+            borderRadius: 4,
+          }}
+        >
+          Not yet triaged — no decision row exists for this issue.
+        </div>
+      ) : (
+        <div
+          data-testid="not-in-mindblown-card-reason"
+          style={{
+            fontSize: 11,
+            color: '#475569',
+            lineHeight: 1.4,
+            padding: 6,
+            background: '#f8fafc',
+            borderRadius: 4,
+            border: '1px solid #f1f5f9',
+          }}
+        >
+          {item.confidence != null && (
+            <span style={{ color: '#94a3b8', marginRight: 6 }}>
+              {item.confidence}%
+            </span>
+          )}
+          {item.reason ?? ''}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        <ActionBtn
+          testId="not-in-mindblown-card-import"
+          label="Import to MindBlown"
+          kind="primary"
+          disabled={busy}
+          onClick={onImport}
+        />
+        {item.kind === 'orphan' ? (
+          <ActionBtn
+            testId="not-in-mindblown-card-mark-skip"
+            label="Mark as skip"
+            kind="default"
+            disabled={busy}
+            onClick={onOrphanSkip}
+          />
+        ) : (
+          <ActionBtn
+            testId="not-in-mindblown-card-reclassify"
+            label={busy ? '…' : 'Re-classify'}
+            kind="ghost"
+            disabled={busy}
+            onClick={onReclassify}
+          />
+        )}
+        {item.kind === 'pending-skipped' && (
+          <ActionBtn
+            testId="not-in-mindblown-card-confirm-skip"
+            label="Confirm skip"
+            kind="default"
+            disabled={busy}
+            onClick={onConfirmSkip}
+          />
+        )}
+      </div>
+    </div>
+  );
 }

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -1352,3 +1352,133 @@ export function bulkReclassifyTriageDecisions(
     },
   );
 }
+
+// ── Not-in-MindBlown unified view (#140) ─────────────────────────
+//
+// Surfaces every GitHub ticket that isn't currently a node in this map,
+// split into four buckets:
+//   - 'skipped'         — decision=skip AND reviewed=true
+//   - 'pending-skipped' — decision=skip AND reviewed=false
+//   - 'uncertain'       — decision=uncertain
+//   - 'orphan'          — no triage row + no node carrying the externalId
+//
+// The orphan bucket needs a live GitHub fetch via importGitHubIssues; if
+// GitHub isn't configured (or the API call fails) we still return the
+// decision-row buckets and signal the orphan-bucket state via
+// `orphansAvailable` + `orphansError`.
+
+export type NotInMindBlownBucket =
+  | 'skipped'
+  | 'pending-skipped'
+  | 'uncertain'
+  | 'orphan';
+
+export interface NotInMindBlownItem {
+  kind: NotInMindBlownBucket;
+
+  // Decision-row buckets (skipped/pending-skipped/uncertain) carry these.
+  // Orphans have neither.
+  triageDecisionId?: string;
+  decision?: 'skip' | 'uncertain';
+  reason?: string;
+  confidence?: number;
+  decidedAt?: string;
+
+  // Common fields — always set.
+  externalId: string; // "owner/repo#NNN"
+  issueTitle: string;
+  issueState: 'open' | 'closed';
+  issueUrl: string;
+}
+
+export interface ListNotInMindBlownFilters {
+  /** Narrow to one bucket (or pass 'all' / omit to get everything). */
+  bucket?: NotInMindBlownBucket | 'all' | 'orphans';
+  /** Default 50, hard cap 200. */
+  limit?: number;
+  /** ISO timestamp — applies only to decision-row buckets. */
+  since?: string;
+}
+
+export interface ListNotInMindBlownResponse {
+  mapId: string;
+  bucket: string;
+  total: number;
+  returned: number;
+  /** False when GitHub isn't configured or the import call failed. */
+  orphansAvailable: boolean;
+  /** Set when orphansAvailable is false, explains why. */
+  orphansError: string | null;
+  items: NotInMindBlownItem[];
+}
+
+export interface OrphanImportBody {
+  externalId: string;
+  issueTitle: string;
+  issueState?: 'open' | 'closed';
+  parentNodeId: string;
+  reason?: string;
+}
+
+export interface OrphanImportResponse {
+  decisionId: string | null;
+  nodeId: string | null;
+  status: 'imported';
+}
+
+export function importOrphanIssue(
+  mapId: string,
+  body: OrphanImportBody,
+): Promise<OrphanImportResponse> {
+  return request<OrphanImportResponse>(
+    `/api/maps/${mapId}/triage-decisions/orphan-import`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+export interface OrphanSkipBody {
+  externalId: string;
+  issueTitle: string;
+  issueState?: 'open' | 'closed';
+  reason?: string;
+}
+
+export interface OrphanSkipResponse {
+  decisionId: string | null;
+  status: 'skipped';
+}
+
+export function skipOrphanIssue(
+  mapId: string,
+  body: OrphanSkipBody,
+): Promise<OrphanSkipResponse> {
+  return request<OrphanSkipResponse>(
+    `/api/maps/${mapId}/triage-decisions/orphan-skip`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+export function listNotInMindBlown(
+  mapId: string,
+  filters: ListNotInMindBlownFilters = {},
+): Promise<ListNotInMindBlownResponse> {
+  const qs = new URLSearchParams();
+  if (filters.bucket) {
+    // Server accepts 'orphan' as a bucket value but the user-facing
+    // filter is plural ('orphans'); honor either spelling on the way
+    // out. The server validation matches both.
+    qs.set('bucket', filters.bucket === 'orphan' ? 'orphans' : filters.bucket);
+  }
+  if (filters.limit) qs.set('limit', String(filters.limit));
+  if (filters.since) qs.set('since', filters.since);
+  const q = qs.toString();
+  return request<ListNotInMindBlownResponse>(
+    `/api/maps/${mapId}/triage-decisions/not-in-mindblown${q ? `?${q}` : ''}`,
+  );
+}

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -235,6 +235,11 @@ export function createChatBackend(userId: string): ToolBackend {
         'confirm_triage is not available through the in-app chat — call it via the MCP HTTP endpoint.',
       );
     },
+    async listNotInMindBlown(_mapId, _filters) {
+      throw new Error(
+        'list_not_in_mindblown is not available through the in-app chat — call it via the MCP HTTP endpoint.',
+      );
+    },
 
     // ── Orchestration substrate (#111) ──────────────────────────
     // Delegates to packages/server/src/services/orchestration.ts so the

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -35,7 +35,19 @@ interface TriageRow {
 }
 
 const triageRows = new Map<string, TriageRow>();
-const nodes = new Map<string, { id: string; mapId: string; parentId: string | null }>();
+// #140 added `externalLinks` so the not-in-mindblown route's orphan
+// branch can filter out issues already attached to a node. Tests that
+// don't care about orphans seed `nodes` without setting externalLinks
+// (the field stays undefined, which the route treats as no links).
+const nodes = new Map<
+  string,
+  {
+    id: string;
+    mapId: string;
+    parentId: string | null;
+    externalLinks?: Array<{ provider: string; externalId: string }>;
+  }
+>();
 // Phase 3 (#96) — history insert recorder for the GET .../history route
 // test. Inserts from the mutation routes also land here so a test can
 // assert "the override route wrote a history row" without spinning up
@@ -162,7 +174,8 @@ vi.mock('../../db/connection.js', () => {
       }),
     }),
     insert: (table: { __name?: string }) => ({
-      values: async (vals: Record<string, unknown>) => {
+      values: (vals: Record<string, unknown>) => {
+        let inserted: { id: string } | null = null;
         if (table?.__name === 'triageDecisionHistory') {
           const id = `h${historyRows.size + 1}`;
           historyRows.set(id, {
@@ -180,8 +193,38 @@ vi.mock('../../db/connection.js', () => {
             newParentNodeId: (vals.newParentNodeId as string | null) ?? null,
             reason: (vals.reason as string | null) ?? null,
           });
+          inserted = { id };
+        } else if (table?.__name === 'triageDecisions') {
+          // #140: orphan-import / orphan-skip INSERT into the triage
+          // table. Build a minimal row that the GET-list route would
+          // also surface; the synthetic id mirrors the seedRow pattern.
+          const id = `auto-tr-${triageRows.size + 1}`;
+          const row: TriageRow = {
+            id,
+            mapId: vals.mapId as string,
+            externalId: vals.externalId as string,
+            issueTitle: vals.issueTitle as string,
+            issueState: vals.issueState as string,
+            decision: (vals.decision as 'place' | 'skip' | 'uncertain'),
+            reason: (vals.reason as string) ?? '',
+            confidence: (vals.confidence as number) ?? 100,
+            placedNodeId: (vals.placedNodeId as string | null) ?? null,
+            suggestedParentNodeId:
+              (vals.suggestedParentNodeId as string | null) ?? null,
+            decidedAt: (vals.decidedAt as Date) ?? new Date(),
+            decidedBy: (vals.decidedBy as 'auto' | 'operator') ?? 'operator',
+            reviewed: (vals.reviewed as boolean) ?? false,
+            reviewedAt: (vals.reviewedAt as Date | null) ?? null,
+            reviewedBy: (vals.reviewedBy as string | null) ?? null,
+          };
+          triageRows.set(id, row);
+          inserted = { id };
         }
-        return { returning: async () => [] };
+        const thenable = {
+          then: (onFulfilled: (v: unknown) => unknown) => Promise.resolve(undefined).then(onFulfilled),
+          returning: async () => (inserted ? [inserted] : []),
+        };
+        return thenable;
       },
     }),
     transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(db),
@@ -198,6 +241,12 @@ vi.mock('../../db/schema.js', () => {
       id: col('id'),
       mapId: col('mapId'),
       parentId: col('parentId'),
+      // #140: not-in-mindblown's orphan branch reads externalLinks to
+      // filter out issues already attached to a node. The mock node
+      // store carries the column verbatim — predicates that match by
+      // mapId still work; the route only reads the field, doesn't
+      // filter on it.
+      externalLinks: col('externalLinks'),
     },
     triageDecisions: {
       __name: 'triageDecisions',
@@ -331,6 +380,48 @@ vi.mock('../../sync/mapContext.js', () => ({
   })),
 }));
 
+// ── #140 mocks: GitHub context + issue importer for the
+//    /not-in-mindblown route's orphan-bucket branch.
+//
+// `getGitHubContextForMap` is read once when the orphan branch runs;
+// returning `null` simulates a map with no GitHub integration, which the
+// route handles by setting `orphansAvailable: false` and skipping the
+// fetch. Tests that exercise the orphan branch flip the mock to return
+// a real context first.
+//
+// `importGitHubIssues` is the workhorse — each test seeds the issue
+// array it wants visible to the orphan bucket. The shape mirrors the
+// real ImportedIssue: `{ issue, externalLink }`.
+const githubContextMock = vi.hoisted(() =>
+  vi.fn(async (_mapId: string) => null as
+    | { owner: string; repo: string; token: string }
+    | null),
+);
+vi.mock('../../lib/githubContext.js', () => ({
+  getGitHubContextForMap: githubContextMock,
+}));
+
+interface FakeImportedIssue {
+  issue: {
+    number: number;
+    title: string;
+    state: 'open' | 'closed';
+    html_url: string;
+  };
+  externalLink: { externalId: string };
+}
+const importGitHubIssuesMock = vi.hoisted(() =>
+  vi.fn(async (
+    _owner: string,
+    _repo: string,
+    _token: string,
+    _opts?: { includeAll?: boolean },
+  ): Promise<FakeImportedIssue[]> => []),
+);
+vi.mock('@mindblown/integrations', () => ({
+  importGitHubIssues: importGitHubIssuesMock,
+}));
+
 import { triageRoutes } from '../triage.js';
 
 // ── Harness ──────────────────────────────────────────────────────
@@ -357,6 +448,12 @@ beforeEach(() => {
   triageIssueMock.mockClear();
   applyTriageLabelMock.mockReset();
   applyTriageLabelMock.mockImplementation(async () => undefined);
+  // #140 — reset the GitHub-context + import mocks so each test
+  // explicitly opts into the orphan-bucket branch by re-arming them.
+  githubContextMock.mockReset();
+  githubContextMock.mockImplementation(async () => null);
+  importGitHubIssuesMock.mockReset();
+  importGitHubIssuesMock.mockImplementation(async () => []);
 });
 
 // ── Auth gate ────────────────────────────────────────────────────
@@ -1882,5 +1979,426 @@ describe('GET .../triage-decisions/:decisionId/history', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().total).toBe(0);
     expect(res.json().history).toEqual([]);
+  });
+});
+
+// ── Not-in-MindBlown unified view (#140) ─────────────────────────
+
+describe('GET .../triage-decisions/not-in-mindblown', () => {
+  it('403 for API-key auth', async () => {
+    permissionLevel = 'admin';
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error?.code).toBe('FORBIDDEN');
+  });
+
+  it('returns 200 for a JWT session with view permission', async () => {
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().items).toEqual([]);
+  });
+
+  it('partitions decision rows into skipped / pending-skipped / uncertain', async () => {
+    // Three decision rows, one per bucket:
+    seedRow({
+      id: 'tr-skipped',
+      decision: 'skip',
+      reviewed: true,
+      externalId: 'o/r#1',
+      issueTitle: 'Skipped, reviewed',
+    });
+    seedRow({
+      id: 'tr-pending',
+      decision: 'skip',
+      reviewed: false,
+      externalId: 'o/r#2',
+      issueTitle: 'Skipped, NOT reviewed',
+    });
+    seedRow({
+      id: 'tr-uncertain',
+      decision: 'uncertain',
+      reviewed: false,
+      externalId: 'o/r#3',
+      issueTitle: 'Uncertain',
+    });
+    // A `place` decision must NOT be returned by this endpoint — the
+    // unified view is about issues NOT in MindBlown, and place rows
+    // are (in theory) attached to a node.
+    seedRow({
+      id: 'tr-place',
+      decision: 'place',
+      reviewed: true,
+      externalId: 'o/r#4',
+      issueTitle: 'Placed already',
+    });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const items = res.json().items as Array<{ kind: string; externalId: string }>;
+    const byKind = items.reduce<Record<string, string[]>>((acc, it) => {
+      acc[it.kind] = acc[it.kind] ?? [];
+      acc[it.kind].push(it.externalId);
+      return acc;
+    }, {});
+    expect(byKind.skipped).toEqual(['o/r#1']);
+    expect(byKind['pending-skipped']).toEqual(['o/r#2']);
+    expect(byKind.uncertain).toEqual(['o/r#3']);
+    // The place row never surfaces.
+    expect(items.some((i) => i.externalId === 'o/r#4')).toBe(false);
+  });
+
+  it('bucket=skipped narrows the result to skip+reviewed rows', async () => {
+    seedRow({ id: 'tr-skipped', decision: 'skip', reviewed: true, externalId: 'o/r#1' });
+    seedRow({ id: 'tr-pending', decision: 'skip', reviewed: false, externalId: 'o/r#2' });
+    seedRow({ id: 'tr-uncertain', decision: 'uncertain', externalId: 'o/r#3' });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown?bucket=skipped',
+    });
+    await app.close();
+    expect(res.json().items).toHaveLength(1);
+    expect(res.json().items[0].kind).toBe('skipped');
+  });
+
+  it('bucket=pending-skipped narrows to skip+unreviewed', async () => {
+    seedRow({ id: 'tr-skipped', decision: 'skip', reviewed: true, externalId: 'o/r#1' });
+    seedRow({ id: 'tr-pending', decision: 'skip', reviewed: false, externalId: 'o/r#2' });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown?bucket=pending-skipped',
+    });
+    await app.close();
+    expect(res.json().items).toHaveLength(1);
+    expect(res.json().items[0].kind).toBe('pending-skipped');
+  });
+
+  it('bucket=uncertain narrows to uncertain decisions', async () => {
+    seedRow({ id: 'tr-skipped', decision: 'skip', reviewed: true, externalId: 'o/r#1' });
+    seedRow({ id: 'tr-uncertain', decision: 'uncertain', externalId: 'o/r#3' });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown?bucket=uncertain',
+    });
+    await app.close();
+    expect(res.json().items).toHaveLength(1);
+    expect(res.json().items[0].kind).toBe('uncertain');
+  });
+
+  it('400 on an invalid bucket value', async () => {
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown?bucket=banana',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error?.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns orphans for GitHub issues with no triage row + no node link', async () => {
+    // Arm the GitHub mocks: one map context + three GH issues. Two
+    // are already represented in the map (one via a triage row, one
+    // via an externalLink on a node); the third has neither and
+    // should land in the orphan bucket.
+    githubContextMock.mockImplementation(async () => ({
+      owner: 'o',
+      repo: 'r',
+      token: 't',
+    }));
+    importGitHubIssuesMock.mockImplementation(async () => [
+      {
+        issue: { number: 1, title: 'Has triage row', state: 'open', html_url: 'https://github.com/o/r/issues/1' },
+        externalLink: { externalId: 'o/r#1' },
+      },
+      {
+        issue: { number: 2, title: 'Linked on node', state: 'open', html_url: 'https://github.com/o/r/issues/2' },
+        externalLink: { externalId: 'o/r#2' },
+      },
+      {
+        issue: { number: 3, title: 'Orphan!', state: 'open', html_url: 'https://github.com/o/r/issues/3' },
+        externalLink: { externalId: 'o/r#3' },
+      },
+    ]);
+    // Issue #1 already has a triage_decisions row.
+    seedRow({ id: 'tr-1', decision: 'skip', reviewed: true, externalId: 'o/r#1' });
+    // Issue #2 is linked on a node in this map.
+    nodes.set('node-linked', {
+      id: 'node-linked',
+      mapId: 'map-1',
+      parentId: null,
+      externalLinks: [{ provider: 'github', externalId: 'o/r#2' }],
+    });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().orphansAvailable).toBe(true);
+    const items = res.json().items as Array<{ kind: string; externalId: string }>;
+    const orphans = items.filter((i) => i.kind === 'orphan');
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].externalId).toBe('o/r#3');
+    // And the existing decision-row is still there in its own bucket.
+    expect(items.some((i) => i.kind === 'skipped' && i.externalId === 'o/r#1')).toBe(true);
+  });
+
+  it('bucket=orphans returns ONLY the orphan items', async () => {
+    githubContextMock.mockImplementation(async () => ({
+      owner: 'o',
+      repo: 'r',
+      token: 't',
+    }));
+    importGitHubIssuesMock.mockImplementation(async () => [
+      {
+        issue: { number: 1, title: 'Orphan', state: 'open', html_url: 'https://github.com/o/r/issues/1' },
+        externalLink: { externalId: 'o/r#1' },
+      },
+    ]);
+    seedRow({ id: 'tr-skipped', decision: 'skip', reviewed: true, externalId: 'o/r#999' });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown?bucket=orphans',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const items = res.json().items as Array<{ kind: string }>;
+    expect(items.every((i) => i.kind === 'orphan')).toBe(true);
+    expect(items).toHaveLength(1);
+  });
+
+  it('orphansAvailable=false + orphansError set when GitHub not configured', async () => {
+    // Default mock state returns null context → orphan branch skips.
+    seedRow({ id: 'tr-skipped', decision: 'skip', reviewed: true, externalId: 'o/r#1' });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().orphansAvailable).toBe(false);
+    expect(res.json().orphansError).toMatch(/not configured/);
+    // Decision-row buckets still return cleanly.
+    expect(res.json().items).toHaveLength(1);
+  });
+
+  it('orphansAvailable=false when importGitHubIssues throws — request still succeeds', async () => {
+    githubContextMock.mockImplementation(async () => ({
+      owner: 'o',
+      repo: 'r',
+      token: 't',
+    }));
+    importGitHubIssuesMock.mockImplementation(async () => {
+      throw new Error('rate limit hit');
+    });
+    seedRow({ id: 'tr-1', decision: 'skip', reviewed: true });
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().orphansAvailable).toBe(false);
+    expect(res.json().orphansError).toMatch(/rate limit/);
+  });
+
+  it('honors limit (default 50, cap 200)', async () => {
+    for (let i = 0; i < 10; i++) {
+      seedRow({ id: `tr-${i}`, decision: 'skip', reviewed: true, externalId: `o/r#${i}` });
+    }
+    permissionLevel = 'view';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/maps/map-1/triage-decisions/not-in-mindblown?limit=3',
+    });
+    await app.close();
+    expect(res.json().total).toBe(10);
+    expect(res.json().returned).toBe(3);
+    expect(res.json().items).toHaveLength(3);
+  });
+});
+
+// ── Orphan-import / Orphan-skip routes (#140) ────────────────────
+
+describe('POST .../triage-decisions/orphan-import', () => {
+  it('403 for API-key auth', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload: {
+        externalId: 'o/r#42',
+        issueTitle: 'New',
+        parentNodeId: 'epic-1',
+      },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('creates a node + triage row when the issue is a true orphan', async () => {
+    nodes.set('epic-1', { id: 'epic-1', mapId: 'map-1', parentId: null });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload: {
+        externalId: 'o/r#42',
+        issueTitle: 'New orphan',
+        issueState: 'open',
+        parentNodeId: 'epic-1',
+        reason: 'manual import',
+      },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('imported');
+    expect(res.json().nodeId).toBe('created-node');
+    expect(createNodeMock).toHaveBeenCalledOnce();
+    // The triage row was inserted with operator-decided + reviewed.
+    const inserted = [...triageRows.values()].find(
+      (r) => r.externalId === 'o/r#42',
+    );
+    expect(inserted).toBeDefined();
+    expect(inserted!.decision).toBe('place');
+    expect(inserted!.decidedBy).toBe('operator');
+    expect(inserted!.reviewed).toBe(true);
+  });
+
+  it('rejects when a triage row already exists for the externalId (409 NOT_ORPHAN)', async () => {
+    seedRow({ id: 'tr-existing', externalId: 'o/r#42', decision: 'skip' });
+    nodes.set('epic-1', { id: 'epic-1', mapId: 'map-1', parentId: null });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload: {
+        externalId: 'o/r#42',
+        issueTitle: 'New',
+        parentNodeId: 'epic-1',
+      },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error?.code).toBe('NOT_ORPHAN');
+    expect(createNodeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when parentNodeId is not in this map', async () => {
+    nodes.set('outside', { id: 'outside', mapId: 'other-map', parentId: null });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload: {
+        externalId: 'o/r#42',
+        issueTitle: 'New',
+        parentNodeId: 'outside',
+      },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    expect(createNodeMock).not.toHaveBeenCalled();
+  });
+
+  it('400 when externalId / issueTitle / parentNodeId missing', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload: { externalId: 'o/r#42' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST .../triage-decisions/orphan-skip', () => {
+  it('403 for API-key auth', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-skip',
+      payload: { externalId: 'o/r#42', issueTitle: 'x' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('inserts a skip row, no node created', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-skip',
+      payload: {
+        externalId: 'o/r#7',
+        issueTitle: 'Orphan to skip',
+        issueState: 'open',
+      },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('skipped');
+    const inserted = [...triageRows.values()].find(
+      (r) => r.externalId === 'o/r#7',
+    );
+    expect(inserted).toBeDefined();
+    expect(inserted!.decision).toBe('skip');
+    expect(inserted!.decidedBy).toBe('operator');
+    expect(inserted!.reviewed).toBe(true);
+    expect(createNodeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when a triage row already exists (409 NOT_ORPHAN)', async () => {
+    seedRow({ id: 'tr-existing', externalId: 'o/r#7' });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-skip',
+      payload: { externalId: 'o/r#7', issueTitle: 'x' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error?.code).toBe('NOT_ORPHAN');
   });
 });

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -157,6 +157,16 @@ function buildSelectChain(fields?: Record<string, unknown>) {
   };
 }
 
+// #141 race-fix harness: a hoisted holder so the test can install a gate
+// that the mocked `db.transaction` will consult before invoking the
+// callback. `gate` returns (or resolves to) void; resolving it lets the
+// transaction body run. The race test uses this to hold the second tx
+// outside its callback until the first tx has committed.
+const txGateHolder = vi.hoisted(() => ({
+  enter: undefined as ((n: number) => Promise<void> | void) | undefined,
+  count: 0,
+}));
+
 vi.mock('../../db/connection.js', () => {
   const db = {
     select: (fields?: Record<string, unknown>) => buildSelectChain(fields),
@@ -227,7 +237,23 @@ vi.mock('../../db/connection.js', () => {
         return thenable;
       },
     }),
-    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(db),
+    // #141 race-fix: orphan-import / orphan-skip routes call
+    // `tx.execute(sql\`SELECT pg_advisory_xact_lock(...)\`)` inside their
+    // transactions. The mock has no real DB, so `execute` is a no-op.
+    // The gate below lets a test simulate Postgres's advisory-lock
+    // serialization: when armed, the Nth transaction waits on the
+    // promise returned by `__txGate(N)` before its callback runs, so the
+    // test can hold #2 outside the tx body until #1 has committed (i.e.
+    // its insert is visible to the in-tx precheck).
+    execute: async () => undefined,
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      if (txGateHolder.enter) {
+        const n = txGateHolder.count;
+        txGateHolder.count = n + 1;
+        await txGateHolder.enter(n);
+      }
+      return cb(db);
+    },
   };
   return { db };
 });
@@ -454,6 +480,9 @@ beforeEach(() => {
   githubContextMock.mockImplementation(async () => null);
   importGitHubIssuesMock.mockReset();
   importGitHubIssuesMock.mockImplementation(async () => []);
+  // #141 race-fix harness: clear any gate left armed by a previous test.
+  txGateHolder.enter = undefined;
+  txGateHolder.count = 0;
 });
 
 // ── Auth gate ────────────────────────────────────────────────────
@@ -2400,5 +2429,141 @@ describe('POST .../triage-decisions/orphan-skip', () => {
     await app.close();
     expect(res.statusCode).toBe(409);
     expect(res.json().error?.code).toBe('NOT_ORPHAN');
+  });
+});
+
+// ── Ray review (#141 round 2) ────────────────────────────────────
+//
+// Two should-fixes folded in after Ray's APPROVE: the race window on
+// orphan-import / orphan-skip (precheck was outside the tx, so two
+// concurrent callers could both pass it and the loser would crash on
+// the unique constraint) and the `change_type='overridden'` mis-label
+// on brand-new audit rows (semantically it's `'created'`).
+describe('orphan-import / orphan-skip — race-safety + audit-history change_type', () => {
+  it('orphan-import records change_type=created (brand-new row, no previous decision)', async () => {
+    nodes.set('epic-1', { id: 'epic-1', mapId: 'map-1', parentId: null });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload: {
+        externalId: 'o/r#new',
+        issueTitle: 'New orphan',
+        parentNodeId: 'epic-1',
+      },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const history = [...historyRows.values()];
+    expect(history.length).toBe(1);
+    expect(history[0].changeType).toBe('created');
+    expect(history[0].previousDecision).toBeNull();
+    expect(history[0].newDecision).toBe('place');
+  });
+
+  it('orphan-skip records change_type=created (brand-new row, no previous decision)', async () => {
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-skip',
+      payload: { externalId: 'o/r#skip-new', issueTitle: 'Skip me' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const history = [...historyRows.values()];
+    expect(history.length).toBe(1);
+    expect(history[0].changeType).toBe('created');
+    expect(history[0].previousDecision).toBeNull();
+    expect(history[0].newDecision).toBe('skip');
+  });
+
+  it('orphan-import: two concurrent callers — exactly one wins, the other gets 409 NOT_ORPHAN', async () => {
+    // Race-simulation harness: gate the second transaction outside its
+    // callback until the first transaction has fully committed its
+    // INSERT. The fix moves the precheck *inside* the tx after the
+    // advisory lock, so when caller #2's tx body finally runs, its
+    // in-tx precheck reads caller #1's just-inserted row and returns
+    // the documented 409 — not a raw DB error.
+    nodes.set('epic-1', { id: 'epic-1', mapId: 'map-1', parentId: null });
+    permissionLevel = 'edit';
+    let releaseSecond: (() => void) | null = null;
+    const secondReady = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    txGateHolder.enter = (n: number) => {
+      if (n === 0) return; // first tx runs immediately
+      return secondReady; // second tx waits until we release it
+    };
+    const app = await buildApp('jwt');
+    const payload = {
+      externalId: 'o/r#race',
+      issueTitle: 'Racy orphan',
+      parentNodeId: 'epic-1',
+    };
+    const a = app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload,
+    });
+    const b = app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-import',
+      payload,
+    });
+    // First caller completes its transaction (insert visible), then we
+    // release the second caller — its in-tx precheck must now 409.
+    const aResult = await a;
+    releaseSecond!();
+    const bResult = await b;
+    await app.close();
+    const codes = [aResult.statusCode, bResult.statusCode].sort();
+    expect(codes).toEqual([200, 409]);
+    const winner = aResult.statusCode === 200 ? aResult : bResult;
+    const loser = aResult.statusCode === 409 ? aResult : bResult;
+    expect(winner.json().status).toBe('imported');
+    expect(loser.json().error?.code).toBe('NOT_ORPHAN');
+    // Exactly one triage row + one history row got persisted.
+    expect(triageRows.size).toBe(1);
+    expect(historyRows.size).toBe(1);
+    expect([...historyRows.values()][0].changeType).toBe('created');
+  });
+
+  it('orphan-skip: two concurrent callers — exactly one wins, the other gets 409 NOT_ORPHAN', async () => {
+    permissionLevel = 'edit';
+    let releaseSecond: (() => void) | null = null;
+    const secondReady = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    txGateHolder.enter = (n: number) => {
+      if (n === 0) return;
+      return secondReady;
+    };
+    const app = await buildApp('jwt');
+    const payload = { externalId: 'o/r#skip-race', issueTitle: 'Racy skip' };
+    const a = app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-skip',
+      payload,
+    });
+    const b = app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/orphan-skip',
+      payload,
+    });
+    const aResult = await a;
+    releaseSecond!();
+    const bResult = await b;
+    await app.close();
+    const codes = [aResult.statusCode, bResult.statusCode].sort();
+    expect(codes).toEqual([200, 409]);
+    const winner = aResult.statusCode === 200 ? aResult : bResult;
+    const loser = aResult.statusCode === 409 ? aResult : bResult;
+    expect(winner.json().status).toBe('skipped');
+    expect(loser.json().error?.code).toBe('NOT_ORPHAN');
+    expect(triageRows.size).toBe(1);
+    expect(historyRows.size).toBe(1);
+    expect([...historyRows.values()][0].changeType).toBe('created');
   });
 });

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -592,38 +592,49 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         });
       }
 
-      // Conflict guard: if a triage_decisions row OR an externalLink
-      // for this issue already exists, the operator's view was stale —
-      // tell them rather than silently double-inserting. The unified
-      // view will refresh and show the row in its real bucket on the
-      // next poll.
-      const [existingRow] = await db
-        .select({ id: triageDecisions.id })
-        .from(triageDecisions)
-        .where(
-          and(
-            eq(triageDecisions.mapId, req.params.mapId),
-            eq(triageDecisions.externalId, body.externalId),
-          ),
-        );
-      if (existingRow) {
-        return reply.status(409).send({
-          error: {
-            code: 'NOT_ORPHAN',
-            message:
-              'A triage decision already exists for this issue — use the override / confirm route instead',
-          },
-        });
-      }
-
-      // Insert + create the node in a single transaction so a crash
-      // doesn't leave a half-attached row.
+      // Conflict guard + insert in a single transaction. We take a
+      // Postgres advisory xact lock keyed on the externalId so two
+      // concurrent orphan-import calls for the same issue can't both
+      // pass the precheck and race the unique `(map_id, external_id)`
+      // constraint — the loser would otherwise crash with a raw DB
+      // error (500) instead of the documented `409 NOT_ORPHAN`.
+      //
+      // Same lock pattern as `ensureNodeForIssue` in
+      // sync/githubIngest.ts:127 — precheck inside the tx with the
+      // lock held, then INSERT in the same tx so the row is visible
+      // to the next caller's precheck the instant we commit.
       const isClosed = issueState === 'closed';
       const externalId = body.externalId;
       const issueTitle = body.issueTitle;
       const reason = body.reason ?? 'Operator imported orphan from GitHub';
       const parentNodeId = body.parentNodeId;
-      const result = await db.transaction(async (tx) => {
+      type TxResult =
+        | { kind: 'conflict' }
+        | {
+            kind: 'ok';
+            node: Awaited<ReturnType<typeof nodeDb.createNode>> | null;
+            decisionId: string | null;
+          };
+      const txResult: TxResult = await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtextextended(${externalId}, 0))`,
+        );
+        // Re-run the precheck *inside* the tx with the lock held so a
+        // concurrent caller that got past its own precheck (before we
+        // took the lock) is now blocked behind us; when it wakes up,
+        // its precheck reads our just-inserted row and 409s.
+        const [existingRow] = await tx
+          .select({ id: triageDecisions.id })
+          .from(triageDecisions)
+          .where(
+            and(
+              eq(triageDecisions.mapId, req.params.mapId),
+              eq(triageDecisions.externalId, externalId),
+            ),
+          );
+        if (existingRow) {
+          return { kind: 'conflict' };
+        }
         const node = await nodeDb.createNode(
           {
             mapId: req.params.mapId,
@@ -667,9 +678,24 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
             reviewedBy: userId,
           })
           .returning({ id: triageDecisions.id });
-        return { node: updated ?? node, decisionId: inserted?.id ?? null };
+        return {
+          kind: 'ok',
+          node: updated ?? node,
+          decisionId: inserted?.id ?? null,
+        };
       });
 
+      if (txResult.kind === 'conflict') {
+        return reply.status(409).send({
+          error: {
+            code: 'NOT_ORPHAN',
+            message:
+              'A triage decision already exists for this issue — use the override / confirm route instead',
+          },
+        });
+      }
+
+      const result = txResult;
       if (result.node) {
         broadcast(req.params.mapId, {
           type: 'node:created',
@@ -678,10 +704,16 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         });
       }
       if (result.decisionId) {
+        // Brand-new row — there's no previous decision to override, so
+        // the audit-history `change_type` is 'created'. The orphan
+        // routes only reach this branch when the precheck above said
+        // no row existed, so the orphan case maps cleanly onto the
+        // ingest path's `previous ? 'overridden' : 'created'` rule
+        // (sync/githubIngest.ts:808).
         await recordTriageHistory({
           decisionId: result.decisionId,
           changedBy: userId,
-          changeType: 'overridden',
+          changeType: 'created',
           previousDecision: null,
           newDecision: 'place',
           previousConfidence: null,
@@ -745,18 +777,57 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       const issueState = body.issueState === 'closed' ? 'closed' : 'open';
       const reason = body.reason ?? 'Operator marked orphan as skip';
 
-      // Same conflict-guard as orphan-import: the row mustn't already
-      // exist.
-      const [existingRow] = await db
-        .select({ id: triageDecisions.id })
-        .from(triageDecisions)
-        .where(
-          and(
-            eq(triageDecisions.mapId, req.params.mapId),
-            eq(triageDecisions.externalId, body.externalId),
-          ),
+      // Same conflict-guard as orphan-import + race protection: take an
+      // advisory xact lock keyed on externalId so the precheck + INSERT
+      // run atomically against any concurrent orphan-skip /
+      // orphan-import for the same issue. Without the lock, two callers
+      // could both pass a pre-tx precheck and the loser would hit the
+      // unique `(map_id, external_id)` constraint as a raw 500 instead
+      // of a documented 409 NOT_ORPHAN.
+      const externalId = body.externalId;
+      const issueTitle = body.issueTitle;
+      type SkipTxResult =
+        | { kind: 'conflict' }
+        | { kind: 'ok'; decisionId: string | null };
+      const txResult: SkipTxResult = await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtextextended(${externalId}, 0))`,
         );
-      if (existingRow) {
+        const [existingRow] = await tx
+          .select({ id: triageDecisions.id })
+          .from(triageDecisions)
+          .where(
+            and(
+              eq(triageDecisions.mapId, req.params.mapId),
+              eq(triageDecisions.externalId, externalId),
+            ),
+          );
+        if (existingRow) {
+          return { kind: 'conflict' };
+        }
+        const [inserted] = await tx
+          .insert(triageDecisions)
+          .values({
+            mapId: req.params.mapId,
+            externalId,
+            issueTitle,
+            issueState,
+            decision: 'skip',
+            reason,
+            confidence: 100,
+            placedNodeId: null,
+            suggestedParentNodeId: null,
+            decidedBy: 'operator',
+            decidedAt: new Date(),
+            reviewed: true,
+            reviewedAt: new Date(),
+            reviewedBy: userId,
+          })
+          .returning({ id: triageDecisions.id });
+        return { kind: 'ok', decisionId: inserted?.id ?? null };
+      });
+
+      if (txResult.kind === 'conflict') {
         return reply.status(409).send({
           error: {
             code: 'NOT_ORPHAN',
@@ -766,33 +837,17 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         });
       }
 
-      const externalId = body.externalId;
-      const issueTitle = body.issueTitle;
-      const [inserted] = await db
-        .insert(triageDecisions)
-        .values({
-          mapId: req.params.mapId,
-          externalId,
-          issueTitle,
-          issueState,
-          decision: 'skip',
-          reason,
-          confidence: 100,
-          placedNodeId: null,
-          suggestedParentNodeId: null,
-          decidedBy: 'operator',
-          decidedAt: new Date(),
-          reviewed: true,
-          reviewedAt: new Date(),
-          reviewedBy: userId,
-        })
-        .returning({ id: triageDecisions.id });
-
-      if (inserted?.id) {
+      const insertedId = txResult.decisionId;
+      if (insertedId) {
+        // Brand-new row → audit-history `change_type` is 'created'.
+        // The orphan routes only insert when the precheck above said
+        // no row existed, so we match the ingest path's
+        // `previous ? 'overridden' : 'created'` rule
+        // (sync/githubIngest.ts:808).
         await recordTriageHistory({
-          decisionId: inserted.id,
+          decisionId: insertedId,
           changedBy: userId,
-          changeType: 'overridden',
+          changeType: 'created',
           previousDecision: null,
           newDecision: 'skip',
           previousConfidence: null,
@@ -806,11 +861,11 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           externalId,
           decision: 'skip',
         });
-        broadcastTriageUpdated(req.params.mapId, 'overridden', [inserted.id]);
+        broadcastTriageUpdated(req.params.mapId, 'overridden', [insertedId]);
       }
 
       return reply.send({
-        decisionId: inserted?.id ?? null,
+        decisionId: insertedId,
         status: 'skipped',
       });
     },

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -65,6 +65,8 @@ import { buildMapContext } from '../sync/mapContext.js';
 import { triageIssue } from '../sync/triage.js';
 import { recordTriageHistory } from '../sync/triageHistory.js';
 import { applyTriageLabel } from '../sync/triageLabelWriteback.js';
+import { getGitHubContextForMap } from '../lib/githubContext.js';
+import { importGitHubIssues } from '@mindblown/integrations';
 import type { ExternalLink } from '@mindblown/core';
 
 // ── Auth helpers ──────────────────────────────────────────────────
@@ -258,6 +260,561 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       decisions: rows,
     });
   });
+
+  // ── GET /api/maps/:mapId/triage-decisions/not-in-mindblown ────
+  // Closes #140. A unified view of every GitHub ticket that is NOT
+  // currently a node in this map, split into four buckets:
+  //
+  //   - 'skipped'         — decision=skip AND reviewed=true
+  //   - 'pending-skipped' — decision=skip AND reviewed=false
+  //   - 'uncertain'       — decision=uncertain (regardless of reviewed)
+  //   - 'orphan'          — no triage_decisions row AND no node anywhere
+  //                         in this map references the issue's externalId
+  //
+  // Today the Triage Panel only surfaces the first three implicitly via
+  // its Pending/Skipped tabs (mixed with `place` rows); orphans are
+  // invisible except via the `github_sync_overview` endpoint. This view
+  // brings them all together with a single shape so the operator (and
+  // Eve via MCP) can answer "what's in GitHub that's not on the
+  // roadmap?" in one round-trip.
+  //
+  // Query params:
+  //   bucket=skipped|pending-skipped|uncertain|orphans|all  (default all)
+  //   limit=N  (default 50, hard cap 200)
+  //   since=ISO  (decision rows only — orphans don't carry a decidedAt)
+  //
+  // The orphan branch needs a live GitHub fetch via importGitHubIssues
+  // (same source the `github_sync_overview` route uses). When GitHub
+  // isn't configured for this map we silently skip orphans rather than
+  // failing the whole call — the decision-bucket data is still useful
+  // on a triage-only setup. The MCP tool surfaces this fact via the
+  // `orphansAvailable` flag.
+  //
+  // Auth: same gate as the other triage routes — session JWT + 'view'
+  // permission, API-key auth rejected.
+  app.get<{
+    Params: { mapId: string };
+    Querystring: {
+      bucket?: string;
+      limit?: string;
+      since?: string;
+    };
+  }>(
+    '/api/maps/:mapId/triage-decisions/not-in-mindblown',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'view');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+
+      const requestedBucket = req.query.bucket ?? 'all';
+      const validBuckets = new Set([
+        'all',
+        'skipped',
+        'pending-skipped',
+        'uncertain',
+        'orphans',
+      ]);
+      if (!validBuckets.has(requestedBucket)) {
+        return reply.status(400).send({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: `bucket must be one of: skipped, pending-skipped, uncertain, orphans, all (got '${requestedBucket}')`,
+          },
+        });
+      }
+
+      const limitRaw = req.query.limit ? parseInt(req.query.limit, 10) : 50;
+      const limit = Number.isFinite(limitRaw) && limitRaw > 0
+        ? Math.min(limitRaw, 200)
+        : 50;
+
+      let sinceDate: Date | null = null;
+      if (req.query.since) {
+        const t = Date.parse(req.query.since);
+        // Same posture as the main list route: silently ignore a
+        // malformed `since` rather than 400-erroring, so a URL typo
+        // doesn't blank the panel.
+        if (Number.isFinite(t)) sinceDate = new Date(t);
+      }
+
+      // ── Bucket 1-3: decision-row buckets (skipped, pending-skipped, uncertain) ──
+      //
+      // We always pull all three buckets unless `bucket` filters us
+      // down — a single SELECT against `triage_decisions` covers all
+      // three, then we partition in memory. The whole-row pre-limit
+      // count is small (capped at 200 server-wide for the existing
+      // triage list), so partitioning client-side is cheap.
+      const decisionFilters = [eq(triageDecisions.mapId, req.params.mapId)];
+      if (sinceDate) {
+        decisionFilters.push(gte(triageDecisions.decidedAt, sinceDate));
+      }
+
+      type DecisionItem = {
+        kind: 'skipped' | 'pending-skipped' | 'uncertain';
+        triageDecisionId: string;
+        decision: 'skip' | 'uncertain';
+        reason: string;
+        confidence: number;
+        decidedAt: string;
+        externalId: string;
+        issueTitle: string;
+        issueState: 'open' | 'closed';
+        issueUrl: string;
+      };
+
+      const decisionItems: DecisionItem[] = [];
+      const needDecisionRows =
+        requestedBucket === 'all' ||
+        requestedBucket === 'skipped' ||
+        requestedBucket === 'pending-skipped' ||
+        requestedBucket === 'uncertain';
+      // Track decision-row externalIds so the orphan branch can filter
+      // them out — same map of triaged ids regardless of bucket filter.
+      const triagedExternalIds = new Set<string>();
+      if (needDecisionRows || requestedBucket === 'orphans') {
+        const rows = await db
+          .select()
+          .from(triageDecisions)
+          .where(and(...decisionFilters))
+          .orderBy(desc(triageDecisions.decidedAt));
+        for (const row of rows) {
+          triagedExternalIds.add(row.externalId);
+          // Decision items only include skip/uncertain — `place`
+          // decisions belong on the map and don't fit "not in
+          // MindBlown" (whether they're actually placed yet is
+          // covered by the existing Pending/Placed tabs).
+          if (row.decision !== 'skip' && row.decision !== 'uncertain') continue;
+          let kind: DecisionItem['kind'];
+          if (row.decision === 'uncertain') {
+            kind = 'uncertain';
+          } else if (row.reviewed) {
+            kind = 'skipped';
+          } else {
+            kind = 'pending-skipped';
+          }
+          if (
+            requestedBucket !== 'all' &&
+            requestedBucket !== 'orphans' &&
+            kind !== requestedBucket
+          ) {
+            continue;
+          }
+          if (!needDecisionRows && requestedBucket === 'orphans') {
+            // We only walked the table to populate triagedExternalIds
+            // for the orphan filter — skip pushing the item.
+            continue;
+          }
+          decisionItems.push({
+            kind,
+            triageDecisionId: row.id,
+            decision: row.decision,
+            reason: row.reason,
+            confidence: row.confidence,
+            decidedAt:
+              row.decidedAt instanceof Date
+                ? row.decidedAt.toISOString()
+                : String(row.decidedAt),
+            externalId: row.externalId,
+            issueTitle: row.issueTitle,
+            issueState: (row.issueState === 'closed' ? 'closed' : 'open'),
+            issueUrl: buildIssueUrlFromExternalId(row.externalId),
+          });
+        }
+      }
+
+      // ── Bucket 4: orphans ──
+      //
+      // GitHub issues that have NO triage_decisions row AND no node in
+      // this map carrying an externalLink with their externalId. Same
+      // logic as `github_sync_overview.onlyInGitHub`, minus rows that
+      // already exist in triage (those are covered by the three buckets
+      // above).
+      //
+      // Three reasons to skip the orphan branch:
+      //   - operator filtered to a non-orphan bucket
+      //   - GitHub isn't configured on this map
+      //   - importGitHubIssues throws (rate limit, network)
+      // We surface `orphansAvailable` and `orphansError` on the response
+      // so the UI can render an inline notice without failing the whole
+      // request — the operator can still triage skip/uncertain rows
+      // when GitHub is unreachable.
+      type OrphanItem = {
+        kind: 'orphan';
+        externalId: string;
+        issueTitle: string;
+        issueState: 'open' | 'closed';
+        issueUrl: string;
+      };
+      const orphanItems: OrphanItem[] = [];
+      let orphansAvailable = false;
+      let orphansError: string | null = null;
+      const needOrphans = requestedBucket === 'all' || requestedBucket === 'orphans';
+      if (needOrphans) {
+        const ghCtx = await getGitHubContextForMap(req.params.mapId);
+        if (!ghCtx) {
+          orphansError = 'GitHub is not configured for this map — orphan bucket skipped';
+        } else {
+          try {
+            const imported = await importGitHubIssues(
+              ghCtx.owner,
+              ghCtx.repo,
+              ghCtx.token,
+              { includeAll: true },
+            );
+            // Build the set of externalIds already on a node in this
+            // map (any node with a github externalLink, deleted or not
+            // — we already filter to `notDeleted` below since deleted
+            // nodes shouldn't count as "in MindBlown").
+            const linkedNodes = await db
+              .select({
+                id: nodes.id,
+                externalLinks: nodes.externalLinks,
+              })
+              .from(nodes)
+              .where(and(eq(nodes.mapId, req.params.mapId), notDeleted));
+            const linkedExternalIds = new Set<string>();
+            for (const n of linkedNodes) {
+              const links = (n.externalLinks as ExternalLink[] | null) ?? [];
+              for (const l of links) {
+                if (l.provider === 'github' && l.externalId) {
+                  linkedExternalIds.add(l.externalId);
+                }
+              }
+            }
+            orphansAvailable = true;
+            for (const item of imported) {
+              const externalId = item.externalLink.externalId;
+              if (triagedExternalIds.has(externalId)) continue;
+              if (linkedExternalIds.has(externalId)) continue;
+              orphanItems.push({
+                kind: 'orphan',
+                externalId,
+                issueTitle: item.issue.title,
+                issueState: item.issue.state,
+                issueUrl: item.issue.html_url,
+              });
+            }
+          } catch (err) {
+            orphansError =
+              err instanceof Error
+                ? `GitHub fetch failed: ${err.message}`
+                : 'GitHub fetch failed';
+          }
+        }
+      }
+
+      // ── Stitch + paginate ──
+      // Items returned newest-first across buckets. Decision rows carry
+      // a real `decidedAt`; orphans don't (no decision row exists) — we
+      // append them after the decision items so the operator sees recent
+      // triage activity at the top, with the "never reviewed at all"
+      // tail at the bottom. Within each bucket we keep the source order
+      // (decisions are sorted by decided_at desc by the SQL; orphans
+      // are sorted by GitHub's `created asc` from importGitHubIssues —
+      // we don't re-sort to avoid a second pass).
+      const allItems = [...decisionItems, ...orphanItems];
+      const total = allItems.length;
+      const paged = allItems.slice(0, limit);
+
+      return reply.send({
+        mapId: req.params.mapId,
+        bucket: requestedBucket,
+        total,
+        returned: paged.length,
+        orphansAvailable,
+        orphansError,
+        items: paged,
+      });
+    },
+  );
+
+  // ── POST /api/maps/:mapId/triage-decisions/orphan-import ─────
+  // #140 — operator picks an orphan (GitHub issue with no decision row
+  // + no node) and imports it into the map. Creates the triage_decisions
+  // row directly (decision='place', decided_by='operator', reviewed=
+  // true), then creates the node under parentNodeId and attaches the
+  // github externalLink. This is the orphan analogue to the existing
+  // /override route's `place` branch, except the row doesn't exist yet
+  // so we INSERT instead of UPDATE.
+  //
+  // Body: { externalId, issueTitle, issueState?, parentNodeId, reason? }
+  app.post<{
+    Params: { mapId: string };
+    Body: {
+      externalId?: string;
+      issueTitle?: string;
+      issueState?: string;
+      parentNodeId?: string;
+      reason?: string;
+    };
+  }>(
+    '/api/maps/:mapId/triage-decisions/orphan-import',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'edit');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+      const userId = req.userId as string;
+      const body = req.body ?? {};
+      if (!body.externalId || typeof body.externalId !== 'string') {
+        return reply.status(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'externalId is required' },
+        });
+      }
+      if (!body.issueTitle || typeof body.issueTitle !== 'string') {
+        return reply.status(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'issueTitle is required' },
+        });
+      }
+      if (!body.parentNodeId || typeof body.parentNodeId !== 'string') {
+        return reply.status(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'parentNodeId is required' },
+        });
+      }
+      const issueState = body.issueState === 'closed' ? 'closed' : 'open';
+
+      // Validate the parent is in this map.
+      const [parent] = await db
+        .select({ id: nodes.id, mapId: nodes.mapId })
+        .from(nodes)
+        .where(and(eq(nodes.id, body.parentNodeId), notDeleted));
+      if (!parent || parent.mapId !== req.params.mapId) {
+        return reply.status(400).send({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'parentNodeId must be a node in this map',
+          },
+        });
+      }
+
+      // Conflict guard: if a triage_decisions row OR an externalLink
+      // for this issue already exists, the operator's view was stale —
+      // tell them rather than silently double-inserting. The unified
+      // view will refresh and show the row in its real bucket on the
+      // next poll.
+      const [existingRow] = await db
+        .select({ id: triageDecisions.id })
+        .from(triageDecisions)
+        .where(
+          and(
+            eq(triageDecisions.mapId, req.params.mapId),
+            eq(triageDecisions.externalId, body.externalId),
+          ),
+        );
+      if (existingRow) {
+        return reply.status(409).send({
+          error: {
+            code: 'NOT_ORPHAN',
+            message:
+              'A triage decision already exists for this issue — use the override / confirm route instead',
+          },
+        });
+      }
+
+      // Insert + create the node in a single transaction so a crash
+      // doesn't leave a half-attached row.
+      const isClosed = issueState === 'closed';
+      const externalId = body.externalId;
+      const issueTitle = body.issueTitle;
+      const reason = body.reason ?? 'Operator imported orphan from GitHub';
+      const parentNodeId = body.parentNodeId;
+      const result = await db.transaction(async (tx) => {
+        const node = await nodeDb.createNode(
+          {
+            mapId: req.params.mapId,
+            parentId: parentNodeId,
+            text: `#${parseIssueNumber(externalId)} ${issueTitle}`,
+            createdBy: userId,
+            percentComplete: isClosed ? 100 : 0,
+            status: isClosed ? 'done' : 'todo',
+          },
+          tx,
+        );
+        const link: ExternalLink = {
+          provider: 'github',
+          externalId,
+          url: buildIssueUrlFromExternalId(externalId),
+          syncEnabled: true,
+          lastSyncedAt: new Date().toISOString(),
+        };
+        const updated = await nodeDb.updateNode(
+          node.id,
+          { externalLinks: [link] },
+          undefined,
+          tx,
+        );
+        const [inserted] = await tx
+          .insert(triageDecisions)
+          .values({
+            mapId: req.params.mapId,
+            externalId,
+            issueTitle,
+            issueState,
+            decision: 'place',
+            reason,
+            confidence: 100,
+            placedNodeId: node.id,
+            suggestedParentNodeId: null,
+            decidedBy: 'operator',
+            decidedAt: new Date(),
+            reviewed: true,
+            reviewedAt: new Date(),
+            reviewedBy: userId,
+          })
+          .returning({ id: triageDecisions.id });
+        return { node: updated ?? node, decisionId: inserted?.id ?? null };
+      });
+
+      if (result.node) {
+        broadcast(req.params.mapId, {
+          type: 'node:created',
+          node: result.node,
+          source: 'triage_orphan_import',
+        });
+      }
+      if (result.decisionId) {
+        await recordTriageHistory({
+          decisionId: result.decisionId,
+          changedBy: userId,
+          changeType: 'overridden',
+          previousDecision: null,
+          newDecision: 'place',
+          previousConfidence: null,
+          newConfidence: 100,
+          previousParentNodeId: null,
+          newParentNodeId: result.node?.id ?? null,
+          reason,
+        });
+        await applyTriageLabel({
+          mapId: req.params.mapId,
+          externalId,
+          decision: 'place',
+        });
+        broadcastTriageUpdated(req.params.mapId, 'overridden', [result.decisionId]);
+      }
+
+      return reply.send({
+        decisionId: result.decisionId,
+        nodeId: result.node?.id ?? null,
+        status: 'imported',
+      });
+    },
+  );
+
+  // ── POST /api/maps/:mapId/triage-decisions/orphan-skip ───────
+  // #140 — operator marks an orphan as "skip" without creating a node.
+  // Inserts a triage_decisions row (decision='skip', decided_by=
+  // 'operator', reviewed=true). After this call the issue moves out of
+  // the 'orphan' bucket and into 'skipped' in the unified view.
+  //
+  // Body: { externalId, issueTitle, issueState?, reason? }
+  app.post<{
+    Params: { mapId: string };
+    Body: {
+      externalId?: string;
+      issueTitle?: string;
+      issueState?: string;
+      reason?: string;
+    };
+  }>(
+    '/api/maps/:mapId/triage-decisions/orphan-skip',
+    async (req, reply) => {
+      const gate = await gateMapAccess(req, req.params.mapId, 'edit');
+      if (gate) {
+        return reply.status(gate.status).send({
+          error: { code: gate.code, message: gate.message },
+        });
+      }
+      const userId = req.userId as string;
+      const body = req.body ?? {};
+      if (!body.externalId || typeof body.externalId !== 'string') {
+        return reply.status(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'externalId is required' },
+        });
+      }
+      if (!body.issueTitle || typeof body.issueTitle !== 'string') {
+        return reply.status(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'issueTitle is required' },
+        });
+      }
+      const issueState = body.issueState === 'closed' ? 'closed' : 'open';
+      const reason = body.reason ?? 'Operator marked orphan as skip';
+
+      // Same conflict-guard as orphan-import: the row mustn't already
+      // exist.
+      const [existingRow] = await db
+        .select({ id: triageDecisions.id })
+        .from(triageDecisions)
+        .where(
+          and(
+            eq(triageDecisions.mapId, req.params.mapId),
+            eq(triageDecisions.externalId, body.externalId),
+          ),
+        );
+      if (existingRow) {
+        return reply.status(409).send({
+          error: {
+            code: 'NOT_ORPHAN',
+            message:
+              'A triage decision already exists for this issue — use the override route instead',
+          },
+        });
+      }
+
+      const externalId = body.externalId;
+      const issueTitle = body.issueTitle;
+      const [inserted] = await db
+        .insert(triageDecisions)
+        .values({
+          mapId: req.params.mapId,
+          externalId,
+          issueTitle,
+          issueState,
+          decision: 'skip',
+          reason,
+          confidence: 100,
+          placedNodeId: null,
+          suggestedParentNodeId: null,
+          decidedBy: 'operator',
+          decidedAt: new Date(),
+          reviewed: true,
+          reviewedAt: new Date(),
+          reviewedBy: userId,
+        })
+        .returning({ id: triageDecisions.id });
+
+      if (inserted?.id) {
+        await recordTriageHistory({
+          decisionId: inserted.id,
+          changedBy: userId,
+          changeType: 'overridden',
+          previousDecision: null,
+          newDecision: 'skip',
+          previousConfidence: null,
+          newConfidence: 100,
+          previousParentNodeId: null,
+          newParentNodeId: null,
+          reason,
+        });
+        await applyTriageLabel({
+          mapId: req.params.mapId,
+          externalId,
+          decision: 'skip',
+        });
+        broadcastTriageUpdated(req.params.mapId, 'overridden', [inserted.id]);
+      }
+
+      return reply.send({
+        decisionId: inserted?.id ?? null,
+        status: 'skipped',
+      });
+    },
+  );
 
   // ── GET /api/maps/:mapId/triage-decisions/:decisionId/history ─
   // Phase 3 (#96). Returns the append-only audit log for a single

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -73,6 +73,51 @@ export interface TriageActionResult {
   placedNodeId?: string | null;
 }
 
+// ── Not-in-MindBlown unified view (#140) ─────────────────────────
+// One result shape covers four buckets: skip + reviewed (skipped),
+// skip + unreviewed (pending-skipped), uncertain, and orphans (GH
+// issues that have no triage_decisions row + no node in the map).
+// The orphan branch needs a live GitHub fetch; if it's unavailable
+// (no integration / API error) the route still returns the decision-
+// row buckets and signals via `orphansAvailable`/`orphansError`.
+
+export type NotInMindBlownKind =
+  | 'skipped'
+  | 'pending-skipped'
+  | 'uncertain'
+  | 'orphan';
+
+export interface NotInMindBlownItem {
+  kind: NotInMindBlownKind;
+  // Decision-row buckets carry these; orphans have neither.
+  triageDecisionId?: string;
+  decision?: 'skip' | 'uncertain';
+  reason?: string;
+  confidence?: number;
+  decidedAt?: string;
+  // Always set.
+  externalId: string;
+  issueTitle: string;
+  issueState: 'open' | 'closed';
+  issueUrl: string;
+}
+
+export interface NotInMindBlownFilters {
+  bucket?: NotInMindBlownKind | 'all' | 'orphans';
+  limit?: number;
+  since?: string;
+}
+
+export interface NotInMindBlownResult {
+  mapId: string;
+  bucket: string;
+  total: number;
+  returned: number;
+  orphansAvailable: boolean;
+  orphansError: string | null;
+  items: NotInMindBlownItem[];
+}
+
 // ── Orchestration substrate (#111) ─────────────────────────────────
 
 export interface ReadyNode {
@@ -191,6 +236,12 @@ export interface ToolBackend {
   ): Promise<TriageActionResult>;
   reclassifyTriage(mapId: string, decisionId: string): Promise<TriageActionResult>;
   confirmTriage(mapId: string, decisionId: string): Promise<TriageActionResult>;
+
+  // ── Not-in-MindBlown unified view (#140) ────────────────────────
+  listNotInMindBlown(
+    mapId: string,
+    filters: NotInMindBlownFilters,
+  ): Promise<NotInMindBlownResult>;
 
   // ── Orchestration substrate (#111) ──────────────────────────────
   readyNodes(

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -83,6 +83,7 @@ function makeRecordingBackend(): {
     overrideTriage: async () => { throw new Error('not implemented'); },
     reclassifyTriage: async () => { throw new Error('not implemented'); },
     confirmTriage: async () => { throw new Error('not implemented'); },
+    listNotInMindBlown: async () => { throw new Error('not implemented'); },
     // Orchestration substrate (#111)
     readyNodes: async () => { throw new Error('not implemented'); },
     claimNode: async () => { throw new Error('not implemented'); },

--- a/packages/tool-kit/src/tools/__tests__/triage.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/triage.test.ts
@@ -15,12 +15,15 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import {
+  listNotInMindBlownTool,
   listTriageDecisionsTool,
   overrideTriageTool,
   reclassifyTriageTool,
   confirmTriageTool,
 } from '../triage.js';
 import type {
+  NotInMindBlownItem,
+  NotInMindBlownResult,
   ToolBackend,
   TriageActionResult,
   TriageDecisionRow,
@@ -39,11 +42,15 @@ interface Recorder {
   } | null;
   lastReclassify: { mapId: string; decisionId: string } | null;
   lastConfirm: { mapId: string; decisionId: string } | null;
+  lastNotInMindBlown: { mapId: string; filters: Record<string, unknown> } | null;
   listResult: TriageListResult;
   overrideResult: TriageActionResult;
   reclassifyResult: TriageActionResult;
   confirmResult: TriageActionResult;
-  throwOn: Partial<Record<'list' | 'override' | 'reclassify' | 'confirm', Error>>;
+  notInMindBlownResult: NotInMindBlownResult;
+  throwOn: Partial<
+    Record<'list' | 'override' | 'reclassify' | 'confirm' | 'notInMindBlown', Error>
+  >;
 }
 
 function makeRecorder(): Recorder {
@@ -52,6 +59,7 @@ function makeRecorder(): Recorder {
     lastOverride: null,
     lastReclassify: null,
     lastConfirm: null,
+    lastNotInMindBlown: null,
     listResult: { mapId: 'm1', total: 0, returned: 0, decisions: [] },
     overrideResult: { decisionId: 'd1', status: 'placed', nodeId: 'n1' },
     reclassifyResult: {
@@ -62,6 +70,15 @@ function makeRecorder(): Recorder {
       reason: 'matches Frontend',
     },
     confirmResult: { decisionId: 'd1', status: 'confirmed', nodeId: 'n1' },
+    notInMindBlownResult: {
+      mapId: 'm1',
+      bucket: 'all',
+      total: 0,
+      returned: 0,
+      orphansAvailable: true,
+      orphansError: null,
+      items: [],
+    },
     throwOn: {},
     backend: {} as ToolBackend,
   };
@@ -100,6 +117,14 @@ function makeRecorder(): Recorder {
       if (state.throwOn.confirm) throw state.throwOn.confirm;
       state.lastConfirm = { mapId, decisionId };
       return state.confirmResult;
+    },
+    listNotInMindBlown: async (mapId, filters) => {
+      if (state.throwOn.notInMindBlown) throw state.throwOn.notInMindBlown;
+      state.lastNotInMindBlown = {
+        mapId,
+        filters: filters as Record<string, unknown>,
+      };
+      return state.notInMindBlownResult;
     },
     // Orchestration substrate (#111)
     readyNodes: async () => { throw new Error('not used'); },
@@ -394,5 +419,135 @@ describe('confirm_triage tool', () => {
         decisionId: 'd1',
       } as never),
     ).rejects.toThrow('API-key auth cannot access');
+  });
+});
+
+// ── list_not_in_mindblown (#140) ─────────────────────────────────
+
+function fakeNotInMindBlownItem(
+  overrides: Partial<NotInMindBlownItem> = {},
+): NotInMindBlownItem {
+  return {
+    kind: 'skipped',
+    triageDecisionId: 'd1',
+    decision: 'skip',
+    reason: 'duplicate',
+    confidence: 90,
+    decidedAt: new Date().toISOString(),
+    externalId: 'o/r#42',
+    issueTitle: 'A title',
+    issueState: 'open',
+    issueUrl: 'https://github.com/o/r/issues/42',
+    ...overrides,
+  };
+}
+
+describe('list_not_in_mindblown tool', () => {
+  it('accepts the documented schema (bucket / limit / since)', () => {
+    const schema = z.object(listNotInMindBlownTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      bucket: 'orphans',
+      limit: 100,
+      since: '2026-01-01T00:00:00Z',
+    });
+    expect(parsed.bucket).toBe('orphans');
+    expect(parsed.limit).toBe(100);
+  });
+
+  it('rejects an invalid bucket value', () => {
+    const schema = z.object(listNotInMindBlownTool.schema);
+    expect(() =>
+      schema.parse({ mapId: 'm1', bucket: 'banana' }),
+    ).toThrow();
+  });
+
+  it('rejects an out-of-range limit', () => {
+    const schema = z.object(listNotInMindBlownTool.schema);
+    expect(() => schema.parse({ mapId: 'm1', limit: 0 })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', limit: 250 })).toThrow();
+  });
+
+  it('happy path: forwards filters to backend and renders breakdown', async () => {
+    const rec = makeRecorder();
+    rec.notInMindBlownResult = {
+      mapId: 'm1',
+      bucket: 'all',
+      total: 3,
+      returned: 3,
+      orphansAvailable: true,
+      orphansError: null,
+      items: [
+        fakeNotInMindBlownItem({ kind: 'skipped', externalId: 'o/r#1' }),
+        fakeNotInMindBlownItem({
+          kind: 'orphan',
+          triageDecisionId: undefined,
+          decision: undefined,
+          reason: undefined,
+          confidence: undefined,
+          decidedAt: undefined,
+          externalId: 'o/r#2',
+        }),
+        fakeNotInMindBlownItem({ kind: 'uncertain', externalId: 'o/r#3' }),
+      ],
+    };
+    const out = await listNotInMindBlownTool.handler(rec.backend, {
+      mapId: 'm1',
+      bucket: 'all',
+      limit: 50,
+    } as never);
+    expect(rec.lastNotInMindBlown).toEqual({
+      mapId: 'm1',
+      filters: { mapId: undefined, bucket: 'all', limit: 50, since: undefined },
+    });
+    // Breakdown line surfaces per-kind counts.
+    expect(out).toContain('skipped=1');
+    expect(out).toContain('orphan=1');
+    expect(out).toContain('uncertain=1');
+    // Orphan item gets the "not yet triaged" suffix instead of a reason.
+    expect(out).toContain('not yet triaged');
+  });
+
+  it('renders the empty-state message when total=0', async () => {
+    const rec = makeRecorder();
+    rec.notInMindBlownResult = {
+      mapId: 'm1',
+      bucket: 'all',
+      total: 0,
+      returned: 0,
+      orphansAvailable: true,
+      orphansError: null,
+      items: [],
+    };
+    const out = await listNotInMindBlownTool.handler(rec.backend, {
+      mapId: 'm1',
+    } as never);
+    expect(out).toContain('No issues found');
+  });
+
+  it('surfaces the orphan-unavailable warning when the backend signals it', async () => {
+    const rec = makeRecorder();
+    rec.notInMindBlownResult = {
+      mapId: 'm1',
+      bucket: 'all',
+      total: 1,
+      returned: 1,
+      orphansAvailable: false,
+      orphansError: 'GitHub not configured',
+      items: [fakeNotInMindBlownItem({ kind: 'skipped' })],
+    };
+    const out = await listNotInMindBlownTool.handler(rec.backend, {
+      mapId: 'm1',
+    } as never);
+    expect(out).toContain('orphan bucket unavailable');
+    expect(out).toContain('GitHub not configured');
+  });
+
+  it('error path: backend throw propagates', async () => {
+    const rec = makeRecorder();
+    rec.throwOn.notInMindBlown = new Error('rate limit');
+    await expect(
+      listNotInMindBlownTool.handler(rec.backend, { mapId: 'm1' } as never),
+    ).rejects.toThrow('rate limit');
   });
 });

--- a/packages/tool-kit/src/tools/triage.ts
+++ b/packages/tool-kit/src/tools/triage.ts
@@ -29,6 +29,7 @@
 import { z } from 'zod';
 import { defineTool } from '../spec.js';
 import type {
+  NotInMindBlownItem,
   TriageDecisionKind,
   TriageDecisionRow,
 } from '../backend.js';
@@ -190,9 +191,94 @@ export const confirmTriageTool = defineTool({
   },
 });
 
+// ── Tool: list_not_in_mindblown (#140) ───────────────────────────
+
+const notInMindBlownBucketEnum = z.enum([
+  'all',
+  'skipped',
+  'pending-skipped',
+  'uncertain',
+  'orphans',
+]);
+
+function renderNotInMindBlownItem(it: NotInMindBlownItem): string {
+  const meta: string[] = [it.externalId, `state=${it.issueState}`];
+  if (it.confidence != null) meta.push(`${it.confidence}%`);
+  if (it.triageDecisionId) meta.push(`decisionId=${it.triageDecisionId}`);
+  const tail = it.kind === 'orphan'
+    ? '\n    not yet triaged'
+    : it.reason
+      ? `\n    reason: ${it.reason}`
+      : '';
+  return `- [${it.kind}] "${it.issueTitle}" (${meta.join(', ')})${tail}`;
+}
+
+export const listNotInMindBlownTool = defineTool({
+  name: 'list_not_in_mindblown',
+  description:
+    "List every GitHub ticket that is NOT currently a node in this map, across four buckets: 'skipped' (decision=skip + reviewed), 'pending-skipped' (decision=skip + unreviewed), 'uncertain' (decision=uncertain), and 'orphan' (no triage row + no node — same set as github_sync_overview.onlyInGitHub). Answers the operator's question 'what's in GitHub that's not on our roadmap?' in one call. The orphan bucket needs GitHub configured on the map; when it's unavailable the response still carries the decision-row buckets and surfaces the reason via orphansAvailable/orphansError. Default returns all four buckets; narrow with bucket=. Default limit 50, max 200.",
+  schema: {
+    mapId: z.string().describe('The map ID'),
+    bucket: notInMindBlownBucketEnum
+      .optional()
+      .describe(
+        "Narrow to one bucket. Pass 'all' (or omit) for every bucket. 'orphans' returns only the GitHub-issue-with-no-decision-row set.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Max items to return (default 50, hard cap 200)'),
+    since: z
+      .string()
+      .optional()
+      .describe(
+        'ISO 8601 — only include decision-row buckets with decided_at >= this instant (orphans have no decided_at and are unaffected)',
+      ),
+  },
+  handler: async (backend, { mapId, bucket, limit, since }) => {
+    const result = await backend.listNotInMindBlown(mapId, {
+      bucket,
+      limit,
+      since,
+    });
+    if (result.total === 0) {
+      const orphanNote = result.orphansAvailable
+        ? ''
+        : ` (orphan bucket unavailable: ${result.orphansError ?? 'GitHub fetch failed'})`;
+      return `No issues found matching bucket='${result.bucket}' in map ${mapId}${orphanNote}.`;
+    }
+    // Per-kind breakdown — gives Eve a one-line "what's the shape" so
+    // she can decide whether to drill in further or summarize.
+    const breakdown: Record<string, number> = {
+      skipped: 0,
+      'pending-skipped': 0,
+      uncertain: 0,
+      orphan: 0,
+    };
+    for (const it of result.items) breakdown[it.kind]++;
+    const breakdownLine = Object.entries(breakdown)
+      .filter(([, n]) => n > 0)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(', ');
+    const summary =
+      result.total > result.returned
+        ? `Showing ${result.returned} of ${result.total} item(s) in map ${mapId} (raise \`limit\` for more, max 200)`
+        : `Showing ${result.returned} item(s) in map ${mapId}`;
+    const orphanWarning = result.orphansAvailable
+      ? ''
+      : `\n(Note: orphan bucket unavailable — ${result.orphansError ?? 'GitHub fetch failed'})`;
+    const lines = result.items.map(renderNotInMindBlownItem);
+    return `${summary} [${breakdownLine}]:${orphanWarning}\n${lines.join('\n')}`;
+  },
+});
+
 export const triageTools = [
   listTriageDecisionsTool,
   overrideTriageTool,
   reclassifyTriageTool,
   confirmTriageTool,
+  listNotInMindBlownTool,
 ];


### PR DESCRIPTION
## Summary

A single surface in the Triage Panel for every GitHub ticket that isn't currently a node in this map, partitioned into four buckets:

| bucket            | predicate                                              |
| ----------------- | ------------------------------------------------------ |
| `skipped`         | triage row with `decision=skip` + `reviewed=true`      |
| `pending-skipped` | triage row with `decision=skip` + `reviewed=false`     |
| `uncertain`       | triage row with `decision=uncertain`                   |
| `orphan`          | no triage row **and** no node linking the externalId   |

Before this PR, buckets 1-3 were mixed into the Pending/Skipped tabs and orphans were invisible from the panel (only reachable via the `github/sync-overview` endpoint). The new tab unifies all four and adds per-card "Import to MindBlown" / "Mark as skip" / "Re-classify" / "Confirm skip" actions tuned to the bucket.

Closes #140.

## What's in this PR

**Backend** (`packages/server`)
- `GET /api/maps/:mapId/triage-decisions/not-in-mindblown` — bucket-filtered list. Returns decision-row buckets even when GitHub is unavailable, signaling the orphan-bucket state via `orphansAvailable` / `orphansError`.
- `POST .../orphan-import` — creates a node + place-decision row in one tx (409 `NOT_ORPHAN` if a row already exists for that externalId).
- `POST .../orphan-skip` — inserts a skip-decision row without creating a node (same 409 conflict guard).
- All three reuse the existing session-JWT-only gate (API-key auth 403'd) plus broadcast `triage:updated` for cross-tab refresh.

**Frontend** (`packages/mindmap`)
- 4th tab on `TriagePanel`: "Not in MindBlown".
- 5 sub-filter pills: All / Skipped / Pending / Uncertain / Orphans.
- Per-card actions per bucket; orphans get a small "Not yet triaged" badge instead of a confidence/reason block.
- `data-testid` on every interactive element (no mindmap test runner yet per #78 follow-ups — pinning markup for the future).

**MCP** (`packages/tool-kit` + `packages/mcp`)
- New tool `list_not_in_mindblown(mapId, bucket?, limit?, since?)` returning a per-kind breakdown ("skipped=3, orphan=2, …") plus item lines, so Eve can answer "what's in GitHub but not on the roadmap?" in one round-trip.

## Round 2 fixes (Ray's review)

Two should-fix items folded in after Ray's APPROVE:

1. **Race condition on orphan-import / orphan-skip.** The pre-existing precheck SELECT ran *outside* the transaction, so two concurrent callers could both pass it and the loser would hit the unique `(map_id, external_id)` constraint as a raw DB error (500) instead of the documented `409 NOT_ORPHAN`. Both routes now take a Postgres advisory xact lock keyed on the externalId at the start of the tx and re-run the precheck *inside* the tx with the lock held — same pattern as `ensureNodeForIssue` in `packages/server/src/sync/githubIngest.ts:127`. Two new race tests hold one transaction in flight via a gate harness, release the second only after the first commits, and assert exactly one returns `200` and the other returns `409 NOT_ORPHAN`.

2. **`change_type='overridden'` on brand-new audit rows.** Both routes previously hard-coded `changeType: 'overridden'` when recording history; semantically a fresh insert (with no previous row — else the precheck would 409) is `'created'`, matching the rule in `packages/server/src/sync/githubIngest.ts:808` (`previous ? 'overridden' : 'created'`). Hard-coded to `'created'` on both routes and asserted in two new tests.

Place-decision exclusion, no-offset pagination, in-memory JSONB scan on `externalLinks`, and the parent-validation query mapId fold are intentionally left as Ray's nits / follow-up work (defensible / acceptable at current scale).

## Persona acceptance test (post-deploy on `mind.project.li`)

1. Open the Triage Panel on the MindBlown self-map, switch to the new "Not in MindBlown" tab.
2. See a mix of buckets across at least one each of skipped / pending / uncertain / orphan.
3. Click "Orphans" → only items with no triage row are shown; bucket badge reads "Orphan".
4. On an orphan: click **Import to MindBlown** → NodePickerModal opens → pick a parent → node is created + a `triage_decisions` row appears with `decision=place, decided_by='operator'`. (Server-side this exercises the new orphan-import route + `recordTriageHistory` writes a `change_type='created'` history row.)
5. On a skipped row: click **Re-classify** → fresh LLM call → bucket may flip from Skipped to Pending (or to place + disappear from this tab).
6. On a pending-skipped row: click **Confirm skip** → row moves into the "Skipped" sub-filter (reviewed=true).

## Test plan

- [x] `pnpm -w typecheck` clean
- [x] `pnpm -w build` clean
- [x] Server tests: 419 / 419 passing (was 415 before Round 2; +4 new tests for the race fix + change_type semantics)
- [x] 11 new tool-kit tests in `triage.test.ts` (38 / 38 passing)
- [x] `rg "pg_advisory_xact_lock" packages/server/src/routes/triage.ts` → matches in both orphan-import and orphan-skip handlers
- [x] `rg "changeType: 'overridden'" packages/server/src/routes/triage.ts` → matches only the override / confirm / reclassify / bulk-override routes, **not** orphan-import or orphan-skip
- [x] `rg "not-in-mindblown|notInMindBlown|NotInMindBlown" packages -l` shows backend route, frontend type, UI tab, MCP backend, MCP tool, tests — all 5 anti-punt layers
- [ ] Persona steps 1-6 above on `mind.project.li` after merge + deploy
