### PR TITLE
feat(github): sync GH issue labels onto node tags

### DIFF
--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -25,6 +25,7 @@ import {
   ensureInboxNode,
   ensureNodeForIssue,
   findNodesByExternalIds,
+  syncIssueLabelsToNodes,
 } from '../sync/githubIngest.js';
 import { triageIssue } from '../sync/triage.js';
 import { buildMapContext } from '../sync/mapContext.js';
@@ -1190,6 +1191,39 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     // doesn't discard the user's prior progress.
     const issuePayload = payload.issue as { number?: number; title?: string } | undefined;
     const payloadAction = payload.action as string | undefined;
+
+    // ── GH label → node tags sync ──────────────────────────────────
+    // Independent of the triage / state-sync logic below. Runs for any
+    // issue event (opened, reopened, edited, labeled, unlabeled, closed)
+    // and writes the current `issue.labels` onto matching nodes' `tags`
+    // as `gh-label:<name>` entries.
+    //
+    // Triage's `isMetadataOnlyEdit` short-circuit (below) skips
+    // label-only edits to avoid LLM cost, but downstream consumers
+    // (Kira dispatcher, future label-aware features) need labels to
+    // be queryable from the node state instead of polling GH. This
+    // sync gives them that without touching the triage path.
+    //
+    // Failures swallowed — the webhook still acknowledges. Catchup
+    // reconciler is the backstop.
+    if (
+      event === 'issues' &&
+      issuePayload?.number != null &&
+      repoFullName
+    ) {
+      const externalId = `${repoFullName}#${issuePayload.number}`;
+      const issue = payload.issue as GitHubIssue | undefined;
+      if (issue) {
+        try {
+          await syncIssueLabelsToNodes(externalId, issue.labels);
+        } catch (err) {
+          console.warn(
+            '[github-ingest] label sync failed:',
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+    }
 
     // ── Auto-ingest new GitHub issues into the map's Inbox ──────────
     // Runs before the close/reopen state-sync below so a `reopened`

--- a/packages/server/src/sync/__tests__/githubIngest.test.ts
+++ b/packages/server/src/sync/__tests__/githubIngest.test.ts
@@ -598,6 +598,8 @@ import {
   ingestNewIssuesForRepo,
   findIngestTargetMaps,
   findNodesByExternalIds,
+  ghLabelsToTagSlice,
+  mergeGhLabelsIntoTags,
 } from '../githubIngest.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────
@@ -1731,5 +1733,54 @@ describe('ensureNodeForIssue — triage cost-opt (#142)', () => {
     // so we should NOT see hash-match either — must be a real LLM call).
     expect(second.status).toBe('triaged_uncertain');
     expect(triageMockCalls.length).toBe(2);
+  });
+});
+
+describe('GH label → node tags sync', () => {
+  it('ghLabelsToTagSlice maps each label name to a gh-label:* tag', () => {
+    expect(ghLabelsToTagSlice([{ name: 'bug' }, { name: 'p1' }])).toEqual([
+      'gh-label:bug',
+      'gh-label:p1',
+    ]);
+  });
+
+  it('ghLabelsToTagSlice returns [] for undefined/empty input', () => {
+    expect(ghLabelsToTagSlice(undefined)).toEqual([]);
+    expect(ghLabelsToTagSlice([])).toEqual([]);
+  });
+
+  it('mergeGhLabelsIntoTags preserves user tags and replaces gh-label slice', () => {
+    const existing = ['user:dan', 'gh-label:old-label', 'priority:p2'];
+    const next = mergeGhLabelsIntoTags(existing, [
+      { name: 'new-label' },
+      { name: 'kira-skip' },
+    ]);
+    expect(next).toEqual([
+      'gh-label:kira-skip',
+      'gh-label:new-label',
+      'priority:p2',
+      'user:dan',
+    ]);
+  });
+
+  it('mergeGhLabelsIntoTags strips gh-label entries when GH labels go to []', () => {
+    const existing = ['user:dan', 'gh-label:was-there'];
+    const next = mergeGhLabelsIntoTags(existing, []);
+    expect(next).toEqual(['user:dan']);
+  });
+
+  it('mergeGhLabelsIntoTags handles undefined existingTags', () => {
+    expect(mergeGhLabelsIntoTags(undefined, [{ name: 'x' }])).toEqual([
+      'gh-label:x',
+    ]);
+  });
+
+  it('mergeGhLabelsIntoTags produces a sorted result for stable diffing', () => {
+    const next = mergeGhLabelsIntoTags(['z-user-tag'], [
+      { name: 'zeta' },
+      { name: 'alpha' },
+    ]);
+    // alphabetical: gh-label:alpha < gh-label:zeta < z-user-tag
+    expect(next).toEqual(['gh-label:alpha', 'gh-label:zeta', 'z-user-tag']);
   });
 });

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -397,6 +397,100 @@ function buildTriagedCreateInput(
     percentComplete: isClosed ? 100 : 0,
     status: isClosed ? 'done' : 'todo',
   };
+  // (tags are populated in the post-create updateNode call, since
+  // CreateNodeInput doesn't accept tags. See ensureNodeForIssue and
+  // the auto-place path.)
+}
+
+/**
+ * GH labels → `gh-label:<name>` entries in the `tags` array.
+ *
+ * The `tags` array is also used for user-set tags, so we namespace
+ * webhook-synced GH labels with a fixed prefix. Reading code (e.g.
+ * Kira's dispatch filter) filters by prefix and strips it.
+ *
+ * Idempotent: returns the same string list for the same input set.
+ */
+export function ghLabelsToTagSlice(
+  labels: Array<{ name: string }> | undefined,
+): string[] {
+  return (labels ?? []).map((l) => `gh-label:${l.name}`);
+}
+
+/**
+ * Merge GH-synced label tags into an existing tags array. User-set
+ * tags (no `gh-label:` prefix) are preserved; old gh-label entries
+ * are replaced with the current set. Result is sorted for stable
+ * diffing.
+ */
+export function mergeGhLabelsIntoTags(
+  existingTags: string[] | undefined,
+  ghLabels: Array<{ name: string }> | undefined,
+): string[] {
+  const userTags = (existingTags ?? []).filter(
+    (t) => !t.startsWith('gh-label:'),
+  );
+  const ghTags = ghLabelsToTagSlice(ghLabels);
+  return [...userTags, ...ghTags].sort();
+}
+
+/**
+ * Sync the GH issue's current labels onto every MindBlown node that links
+ * to this externalId, in every map. No-op when no node references the
+ * externalId. Used by the webhook handler so label changes (which the
+ * triage layer skips as cost-opt) still keep node tags fresh.
+ *
+ * Returns the number of nodes updated.
+ */
+export async function syncIssueLabelsToNodes(
+  externalId: string,
+  ghLabels: Array<{ name: string }> | undefined,
+): Promise<number> {
+  const matches = await findNodesByExternalIdAcrossMaps(externalId);
+  if (matches.length === 0) return 0;
+  let updated = 0;
+  for (const { id, tags } of matches) {
+    const nextTags = mergeGhLabelsIntoTags(tags, ghLabels);
+    // Cheap diff check — skip the write if nothing changed
+    const same =
+      nextTags.length === (tags?.length ?? 0) &&
+      nextTags.every((t, i) => t === (tags ?? [])[i]);
+    if (same) continue;
+    await nodeDb.updateNode(id, { tags: nextTags });
+    updated += 1;
+  }
+  return updated;
+}
+
+/**
+ * Sibling of findNodeInMapByExternalId that scans ALL maps for nodes
+ * referencing the given externalId. Used by the label-sync path which
+ * doesn't know which maps care about this issue.
+ */
+async function findNodesByExternalIdAcrossMaps(
+  externalId: string,
+): Promise<Array<{ id: string; mapId: string; tags: string[] }>> {
+  const rows = await db
+    .select({
+      id: nodes.id,
+      mapId: nodes.mapId,
+      tags: nodes.tags,
+      externalLinks: nodes.externalLinks,
+    })
+    .from(nodes)
+    .where(nodeDb.notDeleted);
+  const out: Array<{ id: string; mapId: string; tags: string[] }> = [];
+  for (const row of rows) {
+    const links = (row.externalLinks as ExternalLink[]) ?? [];
+    if (links.some((l) => l.provider === 'github' && l.externalId === externalId)) {
+      out.push({
+        id: row.id,
+        mapId: row.mapId as string,
+        tags: (row.tags as string[]) ?? [],
+      });
+    }
+  }
+  return out;
 }
 
 /**
@@ -840,6 +934,7 @@ async function ensureNodeForIssueViaTriage(
       {
         externalLinks: [link],
         description: issue.body ?? null,
+        tags: ghLabelsToTagSlice(issue.labels),
       },
       undefined,
       tx,
@@ -1106,6 +1201,7 @@ export async function ensureNodeForIssue(
       {
         externalLinks: [link],
         description: issue.body ?? null,
+        tags: ghLabelsToTagSlice(issue.labels),
       },
       undefined,
       tx,


### PR DESCRIPTION
Adds a label-sync path independent of the triage LLM cost-opt. Kira (Fulcrum CRM dispatcher) can stop polling GH for labels.

- `ghLabelsToTagSlice` / `mergeGhLabelsIntoTags` — pure helpers
- `syncIssueLabelsToNodes(externalId, labels)` — scans all maps, updates tags array  
- Webhook handler calls it for any issue event before existing dispatch logic
- Triage LLM cost-opt unchanged (label-only edits still short-circuit)
- New nodes get labels seeded via the post-create updateNode calls

6 new unit tests. Backfill script for existing nodes lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)