### PR TITLE
feat(mindmap): recursive distribute-all-leaves-in-subtree

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMindmapStore, getWsClient } from './store.js';
-import { computeLayout, computeBounds, distributeLeavesAroundParent } from './layout.js';
+import {
+  computeLayout,
+  computeBounds,
+  distributeLeavesAroundParent,
+  distributeAllLeavesInSubtree,
+} from './layout.js';
 import type { LayoutType } from './layout.js';
 import { MindmapNode } from './MindmapNode.js';
 import { Connector } from './Connector.js';
@@ -1765,9 +1770,27 @@ export function MindmapEditor() {
                 if (!c) return acc;
                 return acc + ((c.childrenIds.length === 0 || c.collapsed) ? 1 : 0);
               }, 0);
-              const manualLeaves = parent.childrenIds.some((id) => {
+              const hasSubtree = parent.childrenIds.some((id) => {
                 const c = nodes[id];
-                return c && (c.x != null || c.y != null);
+                return Boolean(c) && c.childrenIds.length > 0;
+              });
+              // Walk subtree to see if any descendant carries a manual position.
+              const subtreeIds: string[] = [];
+              {
+                const stack = [contextMenu.nodeId];
+                const seen = new Set<string>();
+                while (stack.length > 0) {
+                  const id = stack.pop()!;
+                  if (seen.has(id)) continue;
+                  seen.add(id);
+                  subtreeIds.push(id);
+                  const n = nodes[id];
+                  if (n) for (const cid of n.childrenIds) stack.push(cid);
+                }
+              }
+              const manualInSubtree = subtreeIds.some((id) => {
+                const c = nodes[id];
+                return Boolean(c) && (c.x != null || c.y != null);
               });
               return (
                 <>
@@ -1791,13 +1814,33 @@ export function MindmapEditor() {
                       Distribute leaves around node
                     </button>
                   )}
-                  {manualLeaves && (
+                  {hasSubtree && (
                     <button
                       style={ctxMenuItemStyle}
                       onMouseEnter={(e) => (e.currentTarget.style.background = '#f1f5f9')}
                       onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                       onClick={() => {
-                        for (const id of parent.childrenIds) {
+                        const updates = distributeAllLeavesInSubtree(
+                          contextMenu.nodeId,
+                          nodes,
+                          layoutMap,
+                        );
+                        for (const u of updates) {
+                          updateNode(u.id, { x: u.x, y: u.y });
+                        }
+                        setContextMenu(null);
+                      }}
+                    >
+                      Distribute all leaves in subtree
+                    </button>
+                  )}
+                  {manualInSubtree && (
+                    <button
+                      style={ctxMenuItemStyle}
+                      onMouseEnter={(e) => (e.currentTarget.style.background = '#f1f5f9')}
+                      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                      onClick={() => {
+                        for (const id of subtreeIds) {
                           const c = nodes[id];
                           if (c && (c.x != null || c.y != null)) {
                             updateNode(id, { x: null, y: null });
@@ -1806,7 +1849,7 @@ export function MindmapEditor() {
                         setContextMenu(null);
                       }}
                     >
-                      Reset children to auto-layout
+                      Reset positions in subtree
                     </button>
                   )}
                 </>

--- a/packages/mindmap/src/layout.ts
+++ b/packages/mindmap/src/layout.ts
@@ -496,6 +496,32 @@ export function distributeLeavesAroundParent(
 }
 
 /**
+ * Walk the subtree rooted at `subtreeRoot` and apply
+ * distributeLeavesAroundParent at every node whose direct children include
+ * any leaf-like ones. Lets one click on a tree root fan out every leaf
+ * cluster in the subtree at once.
+ */
+export function distributeAllLeavesInSubtree(
+  subtreeRoot: string,
+  nodes: Record<string, Node>,
+  layoutMap: Map<string, LayoutNode>,
+): Array<{ id: string; x: number; y: number }> {
+  const updates: Array<{ id: string; x: number; y: number }> = [];
+  const stack: string[] = [subtreeRoot];
+  const seen = new Set<string>();
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const node = nodes[id];
+    if (!node) continue;
+    for (const childId of node.childrenIds) stack.push(childId);
+    updates.push(...distributeLeavesAroundParent(id, nodes, layoutMap));
+  }
+  return updates;
+}
+
+/**
  * Compute the bounding box of all layout nodes (for centering/fitting).
  */
 export function computeBounds(


### PR DESCRIPTION
## Summary
Builds on #167. Right-click any node with descendants and pick **Distribute all leaves in subtree** to walk the whole subtree, applying the per-parent radial distribution at every leaf-parent in one click. Lets users fix compressed leaves from the root without descending into each subtree.

Also consolidates "Reset children to auto-layout" → **Reset positions in subtree**: clears manual x/y on every descendant (including the clicked node), so one click undoes a recursive distribute. Shown whenever any descendant carries a manual position.

## Test plan
- [ ] Right-click a deep root (e.g. Fulcrum CRM): "Distribute all leaves in subtree" appears, "Distribute leaves around node" does not (root has no direct leaves).
- [ ] Click it → every leaf cluster fans out radially around its parent; non-leaf siblings stay put.
- [ ] Right-click again → "Reset positions in subtree" appears; clicking it snaps everything back.
- [ ] Right-click a single leaf-parent: both "Distribute leaves around node" and "Distribute all leaves in subtree" appear (the latter is a no-op safety net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)