### PR TITLE
fix(server): decouple watchdog ping from catchup tick (root-cause of chronic kills)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,14 +4,14 @@ import websocket from '@fastify/websocket';
 import { runMigrations } from './db/migrate.js';
 import { seedIfEmpty } from './db/seed.js';
 import { snapshotAllMaps } from './lib/releaseSnapshots.js';
-import { runAllCatchups } from './sync/githubCatchup.js';
+import { runAllCatchups, getLastHealthyTickAt } from './sync/githubCatchup.js';
 import { runDriftAudit } from './sync/driftAudit.js';
 import { resolveDriftAuditIntervalMs } from './sync/driftAuditInterval.js';
 import { parsePositiveIntMs } from './sync/parseInterval.js';
 import { runCanary } from './sync/canary.js';
 import { runWebhookAuthCheck } from './sync/webhookAuthCheck.js';
 import { runTrashGc } from './sync/trashGc.js';
-import { sdNotifyReady } from './sync/sdNotify.js';
+import { sdNotifyReady, sdNotifyWatchdog } from './sync/sdNotify.js';
 import { authRoutes } from './auth.js';
 import { systemRoutes } from './routes/system.js';
 import { registerAuthMiddleware } from './middleware/auth.js';
@@ -179,6 +179,43 @@ async function main(): Promise<void> {
   };
   runCatchup();
   setInterval(runCatchup, CATCHUP_INTERVAL_MS);
+
+  // ── Systemd watchdog heartbeat (decoupled from catchup tick) ───
+  //
+  // Before this, sd_notify WATCHDOG=1 was pinged only at the END of
+  // each successful catchup tick (~every 5 min). With
+  // `WatchdogSec=300` in the unit file, even a 1-second scheduler
+  // drift past the 5-min mark triggered SIGABRT — and that drift
+  // happened often (any long LLM call from triage on a webhook event
+  // could block the event loop and slip the next tick).
+  //
+  // The dedicated 60s heartbeat below pings WATCHDOG=1 as long as
+  // `lastHealthyTickAt` is within `2 × CATCHUP_INTERVAL_MS`
+  // (= 10 min). So scheduler drift up to ~10 min is tolerated; a
+  // truly dead catchup loop (no healthy tick in >10 min) stops
+  // pinging and systemd kills within `WatchdogSec` after that
+  // (= ~15 min total deadline). The previous per-tick ping inside
+  // `githubCatchup.ts` is kept as belt-and-suspenders — pinging more
+  // often than WatchdogSec is harmless.
+  const HEARTBEAT_INTERVAL_MS = 60_000;
+  const HEARTBEAT_STALE_THRESHOLD_MS = 2 * CATCHUP_INTERVAL_MS;
+  setInterval(() => {
+    const stale = Date.now() - getLastHealthyTickAt();
+    if (stale > HEARTBEAT_STALE_THRESHOLD_MS) {
+      // Don't ping — let systemd notice. Logged at warn so the
+      // failure mode is visible in journalctl before SIGABRT lands.
+      console.warn(
+        `[sd-notify] heartbeat NOT pinged: last healthy catchup ${Math.round(stale / 1000)}s ago > ${HEARTBEAT_STALE_THRESHOLD_MS / 1000}s threshold`,
+      );
+      return;
+    }
+    sdNotifyWatchdog().catch((err) => {
+      console.warn(
+        '[sd-notify] heartbeat ping unexpectedly threw:',
+        err instanceof Error ? err.message : err,
+      );
+    });
+  }, HEARTBEAT_INTERVAL_MS);
 
   // ── Drift audit (GitHub→MindBlown reconciliation gate) ──────────
   // The webhook + catchup pair is good at "an event happened, did we

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -733,16 +733,32 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           const cap = maxOverride ?? drifted.length;
 
           // Long manual runs (the whole point of this endpoint) can
-          // exceed the systemd watchdog window (5 min by default) and
-          // get SIGABRT'd mid-LLM-call. Ping the watchdog every 60s
-          // while the audit is running so a 30-min sweep doesn't kill
-          // the service. We can't ping from inside the per-issue loop
-          // (it lives in autoBackfill → backfillMap → ensureNodeForIssue,
-          // three packages deep), but a 60s timer running alongside the
-          // await is good enough: even a single LLM call rarely
-          // exceeds 30s, so the audit's progress is reflected in
-          // pings going through.
+          // exceed the systemd watchdog window. Ping every 60s while
+          // the audit is running. The dedicated heartbeat in index.ts
+          // already covers this case (it pings as long as the catchup
+          // tick is healthy), but pinging here too is belt-and-suspenders
+          // — a single audit-internal ping ensures the watchdog stays
+          // fed even if both heartbeats happen to be skipped while the
+          // event loop is blocked on a slow LLM call.
+          //
+          // Also: log progress every tick. Operator can `journalctl -fu
+          // mindblown-api` and see the audit advancing in real-time, so
+          // a request that fails mid-flight at least surfaces what got
+          // committed. (Work-preservation is already structural: each
+          // issue commits in its own ensureNodeForIssue transaction —
+          // a SIGABRT mid-loop leaves the already-committed rows in
+          // place, and re-running this endpoint resumes from where it
+          // left off because already-triaged orphans drop out of the
+          // orphan set.)
+          console.log(
+            `[drift-audit-manual] map ${req.params.mapId} starting: ${report.onlyInGitHub} orphans, cap=${cap}`,
+          );
+          const startedAt = Date.now();
           const watchdogTimer = setInterval(() => {
+            const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+            console.log(
+              `[drift-audit-manual] map ${req.params.mapId} running… ${elapsedSec}s elapsed`,
+            );
             sdNotifyWatchdog().catch(() => {
               // sdNotifyWatchdog already swallows errors; this catch
               // is defense against the helper changing behaviour.
@@ -755,6 +771,9 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           } finally {
             clearInterval(watchdogTimer);
           }
+          console.log(
+            `[drift-audit-manual] map ${req.params.mapId} done: ${autoBackfill.totalImported} imported, ${autoBackfill.totalManualPending} pending, ${Math.round((Date.now() - startedAt) / 1000)}s`,
+          );
 
           return reply.send({
             mapId: mapRow.id,

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -596,7 +596,17 @@ export async function runAllCatchups(): Promise<ReconcileResult[]> {
   // suppresses its own errors, but a synchronous throw at the top of
   // the function or an unhandled rejection escaping must NOT take down
   // the catchup return value.
+  //
+  // Note (2026-06-08): the dedicated 60s heartbeat in index.ts now
+  // owns the actual sd_notify pings. We keep this per-tick ping in
+  // place as belt-and-suspenders — pinging more often than
+  // WatchdogSec is harmless, and an extra ping on every healthy tick
+  // means the watchdog stays alive even if the 60s heartbeat
+  // setInterval is itself skipped due to event-loop blocking. We
+  // also record `lastHealthyTickAt` so the heartbeat knows whether
+  // to ping.
   if (isHealthyTick(results)) {
+    lastHealthyTickAt = Date.now();
     try {
       await sdNotifyWatchdog();
     } catch (err) {
@@ -608,6 +618,28 @@ export async function runAllCatchups(): Promise<ReconcileResult[]> {
   }
 
   return results;
+}
+
+// Timestamp (epoch ms) of the most recent healthy catchup tick.
+// Initialised to process start so the heartbeat doesn't reject the
+// service as unhealthy before the very first tick has a chance to run.
+// Updated in-place above whenever a healthy tick completes; consumed
+// by the dedicated heartbeat in index.ts to decide whether to ping
+// the systemd watchdog independently of the catchup cadence.
+//
+// Decoupling matters because pre-2026-06-08 the watchdog ping was
+// tightly bound to the catchup setInterval — any event-loop hiccup
+// that delayed a tick past 5min triggered SIGABRT even when the
+// service was otherwise healthy. The new heartbeat fires every 60s
+// and only pings if the last healthy tick is within
+// `2 × CATCHUP_INTERVAL_MS` (= 10 min by default), so scheduler
+// drift up to ~10 min is tolerated while a truly dead catchup loop
+// still triggers a kill within ~15 min.
+let lastHealthyTickAt = Date.now();
+
+/** Read-only accessor for the heartbeat in index.ts. */
+export function getLastHealthyTickAt(): number {
+  return lastHealthyTickAt;
 }
 
 /**


### PR DESCRIPTION
Today the API got watchdog-killed 5× in 2 hours (~hourly chronic crashes), then once more during a drift-audit attempt. Root cause: WATCHDOG=1 was pinged inside the 5min catchup tick, with WatchdogSec=5min — any scheduler drift past 5min triggered SIGABRT.

Fix: dedicated 60s heartbeat in index.ts that pings WATCHDOG=1 as long as the catchup loop is healthy (last healthy tick within 10min). Truly-dead catchup still gets killed (~15min deadline) but scheduler drift is tolerated.

Also adds per-60s progress log to the drift audit endpoint so an operator can watch a long run advance via journalctl, and documents the existing per-issue commit pattern that already preserves work on mid-loop kill.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>