### PR TITLE
fix(drift-audit): silence phantom 3am alarms

### DIFF
--- a/packages/server/src/sync/__tests__/driftAudit.test.ts
+++ b/packages/server/src/sync/__tests__/driftAudit.test.ts
@@ -359,8 +359,12 @@ describe('auditDrift', () => {
   });
 
   it('reports one map per opted-in target, not aggregated by repo', async () => {
-    // Two maps bound to the SAME repo, both opted in, with different
-    // linked nodes. We want one report each.
+    // Two maps bound to the SAME repo, both opted in. Each gets its
+    // own report row (no aggregation). Issues 3 and 4 are unlinked
+    // ANYWHERE in the system, so the global-scoped "linked" check flags
+    // them as drift for BOTH maps. Issues 1 and 2 are linked somewhere
+    // (mA and mB respectively) so do NOT count — matching backfill's
+    // `findNodesByExternalIds` skip rule.
     dbState.maps.push({
       id: 'mA',
       name: 'Map A',
@@ -379,15 +383,47 @@ describe('auditDrift', () => {
       githubRepoName: 'repo',
       autoImportNewIssues: true,
     });
-    setupRepoIssues('owner', 'repo', [1, 2, 3]);
-    linkNodeToIssue('mA', 'owner', 'repo', 1); // mA misses 2, 3
-    linkNodeToIssue('mB', 'owner', 'repo', 1);
-    linkNodeToIssue('mB', 'owner', 'repo', 2); // mB misses 3
+    setupRepoIssues('owner', 'repo', [1, 2, 3, 4]);
+    linkNodeToIssue('mA', 'owner', 'repo', 1);
+    linkNodeToIssue('mB', 'owner', 'repo', 2);
 
     const { reports } = await auditDrift();
     const byId = new Map(reports.map((r) => [r.mapId, r]));
     expect(byId.get('mA')?.onlyInGitHub).toBe(2);
-    expect(byId.get('mB')?.onlyInGitHub).toBe(1);
+    expect(byId.get('mA')?.exampleIssues).toEqual([3, 4]);
+    expect(byId.get('mB')?.onlyInGitHub).toBe(2);
+    expect(byId.get('mB')?.exampleIssues).toEqual([3, 4]);
+  });
+
+  it('issue linked in ANOTHER map does not count as drift here', async () => {
+    // Regression for the 3am phantom-drift alarm: an issue linked in
+    // any non-deleted node anywhere is treated as not-drift here, since
+    // `ensureNodeForIssue`'s skip rule would refuse to recreate it
+    // during auto-backfill. Pre-fix this test reported drift=1; backfill
+    // then logged "imported 0/1 (0 errored)" and pushed status=down.
+    dbState.maps.push({
+      id: 'mAudit',
+      name: 'Audit Target',
+      workspaceId: 'ws',
+      githubInstallationId: 'inst-1',
+      githubRepoOwner: 'owner',
+      githubRepoName: 'repo',
+      autoImportNewIssues: true,
+    });
+    dbState.maps.push({
+      id: 'mOther',
+      name: 'Other Map',
+      workspaceId: 'ws',
+      githubInstallationId: null,
+      githubRepoOwner: null,
+      githubRepoName: null,
+      autoImportNewIssues: false,
+    });
+    setupRepoIssues('owner', 'repo', [99]);
+    linkNodeToIssue('mOther', 'owner', 'repo', 99); // linked elsewhere
+
+    const { reports } = await auditDrift();
+    expect(reports).toEqual([]);
   });
 
   it('falls back to a PAT integration when the App token mint fails', async () => {

--- a/packages/server/src/sync/__tests__/kumaPush.test.ts
+++ b/packages/server/src/sync/__tests__/kumaPush.test.ts
@@ -10,13 +10,14 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { pushKumaHeartbeat } from '../kumaPush.js';
+import { pushKumaHeartbeat, _resetKumaSuppressionForTests } from '../kumaPush.js';
 
 describe('pushKumaHeartbeat', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    _resetKumaSuppressionForTests();
   });
 
   afterEach(() => {
@@ -102,6 +103,84 @@ describe('pushKumaHeartbeat', () => {
     await pushKumaHeartbeat('', 'up', 'msg', '[kuma-push] test');
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses repeated identical failures within a logTag', async () => {
+    // Kuma returning the same 404 on every tick (e.g. operator deleted
+    // the monitor on Kuma's side) used to spam one warn per tick, every
+    // 5 minutes, forever. The helper should warn once then go quiet
+    // until the signature changes.
+    const fetchMock = vi.fn(
+      async (_input: unknown, _init?: unknown) => ({ ok: false, status: 404 }) as Response,
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    for (let i = 0; i < 5; i += 1) {
+      await pushKumaHeartbeat(
+        'https://kuma.example/api/push/missing',
+        'up',
+        `tick ${i}`,
+        '[kuma-push] catchup',
+      );
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    // Only the first 404 logs; the next four are suppressed.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0].join(' ')).toContain('404');
+  });
+
+  it('logs a "recovered" line when a previously-failing push starts succeeding', async () => {
+    // First two ticks fail with 404, then Kuma comes back. We want a
+    // single recovery line in the journal so the operator knows the
+    // monitor is healthy again without grepping for missing warns.
+    const responses: Array<{ ok: boolean; status: number }> = [
+      { ok: false, status: 404 },
+      { ok: false, status: 404 },
+      { ok: true, status: 200 },
+      { ok: true, status: 200 },
+    ];
+    const fetchMock = vi.fn(async () => responses.shift() as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    for (let i = 0; i < 4; i += 1) {
+      await pushKumaHeartbeat(
+        'https://kuma.example/api/push/recovers',
+        'up',
+        `tick ${i}`,
+        '[kuma-push] catchup',
+      );
+    }
+
+    // 404 once, recovery once, ok ticks silent → 2 warns total.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0].join(' ')).toContain('404');
+    expect(warnSpy.mock.calls[1].join(' ')).toContain('recovered');
+  });
+
+  it('logs again when the failure signature changes (404 → 500)', async () => {
+    // Distinct failure modes shouldn't be silenced by a previous
+    // suppression for a different status code.
+    const responses: Array<{ ok: boolean; status: number }> = [
+      { ok: false, status: 404 },
+      { ok: false, status: 404 },
+      { ok: false, status: 500 },
+    ];
+    const fetchMock = vi.fn(async () => responses.shift() as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    for (let i = 0; i < 3; i += 1) {
+      await pushKumaHeartbeat(
+        'https://kuma.example/api/push/changing',
+        'up',
+        `tick ${i}`,
+        '[kuma-push] catchup',
+      );
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0].join(' ')).toContain('404');
+    expect(warnSpy.mock.calls[1].join(' ')).toContain('500');
   });
 
   it('URL-encodes special characters in the msg query param', async () => {

--- a/packages/server/src/sync/driftAudit.ts
+++ b/packages/server/src/sync/driftAudit.ts
@@ -188,10 +188,18 @@ async function resolveTargets(): Promise<ResolvedTargets> {
 
 /**
  * Audit drift for one target map: fetch open issues from GitHub,
- * cross-reference against linked nodes IN THAT MAP, count issues that
- * have no MindBlown node.
+ * cross-reference against linked nodes ANYWHERE in the system, count
+ * issues that have no MindBlown node at all.
  *
- * Returns null if the map is currently clean. Returns a DriftReport
+ * Why globally-scoped (not per-map): the actual ingest skip rule in
+ * `ensureNodeForIssue` → `findNodesByExternalIds` is globally-scoped
+ * — a backfill won't re-create a node for an issue already linked
+ * elsewhere. A per-map "linked" check here would flag drift that
+ * backfill can't heal, producing the "imported 0/N (0 errored)" loop
+ * that pushes `status=down` for phantom drift and pages the operator
+ * at 3am for nothing. Keep this aligned with backfill's reality.
+ *
+ * Returns null if no genuinely-missing issues. Returns a DriftReport
  * with `onlyInGitHub > 0` otherwise.
  */
 async function auditOneMap(t: AuditTarget): Promise<DriftReport | null> {
@@ -201,11 +209,13 @@ async function auditOneMap(t: AuditTarget): Promise<DriftReport | null> {
     includeAll: false,
   });
 
-  // Build externalId lookup from this map's nodes.
+  // Build externalId lookup from EVERY non-deleted node (not just this
+  // map). Matches the skip semantics in githubIngest.findNodesByExternalIds
+  // so audit + backfill agree on what counts as "linked".
   const mapNodes = await db
     .select({ externalLinks: nodes.externalLinks })
     .from(nodes)
-    .where(and(eq(nodes.mapId, t.mapId), notDeleted));
+    .where(notDeleted);
 
   const linkedExternalIds = new Set<string>();
   for (const n of mapNodes) {

--- a/packages/server/src/sync/kumaPush.ts
+++ b/packages/server/src/sync/kumaPush.ts
@@ -23,9 +23,42 @@ const KUMA_PUSH_TIMEOUT_MS = 5000;
 export type KumaStatus = 'up' | 'down';
 
 /**
+ * Per-`logTag` memo of the last failure signature we already warned
+ * about. Used to collapse repeating identical failures (e.g. Kuma
+ * returning `404` every 5 minutes because the operator deleted the
+ * monitor on Kuma's side) into a single warn line + a single recovery
+ * warn line when the failure clears.
+ *
+ * Keyed by `logTag` (which is unique per call site, e.g. catchup vs
+ * drift audit vs auth failure), so concurrent monitors don't suppress
+ * each other.
+ *
+ * Failure signatures:
+ *   - `http:<status>` for non-2xx responses
+ *   - `err:<message>` for thrown fetch/timeout errors
+ *   - `ok`            for the recovery transition
+ */
+const lastFailureByTag = new Map<string, string | null>();
+
+/**
+ * Reset the suppression memo. Production never calls this; the tests
+ * use it to start each case from a clean slate.
+ */
+export function _resetKumaSuppressionForTests(): void {
+  lastFailureByTag.clear();
+}
+
+/**
  * GET the Kuma push URL with status + msg query params. Errors (timeout,
- * non-2xx, network) are logged and swallowed — the caller's main flow
- * never fails because of a heartbeat hiccup.
+ * non-2xx, network) are swallowed — the caller's main flow never fails
+ * because of a heartbeat hiccup.
+ *
+ * Logging policy: warn the FIRST time a given failure signature is seen
+ * for a given `logTag`, then stay silent on every subsequent identical
+ * tick. When the signature changes (recovery to 2xx, or a new error
+ * kind), log once more. This keeps a misconfigured Kuma monitor from
+ * spamming the journal every 5 minutes while still surfacing real
+ * incidents.
  *
  * `logTag` is the prefix used in the warn log so multiple call sites are
  * easy to distinguish ("[kuma-push] catchup heartbeat" vs
@@ -49,15 +82,41 @@ export async function pushKumaHeartbeat(
   const sep = url.includes('?') ? '&' : '?';
   const fullUrl = `${url}${sep}status=${encodeURIComponent(status)}&msg=${encodeURIComponent(msg)}&ping=${Date.now()}`;
 
+  let signature: string;
+  let logLine: string | null = null;
+
   try {
     const res = await fetch(fullUrl, {
       method: 'GET',
       signal: AbortSignal.timeout(KUMA_PUSH_TIMEOUT_MS),
     });
     if (!res.ok) {
-      console.warn(`${logTag} HTTP ${res.status}`);
+      signature = `http:${res.status}`;
+      logLine = `${logTag} HTTP ${res.status}`;
+    } else {
+      signature = 'ok';
     }
   } catch (err) {
-    console.warn(`${logTag} failed:`, err instanceof Error ? err.message : err);
+    const msgStr = err instanceof Error ? err.message : String(err);
+    signature = `err:${msgStr}`;
+    logLine = `${logTag} failed: ${msgStr}`;
+  }
+
+  const prev = lastFailureByTag.get(logTag) ?? null;
+  if (signature === 'ok') {
+    // Recovery: warn once if we were previously in a failure state, then
+    // clear so the next failure (if any) logs immediately.
+    if (prev && prev !== 'ok') {
+      console.warn(`${logTag} recovered (was ${prev})`);
+    }
+    lastFailureByTag.set(logTag, 'ok');
+    return;
+  }
+
+  // Failure path. Log only when the signature changed (first occurrence
+  // or transition to a different failure mode).
+  if (signature !== prev) {
+    console.warn(logLine);
+    lastFailureByTag.set(logTag, signature);
   }
 }


### PR DESCRIPTION
## Summary

- Drift audit and auto-backfill disagreed on what "linked" meant: audit scoped per-map, backfill scoped globally. Result: issues linked in any other map were flagged as drift, then silently skipped by backfill (`imported 0/N (0 errored)`), pushing `status=down msg=manual-N` to Kuma and paging at 3:34 UTC for nothing. Align drift audit to backfill's global semantics.
- Reduce Kuma push log spam — when Kuma returns the same status every tick (e.g. operator deleted a monitor and the API now sees 404 every 5 min), warn once on the first occurrence and on each signature change, stay silent on identical repeats, and emit a single "recovered" line when it clears.

## Root cause

`packages/server/src/sync/driftAudit.ts` `auditOneMap` built `linkedExternalIds` from `nodes` filtered by `eq(nodes.mapId, t.mapId)`. `packages/server/src/sync/githubIngest.ts` `findNodesByExternalIds` (used by backfill and `ensureNodeForIssue`'s skip rule) does not filter by map. So drift audit could report drift that backfill structurally refuses to heal, producing the phantom-alarm loop.

## Test plan

- [x] `pnpm --filter @mindblown/server test src/sync/__tests__/driftAudit.test.ts src/sync/__tests__/kumaPush.test.ts` — 22 tests pass, including new regression: "issue linked in ANOTHER map does not count as drift here" and three Kuma-push log-suppression cases (first-warn, recovery, signature-change).
- [x] Full server suite — only pre-existing failures on master (triage-routes bulk-confirm 400 expectation), not introduced here.
- [ ] After merge + deploy: watch `journalctl -u mindblown-api | grep -E 'drift|kuma-push'` for one drift-audit cycle (runs daily at 03:34 UTC, can also be triggered via the manual endpoint) — expect `no-drift` push, no `manual-7` follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)