### PR TITLE
feat(github): pull_request.merged webhook (#152)

### DIFF
--- a/packages/integrations/src/github.ts
+++ b/packages/integrations/src/github.ts
@@ -385,7 +385,7 @@ export function processWebhook(
     const text = `${prTitle} ${prBody}`;
     const repoName = payload.repository?.full_name ?? '';
 
-    const issueRefs = extractIssueReferences(text);
+    const issueRefs = extractClosingIssueRefs(text);
     if (issueRefs.length > 0) {
       // Return update for the first referenced issue
       const issueNumber = issueRefs[0];
@@ -404,17 +404,23 @@ export function processWebhook(
 }
 
 /**
- * Extract issue number references from text.
- * Matches: Closes #42, Fixes #42, Resolves #42 (case-insensitive)
+ * Extract closing-issue references from PR body/title text.
+ * Matches the GitHub auto-close keywords: Closes #42, Fixes #42, Resolves #42
+ * (case-insensitive; covers `close`/`closes`/`closed`/`fix`/`fixes`/`fixed`/
+ * `resolve`/`resolves`/`resolved`). De-duplicates so the same issue isn't
+ * processed twice when both PR title and body reference it.
+ *
+ * Exported for the webhook handler in @mindblown/server (#152) — needs to
+ * iterate ALL refs, not just the first one returned by processWebhook.
  */
-function extractIssueReferences(text: string): number[] {
+export function extractClosingIssueRefs(text: string): number[] {
   const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
-  const refs: number[] = [];
+  const refs = new Set<number>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {
-    refs.push(parseInt(match[1], 10));
+    refs.add(parseInt(match[1], 10));
   }
-  return refs;
+  return [...refs];
 }
 
 // ── Label helpers ────────────────────────────────────────────────

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -11,6 +11,7 @@ export {
   updateGitHubIssue,
   closeGitHubIssue,
   processWebhook,
+  extractClosingIssueRefs,
   importGitHubIssues,
   fetchChangedIssues,
   extractVersionFromMilestone,

--- a/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
+++ b/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
@@ -1,0 +1,399 @@
+/**
+ * #152 — pull_request: closed (merged=true) → linked nodes transition to done.
+ *
+ * Covers the new branch in routes/integrations.ts that subscribes to PR
+ * merge events for repos that don't send `issues` webhooks (e.g.
+ * FulcrumCRM/crm). Verifies:
+ *
+ *   1. Multi-issue: PR body with "Closes #1, fixes #2" transitions BOTH
+ *      linked nodes (the legacy processWebhook PR branch only returned
+ *      the first ref).
+ *   2. Idempotency: replay of the same payload finds the node already
+ *      done and reports `already_done` without writing.
+ *   3. Unsigned requests are rejected before the handler reaches the DB.
+ *   4. Non-merged closures (PR closed without merging) are passed
+ *      through unchanged.
+ *   5. References to issues with no linked MindBlown node are reported
+ *      as `not_linked` (not an error).
+ *
+ * Signature verification is stubbed to pass; HMAC plumbing is covered
+ * by separate tests in `webhookAuthCheck.test.ts`. The processWebhook
+ * fallthrough is mocked to a no-op so we can isolate the new branch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+interface NodeRow {
+  id: string;
+  externalLinks: Array<{
+    provider: string;
+    externalId: string;
+    url: string;
+    syncEnabled: boolean;
+    lastSyncedAt: string | null;
+    previousPercentComplete?: number | null;
+    previousStatus?: string | null;
+  }>;
+}
+
+interface NodeRecord extends NodeRow {
+  mapId: string;
+  status: string | null;
+  percentComplete: number | null;
+}
+
+const mocks = vi.hoisted(() => {
+  const nodeStore = new Map<string, {
+    mapId: string;
+    status: string | null;
+    percentComplete: number | null;
+    externalLinks: NodeRow['externalLinks'];
+  }>();
+  return {
+    nodeStore,
+    getNodeMock: vi.fn(),
+    updateNodeMock: vi.fn(),
+    selectNodesMock: vi.fn(),
+    broadcastMock: vi.fn(),
+    verifySignatureMock: vi.fn(async () => true),
+    processWebhookMock: vi.fn(() => ({ action: 'noop', nodeUpdates: null, externalId: null })),
+  };
+});
+
+vi.mock('@mindblown/integrations', () => ({
+  createGitHubIssue: vi.fn(),
+  getGitHubIssue: vi.fn(),
+  importGitHubIssues: vi.fn(),
+  extractVersionFromMilestone: vi.fn(),
+  // Real implementation — the regex is the unit under test for ref extraction.
+  extractClosingIssueRefs: (text: string): number[] => {
+    const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+    const refs = new Set<number>();
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      refs.add(parseInt(match[1], 10));
+    }
+    return [...refs];
+  },
+  processWebhook: mocks.processWebhookMock,
+  verifyWebhookSignature: mocks.verifySignatureMock,
+  mintInstallationToken: vi.fn(),
+  isGitHubAppConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../../db/connection.js', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: async () => mocks.selectNodesMock(),
+      }),
+    }),
+    update: () => ({
+      set: () => ({ where: async () => undefined }),
+    }),
+    insert: () => ({ values: () => ({ returning: async () => [] }) }),
+    transaction: async <T,>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb({}),
+  },
+}));
+
+vi.mock('../../db/schema.js', () => ({
+  integrations: { __name: 'integrations' },
+  versions: { __name: 'versions' },
+  nodes: { __name: 'nodes' },
+  maps: { __name: 'maps' },
+  triageDecisions: { __name: 'triageDecisions' },
+}));
+
+vi.mock('../../db/nodes.js', () => ({
+  getNode: mocks.getNodeMock,
+  createNode: vi.fn(),
+  updateNode: mocks.updateNodeMock,
+  notDeleted: { __pred: true, check: () => true },
+}));
+
+vi.mock('../../sync/githubCatchup.js', () => ({ reconcileRepo: vi.fn() }));
+vi.mock('../../sync/driftAudit.js', () => ({ runDriftAudit: vi.fn() }));
+vi.mock('../../sync/webhookAuthCheck.js', () => ({ recordWebhookCall: vi.fn() }));
+vi.mock('../../auth.js', () => ({ requireAdmin: vi.fn() }));
+vi.mock('../../sync/parentEpicRollup.js', () => ({
+  rollupParentsForChildTitle: vi.fn(),
+}));
+vi.mock('../../sync/githubIngest.js', () => ({
+  ingestNewIssuesForRepo: vi.fn(),
+  ensureInboxNode: vi.fn(),
+  ensureNodeForIssue: vi.fn(),
+  findNodesByExternalIds: vi.fn(),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: mocks.broadcastMock }));
+vi.mock('../../sync/triage.js', () => ({
+  triageIssue: vi.fn(),
+  clearTriageDebounce: vi.fn(),
+  computeInputHash: vi.fn(),
+  markTriageDebounce: vi.fn(),
+  isWithinDebounceWindow: vi.fn(() => false),
+}));
+vi.mock('../../sync/mapContext.js', () => ({ buildMapContext: vi.fn() }));
+vi.mock('../../sync/triageHistory.js', () => ({ recordTriageHistory: vi.fn() }));
+vi.mock('../../sync/triageLabelWriteback.js', () => ({ applyTriageLabel: vi.fn() }));
+vi.mock('../../lib/githubContext.js', () => ({
+  getGitHubContextForMap: vi.fn(async () => null),
+}));
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({ __pred: true, check: () => true })),
+  and: vi.fn(() => ({ __pred: true, check: () => true })),
+}));
+
+import { integrationRoutes } from '../integrations.js';
+
+async function buildApp(logger = false): Promise<FastifyInstance> {
+  const app = Fastify({ logger });
+  await app.register(integrationRoutes);
+  return app;
+}
+
+function prMergedPayload(opts: { number: number; title: string; body: string | null }): Record<string, unknown> {
+  return {
+    action: 'closed',
+    pull_request: {
+      number: opts.number,
+      merged: true,
+      html_url: `https://github.com/owner/repo/pull/${opts.number}`,
+      title: opts.title,
+      body: opts.body,
+    },
+    repository: { full_name: 'owner/repo' },
+  };
+}
+
+function seedLinkedNode(args: {
+  nodeId: string;
+  externalId: string;
+  status?: string | null;
+  percentComplete?: number | null;
+}): NodeRecord {
+  const node: NodeRecord = {
+    id: args.nodeId,
+    mapId: 'map-1',
+    status: args.status ?? 'in_progress',
+    percentComplete: args.percentComplete ?? 50,
+    externalLinks: [
+      {
+        provider: 'github',
+        externalId: args.externalId,
+        url: `https://github.com/${args.externalId.replace('#', '/issues/')}`,
+        syncEnabled: true,
+        lastSyncedAt: null,
+      },
+    ],
+  };
+  return node;
+}
+
+beforeEach(() => {
+  mocks.getNodeMock.mockReset();
+  mocks.updateNodeMock.mockReset();
+  mocks.selectNodesMock.mockReset();
+  // Default to an empty result set; tests override per-case. Empty is
+  // safe because both consumers — the integration-secret loop and the
+  // findNodeByExternalId scan — expect an array.
+  mocks.selectNodesMock.mockResolvedValue([]);
+  mocks.broadcastMock.mockReset();
+  mocks.verifySignatureMock.mockReset();
+  mocks.verifySignatureMock.mockResolvedValue(true);
+  mocks.processWebhookMock.mockReset();
+  mocks.processWebhookMock.mockReturnValue({ action: 'noop', nodeUpdates: null, externalId: null });
+  process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-secret';
+});
+
+describe('webhook: pull_request.closed merged=true (#152)', () => {
+  it('transitions a single linked node to done', async () => {
+    const node = seedLinkedNode({ nodeId: 'n-100', externalId: 'owner/repo#100' });
+    mocks.selectNodesMock.mockResolvedValue([{ id: node.id, externalLinks: node.externalLinks }]);
+    mocks.getNodeMock.mockResolvedValue(node);
+    mocks.updateNodeMock.mockResolvedValue({ ...node, status: 'done', percentComplete: 100 });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: prMergedPayload({ number: 555, title: 'feat: add Y (Closes #100)', body: null }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toMatchObject({
+      received: true,
+      action: 'pull_request.merged',
+      prNumber: 555,
+      matched: true,
+    });
+    expect(body.transitions).toEqual([
+      { externalId: 'owner/repo#100', nodeId: 'n-100', status: 'transitioned' },
+    ]);
+    expect(mocks.updateNodeMock).toHaveBeenCalledTimes(1);
+    const [calledNodeId, calledFields] = mocks.updateNodeMock.mock.calls[0];
+    expect(calledNodeId).toBe('n-100');
+    expect(calledFields).toMatchObject({ status: 'done', percentComplete: 100 });
+    expect(mocks.broadcastMock).toHaveBeenCalledWith(
+      'map-1',
+      expect.objectContaining({ type: 'node:updated', source: 'github_webhook_pr_merge' }),
+    );
+  });
+
+  it('iterates ALL closing refs in PR body (multi-issue support)', async () => {
+    const nodeA = seedLinkedNode({ nodeId: 'n-A', externalId: 'owner/repo#1' });
+    const nodeB = seedLinkedNode({ nodeId: 'n-B', externalId: 'owner/repo#2' });
+    mocks.selectNodesMock.mockResolvedValue([
+      { id: nodeA.id, externalLinks: nodeA.externalLinks },
+      { id: nodeB.id, externalLinks: nodeB.externalLinks },
+    ]);
+    mocks.getNodeMock.mockImplementation(async (id: string) =>
+      id === 'n-A' ? nodeA : id === 'n-B' ? nodeB : null,
+    );
+    mocks.updateNodeMock.mockImplementation(async (id: string) => ({
+      ...(id === 'n-A' ? nodeA : nodeB),
+      status: 'done',
+      percentComplete: 100,
+    }));
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: prMergedPayload({
+        number: 999,
+        title: 'big sweep',
+        body: 'Closes #1, fixes #2',
+      }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.updateNodeMock).toHaveBeenCalledTimes(2);
+    const transitioned = res.json().transitions as Array<{ externalId: string; status: string }>;
+    expect(transitioned).toHaveLength(2);
+    expect(transitioned.every((t) => t.status === 'transitioned')).toBe(true);
+  });
+
+  it('is idempotent — replaying the same merge does NOT re-transition', async () => {
+    const node = seedLinkedNode({
+      nodeId: 'n-200',
+      externalId: 'owner/repo#200',
+      status: 'done',
+      percentComplete: 100,
+    });
+    mocks.selectNodesMock.mockResolvedValue([{ id: node.id, externalLinks: node.externalLinks }]);
+    mocks.getNodeMock.mockResolvedValue(node);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: prMergedPayload({ number: 200, title: 'Closes #200', body: null }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().transitions).toEqual([
+      { externalId: 'owner/repo#200', nodeId: 'n-200', status: 'already_done' },
+    ]);
+    expect(mocks.updateNodeMock).not.toHaveBeenCalled();
+    expect(mocks.broadcastMock).not.toHaveBeenCalled();
+  });
+
+  it('reports refs with no linked node as not_linked (not an error)', async () => {
+    mocks.selectNodesMock.mockResolvedValue([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: prMergedPayload({ number: 7, title: 'Closes #404', body: null }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      action: 'pull_request.merged',
+      matched: false,
+      transitions: [
+        { externalId: 'owner/repo#404', nodeId: '', status: 'not_linked' },
+      ],
+    });
+    expect(mocks.updateNodeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsigned requests with 401 before touching the DB', async () => {
+    mocks.verifySignatureMock.mockResolvedValue(false);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=forged',
+      },
+      payload: prMergedPayload({ number: 1, title: 'Closes #1', body: null }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(401);
+    // The legacy PAT-secret lookup runs a SELECT before the 401, but
+    // no mutations and no node lookups should fire.
+    expect(mocks.updateNodeMock).not.toHaveBeenCalled();
+    expect(mocks.getNodeMock).not.toHaveBeenCalled();
+    expect(mocks.broadcastMock).not.toHaveBeenCalled();
+  });
+
+  it('PR closed without merging (merged=false) does not transition anything', async () => {
+    const node = seedLinkedNode({ nodeId: 'n-300', externalId: 'owner/repo#300' });
+    mocks.selectNodesMock.mockResolvedValue([{ id: node.id, externalLinks: node.externalLinks }]);
+    mocks.getNodeMock.mockResolvedValue(node);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: {
+        action: 'closed',
+        pull_request: {
+          number: 300,
+          merged: false,
+          html_url: 'https://github.com/owner/repo/pull/300',
+          title: 'Closes #300',
+          body: null,
+        },
+        repository: { full_name: 'owner/repo' },
+      },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.updateNodeMock).not.toHaveBeenCalled();
+    // Falls through to processWebhook mock (which returns a noop).
+    expect(mocks.processWebhookMock).toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -9,6 +9,7 @@ import {
   getGitHubIssue,
   importGitHubIssues,
   extractVersionFromMilestone,
+  extractClosingIssueRefs,
   processWebhook,
   verifyWebhookSignature,
   mintInstallationToken,
@@ -1448,6 +1449,100 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         action: actionLabel,
         matched: true,
         nodeId,
+      });
+    }
+
+    // ── pull_request: closed + merged=true → transition linked nodes ─
+    //
+    // #152 — when a PR merges with `Closes #N` references in title or
+    // body, transition every referenced issue's linked node to done.
+    // Cuts the up-to-6h lag that the drift audit catches (catchup runs
+    // every 5min but only flips state on issue-close webhooks, which
+    // require the `issues` event subscription — not every repo has it).
+    //
+    // Iterates ALL refs (PR title + body), unlike the legacy
+    // processWebhook PR branch which only returned the first. The
+    // existing issues.closed handler still runs for repos subscribed
+    // to that event — this branch is the PR-only-subscription path.
+    //
+    // Idempotent: a second webhook for the same PR (replay or
+    // misconfigured retry) finds the node already at status='done' +
+    // percentComplete=100 and emits no second transition.
+    if (
+      event === 'pull_request' &&
+      payloadAction === 'closed' &&
+      (payload.pull_request as { merged?: boolean } | undefined)?.merged === true &&
+      repoFullName
+    ) {
+      const pr = payload.pull_request as {
+        number: number;
+        merged: boolean;
+        body: string | null;
+        title: string;
+      };
+      const refs = extractClosingIssueRefs(`${pr.title ?? ''} ${pr.body ?? ''}`);
+      const transitions: Array<{
+        externalId: string;
+        nodeId: string;
+        status: 'transitioned' | 'already_done' | 'not_linked';
+      }> = [];
+
+      for (const issueNumber of refs) {
+        const externalId = `${repoFullName}#${issueNumber}`;
+        const nodeId = await findNodeByExternalId(externalId);
+        if (!nodeId) {
+          transitions.push({ externalId, nodeId: '', status: 'not_linked' });
+          continue;
+        }
+        const node = await nodeDb.getNode(nodeId);
+        if (!node) {
+          transitions.push({ externalId, nodeId, status: 'not_linked' });
+          continue;
+        }
+        // Idempotency: replay → no second transition.
+        if (node.status === 'done' && node.percentComplete === 100) {
+          transitions.push({ externalId, nodeId, status: 'already_done' });
+          continue;
+        }
+        const links = node.externalLinks.map((l) => ({ ...l }));
+        const linkIdx = links.findIndex(
+          (l) => l.provider === 'github' && l.externalId === externalId,
+        );
+        if (linkIdx >= 0) {
+          links[linkIdx] = {
+            ...links[linkIdx],
+            previousPercentComplete: node.percentComplete,
+            previousStatus: node.status,
+            lastSyncedAt: new Date().toISOString(),
+          };
+        }
+        const updates: nodeDb.UpdateNodeInput = {
+          percentComplete: 100,
+          status: 'done',
+          externalLinks: links,
+        };
+        const updated = await nodeDb.updateNode(nodeId, updates);
+        if (updated) {
+          broadcast(updated.mapId, {
+            type: 'node:updated',
+            nodeId,
+            fields: Object.keys(updates),
+            node: updated,
+            source: 'github_webhook_pr_merge',
+          });
+        }
+        console.log(
+          `[gh-webhook] PR #${pr.number} merged → transitioned node ${nodeId} (${externalId}) to done`,
+        );
+        transitions.push({ externalId, nodeId, status: 'transitioned' });
+      }
+
+      return reply.send({
+        received: true,
+        action: 'pull_request.merged',
+        prNumber: pr.number,
+        matched: transitions.some((t) => t.status === 'transitioned' || t.status === 'already_done'),
+        transitions,
       });
     }
 


### PR DESCRIPTION
Closes #152.

## Summary
- New branch in `/api/webhooks/github` for `pull_request.closed merged=true`
- Extracts ALL `Closes/Fixes/Resolves #N` refs from PR title + body (legacy path only returned the first ref)
- Transitions each referenced node's linked node to `status='done', percentComplete=100`, preserving prior state in `externalLinks` for revert symmetry with the existing `issues.reopened` path
- Idempotent — replay finds the node already done and reports `already_done` without writing
- Logs each transition for audit grep
- `extractClosingIssueRefs` is now exported from `@mindblown/integrations` (renamed from private `extractIssueReferences`)

## Why
Today GH→MindBlown sync runs via the catchup loop (every 5 min) and drift audit (every 6h). When a PR merges with `Closes #NNN`, the linked GH issue closes — but for repos that don't subscribe MindBlown to the `issues` event (only `pull_request`), the MindBlown node's status transition can lag up to 6h. This is the gap Kira's autonomous-dispatch loop on FulcrumCRM/crm hits today.

## Acceptance (per ticket)
- [x] `POST /api/webhooks/github` endpoint handles PR-merge (existing route, new branch)
- [x] HMAC signature verification (reuses existing flow — both App webhook secret and legacy PAT secrets supported)
- [x] On `pull_request: closed` with `merged=true`: parses PR title + body for `Closes #N` (regex matches all keywords + variants), looks up linked nodes, transitions to done
- [x] Logs the transition (audit grep — `[gh-webhook] PR #X merged → transitioned …`)
- [x] Idempotent — replay returns `already_done` for nodes already at `status='done', percentComplete=100`

## Endpoint path
The ticket suggested `POST /webhook/github` but the existing webhook lives at `/api/webhooks/github` with the full HMAC + audit plumbing already in place. Reusing it keeps configuration consistent across PAT and GitHub App setups. Configure on FulcrumCRM/crm side:
- URL: `https://mind.project.li/api/webhooks/github`
- Events: `pull_request`
- Secret: matches `GITHUB_APP_WEBHOOK_SECRET` on the mindblown server

If a separate `/webhook/github` alias is wanted later, we can add it as a thin redirect.

## Test plan
- [x] `pnpm --filter @mindblown/server test src/routes/__tests__/pr-merge-webhook.test.ts` — 6/6 pass
- [x] Multi-issue PR: `Closes #1, fixes #2` → both nodes transition (regression for the legacy single-ref path)
- [x] Idempotency: replay does not re-transition or re-broadcast
- [x] Unsigned requests rejected with 401 before DB writes
- [x] `pull_request.closed` with `merged=false` falls through (no transition)
- [x] Refs to issues with no linked node reported as `not_linked` (not an error)
- [ ] Smoke test after deploy: configure FulcrumCRM/crm webhook, merge a test PR with `Closes #X`, verify the linked MindBlown node flips within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)