### PR TITLE
feat(mindmap): distribute leaf children radially around a parent

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMindmapStore, getWsClient } from './store.js';
-import { computeLayout, computeBounds } from './layout.js';
+import { computeLayout, computeBounds, distributeLeavesAroundParent } from './layout.js';
 import type { LayoutType } from './layout.js';
 import { MindmapNode } from './MindmapNode.js';
 import { Connector } from './Connector.js';
@@ -1757,6 +1757,61 @@ export function MindmapEditor() {
                 Deep refine subtree…
               </button>
             )}
+            {(() => {
+              const parent = nodes[contextMenu.nodeId];
+              if (!parent) return null;
+              const leafLikeCount = parent.childrenIds.reduce((acc, id) => {
+                const c = nodes[id];
+                if (!c) return acc;
+                return acc + ((c.childrenIds.length === 0 || c.collapsed) ? 1 : 0);
+              }, 0);
+              const manualLeaves = parent.childrenIds.some((id) => {
+                const c = nodes[id];
+                return c && (c.x != null || c.y != null);
+              });
+              return (
+                <>
+                  {leafLikeCount >= 2 && (
+                    <button
+                      style={ctxMenuItemStyle}
+                      onMouseEnter={(e) => (e.currentTarget.style.background = '#f1f5f9')}
+                      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                      onClick={() => {
+                        const updates = distributeLeavesAroundParent(
+                          contextMenu.nodeId,
+                          nodes,
+                          layoutMap,
+                        );
+                        for (const u of updates) {
+                          updateNode(u.id, { x: u.x, y: u.y });
+                        }
+                        setContextMenu(null);
+                      }}
+                    >
+                      Distribute leaves around node
+                    </button>
+                  )}
+                  {manualLeaves && (
+                    <button
+                      style={ctxMenuItemStyle}
+                      onMouseEnter={(e) => (e.currentTarget.style.background = '#f1f5f9')}
+                      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                      onClick={() => {
+                        for (const id of parent.childrenIds) {
+                          const c = nodes[id];
+                          if (c && (c.x != null || c.y != null)) {
+                            updateNode(id, { x: null, y: null });
+                          }
+                        }
+                        setContextMenu(null);
+                      }}
+                    >
+                      Reset children to auto-layout
+                    </button>
+                  )}
+                </>
+              );
+            })()}
             <div style={{ height: 1, background: '#e2e8f0', margin: '4px 0' }} />
             <button
               style={ctxMenuItemStyle}

--- a/packages/mindmap/src/layout.ts
+++ b/packages/mindmap/src/layout.ts
@@ -433,6 +433,69 @@ export function computeLayout(
 }
 
 /**
+ * Compute radial positions for the leaf-like children of a parent node,
+ * spread evenly around 360°. "Leaf-like" = child has no children OR is
+ * collapsed (so it's visually a single node). Non-leaf expanded children
+ * are skipped so their subtrees are left alone.
+ *
+ * Returns updates the caller can persist via updateNode. Returns [] when
+ * there's nothing useful to distribute.
+ */
+export function distributeLeavesAroundParent(
+  parentId: string,
+  nodes: Record<string, Node>,
+  layoutMap: Map<string, LayoutNode>,
+): Array<{ id: string; x: number; y: number }> {
+  const parent = nodes[parentId];
+  if (!parent) return [];
+  const parentLayout = layoutMap.get(parentId);
+  if (!parentLayout) return [];
+
+  const leafLayouts: LayoutNode[] = [];
+  for (const childId of parent.childrenIds) {
+    const child = nodes[childId];
+    if (!child) continue;
+    const isLeafLike = child.childrenIds.length === 0 || child.collapsed;
+    if (!isLeafLike) continue;
+    const ln = layoutMap.get(childId);
+    if (ln) leafLayouts.push(ln);
+  }
+  if (leafLayouts.length === 0) return [];
+
+  const maxLeafW = Math.max(...leafLayouts.map((l) => l.width));
+  const maxLeafH = Math.max(...leafLayouts.map((l) => l.height));
+  const N = leafLayouts.length;
+
+  const cx = parentLayout.x + parentLayout.width / 2;
+  const cy = parentLayout.y + parentLayout.height / 2;
+
+  // Radius must clear the parent and (for N≥2) give each chord enough room
+  // for one leaf bounding box plus a small gap.
+  const SPACING = 16;
+  const PARENT_GAP = 40;
+  const radiusForParent =
+    Math.max(parentLayout.width, parentLayout.height) / 2 +
+    Math.max(maxLeafW, maxLeafH) / 2 +
+    PARENT_GAP;
+  const minChord = Math.max(maxLeafW, maxLeafH) + SPACING;
+  const radiusForFit = N >= 2 ? minChord / (2 * Math.sin(Math.PI / N)) : 0;
+  const radius = Math.max(radiusForParent, radiusForFit);
+
+  // Start at the top (−π/2) and walk clockwise so the distribution is stable
+  // and visually predictable regardless of layout direction.
+  const startAngle = -Math.PI / 2;
+
+  return leafLayouts.map((ln, i) => {
+    const angle = startAngle + (i / N) * 2 * Math.PI;
+    return {
+      id: ln.id,
+      x: cx + radius * Math.cos(angle) - ln.width / 2,
+      y: cy + radius * Math.sin(angle) - ln.height / 2,
+    };
+  });
+}
+
+/**
  * Compute the bounding box of all layout nodes (for centering/fitting).
  */
 export function computeBounds(


### PR DESCRIPTION
## Summary
- Right-click a node with ≥2 leaf-like children → **Distribute leaves around node**. Places them evenly around 360° at a radius wide enough to clear the parent and avoid overlap, then persists manual `x`/`y` per child via `updateNode`.
- Right-click any node whose children carry manual positions → **Reset children to auto-layout** clears `x`/`y` back to `null`.
- "Leaf-like" = child has no children OR is collapsed, so expanded sibling subtrees are left untouched.

Motivated by leaf-heavy fan-outs that the column-wrap layout compresses tightly; this lets the user spread them around the parent to use the available whitespace.

## Test plan
- [ ] Right-click a node with many leaf children → menu shows "Distribute leaves around node"; clicking spreads them in a circle, parent stays put.
- [ ] Right-click again → "Reset children to auto-layout" appears; clicking snaps them back.
- [ ] Mixed parent (some leaf, some expanded-subtree children) → only leaves move; subtrees stay put.
- [ ] Collapsed children are treated as leaves and get distributed.
- [ ] Node with no leaf children → menu item not shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)