### PR TITLE
fix(ws): heartbeat-based dead client eviction

### DIFF
--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -9,13 +9,21 @@ interface WS {
   readyState: number;
   send(data: string): void;
   on(event: string, cb: (...args: unknown[]) => void): void;
+  ping(): void;
+  terminate(): void;
 }
 
 interface ConnectedClient {
   ws: WS;
   userId: string | null;
   userName: string | null;
+  /** Set true on every pong; cleared by the sweeper before each ping. A
+   * client that doesn't pong within one HEARTBEAT_INTERVAL_MS window is
+   * declared dead and force-closed via terminate(). */
+  isAlive: boolean;
 }
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
 
 /**
  * Map of mapId -> Set of connected clients.
@@ -74,7 +82,10 @@ export async function registerWebSocket(app: FastifyInstance): Promise<void> {
         }
       }
 
-      const client: ConnectedClient = { ws, userId, userName };
+      const client: ConnectedClient = { ws, userId, userName, isAlive: true };
+      ws.on('pong', () => {
+        client.isAlive = true;
+      });
 
       // Join the room
       if (!rooms.has(mapId)) {
@@ -177,4 +188,34 @@ export async function registerWebSocket(app: FastifyInstance): Promise<void> {
       });
     },
   );
+
+  // Heartbeat sweeper. Without this, half-open TCP connections (browser
+  // tab killed, NAT dropped the flow, network changed) never fire `close`
+  // on the server side, and rooms accumulate ghost clients monotonically.
+  // Each broadcast then iterates every ghost and tries to write — wasted
+  // work that blocks the event loop. Observed in prod 2026-06-08:
+  // 511 connects vs 2 disconnects in 18 min → 256 ghosts in a single map.
+  //
+  // Pattern: mark dead → ping → next tick checks if pong arrived; if not,
+  // terminate (forces RST → `close` listener runs → room cleanup).
+  const sweeper = setInterval(() => {
+    for (const clients of rooms.values()) {
+      for (const client of clients) {
+        if (!client.isAlive) {
+          client.ws.terminate();
+          continue;
+        }
+        client.isAlive = false;
+        try {
+          client.ws.ping();
+        } catch {
+          client.ws.terminate();
+        }
+      }
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+
+  app.addHook('onClose', async () => {
+    clearInterval(sweeper);
+  });
 }


### PR DESCRIPTION
## Summary

WebSocket rooms accumulate ghost clients monotonically. Observed in prod 2026-06-08:

- **511 WS connects vs 2 disconnects** in 18 minutes on map `775a441c`
- Room reached **256 phantom clients** before manual restart
- Each broadcast iterates all 256 → event-loop pressure → contributes to chat SSE timeouts ("Connection to the AI was lost" red toasts)

Browser tabs that die uncleanly (NAT drop, network change, tab killed, machine sleep) never fire `close` server-side, so the room counter only ever grows until the next `systemctl restart`.

## Fix

Add a 30s ping/pong sweeper:

1. Tag each client with `isAlive`
2. `pong` listener flips it back to true
3. Sweeper loop: any client still `isAlive === false` from last tick gets `terminate()` (forces RST → existing `close` listener fires → proper room cleanup); the rest get a fresh `ping()` and have their `isAlive` reset to false
4. Tear the interval down on Fastify `onClose` so dev-restart doesn't leak

Pairs cleanly with the prod `WatchdogSec` bump (300s → 900s) — even if Anthropic takes 3 minutes per chat turn, the event loop isn't simultaneously fanning out to hundreds of dead sockets.

## Test plan

- [ ] Deploy to prod
- [ ] Open the map in a tab, confirm `[ws] Client connected` log
- [ ] Kill the tab (don't close cleanly — use task manager or browser process kill)
- [ ] Within 60s, confirm `[ws] Client disconnected` appears in the journal
- [ ] Open + close 10 tabs in quick succession; confirm room size returns to 0 within ~60s
- [ ] Verify no regression in cursor/presence broadcast (open two tabs, move mouse in one, see other tab's cursor update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)