### PR TITLE
feat(triage): UI toggle for triage_enabled + label_writeback

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -325,6 +325,23 @@ export interface MindMap {
    * is handled by treating a dangling ID as "recreate on next ingest").
    */
   githubInboxNodeId?: string | null;
+  /**
+   * Per-map opt-in for the AI triage pipeline. When true, new GitHub
+   * issues bound to this map go through the LLM triage classifier
+   * before any node is created; high-confidence place decisions
+   * auto-create the node, low-confidence ones wait in the Triage panel.
+   * Default false → ingest behaves like vanilla auto-import.
+   * Server source: `maps.triage_enabled`.
+   */
+  triageEnabled?: boolean;
+  /**
+   * Per-map opt-in for GitHub label write-back. When true, finalized
+   * triage decisions write `triage:placed` / `triage:skipped` labels
+   * back to the source GitHub issue. Best-effort: a label write failure
+   * never blocks the triage flow. Requires `triageEnabled` to do anything.
+   * Server source: `maps.triage_label_writeback`.
+   */
+  triageLabelWriteback?: boolean;
 }
 
 // ── User / Workspace / Team ─────────────────────────────────────

--- a/packages/mindmap/src/GitHubPanel.tsx
+++ b/packages/mindmap/src/GitHubPanel.tsx
@@ -455,6 +455,84 @@ export function GitHubSettingsDialog({
   const [autoImportSaving, setAutoImportSaving] = useState(false);
   const [ingestNotice, setIngestNotice] = useState<string | null>(null);
 
+  // ── AI triage toggle (per-map opt-in for the LLM classifier) ────
+  // Cascade: triage requires auto-import; label-writeback requires triage.
+  // Server defaults are false; we mirror that here so existing maps
+  // don't suddenly start classifying issues.
+  const [triageEnabled, setTriageEnabled] = useState<boolean>(
+    currentMap?.triageEnabled ?? false,
+  );
+  const [triageLabelWriteback, setTriageLabelWriteback] = useState<boolean>(
+    currentMap?.triageLabelWriteback ?? false,
+  );
+  useEffect(() => {
+    setTriageEnabled(currentMap?.triageEnabled ?? false);
+    setTriageLabelWriteback(currentMap?.triageLabelWriteback ?? false);
+  }, [currentMap?.id, currentMap?.triageEnabled, currentMap?.triageLabelWriteback]);
+  const [triageSaving, setTriageSaving] = useState(false);
+  const [labelWritebackSaving, setLabelWritebackSaving] = useState(false);
+  // When the operator toggles triage from ON → OFF we surface a confirm
+  // modal instead of firing the PATCH immediately. Enabling is low-stakes
+  // and skips the modal.
+  const [showTriageDisableConfirm, setShowTriageDisableConfirm] = useState(false);
+
+  const persistTriageDisable = async () => {
+    setShowTriageDisableConfirm(false);
+    setTriageSaving(true);
+    setError(null);
+    try {
+      // Disabling triage also disables label writeback in the same PATCH —
+      // keeps the DB consistent if the operator re-enables triage later
+      // and forgets the dependent flag.
+      const patch: Record<string, unknown> = { triageEnabled: false };
+      if (triageLabelWriteback) patch.triageLabelWriteback = false;
+      await api.updateMap(mapId, patch);
+      setTriageEnabled(false);
+      if (triageLabelWriteback) setTriageLabelWriteback(false);
+      await loadMap(mapId);
+    } catch (e: any) {
+      setError(e.message ?? 'Failed to update AI triage setting');
+    } finally {
+      setTriageSaving(false);
+    }
+  };
+
+  const handleToggleTriageEnabled = async (next: boolean) => {
+    if (!next) {
+      // Open the confirmation modal; the actual PATCH fires from there.
+      setShowTriageDisableConfirm(true);
+      return;
+    }
+    setTriageSaving(true);
+    setError(null);
+    try {
+      await api.updateMap(mapId, { triageEnabled: true });
+      setTriageEnabled(true);
+      await loadMap(mapId);
+    } catch (e: any) {
+      setError(e.message ?? 'Failed to update AI triage setting');
+    } finally {
+      setTriageSaving(false);
+    }
+  };
+
+  const handleToggleLabelWriteback = async (next: boolean) => {
+    setLabelWritebackSaving(true);
+    setError(null);
+    try {
+      await api.updateMap(mapId, { triageLabelWriteback: next });
+      setTriageLabelWriteback(next);
+      await loadMap(mapId);
+    } catch (e: any) {
+      setError(e.message ?? 'Failed to update label writeback setting');
+    } finally {
+      setLabelWritebackSaving(false);
+    }
+  };
+
+  const triageDisabledByAutoImport = !autoImport;
+  const labelWritebackDisabledByTriage = !triageEnabled;
+
   const handleToggleAutoImport = async (next: boolean) => {
     setAutoImportSaving(true);
     setError(null);
@@ -741,6 +819,134 @@ export function GitHubSettingsDialog({
               </label>
             </div>
 
+            {/* AI triage toggle — requires auto-import to be on. */}
+            <div
+              style={{
+                marginBottom: 12,
+                padding: '10px 14px',
+                borderRadius: 8,
+                background: triageDisabledByAutoImport ? '#f1f5f9' : '#f8fafc',
+                border: '1px solid #e2e8f0',
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 10,
+                opacity: triageDisabledByAutoImport ? 0.55 : 1,
+              }}
+              title={
+                triageDisabledByAutoImport
+                  ? 'Triage only fires on imported issues.'
+                  : undefined
+              }
+            >
+              <input
+                id="github-triage-enabled"
+                data-testid="map-settings-triage-enabled"
+                type="checkbox"
+                checked={triageEnabled && !triageDisabledByAutoImport}
+                disabled={triageDisabledByAutoImport || triageSaving}
+                onChange={(e) => handleToggleTriageEnabled(e.target.checked)}
+                style={{ marginTop: 3 }}
+              />
+              <label
+                htmlFor="github-triage-enabled"
+                style={{
+                  cursor: triageDisabledByAutoImport ? 'not-allowed' : 'pointer',
+                  flex: 1,
+                }}
+              >
+                <div style={{ fontSize: 12, fontWeight: 600, color: '#1e293b' }}>
+                  AI triage incoming issues
+                </div>
+                <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>
+                  Claude classifies new issues (skip/place/uncertain). High-confidence
+                  places auto-create nodes; low-confidence ones wait in the Triage panel.
+                </div>
+                {triageDisabledByAutoImport && (
+                  <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 4, fontStyle: 'italic' }}>
+                    Triage only fires on imported issues — enable auto-import first.
+                  </div>
+                )}
+              </label>
+            </div>
+
+            {/* Label writeback toggle — requires AI triage to be on. */}
+            <div
+              style={{
+                marginBottom: 16,
+                padding: '10px 14px',
+                borderRadius: 8,
+                background: labelWritebackDisabledByTriage ? '#f1f5f9' : '#f8fafc',
+                border: '1px solid #e2e8f0',
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 10,
+                opacity: labelWritebackDisabledByTriage ? 0.55 : 1,
+              }}
+              title={
+                labelWritebackDisabledByTriage
+                  ? 'Labels are written by the triage pipeline.'
+                  : undefined
+              }
+            >
+              <input
+                id="github-triage-label-writeback"
+                data-testid="map-settings-triage-label-writeback"
+                type="checkbox"
+                checked={triageLabelWriteback && !labelWritebackDisabledByTriage}
+                disabled={labelWritebackDisabledByTriage || labelWritebackSaving}
+                onChange={(e) => handleToggleLabelWriteback(e.target.checked)}
+                style={{ marginTop: 3 }}
+              />
+              <label
+                htmlFor="github-triage-label-writeback"
+                style={{
+                  cursor: labelWritebackDisabledByTriage ? 'not-allowed' : 'pointer',
+                  flex: 1,
+                }}
+              >
+                <div style={{ fontSize: 12, fontWeight: 600, color: '#1e293b' }}>
+                  Write triage labels back to GitHub
+                </div>
+                <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>
+                  Writes <code>triage:placed</code> / <code>triage:skipped</code> labels to GitHub
+                  when decisions are reviewed. Requires labels to exist in the repo.
+                </div>
+                {labelWritebackDisabledByTriage && (
+                  <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 4, fontStyle: 'italic' }}>
+                    Labels are written by the triage pipeline — enable AI triage first.
+                  </div>
+                )}
+              </label>
+            </div>
+
+            {/* Status badge — shown when triage is fully active. */}
+            {triageEnabled && !triageDisabledByAutoImport && (
+              <div
+                data-testid="map-settings-triage-status-badge"
+                style={{
+                  marginBottom: 16,
+                  padding: '6px 10px',
+                  borderRadius: 6,
+                  background: '#dcfce7',
+                  border: '1px solid #bbf7d0',
+                  color: '#166534',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                }}
+              >
+                <span aria-hidden>✓</span>
+                AI triage active
+                {triageLabelWriteback && !labelWritebackDisabledByTriage && (
+                  <span style={{ fontWeight: 500, color: '#15803d' }}>
+                    · labels write back to GitHub
+                  </span>
+                )}
+              </div>
+            )}
+
             {ingestNotice && (
               <div
                 style={{
@@ -987,6 +1193,99 @@ export function GitHubSettingsDialog({
             </div>
           </div>
         )}
+      </div>
+
+      {showTriageDisableConfirm && (
+        <TriageDisableConfirmModal
+          onCancel={() => setShowTriageDisableConfirm(false)}
+          onConfirm={persistTriageDisable}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Triage disable confirmation modal ────────────────────────────
+// Surfaced when the operator flips `triageEnabled` from ON → OFF.
+// Enabling is low-stakes and skips this modal.
+
+function TriageDisableConfirmModal({
+  onCancel,
+  onConfirm,
+}: {
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div
+      data-testid="map-settings-triage-disable-confirm"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.4)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 120,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        style={{
+          width: 400,
+          maxWidth: '90vw',
+          background: '#fff',
+          borderRadius: 12,
+          boxShadow: '0 8px 32px rgba(0,0,0,0.16)',
+          padding: 24,
+        }}
+      >
+        <h3 style={{ margin: '0 0 12px', fontSize: 15, fontWeight: 700, color: '#1e293b' }}>
+          Disable AI triage?
+        </h3>
+        <p style={{ margin: '0 0 18px', fontSize: 12, lineHeight: 1.5, color: '#475569' }}>
+          Disabling AI triage stops automatic classification of new GitHub issues.
+          Existing decisions stay; new issues will land flat under "GitHub Inbox" again.
+          Continue?
+        </p>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button
+            onClick={onCancel}
+            data-testid="map-settings-triage-disable-confirm-cancel"
+            style={{
+              background: '#f1f5f9',
+              border: 'none',
+              borderRadius: 6,
+              padding: '8px 16px',
+              fontSize: 12,
+              fontWeight: 600,
+              color: '#475569',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            data-testid="map-settings-triage-disable-confirm-ok"
+            style={{
+              background: '#dc2626',
+              color: '#fff',
+              border: 'none',
+              borderRadius: 6,
+              padding: '8px 16px',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            Disable triage
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -95,5 +95,7 @@ export function dbMapToCore(row: Record<string, unknown>): MindMap {
     githubRepoName: (get('githubRepoName', 'github_repo_name') as string) ?? null,
     autoImportNewIssues: (get('autoImportNewIssues', 'auto_import_new_issues') as boolean) ?? false,
     githubInboxNodeId: (get('githubInboxNodeId', 'github_inbox_node_id') as string) ?? null,
+    triageEnabled: (get('triageEnabled', 'triage_enabled') as boolean) ?? false,
+    triageLabelWriteback: (get('triageLabelWriteback', 'triage_label_writeback') as boolean) ?? false,
   };
 }

--- a/packages/server/src/db/maps.ts
+++ b/packages/server/src/db/maps.ts
@@ -121,6 +121,8 @@ export interface UpdateMapInput {
   githubRepoName?: string | null;
   autoImportNewIssues?: boolean;
   githubInboxNodeId?: string | null;
+  triageEnabled?: boolean;
+  triageLabelWriteback?: boolean;
 }
 
 export async function updateMap(mapId: string, input: UpdateMapInput): Promise<MindMap | null> {
@@ -142,6 +144,8 @@ export async function updateMap(mapId: string, input: UpdateMapInput): Promise<M
   if (input.githubRepoName !== undefined) updates.githubRepoName = input.githubRepoName;
   if (input.autoImportNewIssues !== undefined) updates.autoImportNewIssues = input.autoImportNewIssues;
   if (input.githubInboxNodeId !== undefined) updates.githubInboxNodeId = input.githubInboxNodeId;
+  if (input.triageEnabled !== undefined) updates.triageEnabled = input.triageEnabled;
+  if (input.triageLabelWriteback !== undefined) updates.triageLabelWriteback = input.triageLabelWriteback;
 
   const [row] = await db.update(maps).set(updates).where(eq(maps.id, mapId)).returning();
   if (!row) return null;

--- a/packages/server/src/routes/__tests__/maps-triage-flags.test.ts
+++ b/packages/server/src/routes/__tests__/maps-triage-flags.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Round-trip tests for the per-map triage flags exposed via PUT /api/maps/:id.
+ *
+ * The columns `triage_enabled` and `triage_label_writeback` exist on the
+ * `maps` table and were only flip-able via SQL until the UI toggle landed.
+ * These tests lock down the API surface so the frontend toggle can write
+ * to them, and the GET map handler reads them back as `triageEnabled` /
+ * `triageLabelWriteback` camelCase on the MindMap response.
+ *
+ * Mock pattern mirrors admin-endpoints-guard.test.ts — stub the DB +
+ * permissions module so we exercise route wiring without standing up
+ * Postgres. The interesting assertion is that the PUT request body is
+ * forwarded verbatim to `mapDb.updateMap` (camelCase keys preserved).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const updateMapMock = vi.fn();
+const getMapMock = vi.fn();
+const listMapsForUserMock = vi.fn(async () => []);
+const createBaselineMock = vi.fn();
+const deleteMapMock = vi.fn();
+const createMapMock = vi.fn();
+
+vi.mock('../../db/maps.js', () => ({
+  updateMap: (...args: unknown[]) => updateMapMock(...args),
+  getMap: (...args: unknown[]) => getMapMock(...args),
+  listMapsForUser: (...args: unknown[]) => listMapsForUserMock(...args),
+  createBaseline: (...args: unknown[]) => createBaselineMock(...args),
+  deleteMap: (...args: unknown[]) => deleteMapMock(...args),
+  createMap: (...args: unknown[]) => createMapMock(...args),
+}));
+
+const getPermissionMock = vi.fn(async () => 'edit' as 'view' | 'edit' | 'admin' | null);
+vi.mock('../../db/permissions.js', () => ({
+  getPermission: (...args: unknown[]) => getPermissionMock(...args),
+  hasPermission: (actual: string | null, required: string) => {
+    if (actual == null) return false;
+    const rank: Record<string, number> = { view: 1, edit: 2, admin: 3 };
+    return (rank[actual] ?? 0) >= (rank[required] ?? 0);
+  },
+}));
+
+vi.mock('../../db/versions.js', () => ({}));
+vi.mock('../../db/cycles.js', () => ({}));
+vi.mock('../../db/connection.js', () => ({ db: {} }));
+vi.mock('../../db/schema.js', () => ({
+  workspaces: {},
+  users: {},
+  releaseSnapshots: {},
+}));
+vi.mock('../../lib/releaseForecast.js', () => ({
+  computeReleaseForecast: vi.fn(),
+}));
+vi.mock('../../lib/releaseSnapshots.js', () => ({
+  snapshotReleaseForecastForMap: vi.fn(),
+}));
+vi.mock('../../lib/calendarIcs.js', () => ({
+  buildCalendarIcs: vi.fn(),
+  calendarTokenFor: vi.fn(),
+  verifyCalendarToken: vi.fn(),
+  CALENDAR_VIEWS: [],
+}));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  lte: vi.fn(),
+  desc: vi.fn(),
+}));
+
+import { mapRoutes } from '../maps.js';
+
+// ── Test harness ──────────────────────────────────────────────────
+
+const USER_ID = 'uuuu-uuuu-uuuu-uuuu';
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    req.userId = USER_ID;
+    req.authSource = 'jwt';
+  });
+  await app.register(mapRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  updateMapMock.mockReset();
+  getMapMock.mockReset();
+  getPermissionMock.mockClear();
+});
+
+// ── Cases ─────────────────────────────────────────────────────────
+
+describe('PUT /api/maps/:id — triage flag round-trip', () => {
+  it('forwards triageEnabled to updateMap and returns the updated row', async () => {
+    updateMapMock.mockResolvedValueOnce({
+      id: MAP_ID,
+      name: 'My Map',
+      triageEnabled: true,
+      triageLabelWriteback: false,
+      autoImportNewIssues: true,
+    });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { triageEnabled: true },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMapMock).toHaveBeenCalledOnce();
+    expect(updateMapMock.mock.calls[0][0]).toBe(MAP_ID);
+    expect(updateMapMock.mock.calls[0][1]).toEqual({ triageEnabled: true });
+    expect(res.json().triageEnabled).toBe(true);
+  });
+
+  it('forwards triageLabelWriteback to updateMap and returns the updated row', async () => {
+    updateMapMock.mockResolvedValueOnce({
+      id: MAP_ID,
+      name: 'My Map',
+      triageEnabled: true,
+      triageLabelWriteback: true,
+      autoImportNewIssues: true,
+    });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { triageLabelWriteback: true },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMapMock.mock.calls[0][1]).toEqual({ triageLabelWriteback: true });
+    expect(res.json().triageLabelWriteback).toBe(true);
+  });
+
+  it('round-trips both flags in a single PATCH (e.g. disable cascade)', async () => {
+    updateMapMock.mockResolvedValueOnce({
+      id: MAP_ID,
+      name: 'My Map',
+      triageEnabled: false,
+      triageLabelWriteback: false,
+      autoImportNewIssues: true,
+    });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { triageEnabled: false, triageLabelWriteback: false },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMapMock.mock.calls[0][1]).toEqual({
+      triageEnabled: false,
+      triageLabelWriteback: false,
+    });
+    expect(res.json().triageEnabled).toBe(false);
+    expect(res.json().triageLabelWriteback).toBe(false);
+  });
+
+  it('403s when the caller lacks edit permission (regression guard)', async () => {
+    getPermissionMock.mockResolvedValueOnce('view' as const);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { triageEnabled: true },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(403);
+    expect(updateMapMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds UI toggles in the existing GitHub Settings dialog for the two per-map triage flags (`triage_enabled` + `triage_label_writeback`) that were previously only flippable via SQL or a raw PATCH.

- **AI triage** toggle classifies new GitHub issues via Claude (skip / place / uncertain). High-confidence places auto-create nodes; low-confidence ones wait in the Triage panel.
- **Label writeback** toggle writes `triage:placed` / `triage:skipped` back to GitHub when decisions are reviewed.

## UX decisions

- **Cascading disable.** Triage toggle is disabled (greyed + tooltip) when auto-import is off — *"Triage only fires on imported issues."* Label writeback is disabled when triage is off — *"Labels are written by the triage pipeline."*
- **Disable confirmation modal.** Flipping triage from ON → OFF surfaces a confirm dialog (existing decisions stay; new issues land flat under GitHub Inbox again). Enabling is low-stakes and skips the modal. Disabling also clears `triage_label_writeback` in the same PATCH so the DB stays consistent if triage is later re-enabled.
- **Status badge.** When triage is fully active, a green badge near the bottom of the dialog reads *"AI triage active"* (and *"· labels write back to GitHub"* when both flags are on), so the operator can see current state at a glance.

## Layered changes

| Layer | File | What |
|---|---|---|
| Type | `packages/core/src/types.ts` | `MindMap.triageEnabled` / `triageLabelWriteback` |
| API | `packages/server/src/routes/maps.ts` | `PUT /api/maps/:id` already forwards body verbatim; no route change needed |
| DB | `packages/server/src/db/maps.ts` + `helpers.ts` | `UpdateMapInput` + `dbMapToCore` accept/surface both fields |
| UI | `packages/mindmap/src/GitHubPanel.tsx` | Two new toggles + confirm modal + status badge |
| Tests | `packages/server/src/routes/__tests__/maps-triage-flags.test.ts` | 4 new tests for the round-trip + permission gate |

## Anti-punt

Toggles + disable-confirmation + status badge all ship in this PR. No per-map confidence-threshold selector — `TRIAGE_AUTO_APPLY_CONFIDENCE` env var remains the source for now (separate design discussion).

## Test plan

- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w build` — clean
- [x] `pnpm -w test` — passes (pre-existing flake in `triage-routes.test.ts > peakActive` parallel-timing test is unrelated; passes on retry)
- [ ] Manual: open GitHubSettingsDialog on a map; toggles render with correct state; disabling triggers the confirmation modal; PATCH persists; reload shows the updated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)