### PR TITLE
perf(triage): diff-aware skip + body-hash idempotency + per-issue debounce (closes #142)

### DIFF
--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -568,6 +568,17 @@ export async function runMigrations(): Promise<void> {
     ALTER TABLE triage_decisions ADD COLUMN IF NOT EXISTS suggested_parent_node_id UUID
   `);
 
+  // ── Triage cost opt (#142) — body-hash idempotency ────────────
+  // SHA-256 of the canonical (title + body + sorted labels + state)
+  // tuple used for the last successful auto-triage call. When a webhook
+  // arrives whose hash matches this column, the LLM call is skipped
+  // entirely. Existing rows keep `NULL` until their next auto-triage
+  // populates the column (lazy migration — no backfill). Operator
+  // reclassify accepts `force=true` to bypass the hash short-circuit.
+  await db.execute(sql`
+    ALTER TABLE triage_decisions ADD COLUMN IF NOT EXISTS last_input_hash TEXT
+  `);
+
   // ── Phase 3 (#96) — opt-in GitHub label write-back per map ────
   // When true, finalized triage decisions write `triage:placed` /
   // `triage:skipped` labels back to the source GitHub issue. Default

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -381,6 +381,12 @@ export const triageDecisions = pgTable('triage_decisions', {
   reviewed: boolean('reviewed').notNull().default(false),
   reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
   reviewedBy: uuid('reviewed_by').references(() => users.id),
+  // SHA-256 of JSON.stringify({title, body, labels: sorted, state}). Populated
+  // lazily by the next auto-triage call; existing rows keep NULL until they're
+  // re-evaluated. When the freshly-computed hash matches this column, the LLM
+  // call is short-circuited (#142). Operators bypass via `force=true` on the
+  // reclassify route.
+  lastInputHash: text('last_input_hash'),
 });
 
 // ── Triage Decision History (#96, Phase 3) ────────────────────────

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -32,6 +32,11 @@ interface TriageRow {
   reviewed: boolean;
   reviewedAt: Date | null;
   reviewedBy: string | null;
+  // #142 cost-opt: webhook hash-idempotency column. Reclassify routes
+  // (single + bulk) MUST null this so the next real webhook delivery
+  // doesn't short-circuit on a stale hash compare against the new
+  // decision. Optional on the type because most tests don't care.
+  lastInputHash?: string | null;
 }
 
 const triageRows = new Map<string, TriageRow>();
@@ -396,13 +401,14 @@ vi.mock('../../sync/triageLabelWriteback.js', () => ({
   applyTriageLabel: applyTriageLabelMock,
 }));
 
+// #143 round-2 (Ray's review): reclassify routes (single + bulk) must
+// clear the debounce so a webhook within the 60s window isn't squashed
+// after operator action. Hoisted as a named mock so tests can assert
+// `(mapId, externalId)` was passed.
+const clearTriageDebounceMock = vi.hoisted(() => vi.fn());
 vi.mock('../../sync/triage.js', () => ({
   triageIssue: mocks.triageIssueMock,
-  // #142 cost-opt — reclassify route clears the debounce on the
-  // operator's behalf. Tests don't assert on this call, but the
-  // symbol must exist or the import resolves to undefined and the
-  // route throws on the first call.
-  clearTriageDebounce: vi.fn(),
+  clearTriageDebounce: clearTriageDebounceMock,
   computeInputHash: vi.fn(() => 'mock-hash'),
   markTriageDebounce: vi.fn(),
   isWithinDebounceWindow: vi.fn(() => false),
@@ -483,6 +489,9 @@ beforeEach(() => {
   updateNodeMock.mockClear();
   moveNodeMock.mockClear();
   triageIssueMock.mockClear();
+  // #143 round-2: clear so a per-test assertion on (mapId, externalId)
+  // doesn't bleed across cases.
+  clearTriageDebounceMock.mockClear();
   applyTriageLabelMock.mockReset();
   applyTriageLabelMock.mockImplementation(async () => undefined);
   // #140 — reset the GitHub-context + import mocks so each test
@@ -1212,6 +1221,33 @@ describe('POST .../reclassify', () => {
     expect(row.suggestedParentNodeId).toBe('epic-1');
   });
 
+  // #143 round-2 (Ray's review): single-row reclassify MUST clear
+  // lastInputHash (so the next webhook delivery re-evaluates against
+  // fresh content) AND clear the per-issue debounce (so a webhook
+  // within the 60s window isn't squashed after the operator action).
+  // The same invariant must hold on the bulk-reclassify route — see the
+  // matching test in the bulk-reclassify describe block.
+  it('reclassify clears lastInputHash and calls clearTriageDebounce(mapId, externalId)', async () => {
+    seedRow({
+      id: 'tr-1',
+      externalId: 'o/r#42',
+      decision: 'uncertain',
+      confidence: 30,
+      lastInputHash: 'some-old-hash',
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/reclassify',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const row = triageRows.get('tr-1')!;
+    expect(row.lastInputHash).toBeNull();
+    expect(clearTriageDebounceMock).toHaveBeenCalledWith('map-1', 'o/r#42');
+  });
+
   it('reclassify → skip nulls suggestedParentNodeId', async () => {
     triageIssueMock.mockResolvedValueOnce({
       decision: 'skip' as const,
@@ -1784,6 +1820,43 @@ describe('POST .../bulk-reclassify', () => {
     expect(triageRows.get('a')!.decision).toBe('uncertain');
     // Row B has the default-mock result.
     expect(triageRows.get('b')!.decision).toBe('place');
+  });
+
+  // #143 round-2 (Ray's review): bulk-reclassify must mirror the
+  // single-row /reclassify route's hash + debounce clearing. Without
+  // this, after a bulk re-run the rows keep their OLD lastInputHash and
+  // the next real `issues.edited` webhook short-circuits on a stale
+  // hash compare — leaving the row with the new decision but masking
+  // that subsequent edits aren't being re-evaluated.
+  it('bulk-reclassify clears lastInputHash + calls clearTriageDebounce per row', async () => {
+    seedRow({
+      id: 'a',
+      externalId: 'o/r#100',
+      decision: 'uncertain',
+      lastInputHash: 'stale-hash-a',
+    });
+    seedRow({
+      id: 'b',
+      externalId: 'o/r#200',
+      decision: 'uncertain',
+      lastInputHash: 'stale-hash-b',
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/bulk-reclassify',
+      payload: { decisionIds: ['a', 'b'] },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    // Both rows had their hash nulled.
+    expect(triageRows.get('a')!.lastInputHash).toBeNull();
+    expect(triageRows.get('b')!.lastInputHash).toBeNull();
+    // Debounce cleared once per row, with the correct (mapId, externalId).
+    expect(clearTriageDebounceMock).toHaveBeenCalledTimes(2);
+    expect(clearTriageDebounceMock).toHaveBeenCalledWith('map-1', 'o/r#100');
+    expect(clearTriageDebounceMock).toHaveBeenCalledWith('map-1', 'o/r#200');
   });
 });
 

--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -285,6 +285,9 @@ vi.mock('../../db/schema.js', () => {
       confidence: col('confidence'),
       issueState: col('issueState'),
       suggestedParentNodeId: col('suggestedParentNodeId'),
+      // #142 — reclassify route writes lastInputHash:null to force the
+      // next webhook re-evaluation; column must exist on the schema mock.
+      lastInputHash: col('lastInputHash'),
     },
     // Phase 3 (#96) — recordTriageHistory inserts into this table from
     // every mutation route. The route tests don't assert on the history
@@ -395,6 +398,14 @@ vi.mock('../../sync/triageLabelWriteback.js', () => ({
 
 vi.mock('../../sync/triage.js', () => ({
   triageIssue: mocks.triageIssueMock,
+  // #142 cost-opt — reclassify route clears the debounce on the
+  // operator's behalf. Tests don't assert on this call, but the
+  // symbol must exist or the import resolves to undefined and the
+  // route throws on the first call.
+  clearTriageDebounce: vi.fn(),
+  computeInputHash: vi.fn(() => 'mock-hash'),
+  markTriageDebounce: vi.fn(),
+  isWithinDebounceWindow: vi.fn(() => false),
 }));
 
 vi.mock('../../sync/mapContext.js', () => ({

--- a/packages/server/src/routes/__tests__/triage-webhook.test.ts
+++ b/packages/server/src/routes/__tests__/triage-webhook.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Webhook-handler tests for the #142 cost-opt — diff-aware skip on
+ * `issues.edited`.
+ *
+ * The webhook handler in `routes/integrations.ts` is the OUTERMOST
+ * layer of the three cost-opt layers. When GitHub fires an
+ * `issues.edited` event whose `changes` object doesn't carry a
+ * `title` or `body` entry (i.e. only labels / milestone / assignee
+ * changed), the handler MUST:
+ *
+ *   1. Skip the call to `ingestNewIssuesForRepo`, which is the path
+ *      that would otherwise pay for a triage LLM round-trip.
+ *   2. Skip the trailing `processWebhook` fallthrough — the title
+ *      and body of the node would be re-written with the same
+ *      values they already hold, which is a wasted DB UPDATE.
+ *   3. Reply with `{ status: 'metadata_only_skipped' }` so log
+ *      greps can count how often we save the call. Phase 4
+ *      tuning-data collection treats this status as "not a real
+ *      triage event" and skips it for accuracy roll-ups.
+ *
+ * A populated `changes.title` or `changes.body` entry must still
+ * pass through to the ingest path (content actually changed).
+ *
+ * Signature verification is mocked to always pass so each case can
+ * focus on the diff-aware-skip behaviour rather than HMAC plumbing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+// vi.mock factories are hoisted above top-level code, so any spy they
+// reference must also be hoisted. We use vi.hoisted for the shared
+// spies and re-expose them locally for assertions.
+
+const mocks = vi.hoisted(() => ({
+  ingestMock: vi.fn(async () => undefined),
+  processWebhookMock: vi.fn(() => ({ action: 'noop' })),
+  verifySignatureMock: vi.fn(async () => true),
+}));
+const ingestMock = mocks.ingestMock;
+const processWebhookMock = mocks.processWebhookMock;
+const verifySignatureMock = mocks.verifySignatureMock;
+
+vi.mock('@mindblown/integrations', () => ({
+  createGitHubIssue: vi.fn(),
+  getGitHubIssue: vi.fn(),
+  importGitHubIssues: vi.fn(),
+  extractVersionFromMilestone: vi.fn(),
+  processWebhook: mocks.processWebhookMock,
+  verifyWebhookSignature: mocks.verifySignatureMock,
+  mintInstallationToken: vi.fn(),
+  isGitHubAppConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../../db/connection.js', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: async () => [],
+      }),
+    }),
+    update: () => ({
+      set: () => ({ where: async () => undefined }),
+    }),
+    insert: () => ({ values: () => ({ returning: async () => [] }) }),
+    transaction: async <T,>(cb: (tx: unknown) => Promise<T>): Promise<T> =>
+      cb({}),
+  },
+}));
+
+vi.mock('../../db/schema.js', () => ({
+  integrations: { __name: 'integrations' },
+  versions: { __name: 'versions' },
+  nodes: { __name: 'nodes' },
+  maps: { __name: 'maps' },
+  triageDecisions: { __name: 'triageDecisions' },
+}));
+
+vi.mock('../../db/nodes.js', () => ({
+  getNode: vi.fn(async () => null),
+  createNode: vi.fn(),
+  updateNode: vi.fn(async () => null),
+  notDeleted: { __pred: true, check: () => true },
+}));
+
+vi.mock('../../sync/githubCatchup.js', () => ({ reconcileRepo: vi.fn() }));
+vi.mock('../../sync/driftAudit.js', () => ({ runDriftAudit: vi.fn() }));
+vi.mock('../../sync/webhookAuthCheck.js', () => ({ recordWebhookCall: vi.fn() }));
+vi.mock('../../auth.js', () => ({ requireAdmin: vi.fn() }));
+vi.mock('../../sync/parentEpicRollup.js', () => ({
+  rollupParentsForChildTitle: vi.fn(),
+}));
+vi.mock('../../sync/githubIngest.js', () => ({
+  ingestNewIssuesForRepo: mocks.ingestMock,
+  ensureInboxNode: vi.fn(),
+  ensureNodeForIssue: vi.fn(),
+  findNodesByExternalIds: vi.fn(),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../../sync/triage.js', () => ({
+  triageIssue: vi.fn(),
+  clearTriageDebounce: vi.fn(),
+  computeInputHash: vi.fn(),
+  markTriageDebounce: vi.fn(),
+  isWithinDebounceWindow: vi.fn(() => false),
+}));
+vi.mock('../../sync/mapContext.js', () => ({ buildMapContext: vi.fn() }));
+vi.mock('../../sync/triageHistory.js', () => ({
+  recordTriageHistory: vi.fn(),
+}));
+vi.mock('../../sync/triageLabelWriteback.js', () => ({
+  applyTriageLabel: vi.fn(),
+}));
+vi.mock('../../lib/githubContext.js', () => ({
+  getGitHubContextForMap: vi.fn(async () => null),
+}));
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({ __pred: true, check: () => true })),
+  and: vi.fn(() => ({ __pred: true, check: () => true })),
+}));
+
+import { integrationRoutes } from '../integrations.js';
+
+// ── Harness ──────────────────────────────────────────────────────
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(integrationRoutes);
+  return app;
+}
+
+function basePayload(action: string, changes?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    action,
+    issue: {
+      id: 1,
+      number: 42,
+      title: 'Some issue',
+      body: 'a body',
+      state: 'open',
+      labels: [],
+      assignees: [],
+      milestone: null,
+      html_url: 'https://github.com/owner/repo/issues/42',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    repository: { full_name: 'owner/repo' },
+    ...(changes !== undefined ? { changes } : {}),
+  };
+}
+
+beforeEach(() => {
+  ingestMock.mockClear();
+  processWebhookMock.mockClear();
+  verifySignatureMock.mockClear();
+  verifySignatureMock.mockResolvedValue(true);
+  process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-secret';
+});
+
+// ── Diff-aware skip on issues.edited ─────────────────────────────
+
+describe('webhook: issues.edited diff-aware skip (#142 layer 1)', () => {
+  it('metadata-only edit (changes={}) → ingest NOT called, status metadata_only_skipped', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: basePayload('edited', {}),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      received: true,
+      action: 'issues.edited',
+      status: 'metadata_only_skipped',
+    });
+    expect(ingestMock).not.toHaveBeenCalled();
+    // The trailing processWebhook fallthrough should also be skipped
+    // — we don't want a stray UPDATE on the node either.
+    expect(processWebhookMock).not.toHaveBeenCalled();
+  });
+
+  it('metadata-only edit (missing changes entirely) → ingest NOT called', async () => {
+    const app = await buildApp();
+    // Some GitHub deliveries omit `changes` altogether when only
+    // labels changed (the labeled/unlabeled actions carry the diff
+    // instead). Treat as metadata-only.
+    const payload = basePayload('edited');
+    delete payload.changes;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload,
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      status: 'metadata_only_skipped',
+    });
+    expect(ingestMock).not.toHaveBeenCalled();
+  });
+
+  it('title change → ingest IS called (content actually changed)', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: basePayload('edited', { title: { from: 'old title' } }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(ingestMock).toHaveBeenCalledOnce();
+    expect(ingestMock).toHaveBeenCalledWith(
+      { owner: 'owner', repo: 'repo' },
+      [expect.objectContaining({ number: 42 })],
+    );
+  });
+
+  it('body change → ingest IS called', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: basePayload('edited', { body: { from: 'old body' } }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(ingestMock).toHaveBeenCalledOnce();
+  });
+
+  it('issues.opened → ingest IS called (the diff-aware gate only applies to edited)', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: basePayload('opened'),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(ingestMock).toHaveBeenCalledOnce();
+  });
+
+  it('issues.reopened → ingest IS called (lifecycle event, not metadata)', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: basePayload('reopened'),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(ingestMock).toHaveBeenCalledOnce();
+  });
+
+  it('invalid signature → 401 and ingest NOT called', async () => {
+    verifySignatureMock.mockResolvedValueOnce(false);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=bad',
+      },
+      payload: basePayload('edited', { title: { from: 'old' } }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(401);
+    expect(ingestMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -1197,11 +1197,48 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     // swallowed so the webhook still acknowledges the underlying
     // event. The webhook covers opened / reopened / edited; the
     // catchup pass + manual backfill cover everything else.
+    //
+    // ── Cost-opt #142 layer 1: diff-aware skip on issues.edited ────
+    // GitHub's `issues.edited` payload carries a `changes` object
+    // listing what changed (e.g. `{ title: { from: '...' } }`,
+    // `{ body: { from: '...' } }`). When the operator only added /
+    // removed labels, assignees, or a milestone, `changes` is empty
+    // (those edits emit their own `issues.labeled` / `unlabeled` /
+    // `assigned` / `milestoned` actions, NOT a populated `changes`
+    // entry on `edited`). Skip the LLM call in that case — labels
+    // and milestone don't change the triage decision body (labels
+    // are folded into the hash but only as ordering / set
+    // membership; the LLM doesn't see them as decision signal),
+    // and the bot churn of label-rules firing 5-10 edited events
+    // per minute is exactly the worst-case workload this layer
+    // targets. The state-sync block below still runs for closed/
+    // reopened, so we don't lose lifecycle transitions.
+    //
+    // Skipped-edits intentionally don't accumulate triage_decisions
+    // history rows ("metadata_only" never reaches recordTriageHistory)
+    // so Phase 4 tuning-data collection isn't poisoned by edit-storm
+    // noise.
+    const isMetadataOnlyEdit =
+      payloadAction === 'edited' &&
+      (() => {
+        const changes = payload.changes as
+          | { title?: unknown; body?: unknown }
+          | undefined;
+        // Treat a missing/empty `changes` object as metadata-only.
+        // The keys we care about are `title` and `body`; anything else
+        // (`assignees`, `labels` in the rare cases GH does include
+        // them) is metadata. GitHub omits the `changes` key entirely
+        // on label-only edits, so the `!changes` arm covers that.
+        if (!changes || typeof changes !== 'object') return true;
+        return changes.title === undefined && changes.body === undefined;
+      })();
+
     if (
       event === 'issues' &&
       issuePayload?.number != null &&
       repoFullName &&
-      (payloadAction === 'opened' || payloadAction === 'reopened' || payloadAction === 'edited')
+      (payloadAction === 'opened' || payloadAction === 'reopened' || payloadAction === 'edited') &&
+      !isMetadataOnlyEdit
     ) {
       const slashIdx = repoFullName.indexOf('/');
       if (slashIdx > 0) {
@@ -1219,6 +1256,35 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
           }
         }
       }
+    }
+
+    // ── Cost-opt #142 — metadata-only edit short-circuit ──────────
+    // The `edited` action with no title/body change has no work for
+    // the rest of the handler:
+    //   - The state-sync block below is gated on `closed`/`reopened`
+    //     (which doesn't include `edited`), so it's already a no-op.
+    //   - The `processWebhook` fallthrough would update node text +
+    //     description with the same values they already hold (the
+    //     payload's title/body match what's already there, by virtue
+    //     of `changes.title === undefined && changes.body === undefined`).
+    //
+    // Returning early keeps the DB write off the hot path and gives
+    // the operator a clear status code in the webhook response —
+    // useful for log greps when chasing LLM cost. The Phase 4 tuning
+    // data collector explicitly filters this status out of triage
+    // history rollups so label-bot storms don't poison the dataset.
+    if (
+      event === 'issues' &&
+      issuePayload?.number != null &&
+      repoFullName &&
+      isMetadataOnlyEdit
+    ) {
+      return reply.send({
+        received: true,
+        action: 'issues.edited',
+        matched: false,
+        status: 'metadata_only_skipped',
+      });
     }
 
     // ── Triage lifecycle: issues.reopened → re-triage (#95 Phase 2) ──

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -2142,6 +2142,13 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
             decision.decision === 'place'
               ? (decision.parentNodeId ?? null)
               : null;
+          // Cost-opt #142 (Ray review on #143): mirror single
+          // /reclassify exactly — clear the input-hash AND the
+          // per-issue debounce key so the next real `issues.edited`
+          // webhook re-evaluates against fresh content instead of
+          // short-circuiting on a stale hash compare. Without this,
+          // bulk-reclassify leaves the row with the new decision
+          // but masks subsequent edits from being re-evaluated.
           await db
             .update(triageDecisions)
             .set({
@@ -2154,9 +2161,11 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
               reviewed: false,
               reviewedAt: null,
               reviewedBy: null,
+              lastInputHash: null,
               ...(clearPlacedNode ? { placedNodeId: null } : {}),
             })
             .where(eq(triageDecisions.id, row.id));
+          clearTriageDebounce(req.params.mapId, row.externalId);
           const newParent = clearPlacedNode
             ? null
             : decision.decision === 'place'

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -62,7 +62,7 @@ import { notDeleted } from '../db/nodes.js';
 import * as permDb from '../db/permissions.js';
 import { broadcast } from '../ws.js';
 import { buildMapContext } from '../sync/mapContext.js';
-import { triageIssue } from '../sync/triage.js';
+import { triageIssue, clearTriageDebounce } from '../sync/triage.js';
 import { recordTriageHistory } from '../sync/triageHistory.js';
 import { applyTriageLabel } from '../sync/triageLabelWriteback.js';
 import { getGitHubContextForMap } from '../lib/githubContext.js';
@@ -1360,8 +1360,27 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
   // Reclassify writes decidedBy='auto' (the LLM made the new call)
   // and resets reviewed=false (it's a fresh auto-decision that needs
   // re-review). No node is created.
+  //
+  // Cost-opt #142 — the operator reclassify route always force-bypasses
+  // the hash-match short-circuit and the per-issue debounce window:
+  //
+  //   - `force=true` query param is the explicit operator signal; we
+  //     accept it as documentation / parity with future automated
+  //     callers, but the *default* behaviour is also force (any
+  //     operator-initiated reclassify is by definition "I want a
+  //     fresh look"). Without `force`, the LLM still re-runs — the
+  //     hash check lives in the ingest path, not here.
+  //   - After the new decision is written, we clear `last_input_hash`
+  //     so the NEXT webhook delivery for this issue re-evaluates (we
+  //     just told the LLM to think again; we don't want the next
+  //     webhook to short-circuit on the now-stale synthesized-issue
+  //     hash that would have been written by this route).
+  //   - We also call `clearTriageDebounce` so a webhook fired in the
+  //     next 60 s doesn't get debounced — the operator is asking for
+  //     fresh evaluation.
   app.post<{
     Params: { mapId: string; decisionId: string };
+    Querystring: { force?: string };
   }>(
     '/api/maps/:mapId/triage-decisions/:decisionId/reclassify',
     async (req, reply) => {
@@ -1439,6 +1458,20 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       const newSuggestedParentNodeId =
         decision.decision === 'place' ? (decision.parentNodeId ?? null) : null;
 
+      // Cost-opt #142: clear the input-hash on reclassify so the next
+      // webhook delivery for this issue re-evaluates against fresh
+      // content (the operator just told us "look again" — locking in
+      // the synthesized-body hash here would have the next real
+      // webhook short-circuit on a stale comparison, which is the
+      // opposite of what the operator asked for). Also clear the
+      // debounce key so a webhook within the next 60 s isn't squashed.
+      // The `force` query param is currently a no-op — operator
+      // reclassify is always force — but we accept it as a forward-
+      // compat hook for a future automated caller that needs to
+      // distinguish.
+      // (force is intentionally unused for now; documented in the
+      // route comment above.)
+      void req.query.force;
       await db
         .update(triageDecisions)
         .set({
@@ -1451,9 +1484,11 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           reviewed: false,
           reviewedAt: null,
           reviewedBy: null,
+          lastInputHash: null,
           ...(clearPlacedNode ? { placedNodeId: null } : {}),
         })
         .where(eq(triageDecisions.id, row.id));
+      clearTriageDebounce(req.params.mapId, row.externalId);
 
       // Phase 3 audit log — reclassify is recorded as 'auto' since the
       // LLM is the actor here, even though an operator triggered the

--- a/packages/server/src/sync/__tests__/githubIngest.test.ts
+++ b/packages/server/src/sync/__tests__/githubIngest.test.ts
@@ -350,6 +350,7 @@ vi.mock('../../db/schema.js', () => {
       id: col('id'),
       mapId: col('mapId'),
       externalId: col('externalId'),
+      lastInputHash: col('lastInputHash'),
     },
   };
 });
@@ -395,6 +396,16 @@ const triageMockCalls: Array<{ issueNumber: number; mapId: string }> = [];
  */
 let triageMockMidCallHook: (() => Promise<void>) | null = null;
 
+// In-memory state for the cost-opt #142 debounce + hash mocks. The
+// production module keeps its own Map; we mirror just enough of the
+// behaviour here so callers (the SUT) can short-circuit predictably.
+// Tests reset this state in `beforeEach`.
+const _debounceState = new Map<string, number>();
+let _debounceWindowMs = 0; // 0 disables debounce by default in tests
+function debounceKey(mapId: string, externalId: string): string {
+  return `${mapId}/${externalId}`;
+}
+
 vi.mock('../triage.js', () => ({
   triageIssue: vi.fn(async (input: { issue: { number: number }; mapContext: { mapId: string } }) => {
     triageMockCalls.push({
@@ -407,7 +418,47 @@ vi.mock('../triage.js', () => ({
     return { ...triageMockResponse };
   }),
   TRIAGE_AUTO_APPLY_CONFIDENCE: 75,
+  // #142 cost-opt helpers. computeInputHash returns a deterministic
+  // string derived from the issue inputs so hash-match tests can
+  // pre-seed dbState.triageDecisions.lastInputHash with the same
+  // value the SUT will compute.
+  computeInputHash: vi.fn((issue: {
+    title: string;
+    body?: string | null;
+    state: 'open' | 'closed';
+    labels?: Array<{ name: string }> | null;
+  }) => {
+    const labels = (issue.labels ?? []).map((l) => l.name).slice().sort();
+    return `hash:${issue.title}:${issue.body ?? ''}:${labels.join(',')}:${issue.state}`;
+  }),
+  isWithinDebounceWindow: vi.fn((mapId: string, externalId: string, now: number = Date.now()) => {
+    if (_debounceWindowMs <= 0) return false;
+    const lastAt = _debounceState.get(debounceKey(mapId, externalId));
+    if (lastAt === undefined) return false;
+    return now - lastAt < _debounceWindowMs;
+  }),
+  markTriageDebounce: vi.fn((mapId: string, externalId: string, now: number = Date.now()) => {
+    if (_debounceWindowMs <= 0) return;
+    _debounceState.set(debounceKey(mapId, externalId), now);
+  }),
+  clearTriageDebounce: vi.fn((mapId: string, externalId: string) => {
+    _debounceState.delete(debounceKey(mapId, externalId));
+  }),
 }));
+
+// Helpers exposed for cost-opt tests below — they configure the
+// mock's debounce window and read/seed its internal map without
+// importing the SUT module.
+function _testSetDebounceWindowMs(ms: number): void {
+  _debounceWindowMs = ms;
+}
+function _testResetDebounceState(): void {
+  _debounceState.clear();
+  _debounceWindowMs = 0;
+}
+function _testSeedDebounce(mapId: string, externalId: string, ts: number): void {
+  _debounceState.set(debounceKey(mapId, externalId), ts);
+}
 
 const mapContextEpics = [
   { nodeId: 'epic-1', title: 'Frontend', description: 'UI' },
@@ -587,6 +638,9 @@ function resetState() {
   updateNodeThrowOnNthCall = null;
   updateNodeMockShouldThrow = null;
   triageMockMidCallHook = null;
+  // #142 cost-opt — clear debounce state between tests so a stamp
+  // from one case doesn't leak into the next.
+  _testResetDebounceState();
 }
 
 beforeEach(() => {
@@ -1383,5 +1437,299 @@ describe('ensureNodeForIssue — triage fork', () => {
     expect(createNodeCalls.length).toBe(0);
     const rows = [...dbState.triageDecisions.values()];
     expect(rows[0]).toMatchObject({ decision: 'uncertain' });
+  });
+});
+
+// ── #142 cost-opt — hash-match + debounce short-circuits ─────────
+
+describe('ensureNodeForIssue — triage cost-opt (#142)', () => {
+  const ctx = { owner: 'owner', repo: 'repo', createdBy: 'u1' };
+
+  function seedTriageMap(): void {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', {
+      id: 'inbox-1',
+      mapId: 'm1',
+      parentId: 'root-1',
+      externalLinks: [],
+    });
+  }
+
+  // The mocked computeInputHash returns
+  // `hash:${title}:${body ?? ''}:${labels.sorted.join(',')}:${state}`.
+  // Tests pre-seed `lastInputHash` with the same shape so the SUT
+  // matches on the hash-match precheck path.
+  function expectedHash(iss: GitHubIssue): string {
+    const labels = (iss.labels ?? []).map((l) => l.name).slice().sort();
+    return `hash:${iss.title}:${iss.body ?? ''}:${labels.join(',')}:${iss.state}`;
+  }
+
+  // ── Body-hash idempotency ────────────────────────────────────
+
+  it('hash-match precheck → SKIPS LLM call, bumps decided_at, returns triaged_hash_match', async () => {
+    seedTriageMap();
+    const iss = issue(200, { title: 'cached', body: 'body-A' });
+    // Pre-seed an existing decision whose lastInputHash equals the
+    // hash the SUT will compute for `iss`.
+    const oldDecidedAt = new Date(2020, 0, 1);
+    dbState.triageDecisions.set('triage-pre', {
+      id: 'triage-pre',
+      mapId: 'm1',
+      externalId: 'owner/repo#200',
+      issueTitle: 'cached',
+      issueState: 'open',
+      decision: 'skip',
+      reason: 'unrelated',
+      confidence: 80,
+      placedNodeId: null,
+      suggestedParentNodeId: null,
+      decidedAt: oldDecidedAt,
+      decidedBy: 'auto',
+      reviewed: false,
+      lastInputHash: expectedHash(iss),
+    });
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', iss, ctx);
+
+    expect(result.status).toBe('triaged_hash_match');
+    expect(result.triage?.decisionId).toBe('triage-pre');
+    expect(result.triage?.decision).toBe('skip');
+    expect(result.triage?.confidence).toBe(80);
+    // LLM was NOT called.
+    expect(triageMockCalls.length).toBe(0);
+    // decided_at was bumped (the hash-match path runs an UPDATE on
+    // the existing row inside the precheck tx).
+    const row = dbState.triageDecisions.get('triage-pre')!;
+    expect((row.decidedAt as Date).getTime()).toBeGreaterThan(oldDecidedAt.getTime());
+    // No node was created (decision is skip).
+    expect(createNodeCalls.length).toBe(0);
+  });
+
+  it('hash-mismatch → LLM call runs, new hash is persisted on the row', async () => {
+    seedTriageMap();
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'unrelated',
+      confidence: 80,
+    };
+    const iss = issue(201, { title: 'new content', body: 'fresh body' });
+    dbState.triageDecisions.set('triage-stale', {
+      id: 'triage-stale',
+      mapId: 'm1',
+      externalId: 'owner/repo#201',
+      issueTitle: 'old',
+      issueState: 'open',
+      decision: 'skip',
+      reason: 'old reason',
+      confidence: 60,
+      placedNodeId: null,
+      suggestedParentNodeId: null,
+      decidedAt: new Date(2020, 0, 1),
+      decidedBy: 'auto',
+      reviewed: false,
+      lastInputHash: 'hash:stale:::open', // intentionally different
+    });
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', iss, ctx);
+
+    expect(result.status).toBe('triaged_skip');
+    // LLM was called exactly once.
+    expect(triageMockCalls.length).toBe(1);
+    // The row's hash was overwritten with the new content's hash.
+    const row = dbState.triageDecisions.get('triage-stale')!;
+    expect(row.lastInputHash).toBe(expectedHash(iss));
+  });
+
+  it('null lastInputHash (legacy / never-triaged row) → LLM call runs, hash is populated', async () => {
+    seedTriageMap();
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'unrelated',
+      confidence: 80,
+    };
+    const iss = issue(202, { title: 'untouched legacy' });
+    dbState.triageDecisions.set('triage-legacy', {
+      id: 'triage-legacy',
+      mapId: 'm1',
+      externalId: 'owner/repo#202',
+      issueTitle: 'untouched legacy',
+      issueState: 'open',
+      decision: 'skip',
+      reason: 'r',
+      confidence: 50,
+      placedNodeId: null,
+      suggestedParentNodeId: null,
+      decidedAt: new Date(),
+      decidedBy: 'auto',
+      reviewed: false,
+      lastInputHash: null,
+    });
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', iss, ctx);
+
+    expect(result.status).toBe('triaged_skip');
+    expect(triageMockCalls.length).toBe(1);
+    const row = dbState.triageDecisions.get('triage-legacy')!;
+    expect(row.lastInputHash).toBe(expectedHash(iss));
+  });
+
+  it('first-time triage (no existing row) → LLM call runs, hash is persisted on insert', async () => {
+    seedTriageMap();
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'unrelated',
+      confidence: 80,
+    };
+    const iss = issue(203);
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', iss, ctx);
+
+    expect(result.status).toBe('triaged_skip');
+    expect(triageMockCalls.length).toBe(1);
+    const rows = [...dbState.triageDecisions.values()];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].lastInputHash).toBe(expectedHash(iss));
+  });
+
+  it('triage_error → hash is NOT persisted (so the next webhook retries the LLM)', async () => {
+    seedTriageMap();
+    triageMockResponse = {
+      decision: 'uncertain',
+      reason: 'triage_error: upstream 503',
+      confidence: 0,
+    };
+    const iss = issue(204);
+
+    await ensureNodeForIssue('m1', 'inbox-1', iss, ctx);
+
+    const rows = [...dbState.triageDecisions.values()];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].lastInputHash).toBeNull();
+  });
+
+  // ── Per-issue debounce window ───────────────────────────────
+
+  it('within debounce window → short-circuit BEFORE precheck tx, no LLM call, no DB write', async () => {
+    seedTriageMap();
+    _testSetDebounceWindowMs(60_000);
+    _testSeedDebounce('m1', 'owner/repo#205', Date.now());
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', issue(205), ctx);
+
+    expect(result.status).toBe('triaged_debounced');
+    // Neither the LLM nor the precheck tx ran.
+    expect(triageMockCalls.length).toBe(0);
+    expect(dbState.triageDecisions.size).toBe(0);
+    expect(advisoryLocksTaken.length).toBe(0);
+  });
+
+  it('past the debounce window → LLM call runs', async () => {
+    seedTriageMap();
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'unrelated',
+      confidence: 80,
+    };
+    _testSetDebounceWindowMs(60_000);
+    // Stamp the debounce well outside the window.
+    _testSeedDebounce('m1', 'owner/repo#206', Date.now() - 120_000);
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', issue(206), ctx);
+
+    expect(result.status).toBe('triaged_skip');
+    expect(triageMockCalls.length).toBe(1);
+  });
+
+  it('successful LLM call stamps the debounce → second call within window is debounced', async () => {
+    seedTriageMap();
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'unrelated',
+      confidence: 80,
+    };
+    _testSetDebounceWindowMs(60_000);
+    const iss = issue(207, { body: 'a' });
+
+    const first = await ensureNodeForIssue('m1', 'inbox-1', iss, ctx);
+    expect(first.status).toBe('triaged_skip');
+    expect(triageMockCalls.length).toBe(1);
+
+    // Same externalId, different content (so the hash short-circuit
+    // wouldn't fire either). Debounce should still squash it.
+    const second = await ensureNodeForIssue(
+      'm1',
+      'inbox-1',
+      issue(207, { body: 'b' }),
+      ctx,
+    );
+    expect(second.status).toBe('triaged_debounced');
+    expect(triageMockCalls.length).toBe(1); // unchanged
+  });
+
+  it('hash-match path stamps the debounce so a burst rides on the single short-circuit', async () => {
+    seedTriageMap();
+    _testSetDebounceWindowMs(60_000);
+    const iss = issue(208, { title: 'hot' });
+    dbState.triageDecisions.set('triage-hot', {
+      id: 'triage-hot',
+      mapId: 'm1',
+      externalId: 'owner/repo#208',
+      issueTitle: 'hot',
+      issueState: 'open',
+      decision: 'skip',
+      reason: 'r',
+      confidence: 80,
+      placedNodeId: null,
+      suggestedParentNodeId: null,
+      decidedAt: new Date(2020, 0, 1),
+      decidedBy: 'auto',
+      reviewed: false,
+      lastInputHash: expectedHash(iss),
+    });
+
+    const first = await ensureNodeForIssue('m1', 'inbox-1', iss, ctx);
+    expect(first.status).toBe('triaged_hash_match');
+
+    // A second-burst delivery with DIFFERENT content (would normally
+    // call LLM) is squashed by the debounce that the hash-match path
+    // stamped.
+    const second = await ensureNodeForIssue(
+      'm1',
+      'inbox-1',
+      issue(208, { title: 'hot', body: 'new body' }),
+      ctx,
+    );
+    expect(second.status).toBe('triaged_debounced');
+    // LLM never called across the whole burst.
+    expect(triageMockCalls.length).toBe(0);
+  });
+
+  it('triage_error → does NOT stamp the debounce (so retry can happen)', async () => {
+    seedTriageMap();
+    triageMockResponse = {
+      decision: 'uncertain',
+      reason: 'triage_error: upstream 503',
+      confidence: 0,
+    };
+    _testSetDebounceWindowMs(60_000);
+
+    const first = await ensureNodeForIssue('m1', 'inbox-1', issue(209), ctx);
+    expect(first.status).toBe('triaged_uncertain');
+    expect(triageMockCalls.length).toBe(1);
+
+    // Second call with same content — would normally be debounced,
+    // but the prior call was a triage_error so the debounce wasn't
+    // stamped. The LLM is re-tried.
+    const second = await ensureNodeForIssue('m1', 'inbox-1', issue(209), ctx);
+    // It's either triaged_uncertain again (LLM still failing) or
+    // hash-match (the row's hash was NOT persisted on the error,
+    // so we should NOT see hash-match either — must be a real LLM call).
+    expect(second.status).toBe('triaged_uncertain');
+    expect(triageMockCalls.length).toBe(2);
   });
 });

--- a/packages/server/src/sync/__tests__/triage.test.ts
+++ b/packages/server/src/sync/__tests__/triage.test.ts
@@ -17,10 +17,19 @@
  *   - Reason and decision text are preserved verbatim.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { GitHubIssue } from '@mindblown/integrations';
 import type { MapContext } from '../mapContext.js';
-import { triageIssue, type TriageProvider } from '../triage.js';
+import {
+  triageIssue,
+  computeInputHash,
+  isWithinDebounceWindow,
+  markTriageDebounce,
+  clearTriageDebounce,
+  _resetDebounceWindow,
+  _setDebounceWindowMs,
+  type TriageProvider,
+} from '../triage.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────
 
@@ -379,5 +388,151 @@ describe('triageIssue — request construction', () => {
       { provider },
     );
     expect(result.decision).toBe('uncertain');
+  });
+});
+
+// ── #142 cost-opt — input-hash helper ────────────────────────────
+
+describe('computeInputHash', () => {
+  it('returns identical hashes for identical inputs', () => {
+    const a = computeInputHash({
+      title: 'A bug',
+      body: 'Something is broken',
+      state: 'open',
+      labels: [{ name: 'bug' }, { name: 'p1' }],
+    });
+    const b = computeInputHash({
+      title: 'A bug',
+      body: 'Something is broken',
+      state: 'open',
+      labels: [{ name: 'bug' }, { name: 'p1' }],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('is insensitive to label ordering (labels are sorted before hashing)', () => {
+    const a = computeInputHash({
+      title: 't',
+      body: 'b',
+      state: 'open',
+      labels: [{ name: 'bug' }, { name: 'p1' }],
+    });
+    const b = computeInputHash({
+      title: 't',
+      body: 'b',
+      state: 'open',
+      labels: [{ name: 'p1' }, { name: 'bug' }],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('changes when title changes', () => {
+    const a = computeInputHash({ title: 't1', body: '', state: 'open' });
+    const b = computeInputHash({ title: 't2', body: '', state: 'open' });
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when body changes', () => {
+    const a = computeInputHash({ title: 't', body: 'b1', state: 'open' });
+    const b = computeInputHash({ title: 't', body: 'b2', state: 'open' });
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when state changes (closed/open transition is a real signal)', () => {
+    const a = computeInputHash({ title: 't', body: 'b', state: 'open' });
+    const b = computeInputHash({ title: 't', body: 'b', state: 'closed' });
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when a new label is added', () => {
+    const a = computeInputHash({
+      title: 't',
+      body: 'b',
+      state: 'open',
+      labels: [{ name: 'bug' }],
+    });
+    const b = computeInputHash({
+      title: 't',
+      body: 'b',
+      state: 'open',
+      labels: [{ name: 'bug' }, { name: 'critical' }],
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('treats null body and empty-string body as identical', () => {
+    const a = computeInputHash({ title: 't', body: null, state: 'open' });
+    const b = computeInputHash({ title: 't', body: '', state: 'open' });
+    expect(a).toBe(b);
+  });
+
+  it('treats missing labels and empty labels as identical', () => {
+    const a = computeInputHash({ title: 't', body: '', state: 'open' });
+    const b = computeInputHash({
+      title: 't',
+      body: '',
+      state: 'open',
+      labels: [],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('returns a 64-char hex digest (sha256)', () => {
+    const h = computeInputHash({ title: 't', body: 'b', state: 'open' });
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ── #142 cost-opt — per-issue debounce window ────────────────────
+
+describe('debounce window', () => {
+  beforeEach(() => {
+    _resetDebounceWindow();
+    _setDebounceWindowMs(60_000);
+  });
+
+  it('reports `not within window` for a never-stamped key', () => {
+    expect(isWithinDebounceWindow('m1', 'o/r#1')).toBe(false);
+  });
+
+  it('reports `within window` immediately after marking', () => {
+    markTriageDebounce('m1', 'o/r#1');
+    expect(isWithinDebounceWindow('m1', 'o/r#1')).toBe(true);
+  });
+
+  it('expires past the window length', () => {
+    const t0 = 1_000_000;
+    markTriageDebounce('m1', 'o/r#1', t0);
+    expect(isWithinDebounceWindow('m1', 'o/r#1', t0 + 30_000)).toBe(true);
+    expect(isWithinDebounceWindow('m1', 'o/r#1', t0 + 90_000)).toBe(false);
+  });
+
+  it('scopes by (mapId, externalId) — different keys are independent', () => {
+    markTriageDebounce('m1', 'o/r#1');
+    expect(isWithinDebounceWindow('m1', 'o/r#1')).toBe(true);
+    expect(isWithinDebounceWindow('m2', 'o/r#1')).toBe(false);
+    expect(isWithinDebounceWindow('m1', 'o/r#2')).toBe(false);
+  });
+
+  it('clearTriageDebounce removes a single key without disturbing others', () => {
+    markTriageDebounce('m1', 'o/r#1');
+    markTriageDebounce('m1', 'o/r#2');
+    clearTriageDebounce('m1', 'o/r#1');
+    expect(isWithinDebounceWindow('m1', 'o/r#1')).toBe(false);
+    expect(isWithinDebounceWindow('m1', 'o/r#2')).toBe(true);
+  });
+
+  it('window of 0 disables debounce entirely', () => {
+    _setDebounceWindowMs(0);
+    markTriageDebounce('m1', 'o/r#1');
+    expect(isWithinDebounceWindow('m1', 'o/r#1')).toBe(false);
+  });
+
+  it('_resetDebounceWindow clears all keys', () => {
+    markTriageDebounce('m1', 'o/r#1');
+    markTriageDebounce('m1', 'o/r#2');
+    _resetDebounceWindow();
+    expect(isWithinDebounceWindow('m1', 'o/r#1')).toBe(false);
+    expect(isWithinDebounceWindow('m1', 'o/r#2')).toBe(false);
   });
 });

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -54,6 +54,9 @@ import { applyTriageLabel } from './triageLabelWriteback.js';
 import {
   triageIssue,
   TRIAGE_AUTO_APPLY_CONFIDENCE,
+  computeInputHash,
+  isWithinDebounceWindow,
+  markTriageDebounce,
   type TriageDecision,
 } from './triage.js';
 
@@ -75,7 +78,13 @@ export interface IngestResult {
     | 'skipped_closed_outside_window'
     | 'triaged_skip'
     | 'triaged_uncertain'
-    | 'triaged_low_confidence';
+    | 'triaged_low_confidence'
+    // #142 cost-opt short-circuits — all three skip the LLM call but
+    // still update decided_at on the existing row (so dashboards can
+    // tell "we re-checked, same outcome" apart from "stale row").
+    | 'triaged_hash_match'
+    | 'triaged_debounced'
+    | 'metadata_only_skipped';
   nodeId?: string;
   mapId: string;
   /**
@@ -407,6 +416,31 @@ async function ensureNodeForIssueViaTriage(
   ctx: IngestContext,
   externalId: string,
 ): Promise<IngestResult> {
+  // ── Cost-opt #142 layer 2: per-issue debounce ─────────────────
+  // If the same (mapId, externalId) was triaged inside the debounce
+  // window (default 60 s), short-circuit BEFORE the precheck tx +
+  // LLM call. This catches burst webhook deliveries (the GitHub
+  // label-bot fires multiple `issues.edited` events in a second when
+  // multiple labels change at once) and is the cheapest layer to
+  // hit — no DB I/O at all. Hash-match (layer 3) still runs when
+  // the window expires; the two layers work together to keep
+  // long-running churn cheap.
+  //
+  // Debounced calls never touch the DB, so we don't bump decided_at
+  // here either — the LLM wasn't re-evaluated. The dashboard's "last
+  // re-checked at" remains the prior call's timestamp, which is the
+  // honest answer.
+  if (isWithinDebounceWindow(mapId, externalId)) {
+    return { status: 'triaged_debounced', mapId };
+  }
+
+  // Pre-compute the canonical input hash for cost-opt #142 layer 3
+  // (body-hash idempotency). We pass this into the precheck tx so the
+  // hash comparison shares the advisory lock — a concurrent winner
+  // whose hash equals this one (e.g. catchup re-running the same
+  // issue) will have committed last_input_hash before we read it.
+  const incomingHash = computeInputHash(issue);
+
   // ── Race-safety prelude (mindblown#99 fix 1) ────────────────────
   // We do *two* things inside a transaction BEFORE paying for an LLM
   // call:
@@ -426,6 +460,8 @@ async function ensureNodeForIssueViaTriage(
   type PrecheckResult =
     | { kind: 'exists'; nodeId: string }
     | { kind: 'operator_reviewed'; decisionId: string; nodeId: string | null;
+        decision: TriageDecision['decision']; confidence: number }
+    | { kind: 'hash_match'; decisionId: string; nodeId: string | null;
         decision: TriageDecision['decision']; confidence: number }
     | { kind: 'proceed' };
   const precheck: PrecheckResult = await db.transaction(async (tx) => {
@@ -453,6 +489,7 @@ async function ensureNodeForIssueViaTriage(
         decision: triageDecisions.decision,
         confidence: triageDecisions.confidence,
         placedNodeId: triageDecisions.placedNodeId,
+        lastInputHash: triageDecisions.lastInputHash,
       })
       .from(triageDecisions)
       .where(
@@ -474,11 +511,71 @@ async function ensureNodeForIssueViaTriage(
         confidence: existingDecision.confidence as number,
       };
     }
+
+    // (c) Body-hash idempotency (#142 layer 3). If a prior row exists
+    // for this (mapId, externalId) AND its stored hash matches the
+    // incoming one, the inputs that drive a triage decision haven't
+    // changed since last time — skip the LLM call, bump decided_at
+    // only (to record "we re-checked at T, same outcome"). First-
+    // time triage (no row) and rows with NULL hash (lazy-migrated
+    // legacy rows) fall through to the LLM call so the column
+    // populates on the next pass.
+    if (
+      existingDecision &&
+      typeof existingDecision.lastInputHash === 'string' &&
+      existingDecision.lastInputHash === incomingHash
+    ) {
+      const decisionId = existingDecision.id as string;
+      // Bump decided_at inside the same tx so the timestamp is
+      // visible to the next ingest under the lock. We don't touch
+      // decision/confidence/placedNodeId — the existing values are
+      // by definition still authoritative.
+      await tx
+        .update(triageDecisions)
+        .set({ decidedAt: new Date() })
+        .where(eq(triageDecisions.id, decisionId));
+      return {
+        kind: 'hash_match',
+        decisionId,
+        nodeId: (existingDecision.placedNodeId as string | null) ?? null,
+        decision: existingDecision.decision as TriageDecision['decision'],
+        confidence: existingDecision.confidence as number,
+      };
+    }
     return { kind: 'proceed' };
   });
 
   if (precheck.kind === 'exists') {
     return { status: 'skipped_exists', nodeId: precheck.nodeId, mapId };
+  }
+  if (precheck.kind === 'hash_match') {
+    // Hash-match short-circuit (#142 layer 3). Stamp the debounce so
+    // a burst of identical-payload webhooks rides on this single
+    // decision for the next debounce window. Map to the same
+    // status code the original decision would have produced; the
+    // dashboard treats hash-matches as "we re-checked, same answer".
+    markTriageDebounce(mapId, externalId);
+    if (precheck.decision === 'place' && precheck.nodeId) {
+      return {
+        status: 'triaged_hash_match',
+        nodeId: precheck.nodeId,
+        mapId,
+        triage: {
+          decisionId: precheck.decisionId,
+          decision: precheck.decision,
+          confidence: precheck.confidence,
+        },
+      };
+    }
+    return {
+      status: 'triaged_hash_match',
+      mapId,
+      triage: {
+        decisionId: precheck.decisionId,
+        decision: precheck.decision,
+        confidence: precheck.confidence,
+      },
+    };
   }
   if (precheck.kind === 'operator_reviewed') {
     // Treat operator-reviewed rows as authoritative. Map the persisted
@@ -668,6 +765,15 @@ async function ensureNodeForIssueViaTriage(
     const suggestedParentNodeId =
       decision.decision === 'place' ? (decision.parentNodeId ?? null) : null;
 
+    // Persist the canonical input hash so the next webhook can short-
+    // circuit via the hash-match precheck (#142 layer 3). We DON'T
+    // write the hash on triage_error so a transient LLM failure can
+    // be retried on the next webhook — locking in the hash would
+    // mean a 500 from Anthropic permanently muted re-triage for an
+    // unchanged issue, which is the opposite of what we want.
+    const isTriageError = decision.reason.startsWith('triage_error');
+    const nextInputHash: string | null = isTriageError ? null : incomingHash;
+
     const [decisionRow] = await tx
       .insert(triageDecisions)
       .values({
@@ -682,6 +788,7 @@ async function ensureNodeForIssueViaTriage(
         suggestedParentNodeId,
         decidedBy: 'auto',
         reviewed: false,
+        lastInputHash: nextInputHash,
       })
       .onConflictDoUpdate({
         target: [triageDecisions.mapId, triageDecisions.externalId],
@@ -699,6 +806,11 @@ async function ensureNodeForIssueViaTriage(
           decidedAt: new Date(),
           decidedBy: 'auto',
           reviewed: false,
+          // Refresh the input hash on every successful LLM call so
+          // the next webhook can short-circuit. On triage_error we
+          // pass `null` to clear a stale hash — better to re-call
+          // the LLM next time than to lock in an error-state hash.
+          lastInputHash: nextInputHash,
         },
       })
       .returning({ id: triageDecisions.id });
@@ -791,6 +903,15 @@ async function ensureNodeForIssueViaTriage(
         confidence: result.confidence,
       },
     };
+  }
+
+  // Stamp the debounce window for any LLM-paid path EXCEPT triage_error.
+  // The hash column above is also gated on non-error, so the two layers
+  // stay in sync: an error doesn't lock out re-evaluation either via
+  // debounce or via hash-match. Stamped before history/label writebacks
+  // so a downstream failure doesn't undo the debounce.
+  if (!decision.reason.startsWith('triage_error')) {
+    markTriageDebounce(mapId, externalId);
   }
 
   if (result.kind === 'auto_placed') {

--- a/packages/server/src/sync/triage.ts
+++ b/packages/server/src/sync/triage.ts
@@ -34,6 +34,7 @@
  * material accuracy lift. Overridable via TRIAGE_MODEL env var.
  */
 
+import { createHash } from 'crypto';
 import Anthropic from '@anthropic-ai/sdk';
 import type { GitHubIssue } from '@mindblown/integrations';
 import type { MapContext } from './mapContext.js';
@@ -95,6 +96,163 @@ function parseConfidenceEnv(raw: string | undefined, fallback: number): number {
   const n = parseInt(raw, 10);
   if (!Number.isFinite(n) || n < 0 || n > 100) return fallback;
   return n;
+}
+
+// ── Cost optimisation: body-hash idempotency + per-issue debounce ─
+//
+// Three layers stack at progressively coarser granularity (#142):
+//
+//   1. Diff-aware skip on `issues.edited` (webhook handler — outermost).
+//   2. Per-issue debounce window (this module — short-circuits the
+//      same-issue burst inside the LLM-call window).
+//   3. Body-hash idempotency (caller — short-circuits when the canonical
+//      input tuple matches the last persisted hash).
+//
+// Layers 2 + 3 live here because they share the `(mapId, externalId)`
+// keying and they both belong on the LLM-call boundary; the diff-aware
+// skip is webhook-shape-specific and lives next to the payload parsing.
+
+/**
+ * Canonical hash of the inputs that drive a triage decision. SHA-256 of
+ * a JSON-stringified tuple of `{title, body, labels (sorted), state}`.
+ *
+ * Labels are sorted by `name` so the order GitHub returns them in
+ * doesn't poison the hash (the GitHub API doesn't guarantee a stable
+ * label ordering across calls). `body` defaults to the empty string so
+ * a null/undefined body hashes identically across SDK shapes. `state`
+ * is folded in so a closed/reopened transition without a body change
+ * still re-triages — closing an issue is a real signal change.
+ *
+ * Persisted in `triage_decisions.last_input_hash`; compared against the
+ * freshly-computed hash on the next ingest. Identical → LLM call is
+ * skipped (#142 layer 3). Operator reclassify with `force=true`
+ * bypasses the comparison.
+ */
+export function computeInputHash(issue: {
+  title: string;
+  body?: string | null;
+  state: 'open' | 'closed';
+  labels?: Array<{ name: string }> | null;
+}): string {
+  const labels = (issue.labels ?? [])
+    .map((l) => l.name)
+    .filter((n): n is string => typeof n === 'string')
+    .slice()
+    .sort();
+  const payload = JSON.stringify({
+    title: issue.title,
+    body: issue.body ?? '',
+    labels,
+    state: issue.state,
+  });
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+/**
+ * Per-issue debounce window, in milliseconds. A second `triageIssue`
+ * call for the same `(mapId, externalId)` within this window short-
+ * circuits without an LLM round-trip. Defaults to 60 s; override via
+ * the `TRIAGE_DEBOUNCE_WINDOW_MS` env var. Setting to `0` disables
+ * the debounce entirely (useful for tests / per-deploy disable).
+ */
+let _debounceWindowMs = parseDebounceMs(
+  process.env.TRIAGE_DEBOUNCE_WINDOW_MS,
+);
+
+function parseDebounceMs(raw: string | undefined): number {
+  if (!raw) return 60_000;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 60_000;
+  return n;
+}
+
+/**
+ * In-memory map of last-triage timestamps per `(mapId, externalId)`.
+ * Same single-process precedent as #75's catchup counter — works
+ * because the server is a single Node process per deploy. A future
+ * multi-process deploy would need to lift this into Redis; the body-
+ * hash layer below keeps the worst-case cost bounded even without it.
+ */
+const _debounceMap = new Map<string, number>();
+
+function debounceKey(mapId: string, externalId: string): string {
+  return `${mapId}/${externalId}`;
+}
+
+/**
+ * Test-only: clear the debounce map between tests. Production code
+ * never calls this — the entries naturally fall out of the window.
+ */
+export function _resetDebounceWindow(): void {
+  _debounceMap.clear();
+}
+
+/**
+ * Test-only: override the debounce window length. Production code
+ * uses the env-var default; tests use this to drive both
+ * within-window and past-window paths without `setTimeout(60_000)`.
+ */
+export function _setDebounceWindowMs(ms: number): void {
+  _debounceWindowMs = ms;
+}
+
+/**
+ * Returns the current debounce window in milliseconds. Exposed for
+ * callers that want to log a "debounced for Ns" diagnostic. Mostly
+ * useful in tests.
+ */
+export function getDebounceWindowMs(): number {
+  return _debounceWindowMs;
+}
+
+/**
+ * Returns true if `(mapId, externalId)` was triaged within the
+ * debounce window. Caller MUST stamp `markTriageDebounce` after a
+ * successful LLM call — this read-only check is intentionally
+ * decoupled so a caller can fall back to the body-hash layer when
+ * the debounce window expires but the hash still matches.
+ */
+export function isWithinDebounceWindow(
+  mapId: string,
+  externalId: string,
+  now: number = Date.now(),
+): boolean {
+  if (_debounceWindowMs <= 0) return false;
+  const lastAt = _debounceMap.get(debounceKey(mapId, externalId));
+  if (lastAt === undefined) return false;
+  return now - lastAt < _debounceWindowMs;
+}
+
+/**
+ * Stamp the debounce timestamp for `(mapId, externalId)`. Called by
+ * the ingest path after a successful LLM round-trip OR after a
+ * hash-match short-circuit — both count as "we know the current
+ * decision, don't re-call for the next N seconds." Skip on
+ * triage_error so a transient LLM failure doesn't lock us out of
+ * retrying for 60 s.
+ */
+export function markTriageDebounce(
+  mapId: string,
+  externalId: string,
+  now: number = Date.now(),
+): void {
+  if (_debounceWindowMs <= 0) return;
+  _debounceMap.set(debounceKey(mapId, externalId), now);
+}
+
+/**
+ * Clear the debounce timestamp for a single `(mapId, externalId)`.
+ * Used by the operator reclassify route — when the operator forces a
+ * fresh classification, an immediately-following webhook delivery
+ * should NOT be debounced (the operator is explicitly soliciting a
+ * new LLM read). Scoped to the one key so other in-flight bursts
+ * aren't disrupted.
+ */
+export function clearTriageDebounce(
+  mapId: string,
+  externalId: string,
+): void {
+  _debounceMap.delete(debounceKey(mapId, externalId));
 }
 
 // ── Anthropic client (lazy) ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Three independent cost optimizations for the triage pipeline that stack to cut ~80%+ of Anthropic LLM calls during label-only edit storms while preserving correctness on real content changes. Closes #142.

The three layers run innermost-to-outermost (debounce -> hash -> LLM) so the cheapest check fires first:

- **Layer 1 - diff-aware skip on `issues.edited`** (webhook handler). Inspects GitHub's `changes` object; if neither `title` nor `body` changed, returns `metadata_only_skipped` without touching ingest. Catches the typical label-bot churn (5-10 edited events/min with no decision-relevant signal).
- **Layer 2 - per-issue debounce window** (`sync/triage.ts`). Module-level `Map<\${mapId}/\${externalId}, timestamp>`; default 60 s (override via `TRIAGE_DEBOUNCE_WINDOW_MS`). Second `triageIssue` call within window short-circuits before precheck tx -> `triaged_debounced`. Stamped after every successful LLM round-trip OR hash-match; cleared on operator reclassify. Skipped on `triage_error` so transient failures don't lock out retries.
- **Layer 3 - body-hash idempotency** (`triage_decisions.last_input_hash`). SHA-256 of `{title, body, labels.sorted, state}` compared against stored hash inside the precheck tx; identical -> skip LLM, bump `decided_at` only -> `triaged_hash_match`. Lazy migration (no backfill). Operator reclassify clears the hash to force fresh evaluation.

## Round 2 fix (Ray's review)

Ray's review on this PR caught one real correctness gap: the bulk-reclassify route was missing the hash + debounce clear that the single-row /reclassify route already performed.

- `packages/server/src/routes/triage.ts:2145-2168` - bulk-reclassify per-row update now sets `lastInputHash: null` AND calls `clearTriageDebounce(mapId, externalId)`, identical to the single-row path at `:1487, 1491`.

Without this, after a bulk re-run rows kept their OLD `lastInputHash` and the next real `issues.edited` webhook short-circuited on a stale hash compare - leaving the row with the new decision but masking that subsequent edits weren't being re-evaluated. The single-row route always had this; bulk inherited from Phase 2 (#95) before hash/debounce existed and wasn't updated in #142.

New test assertions (test count now 452 -> 454, +2):
- `triage-routes.test.ts` (POST /reclassify describe) - `reclassify clears lastInputHash and calls clearTriageDebounce(mapId, externalId)`. Seeds a row with `lastInputHash: 'some-old-hash'`, posts /reclassify, asserts row hash is now `null` and the `clearTriageDebounce` mock was called with the right `(mapId, externalId)` tuple.
- `triage-routes.test.ts` (POST /bulk-reclassify describe) - `bulk-reclassify clears lastInputHash + calls clearTriageDebounce per row`. Seeds two rows with distinct external ids and stale hashes, asserts both hashes are nulled and the debounce mock was called twice with the correct per-row identifiers.

The hoisted `clearTriageDebounceMock` replaces the previous inline `vi.fn()` so the new assertions can reach it; `beforeEach` clears it between cases.

## Key compatibility decisions

- `metadata_only_skipped` never reaches `triage_decision_history`, so Phase 4 tuning-data isn't poisoned by label-storm noise.
- Operator reclassify route always bypasses hash + debounce (default behaviour; `?force=true` accepted as forward-compat / explicit signal).
- First-time triage (no existing row) bypasses hash check; debounce only fires after at least one prior call.
- `triage_error` decisions don't persist the hash and don't stamp the debounce so the next webhook re-tries the LLM.
- Lazy migration: existing rows have `last_input_hash IS NULL` until their next auto-triage populates the column.

## File map

- `packages/server/src/sync/triage.ts:38-217` - `computeInputHash`, debounce window machinery, `clearTriageDebounce`
- `packages/server/src/sync/githubIngest.ts:421-553` - debounce/hash precheck wired into `ensureNodeForIssueViaTriage`
- `packages/server/src/routes/integrations.ts:1193-1264` - diff-aware skip on `issues.edited`
- `packages/server/src/routes/triage.ts:1380-1530` - operator reclassify clears hash + debounce
- `packages/server/src/routes/triage.ts:2145-2168` - **Round 2:** bulk-reclassify now mirrors single-row hash + debounce clear
- `packages/server/src/db/schema.ts:386-391` + `db/migrate.ts:572-583` - `last_input_hash` column + idempotent migration

## Test plan

- [x] `pnpm -w typecheck` clean
- [x] `pnpm -w build` clean
- [x] `pnpm -w test` passes (419 -> 454, 35 new tests, +2 from Round 2)
- [x] `rg "metadata_only_skipped|last_input_hash|TRIAGE_DEBOUNCE_WINDOW_MS"` matches across schema, migrate, triage.ts, githubIngest.ts, routes, tests
- [x] `rg "lastInputHash: null" packages/server/src/routes/triage.ts` matches in BOTH single-row reclassify and bulk-reclassify
- [x] `rg "clearTriageDebounce" packages/server/src/routes/triage.ts` matches in BOTH single-row reclassify and bulk-reclassify

New test coverage:
- `triage.test.ts` - hash determinism + sensitivity (title/body/state/labels), label ordering insensitivity, null/empty body equivalence, debounce within/past window, scoped keying, clear/reset helpers
- `githubIngest.test.ts` - hash-match short-circuits LLM and bumps `decided_at`; hash-mismatch persists new hash; legacy NULL hash hits LLM; first-time triage persists hash; `triage_error` does NOT persist hash or stamp debounce; debounce squashes second call; hash-match path stamps debounce
- `triage-webhook.test.ts` (new) - `metadata_only_skipped` on `changes={}` and missing `changes`; title/body change still triggers ingest; opened/reopened bypass the gate; bad signature 401s
- `triage-routes.test.ts` - **Round 2:** single-row + bulk-reclassify both null `lastInputHash` and call `clearTriageDebounce(mapId, externalId)` per row
