### PR TITLE
refactor(orchestration): query amp + claim race + release semantics (#118)

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -954,6 +954,8 @@ export interface ClaimNodeResultApi {
 export interface ReleaseNodeResultApi {
   node: { id: string; text: string };
   released: boolean;
+  /** True when the node was already unclaimed (#118 issue 5 — no-op success). */
+  alreadyReleased?: boolean;
 }
 
 export interface ConflictEntryApi {

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -304,16 +304,17 @@ export async function updateNode(
     input.claimedBySession !== undefined || input.claimedAt !== undefined;
 
   if ((statusChanging || pctChanging) && (!claimTouched || !completedAtTouched)) {
-    const [nodeForMap] = await handle
-      .select({ mapId: nodes.mapId })
+    // #118 issue 3 — single JOIN replaces the previous 2-query path
+    // (SELECT node.mapId → SELECT map.statusWorkflow). Cuts the status-
+    // update hot path from 3 queries to 2 (the original UPDATE still
+    // fires below).
+    const [row] = await handle
+      .select({ mapId: nodes.mapId, statusWorkflow: maps.statusWorkflow })
       .from(nodes)
+      .innerJoin(maps, eq(maps.id, nodes.mapId))
       .where(and(eq(nodes.id, nodeId), notDeleted));
-    if (nodeForMap) {
-      const [mapRow] = await handle
-        .select({ statusWorkflow: maps.statusWorkflow })
-        .from(maps)
-        .where(eq(maps.id, nodeForMap.mapId as string));
-      const workflow = ((mapRow?.statusWorkflow as StatusDef[]) ?? []);
+    if (row) {
+      const workflow = ((row.statusWorkflow as StatusDef[]) ?? []);
 
       // Resolve whether the post-update node is "done":
       //   - status (if changing) → check its category in the workflow

--- a/packages/server/src/routes/__tests__/orchestration-routes.test.ts
+++ b/packages/server/src/routes/__tests__/orchestration-routes.test.ts
@@ -247,6 +247,15 @@ function buildTestApp(): FastifyInstance {
         });
       }
 
+      // #118 issue 5 — releasing an unclaimed node is a no-op success.
+      if (node.claimedBySession === null) {
+        return reply.send({
+          node: { id: node.id, text: node.text },
+          released: false,
+          alreadyReleased: true,
+        });
+      }
+
       node.claimedBySession = null;
       node.claimedAt = null;
       node.updatedAt = new Date();
@@ -506,7 +515,7 @@ describe('orchestration routes', () => {
       expect(nodeStore.get('n1')!.claimedBySession).toBe('sess-001');
     });
 
-    it('allows releasing an unclaimed node by any session', async () => {
+    it('releasing an unclaimed node is a no-op success (#118 issue 5)', async () => {
       seedNode({ id: 'n1', claimedBySession: null });
       const res = await app.inject({
         method: 'POST',
@@ -514,6 +523,10 @@ describe('orchestration routes', () => {
         payload: { sessionId: 'sess-001' },
       });
       expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toMatchObject({
+        released: false,
+        alreadyReleased: true,
+      });
     });
   });
 

--- a/packages/server/src/services/__tests__/orchestration.test.ts
+++ b/packages/server/src/services/__tests__/orchestration.test.ts
@@ -1,0 +1,263 @@
+/**
+ * #118 — orchestration service cleanup.
+ *
+ * Targets the real `services/orchestration.ts` functions (NOT the inline
+ * fakes in routes/__tests__/orchestration-routes.test.ts — those don't
+ * exercise the service module; that's tracked separately in #117).
+ *
+ * Coverage:
+ *   - Issue 4: claimNode wraps SELECT + UPDATE in a single transaction
+ *     so the `warned` flag is observable across concurrent claims.
+ *   - Issue 5: releaseNode on an already-unclaimed node returns
+ *     `released: false, alreadyReleased: true` without any DB write
+ *     or broadcast.
+ *
+ * Issue 3 (query amplification) is verified separately in
+ * db/__tests__/nodes-status-update.test.ts since the cut sits in the
+ * nodes DB layer, not the orchestration service.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  updateMock: vi.fn(),
+  txSelectMock: vi.fn(),
+  txUpdateMock: vi.fn(),
+  transactionMock: vi.fn(),
+  broadcastMock: vi.fn(),
+}));
+
+vi.mock('../../db/connection.js', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (_w: unknown) => mocks.selectMock(),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: () => mocks.updateMock(),
+        }),
+      }),
+    }),
+    transaction: (cb: (tx: unknown) => unknown) => {
+      mocks.transactionMock();
+      const tx = {
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              for: (_lock: string) => mocks.txSelectMock(),
+            }),
+          }),
+        }),
+        update: () => ({
+          set: () => ({
+            where: () => ({ returning: () => mocks.txUpdateMock() }),
+          }),
+        }),
+      };
+      return cb(tx);
+    },
+  },
+}));
+
+vi.mock('../../db/schema.js', () => ({
+  nodes: { __name: 'nodes' },
+  maps: { __name: 'maps' },
+}));
+
+vi.mock('../../db/nodes.js', () => ({
+  notDeleted: { __sentinel: 'notDeleted' },
+}));
+
+vi.mock('../../ws.js', () => ({
+  broadcast: mocks.broadcastMock,
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ __pred: 'and', args }),
+  eq: (...args: unknown[]) => ({ __pred: 'eq', args }),
+}));
+
+// Bypass heavy core import — the service only uses a few functions and
+// they're not invoked by the paths under test (claim/release don't read
+// schedule). For paths that DO use core (readyNodes, conflictScan), we
+// don't cover them here.
+vi.mock('@mindblown/core', () => ({
+  resolvedSiblingOrder: vi.fn(),
+  isReady: vi.fn(),
+  scopeOverlap: vi.fn(),
+}));
+
+import { claimNode, releaseNode } from '../orchestration.js';
+
+function nodeRow(overrides: Partial<{
+  id: string;
+  mapId: string;
+  text: string;
+  parentId: string | null;
+  childrenOrder: string[];
+  claimedBySession: string | null;
+  claimedAt: Date | null;
+  status: string | null;
+  percentComplete: number | null;
+  scopes: string[];
+  externalLinks: unknown[];
+  assigneeIds: string[];
+  dependencies: unknown[];
+  tags: string[];
+  customFields: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}> = {}) {
+  return {
+    id: 'n1',
+    mapId: 'm1',
+    text: 'Test node',
+    parentId: null,
+    childrenOrder: [],
+    claimedBySession: null,
+    claimedAt: null,
+    status: null,
+    percentComplete: null,
+    scopes: [],
+    externalLinks: [],
+    assigneeIds: [],
+    dependencies: [],
+    tags: [],
+    customFields: {},
+    autoProgress: 'off',
+    revision: 1,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    createdBy: 'test',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.selectMock.mockReset();
+  mocks.updateMock.mockReset();
+  mocks.txSelectMock.mockReset();
+  mocks.txUpdateMock.mockReset();
+  mocks.transactionMock.mockReset();
+  mocks.broadcastMock.mockReset();
+});
+
+describe('claimNode (#118 issue 4 — transactional)', () => {
+  it('wraps SELECT FOR UPDATE + UPDATE in a single transaction', async () => {
+    const before = nodeRow({ claimedBySession: null });
+    const after = nodeRow({
+      claimedBySession: 'sess-a',
+      claimedAt: new Date('2026-06-08T10:00:00Z'),
+    });
+    mocks.txSelectMock.mockResolvedValue([before]);
+    mocks.txUpdateMock.mockResolvedValue([after]);
+
+    const result = await claimNode('m1', 'n1', 'sess-a');
+
+    expect(mocks.transactionMock).toHaveBeenCalledTimes(1);
+    expect(mocks.txSelectMock).toHaveBeenCalledTimes(1);
+    expect(mocks.txUpdateMock).toHaveBeenCalledTimes(1);
+    // Non-tx code paths must NOT be used for the claim's read or write.
+    expect(mocks.selectMock).not.toHaveBeenCalled();
+    expect(mocks.updateMock).not.toHaveBeenCalled();
+    expect(result.claimed).toBe(true);
+    expect(result.warned).toBe(false);
+    expect(result.node.claimedBySession).toBe('sess-a');
+  });
+
+  it('reports warned=true when the pre-state was claimed by a different session', async () => {
+    const before = nodeRow({
+      claimedBySession: 'sess-other',
+      claimedAt: new Date('2026-06-08T09:00:00Z'),
+    });
+    const after = nodeRow({
+      claimedBySession: 'sess-a',
+      claimedAt: new Date('2026-06-08T10:00:00Z'),
+    });
+    mocks.txSelectMock.mockResolvedValue([before]);
+    mocks.txUpdateMock.mockResolvedValue([after]);
+
+    const result = await claimNode('m1', 'n1', 'sess-a');
+
+    expect(result.warned).toBe(true);
+    expect(result.warning).toContain('sess-other');
+    expect(result.warning).toContain('sess-a');
+  });
+
+  it('does NOT warn when re-claimed by the same session', async () => {
+    const before = nodeRow({
+      claimedBySession: 'sess-a',
+      claimedAt: new Date('2026-06-08T09:00:00Z'),
+    });
+    const after = nodeRow({
+      claimedBySession: 'sess-a',
+      claimedAt: new Date('2026-06-08T10:00:00Z'),
+    });
+    mocks.txSelectMock.mockResolvedValue([before]);
+    mocks.txUpdateMock.mockResolvedValue([after]);
+
+    const result = await claimNode('m1', 'n1', 'sess-a');
+
+    expect(result.warned).toBe(false);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('throws OrchestrationNotFoundError when the node does not exist', async () => {
+    mocks.txSelectMock.mockResolvedValue([]);
+
+    await expect(claimNode('m1', 'ghost', 'sess-a')).rejects.toThrow(
+      /Node ghost not found/,
+    );
+    // The transaction is entered before the throw; UPDATE must not fire.
+    expect(mocks.transactionMock).toHaveBeenCalled();
+    expect(mocks.txUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('releaseNode (#118 issue 5 — unclaimed = no-op success)', () => {
+  it('returns alreadyReleased:true without writing when node is unclaimed', async () => {
+    mocks.selectMock.mockResolvedValue([nodeRow({ claimedBySession: null })]);
+
+    const result = await releaseNode('m1', 'n1', 'sess-a');
+
+    expect(result).toMatchObject({
+      released: false,
+      alreadyReleased: true,
+    });
+    // Critical: no UPDATE issued, no broadcast emitted.
+    expect(mocks.updateMock).not.toHaveBeenCalled();
+    expect(mocks.broadcastMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the claim and reports released:true when caller owns it', async () => {
+    const before = nodeRow({
+      claimedBySession: 'sess-a',
+      claimedAt: new Date('2026-06-08T09:00:00Z'),
+    });
+    const after = nodeRow({ claimedBySession: null, claimedAt: null });
+    mocks.selectMock.mockResolvedValue([before]);
+    mocks.updateMock.mockResolvedValue([after]);
+
+    const result = await releaseNode('m1', 'n1', 'sess-a');
+
+    expect(result.released).toBe(true);
+    expect(result.alreadyReleased).toBeUndefined();
+    expect(mocks.updateMock).toHaveBeenCalledTimes(1);
+    expect(mocks.broadcastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects with ClaimOwnershipError when a different session owns the claim', async () => {
+    mocks.selectMock.mockResolvedValue([
+      nodeRow({ claimedBySession: 'sess-other', claimedAt: new Date() }),
+    ]);
+
+    await expect(releaseNode('m1', 'n1', 'sess-a')).rejects.toThrow(
+      /claimed by session "sess-other"/,
+    );
+    expect(mocks.updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/services/orchestration.ts
+++ b/packages/server/src/services/orchestration.ts
@@ -155,28 +155,37 @@ export async function claimNode(
   nodeId: string,
   sessionId: string,
 ): Promise<ClaimNodeResult> {
-  const [row] = await db
-    .select()
-    .from(nodes)
-    .where(and(eq(nodes.id, nodeId), notDeleted));
-  if (!row) throw new OrchestrationNotFoundError(`Node ${nodeId} not found`);
+  // #118 issue 4 — race-condition fix. Two concurrent claims by
+  // different sessions used to both read pre-state, both report
+  // `warned: false`, and both UPDATE (last write wins). Wrap the
+  // SELECT + UPDATE in a single transaction with FOR UPDATE so the
+  // second tx blocks until the first commits, then observes the
+  // first writer's claim and reports `warned: true`.
+  const { previousClaim, updatedNode } = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(nodes)
+      .where(and(eq(nodes.id, nodeId), notDeleted))
+      .for('update');
+    if (!row) throw new OrchestrationNotFoundError(`Node ${nodeId} not found`);
 
-  const node = dbNodeToCore(row as unknown as Record<string, unknown>);
-  // NOTE: read-then-write without a transaction. The `warned` flag is
-  // best-effort under concurrent claims by different sessions; the soft-
-  // warn semantics of the spec accept this (last-write-wins on the claim,
-  // both writers may report not-warned). See follow-up issue.
-  const warned = node.claimedBySession !== null && node.claimedBySession !== sessionId;
-  const now = new Date();
+    const before = dbNodeToCore(row as unknown as Record<string, unknown>);
+    const now = new Date();
 
-  const [updated] = await db
-    .update(nodes)
-    .set({ claimedBySession: sessionId, claimedAt: now, updatedAt: now })
-    .where(and(eq(nodes.id, nodeId), notDeleted))
-    .returning();
-  if (!updated) throw new OrchestrationNotFoundError(`Node ${nodeId} not found`);
+    const [updatedRow] = await tx
+      .update(nodes)
+      .set({ claimedBySession: sessionId, claimedAt: now, updatedAt: now })
+      .where(and(eq(nodes.id, nodeId), notDeleted))
+      .returning();
+    if (!updatedRow) throw new OrchestrationNotFoundError(`Node ${nodeId} not found`);
 
-  const updatedNode = dbNodeToCore(updated as unknown as Record<string, unknown>);
+    return {
+      previousClaim: before.claimedBySession,
+      updatedNode: dbNodeToCore(updatedRow as unknown as Record<string, unknown>),
+    };
+  });
+
+  const warned = previousClaim !== null && previousClaim !== sessionId;
 
   broadcast(mapId, {
     type: 'node:updated',
@@ -195,7 +204,7 @@ export async function claimNode(
     claimed: true,
     warned,
     warning: warned
-      ? `Node ${nodeId} was already claimed by session "${node.claimedBySession}". Claim transferred to "${sessionId}".`
+      ? `Node ${nodeId} was already claimed by session "${previousClaim}". Claim transferred to "${sessionId}".`
       : undefined,
   };
 }
@@ -220,6 +229,19 @@ export async function releaseNode(
     throw new ClaimOwnershipError(
       `Node ${nodeId} is claimed by session "${node.claimedBySession}", not "${sessionId}". Release rejected.`,
     );
+  }
+
+  // #118 issue 5 — when there's nothing to release, say so. The old
+  // code returned `released: true` for already-unclaimed nodes which
+  // was a misleading no-op. Callers checking `released` to decide
+  // whether to log "claim cleared" now have an `alreadyReleased`
+  // signal to suppress the noise. No DB write, no broadcast.
+  if (node.claimedBySession === null) {
+    return {
+      node: { id: node.id, text: node.text },
+      released: false,
+      alreadyReleased: true,
+    };
   }
 
   const now = new Date();

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -148,7 +148,14 @@ export interface ClaimNodeResult {
 
 export interface ReleaseNodeResult {
   node: { id: string; text: string };
+  /** True when this call actually cleared a claim; false when nothing was claimed. */
   released: boolean;
+  /**
+   * True when the node was already unclaimed at call time (#118 issue 5).
+   * `released` is false in this case — the call is a no-op success.
+   * Callers logging "claim cleared" should suppress when this is true.
+   */
+  alreadyReleased?: boolean;
 }
 
 export interface ConflictEntry {

--- a/packages/tool-kit/src/tools/orchestration.ts
+++ b/packages/tool-kit/src/tools/orchestration.ts
@@ -120,6 +120,9 @@ export const releaseNodeTool = defineTool({
   },
   handler: async (backend, { mapId, nodeId, sessionId }) => {
     const result = await backend.releaseNode(mapId, nodeId, sessionId);
+    if (result.alreadyReleased) {
+      return `Node ${nodeId} ("${result.node.text}") was not claimed — no-op.`;
+    }
     return `Released claim on node ${nodeId} ("${result.node.text}").`;
   },
 });


### PR DESCRIPTION
Closes #118.

## Summary
Three small correctness/perf fixes in the orchestration backend, flagged in the #116 review of the substrate (#111). All cluster on the claim/release/status code path — shipping as one sweep.

### Issue 3 — query amplification on status updates
\`updateNode\` was doing SELECT mapId → SELECT statusWorkflow → UPDATE for every status or percentComplete change. Collapse the two SELECTs into a single \`nodes ⨝ maps\` JOIN. Hot path drops from 3 queries → 2.

### Issue 4 — claimNode race condition
Two concurrent claims by different sessions both read pre-state, both report \`warned: false\`, both UPDATE. Wrap the SELECT + UPDATE in \`db.transaction(...)\` with \`.for('update')\` row lock — second tx blocks until first commits, observes its claim, correctly reports \`warned: true\`.

### Issue 5 — releaseNode unclaimed = misleading success
Old code returned \`released: true\` for a release on an unclaimed node. Now returns \`released: false, alreadyReleased: true\` with no DB write and no broadcast. \`ReleaseNodeResult\` gains the optional \`alreadyReleased\` flag (tool-kit + mcp api type mirrors). \`release_node\` MCP tool surfaces the new state in its text output (\"Node X was not claimed — no-op\").

## Tests
- 7 new service-level tests in \`services/__tests__/orchestration.test.ts\` exercising the real \`services/orchestration.ts\` (the existing \`orchestration-routes.test.ts\` uses inline-fake handlers and wouldn't catch any of these — that's the gap tracked in #117)
- Covers tx isolation for claimNode (success + warned + same-session + not-found) and releaseNode's three branches
- The inline-fake test for \"allows releasing an unclaimed node\" is updated to assert the new \`{ released: false, alreadyReleased: true }\` shape

## Test plan
- [x] \`pnpm --filter @mindblown/server test src/services/__tests__/orchestration.test.ts\` — 7/7 pass
- [x] \`pnpm turbo typecheck\` clean (pre-existing \`maps-triage-flags.test.ts\` spread errors unrelated; reproduce on master)
- [x] Full server suite: 470 pass, 1 pre-existing flake (\`triage-routes.test.ts\` bulk-confirm timing)
- [ ] Smoke after deploy: confirm Kira's release on an already-released node doesn't log a spurious \"claim cleared\" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)