### PR TITLE
feat(orchestration): expose claimedBySession + claimedAt in search_nodes / get_map (#153)

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -130,6 +130,9 @@ export interface NodeWithComputed {
   collapsed: boolean;
   createdAt: string;
   updatedAt: string;
+  // Orchestration substrate (#111) — surfaced for slot accounting (#153).
+  claimedBySession: string | null;
+  claimedAt: string | null;
   computedEffort: number;
   computedProgress: number;
   healthSignal: string;

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -73,6 +73,8 @@ function toNodeWithComputed(
     collapsed: node.collapsed,
     createdAt: toIsoString((node as unknown as { createdAt: unknown }).createdAt),
     updatedAt: toIsoString((node as unknown as { updatedAt: unknown }).updatedAt),
+    claimedBySession: node.claimedBySession,
+    claimedAt: node.claimedAt,
     computedEffort: computed?.computedEffort ?? 0,
     computedProgress: computed?.computedProgress ?? 0,
     healthSignal: computed?.healthSignal ?? 'on_track',

--- a/packages/tool-kit/src/formatters.ts
+++ b/packages/tool-kit/src/formatters.ts
@@ -22,6 +22,16 @@ function progressBar(pct: number): string {
   return `[${'#'.repeat(filled)}${'.'.repeat(empty)}] ${Math.round(clamped)}%`;
 }
 
+/**
+ * Render the orchestration claim state as a compact, parseable token.
+ * Always emitted (even when null) so Kira's slot accounting can parse a
+ * stable field rather than infer absence — see #153.
+ */
+export function formatClaim(session: string | null, at: string | null): string {
+  if (session === null) return 'claim: -';
+  return at ? `claim: ${session}@${at}` : `claim: ${session}`;
+}
+
 function buildNodeLookup(nodes: NodeWithComputed[]): Map<string, NodeWithComputed> {
   const map = new Map<string, NodeWithComputed>();
   for (const n of nodes) map.set(n.id, n);
@@ -53,6 +63,7 @@ function renderTreeNode(
   if (node.externalLinks?.length > 0) {
     parts.push(node.externalLinks.map((l) => `[${l.externalId}]`).join(' '));
   }
+  parts.push(formatClaim(node.claimedBySession, node.claimedAt));
   if (node.dependencies.length > 0) {
     const depLabels = node.dependencies.map((d) => {
       const target = lookup.get(d.targetNodeId);

--- a/packages/tool-kit/src/tools/__tests__/claim-fields.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/claim-fields.test.ts
@@ -1,0 +1,168 @@
+/**
+ * #153 — claimedBySession + claimedAt exposure in get_map / search_nodes
+ *
+ * Kira's autonomous dispatcher counts in-flight claims by session ID. The
+ * MCP text output is her parsing target, so both tools must emit a stable
+ * `claim: …` token on every node (including unclaimed ones, rendered as
+ * `claim: -`) — see the issue body for why omission isn't acceptable.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getMapTool } from '../map.js';
+import { searchNodesTool } from '../node.js';
+import { formatClaim } from '../../formatters.js';
+import type { ToolBackend } from '../../backend.js';
+import type { MapDetail, NodeWithComputed } from '../../types.js';
+
+function stubNode(overrides: Partial<NodeWithComputed> = {}): NodeWithComputed {
+  return {
+    id: 'n1',
+    mapId: 'm1',
+    parentId: null,
+    childrenIds: [],
+    text: 'stub',
+    description: null,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    dependencies: [],
+    versionId: null,
+    cycleId: null,
+    externalLinks: [],
+    collapsed: false,
+    createdAt: '2026-06-08T10:00:00Z',
+    updatedAt: '2026-06-08T10:00:00Z',
+    claimedBySession: null,
+    claimedAt: null,
+    computedEffort: 0,
+    computedProgress: 0,
+    healthSignal: 'on_track',
+    ...overrides,
+  } as NodeWithComputed;
+}
+
+function backendFor(detail: MapDetail): ToolBackend {
+  // Only getMap is exercised by these two tools' read paths; everything
+  // else throws so unexpected calls fail loud.
+  const unimplemented = () => { throw new Error('not implemented'); };
+  return {
+    listMaps: unimplemented,
+    getMap: async () => detail,
+    createMap: unimplemented,
+    updateMap: unimplemented,
+    deleteMap: unimplemented,
+    createNode: unimplemented,
+    updateNode: unimplemented,
+    deleteNode: unimplemented,
+    moveNode: unimplemented,
+    restoreNode: unimplemented,
+    listDeleted: unimplemented,
+    listTriageDecisions: unimplemented,
+    overrideTriage: unimplemented,
+    reclassifyTriage: unimplemented,
+    confirmTriage: unimplemented,
+    listNotInMindBlown: unimplemented,
+    readyNodes: unimplemented,
+    claimNode: unimplemented,
+    releaseNode: unimplemented,
+    conflictScan: unimplemented,
+  } as unknown as ToolBackend;
+}
+
+const root = stubNode({ id: 'root', text: 'Root', childrenIds: ['claimed', 'free'] });
+const claimedLeaf = stubNode({
+  id: 'claimed',
+  text: 'Working on it',
+  parentId: 'root',
+  status: 'in_progress',
+  claimedBySession: 'kira-abc123',
+  claimedAt: '2026-06-08T09:30:00Z',
+});
+const freeLeaf = stubNode({
+  id: 'free',
+  text: 'Open work',
+  parentId: 'root',
+  status: 'todo',
+});
+
+const detail: MapDetail = {
+  map: {
+    id: 'm1',
+    workspaceId: 'ws1',
+    name: 'Test Map',
+    description: null,
+    rootNodeId: 'root',
+    effortUnit: 'hours',
+    healthThreshold: 0.2,
+    computedProgress: 0,
+    healthSignal: 'on_track',
+    createdAt: '2026-06-08T10:00:00Z',
+    updatedAt: '2026-06-08T10:00:00Z',
+    statusWorkflow: [],
+    baselines: [],
+    wipLimit: null,
+  },
+  nodes: [root, claimedLeaf, freeLeaf],
+};
+
+describe('formatClaim', () => {
+  it('emits `claim: -` for unclaimed nodes (never omits)', () => {
+    expect(formatClaim(null, null)).toBe('claim: -');
+  });
+
+  it('emits session@timestamp for claimed nodes', () => {
+    expect(formatClaim('kira-abc', '2026-06-08T09:30:00Z')).toBe(
+      'claim: kira-abc@2026-06-08T09:30:00Z',
+    );
+  });
+
+  it('tolerates missing timestamp (defensive — shouldnt happen in practice)', () => {
+    expect(formatClaim('kira-abc', null)).toBe('claim: kira-abc');
+  });
+});
+
+describe('get_map renders claim state on every node', () => {
+  it('emits claim: <session>@<iso> for claimed nodes and claim: - for free nodes', async () => {
+    const out = await getMapTool.handler(backendFor(detail), { mapId: 'm1' } as never);
+    // Both null and non-null cases reach the output.
+    expect(out).toContain('claim: kira-abc123@2026-06-08T09:30:00Z');
+    expect(out).toContain('claim: -');
+    // Claimed line is the one labelled "Working on it".
+    const claimedLine = out.split('\n').find((l) => l.includes('Working on it'))!;
+    expect(claimedLine).toContain('claim: kira-abc123@2026-06-08T09:30:00Z');
+    const freeLine = out.split('\n').find((l) => l.includes('Open work'))!;
+    expect(freeLine).toContain('claim: -');
+  });
+});
+
+describe('search_nodes renders claim state on every result line', () => {
+  it('includes claim token for both claimed and unclaimed matches', async () => {
+    const out = await searchNodesTool.handler(backendFor(detail), {
+      mapId: 'm1',
+      query: '*',
+    } as never);
+    expect(out).toContain('claim: kira-abc123@2026-06-08T09:30:00Z');
+    expect(out).toContain('claim: -');
+    const claimedLine = out.split('\n').find((l) => l.includes('Working on it'))!;
+    expect(claimedLine).toMatch(/claim: kira-abc123@2026-06-08T09:30:00Z/);
+    const freeLine = out.split('\n').find((l) => l.includes('Open work'))!;
+    expect(freeLine).toMatch(/claim: -/);
+  });
+
+  it('filters narrow results but the surviving lines still carry claim tokens', async () => {
+    const out = await searchNodesTool.handler(backendFor(detail), {
+      mapId: 'm1',
+      query: '*',
+      status: 'in_progress',
+    } as never);
+    expect(out).toContain('Working on it');
+    expect(out).toContain('claim: kira-abc123@2026-06-08T09:30:00Z');
+    expect(out).not.toContain('Open work');
+  });
+});

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { defineTool } from '../spec.js';
+import { formatClaim } from '../formatters.js';
 
 export const createNodeTool = defineTool({
   name: 'create_node',
@@ -276,7 +277,8 @@ export const searchNodesTool = defineTool({
       const links = n.externalLinks?.length > 0
         ? ' ' + n.externalLinks.map((l) => `[${l.externalId}]`).join(' ')
         : '';
-      return `- "${n.text}" (id: ${n.id}) — ${progress}% ${health}${n.status ? ` [${n.status}]` : ''}${n.priority ? ` ${n.priority}` : ''}${links}`;
+      const claim = ' ' + formatClaim(n.claimedBySession, n.claimedAt);
+      return `- "${n.text}" (id: ${n.id}) — ${progress}% ${health}${n.status ? ` [${n.status}]` : ''}${n.priority ? ` ${n.priority}` : ''}${links}${claim}`;
     });
 
     return `Found ${matches.length} node(s) matching "${query}":\n${lines.join('\n')}`;

--- a/packages/tool-kit/src/types.ts
+++ b/packages/tool-kit/src/types.ts
@@ -46,6 +46,9 @@ export interface NodeWithComputed {
   collapsed: boolean;
   createdAt: string;
   updatedAt: string;
+  // Orchestration substrate (#111) — surfaced for slot accounting (#153).
+  claimedBySession: string | null;
+  claimedAt: string | null;
   computedEffort: number;
   computedProgress: number;
   healthSignal: string;


### PR DESCRIPTION
Closes #153.

## Summary
- Both `search_nodes` and `get_map` MCP tools now emit a `claim: …` token on every node
- Unclaimed: `claim: -`. Claimed: `claim: <sessionId>@<isoTimestamp>`
- Always emitted (no omission on null) so Kira's parser doesn't need absence inference
- Underlying REST routes already returned the fields via spread; this PR threads them through the tool-kit `NodeWithComputed` type + formatter + the in-process chat backend projection

## Why
Kira (FulcrumCRM/crm autonomous dispatcher, FulcrumCRM/crm#2305) needs to count her own in-flight claims to compute `slots = workerCount - active_claims`. With the fields hidden in the tool output, she's been inflating `workerCount=15` as a workaround. This PR unblocks reverting that hack and gives Jenna's stale-claim housekeeping a reliable signal too.

## Acceptance (per ticket)
- [x] `search_nodes` rows include `claimedBySession` + `claimedAt`
- [x] `get_map` tree nodes include both fields
- [x] Null is rendered, not omitted (`claim: -`)
- [x] Additive — existing parsers don't break
- [x] Tests assert both null and non-null cases in both tool outputs (`claim-fields.test.ts`, 6 tests)

## Test plan
- [x] `pnpm --filter @mindblown/tool-kit test` — 44/44 pass (6 new)
- [x] `pnpm turbo typecheck` clean (pre-existing `maps-triage-flags.test.ts` spread-arg errors and `triage-routes.test.ts` concurrency flake are unrelated; both reproduce on master)
- [ ] Smoke test on the Fulcrum CRM Roadmap after deploy: confirm Kira's `slots` accounting parses claim tokens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)