### PR TITLE
fix(mindmap): treat depth-limited nodes as leaf-like for distribution

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -1765,15 +1765,16 @@ export function MindmapEditor() {
             {(() => {
               const parent = nodes[contextMenu.nodeId];
               if (!parent) return null;
+              // "Visually leaf-like" mirrors distributeLeavesAroundParent:
+              // a child the user sees as a leaf, whether by data, collapse,
+              // or depth-limit hiding.
               const leafLikeCount = parent.childrenIds.reduce((acc, id) => {
                 const c = nodes[id];
-                if (!c) return acc;
-                return acc + ((c.childrenIds.length === 0 || c.collapsed) ? 1 : 0);
+                if (!c || !layoutMap.has(id)) return acc;
+                const hasVisibleChildren = c.childrenIds.some((cid) => layoutMap.has(cid));
+                return acc + (hasVisibleChildren ? 0 : 1);
               }, 0);
-              const hasSubtree = parent.childrenIds.some((id) => {
-                const c = nodes[id];
-                return Boolean(c) && c.childrenIds.length > 0;
-              });
+              const hasSubtree = parent.childrenIds.length > 0;
               // Walk subtree to see if any descendant carries a manual position.
               const subtreeIds: string[] = [];
               {

--- a/packages/mindmap/src/layout.ts
+++ b/packages/mindmap/src/layout.ts
@@ -455,10 +455,14 @@ export function distributeLeavesAroundParent(
   for (const childId of parent.childrenIds) {
     const child = nodes[childId];
     if (!child) continue;
-    const isLeafLike = child.childrenIds.length === 0 || child.collapsed;
-    if (!isLeafLike) continue;
     const ln = layoutMap.get(childId);
-    if (ln) leafLayouts.push(ln);
+    if (!ln) continue; // child isn't visible; nothing to position
+    // "Visually leaf-like" = no visible descendants. Covers true leaves,
+    // collapsed nodes, and depth-limited nodes (data children exist but
+    // none are laid out).
+    const hasVisibleChildren = child.childrenIds.some((id) => layoutMap.has(id));
+    if (hasVisibleChildren) continue;
+    leafLayouts.push(ln);
   }
   if (leafLayouts.length === 0) return [];
 


### PR DESCRIPTION
## Summary
Follow-up to #167 / #171. The recursive "Distribute all leaves in subtree" did nothing on large maps because `distributeLeavesAroundParent` checked **data-level** leaf-ness (`childrenIds.length === 0 || collapsed`), silently skipping depth-limited nodes — they have children in data but none rendered, so the user sees them as leaves but the code didn't.

New rule: a child is leaf-like for distribution iff it's **visible** AND **none of its children are visible**. Covers true leaves, collapsed nodes, and depth-limit-hidden subtrees uniformly.

Also widens the recursive menu gate so it appears whenever the right-clicked node has any children (the per-parent gate still requires ≥2 visible leaves).

## Test plan
- [ ] Open a map where rendering is depth-limited (some nodes show `+N ▶` badges for hidden descendants).
- [ ] Right-click the root → "Distribute all leaves in subtree" appears and now actually fans out leaf clusters at every visible leaf-parent.
- [ ] Right-click a parent of `+N`-badged nodes → "Distribute leaves around node" appears (was hidden before because the data-level check thought they weren't leaves).
- [ ] Reset still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)