### PR TITLE
feat(api): GET /api/prs/open returns open-PR snapshots

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -29,6 +29,7 @@ import { feedbackRoutes } from './routes/feedback.js';
 import { apiKeyRoutes } from './routes/api-keys.js';
 import { mcpRoutes } from './routes/mcp.js';
 import { orchestrationRoutes } from './routes/orchestration.js';
+import { prRoutes } from './routes/prs.js';
 import { runStaleClaimSweep } from './sync/staleClaimSweeper.js';
 import { registerWebSocket } from './ws.js';
 
@@ -91,6 +92,7 @@ async function main(): Promise<void> {
   await app.register(apiKeyRoutes);
   await app.register(mcpRoutes);
   await app.register(orchestrationRoutes);
+  await app.register(prRoutes);
   await app.register(systemRoutes);
   await registerWebSocket(app);
 

--- a/packages/server/src/routes/prs.ts
+++ b/packages/server/src/routes/prs.ts
@@ -1,0 +1,77 @@
+/**
+ * Open-PRs read endpoint.
+ *
+ *   GET /api/prs/open?repo=<owner/name>
+ *
+ * Returns every node whose `linked_pr.state === 'open'` and (if `repo`
+ * filter is supplied) `linked_pr.repo === repo`.
+ *
+ * Designed for autonomous consumers (e.g. `bin/kira-review` on the CRM
+ * side) that previously polled the GitHub API for the same data. With
+ * webhook ingest of `pull_request.*` + `pull_request_review.submitted`
+ * + `check_suite.completed` writing `nodes.linked_pr`, MindBlown is
+ * now the canonical source for PR lifecycle state and this endpoint
+ * is the single read those consumers need per tick.
+ *
+ * Output shape (one element per node):
+ *   {
+ *     nodeId: string,
+ *     externalIds: string[],   // GH issue refs the node mirrors
+ *     linkedPr: LinkedPrState  // full snapshot incl. reviews/checks/files
+ *   }
+ *
+ * Auth: requires a session/API-key authenticated user (req.userId).
+ * The endpoint is read-only and returns no cross-user data because
+ * MindBlown is single-tenant for now.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { sql } from 'drizzle-orm';
+import { db } from '../db/connection.js';
+import { nodes } from '../db/schema.js';
+import type { LinkedPrState, ExternalLink } from '@mindblown/core';
+
+export async function prRoutes(app: FastifyInstance): Promise<void> {
+  app.get<{ Querystring: { repo?: string } }>(
+    '/api/prs/open',
+    async (req, reply) => {
+      if (!req.userId) {
+        return reply.status(401).send({
+          error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+        });
+      }
+
+      const repo = req.query.repo;
+
+      // Filter at the DB level — small index on linked_pr->>'state' would
+      // help if the node count grows large, but for current sizes a seq
+      // scan is fine (10s of thousands of rows total).
+      const rows = await db
+        .select({
+          id: nodes.id,
+          externalLinks: nodes.externalLinks,
+          linkedPr: nodes.linkedPr,
+        })
+        .from(nodes)
+        .where(sql`${nodes.linkedPr} IS NOT NULL AND ${nodes.linkedPr}->>'state' = 'open' AND ${nodes.deletedAt} IS NULL`);
+
+      const out = [];
+      for (const row of rows) {
+        const linkedPr = row.linkedPr as LinkedPrState | null;
+        if (!linkedPr) continue;
+        if (repo && linkedPr.repo !== repo) continue;
+        const links = (row.externalLinks as ExternalLink[]) ?? [];
+        const externalIds = links
+          .filter((l) => l.provider === 'github' && l.externalId)
+          .map((l) => l.externalId as string);
+        out.push({
+          nodeId: row.id,
+          externalIds,
+          linkedPr,
+        });
+      }
+
+      return reply.send({ prs: out });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/prs/open?repo=<owner/name>` returning every node whose `linked_pr.state = 'open'` (optionally filtered to one GH repo).
- Companion to the PR-state ingest from #168 — provides the single read that lets Kira's `kira-review` loop replace its per-tick GH polling with one MindBlown HTTP call.

## Output shape

```json
{
  "prs": [
    {
      "nodeId": "...",
      "externalIds": ["FulcrumCRM/crm#2297"],
      "linkedPr": {
        "number": 2354,
        "repo": "FulcrumCRM/crm",
        "state": "open",
        "mergeable": true,
        "draft": false,
        "head": "max/...",
        "base": "main",
        "author": "...",
        "reviews": [...],
        "checks": {"state": "...", "failures": [...]},
        "changedFiles": [...],
        "lastSyncedAt": "..."
      }
    }
  ]
}
```

## Test plan

- [x] Typecheck clean.
- [ ] Post-deploy: `curl -H "Authorization: Bearer $TOKEN" mind.project.li/api/prs/open?repo=FulcrumCRM/crm` returns PR #2354 (seeded by #168 test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)