### PR TITLE
fix(chat): reject empty text blocks before Anthropic does

### DIFF
--- a/packages/server/src/ai/providers/anthropic.ts
+++ b/packages/server/src/ai/providers/anthropic.ts
@@ -41,15 +41,19 @@ function toAnthropicMessages(messages: NormalizedMessage[]): Anthropic.MessagePa
   const out: Anthropic.MessageParam[] = [];
   for (const m of messages) {
     if (m.role === 'user') {
-      out.push({ role: 'user', content: m.content });
+      // Anthropic rejects empty text blocks ("text content blocks must be non-empty").
+      // A whitespace placeholder preserves user→assistant alternation when client
+      // history replays a no-op turn.
+      out.push({ role: 'user', content: m.content || ' ' });
     } else if (m.role === 'assistant') {
       const blocks: Anthropic.ContentBlockParam[] = [];
       if (m.content) blocks.push({ type: 'text', text: m.content });
       for (const tc of m.toolCalls) {
         blocks.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.args });
       }
-      // An assistant message must have at least one content block.
-      if (blocks.length === 0) blocks.push({ type: 'text', text: '' });
+      // Assistant messages need ≥1 content block AND each text block must be
+      // non-empty. A space satisfies both.
+      if (blocks.length === 0) blocks.push({ type: 'text', text: ' ' });
       out.push({ role: 'assistant', content: blocks });
     } else {
       out.push({

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -563,11 +563,15 @@ Rules:
         }
 
         // Append the assistant turn so the next provider call sees the history.
-        messages.push({
-          role: 'assistant',
-          content: assistantText,
-          toolCalls: firstToolCall ? [firstToolCall] : [],
-        });
+        // Skip turns with neither text nor a tool call — Anthropic rejects empty
+        // text blocks, and replaying a no-op turn next request would 400.
+        if (assistantText || firstToolCall) {
+          messages.push({
+            role: 'assistant',
+            content: assistantText,
+            toolCalls: firstToolCall ? [firstToolCall] : [],
+          });
+        }
 
         if (!firstToolCall) break;
 


### PR DESCRIPTION
## Summary
- Opus 4.7 sometimes ends a turn with no text and no tool call. The orchestrator was persisting that as an empty assistant turn, the chat UI replayed it on the next user message, and the Anthropic serializer's fallback emitted `{ type: 'text', text: '' }` — which the API rejects with `400 invalid_request_error: messages: text content blocks must be non-empty`, bricking the conversation.
- Two-part fix: defensive serializer (substitute a space for any empty content block) + upstream guard (orchestrator no longer persists empty assistant turns).
- A space placeholder is invisible to the user but preserves user/assistant alternation when client history replays a stale no-op turn.

## Test plan
- [ ] Deploy to LXC 106
- [ ] Start a fresh chat in mind.project.li → AI replies normally
- [ ] Trigger a tool-call sequence (e.g. ask to create a node) → tool runs, follow-up text renders, no 400
- [ ] Resume a previously broken conversation → either still broken (empty turn already in history; expected, fresh convo clears it) or recovers (server-side space substitution masks it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)