### PR TITLE
fix(triage): drift-audit banner shows real decision breakdown

### DIFF
--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -1790,11 +1790,19 @@ function NotInMindBlownView({
           }}
         >
           <span style={{ flex: 1 }}>
-            Drift audit done. Processed <strong>{driftResult.counts.driftedIssues}</strong>{' '}
-            orphan{driftResult.counts.driftedIssues === 1 ? '' : 's'}:{' '}
-            <strong>{driftResult.counts.imported}</strong> imported,{' '}
-            <strong>{driftResult.counts.manualPending}</strong> manual{' '}
-            ({Math.round(driftResult.counts.elapsedMs / 1000)}s).
+            Drift audit done in{' '}
+            {Math.round(driftResult.counts.elapsedMs / 1000)}s. Triaged{' '}
+            <strong>{driftResult.counts.triaged}</strong> orphan
+            {driftResult.counts.triaged === 1 ? '' : 's'}:{' '}
+            <strong>{driftResult.counts.placed}</strong> placed,{' '}
+            <strong>{driftResult.counts.skipped}</strong> skipped,{' '}
+            <strong>{driftResult.counts.uncertain}</strong> uncertain
+            {driftResult.counts.errored > 0
+              ? `, ${driftResult.counts.errored} errored`
+              : ''}
+            {driftResult.counts.queuedForNextRun > 0
+              ? `. ${driftResult.counts.queuedForNextRun} above cap — run again to clear.`
+              : '.'}
           </span>
           <button
             onClick={onDismissDriftResult}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -1505,9 +1505,31 @@ export interface DriftAuditRunResponse {
   };
   counts: {
     driftedIssues: number;
-    imported: number;
-    manualPending: number;
+    /**
+     * Total orphans actually run through Claude this batch. Sum of
+     * placed + skipped + uncertain. Reflects the operator's slider
+     * cap, NOT the full orphan count (which is driftedIssues).
+     */
+    triaged: number;
+    /** Decision='place' → node was auto-created. */
+    placed: number;
+    /** Decision='skip' → triage row, no node. Finished, not pending. */
+    skipped: number;
+    /** Decision='uncertain' → goes to Pending review tab. */
+    uncertain: number;
+    /** Per-issue ingest failures (network, LLM timeout, etc.). */
+    errored: number;
+    /**
+     * Orphans NOT processed this run because they were above the
+     * operator's slider cap. These remain orphans and need another
+     * audit run to clear.
+     */
+    queuedForNextRun: number;
     elapsedMs: number;
+    /** @deprecated Use `placed` instead. Kept for the old banner. */
+    imported?: number;
+    /** @deprecated Use `queuedForNextRun` instead. */
+    manualPending?: number;
   };
 }
 

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -771,9 +771,39 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           } finally {
             clearInterval(watchdogTimer);
           }
-          const manualPending = Math.max(0, drifted.length - backfillResult.imported);
+          // Decision-type breakdown for the response. backfillMap only
+          // reports `imported` (= node-created = decision='place'), so
+          // we re-query triage_decisions for rows decided since the
+          // audit started to count skip / uncertain too. Without this,
+          // the UI banner showed "N imported, M manual pending" where
+          // M wrongly conflated above-cap drift with skip/uncertain
+          // decisions that were actually finished.
+          const decisionBreakdownRows = await db
+            .select({
+              decision: triageDecisions.decision,
+              count: sql<number>`count(*)::int`,
+            })
+            .from(triageDecisions)
+            .where(
+              and(
+                eq(triageDecisions.mapId, req.params.mapId),
+                gte(triageDecisions.decidedAt, new Date(startedAt)),
+              ),
+            )
+            .groupBy(triageDecisions.decision);
+          const placedCount =
+            decisionBreakdownRows.find((r) => r.decision === 'place')?.count ?? 0;
+          const skippedCount =
+            decisionBreakdownRows.find((r) => r.decision === 'skip')?.count ?? 0;
+          const uncertainCount =
+            decisionBreakdownRows.find((r) => r.decision === 'uncertain')?.count ?? 0;
+          const triagedCount = placedCount + skippedCount + uncertainCount;
+          // "Queued for next run" — orphans found this sweep that were
+          // above the operator's cap. NOT skip/uncertain decisions.
+          const queuedForNextRun = Math.max(0, drifted.length - triagedCount);
+
           console.log(
-            `[drift-audit-manual] map ${req.params.mapId} done: ${backfillResult.imported} imported, ${backfillResult.errored} errored, ${manualPending} remaining, ${Math.round((Date.now() - startedAt) / 1000)}s`,
+            `[drift-audit-manual] map ${req.params.mapId} done: triaged=${triagedCount} (placed=${placedCount}, skipped=${skippedCount}, uncertain=${uncertainCount}), errored=${backfillResult.errored}, queued=${queuedForNextRun}, ${Math.round((Date.now() - startedAt) / 1000)}s`,
           );
 
           return reply.send({
@@ -784,21 +814,27 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
               exampleIssues: drifted.slice(0, 5),
             },
             autoBackfill: {
-              totalImported: backfillResult.imported,
-              totalManualPending: manualPending,
+              totalImported: placedCount,
+              // Above-cap = "needs another run". Skip/uncertain are
+              // FINISHED, they don't belong here.
+              totalManualPending: queuedForNextRun,
               outcomes: [
                 {
                   mapId: mapRow.id,
                   mapName: mapRow.name,
                   kind: 'healed' as const,
-                  imported: backfillResult.imported,
+                  imported: placedCount,
                 },
               ],
             },
             counts: {
               driftedIssues: drifted.length,
-              imported: backfillResult.imported,
-              manualPending,
+              triaged: triagedCount,
+              placed: placedCount,
+              skipped: skippedCount,
+              uncertain: uncertainCount,
+              errored: backfillResult.errored,
+              queuedForNextRun,
               elapsedMs: Date.now() - t0,
             },
           });


### PR DESCRIPTION
Today's 25-orphan sample showed '5 imported, 340 manual' — wrong, the 16 skip + 3 uncertain were finished not pending. Server now queries triage_decisions for true counts and exposes placed/skipped/uncertain/queuedForNextRun. Validated on the 320-cap follow-up: 158 placed + 135 skipped + 27 uncertain = 320.