### PR TITLE
fix(chat): let Opus chain tool calls; keep one-per-turn for Ollama

### DIFF
--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -473,6 +473,15 @@ Node to break down: "${targetNode.text}"`;
           ? `If the user names a node that doesn't appear in the tree above, treat it as a possible typo or paraphrase — try search_nodes (substring) or semantic_search (meaning) before assuming they meant something literal. E.g. "rename the lawyer node" on a map with no "lawyer" likely means "layer". When still unsure after one search, ask one short clarifying question instead of guessing.`
           : `If the user names a node that doesn't appear in the tree above, treat it as a possible typo — try search_nodes with the closest substring before assuming they meant something literal. E.g. "rename the lawyer node" on a map with no "lawyer" likely means "layer". When still unsure, ask one short clarifying question instead of guessing.`;
 
+      // Pacing rule diverges by provider: Opus 4.7 chains tool calls reliably,
+      // so let it finish the whole job in one user turn (saves cache misses
+      // from intermediate confirmation rounds). Ollama 14B drifts when asked
+      // to chain — keep the one-call-per-message constraint there.
+      const pacingRule =
+        provider.name === 'anthropic'
+          ? `Make all the tool calls needed to complete the user's request, then give one brief summary at the end. Do not stop after each tool call to ask for confirmation — only pause if the next action is genuinely ambiguous.`
+          : `One tool call per message. Confirm what you did in one short English sentence.`;
+
       const systemPrompt = `You manage a project mindmap. Reply ONLY in English.
 
 mapId = "${body.mapId}"
@@ -486,7 +495,7 @@ ${treeText}
 Rules:
 1. Only use IDs shown in [id:...] above. Never invent an ID.
 2. For move_node: "source" is the node being moved, "destination" is where it goes.
-3. One tool call per message. Confirm what you did in one short English sentence.
+3. ${pacingRule}
 4. You cannot delete nodes.
 5. ${typoRecoveryHint}`;
 


### PR DESCRIPTION
## Summary
- User report: "AI Chat only makes one step and then I need to say continue, and burns through tokens like crazy."
- Root cause: Rule 3 of the chat system prompt — "One tool call per message" — is a defense from when Ollama 14B was the only chat backend (added 2026-04-11). It was never relaxed when MAX_STEPS got raised 6 → 12 in 9f652c0 "for sophisticated restructures." So the orchestrator could run 12 steps, but the prompt explicitly told the model to stop after one.
- On the Anthropic path this surfaces as needing manual "continue" prompts. It also amplifies token burn: every confirmation round = another model call; the system prompt embeds the full mindmap tree before the cache breakpoint (`anthropic.ts:92-98`), so any tool that mutates the tree busts the cache for the next round.

## Fix
- Split Rule 3 by provider:
  - Anthropic: "Make all the tool calls needed to complete the user's request, then give one brief summary at the end. Do not stop after each tool call to ask for confirmation."
  - Ollama: keeps the existing "one tool call per message" wording — 14B genuinely can't chain reliably.

## Follow-up worth considering (not in this PR)
Cache invalidation from tree-in-system-prompt is structural — every mutating tool call busts the cache for the next iteration. Moving the tree out of the system prompt (let the model call get_map / search_nodes on demand) would dramatically improve hit rate at the cost of a slightly chattier first turn. Worth a separate PR if token burn is still uncomfortable after this lands.

## Test plan
- [ ] Deploy to LXC 106
- [ ] Ask the Anthropic chat to do something requiring 3+ tool calls (e.g. "create three child nodes under X"). It should do them all in one turn without prompting for "continue".
- [ ] Single-call requests still work and end with a one-line summary.
- [ ] Ollama-mode chat still behaves one-per-turn (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)