### PR TITLE
fix(triage): drift-audit slider sees true orphan total (not just paginated 200)

### DIFF
--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -140,6 +140,11 @@ export function TriagePanel({
   const [notInMindBlownFilter, setNotInMindBlownFilter] = useState<NotInMindBlownFilter>('all');
   const [orphansAvailable, setOrphansAvailable] = useState(true);
   const [orphansError, setOrphansError] = useState<string | null>(null);
+  // True orphan count for this map — used to size the drift-audit
+  // slider correctly. Comes from the server's pre-pagination count
+  // (server > 2026-06-08); pre-2026-06-08 servers omit the field and
+  // we fall back to counting the visible items.
+  const [orphanTotal, setOrphanTotal] = useState<number | null>(null);
   // Picker mode tracks which not-in-mindblown card opened the modal so
   // the pick handler knows whether to call /override (decision-row
   // buckets) or to create+attach a node from scratch (orphan bucket).
@@ -299,6 +304,10 @@ export function TriagePanel({
         setNotInMindBlownItems(res.items);
         setOrphansAvailable(res.orphansAvailable);
         setOrphansError(res.orphansError);
+        // Prefer the server-supplied per-bucket count. Fall back to
+        // null so the trigger banner can fall through to counting
+        // visible items (legacy server compatibility).
+        setOrphanTotal(res.counts ? res.counts.orphan : null);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -798,7 +807,10 @@ export function TriagePanel({
             onOrphanSkip={handleOrphanSkip}
             onReclassify={handleNotInMindBlownReclassify}
             onConfirmSkip={handleNotInMindBlownConfirmSkip}
-            orphanCount={notInMindBlownItems.filter((i) => i.kind === 'orphan').length}
+            orphanCount={
+              orphanTotal ??
+              notInMindBlownItems.filter((i) => i.kind === 'orphan').length
+            }
             driftBusy={driftBusy}
             driftResult={driftResult}
             driftError={driftError}
@@ -904,7 +916,10 @@ export function TriagePanel({
       {/* Drift-audit trigger modal */}
       {driftModalOpen && (
         <DriftAuditModal
-          orphanCount={notInMindBlownItems.filter((i) => i.kind === 'orphan').length}
+          orphanCount={
+            orphanTotal ??
+            notInMindBlownItems.filter((i) => i.kind === 'orphan').length
+          }
           busy={driftBusy}
           error={driftError}
           onCancel={() => {

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -1410,6 +1410,23 @@ export interface ListNotInMindBlownResponse {
   /** Set when orphansAvailable is false, explains why. */
   orphansError: string | null;
   items: NotInMindBlownItem[];
+  /**
+   * Pre-pagination per-bucket counts. Reflects the true backlog size
+   * even when `items` is short (default limit=50, hard cap 200). The
+   * "Not in MindBlown" view uses these to label the trigger banner +
+   * size the drift-audit slider correctly — without them the slider
+   * caps at min(orphanCount, items.length) which is wrong whenever
+   * the orphan tail is bigger than the page.
+   *
+   * Optional for compatibility with pre-2026-06-08 servers; UI falls
+   * back to counting `items` when the field is absent.
+   */
+  counts?: {
+    orphan: number;
+    skipped: number;
+    'pending-skipped': number;
+    uncertain: number;
+  };
 }
 
 export interface OrphanImportBody {

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -520,6 +520,23 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       const total = allItems.length;
       const paged = allItems.slice(0, limit);
 
+      // Per-bucket counts so the UI can show "N orphans waiting" + size
+      // the drift-audit slider correctly even when the paginated list
+      // is shorter than the true count (default limit=50, hard cap 200,
+      // but a fresh map can have 345+ orphans). All four counts are
+      // pre-pagination — they reflect the full bucket, not what fits
+      // in `items`.
+      let orphanCount = 0;
+      let skippedCount = 0;
+      let pendingSkippedCount = 0;
+      let uncertainCount = 0;
+      for (const di of decisionItems) {
+        if (di.kind === 'skipped') skippedCount++;
+        else if (di.kind === 'pending-skipped') pendingSkippedCount++;
+        else if (di.kind === 'uncertain') uncertainCount++;
+      }
+      orphanCount = orphanItems.length;
+
       return reply.send({
         mapId: req.params.mapId,
         bucket: requestedBucket,
@@ -528,6 +545,12 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         orphansAvailable,
         orphansError,
         items: paged,
+        counts: {
+          orphan: orphanCount,
+          skipped: skippedCount,
+          'pending-skipped': pendingSkippedCount,
+          uncertain: uncertainCount,
+        },
       });
     },
   );


### PR DESCRIPTION
Bug found 30s after #145 deployed: trigger banner said 200 instead of 345. Server now returns pre-pagination per-bucket counts; client uses counts.orphan for the slider.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>