### PR TITLE
fix(pr-sync): wire pull_request.closed → handlePrClosed clears linkedPr

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -1765,15 +1765,16 @@ export function MindmapEditor() {
             {(() => {
               const parent = nodes[contextMenu.nodeId];
               if (!parent) return null;
+              // "Visually leaf-like" mirrors distributeLeavesAroundParent:
+              // a child the user sees as a leaf, whether by data, collapse,
+              // or depth-limit hiding.
               const leafLikeCount = parent.childrenIds.reduce((acc, id) => {
                 const c = nodes[id];
-                if (!c) return acc;
-                return acc + ((c.childrenIds.length === 0 || c.collapsed) ? 1 : 0);
+                if (!c || !layoutMap.has(id)) return acc;
+                const hasVisibleChildren = c.childrenIds.some((cid) => layoutMap.has(cid));
+                return acc + (hasVisibleChildren ? 0 : 1);
               }, 0);
-              const hasSubtree = parent.childrenIds.some((id) => {
-                const c = nodes[id];
-                return Boolean(c) && c.childrenIds.length > 0;
-              });
+              const hasSubtree = parent.childrenIds.length > 0;
               // Walk subtree to see if any descendant carries a manual position.
               const subtreeIds: string[] = [];
               {

--- a/packages/mindmap/src/layout.ts
+++ b/packages/mindmap/src/layout.ts
@@ -455,10 +455,14 @@ export function distributeLeavesAroundParent(
   for (const childId of parent.childrenIds) {
     const child = nodes[childId];
     if (!child) continue;
-    const isLeafLike = child.childrenIds.length === 0 || child.collapsed;
-    if (!isLeafLike) continue;
     const ln = layoutMap.get(childId);
-    if (ln) leafLayouts.push(ln);
+    if (!ln) continue; // child isn't visible; nothing to position
+    // "Visually leaf-like" = no visible descendants. Covers true leaves,
+    // collapsed nodes, and depth-limited nodes (data children exist but
+    // none are laid out).
+    const hasVisibleChildren = child.childrenIds.some((id) => layoutMap.has(id));
+    if (hasVisibleChildren) continue;
+    leafLayouts.push(ln);
   }
   if (leafLayouts.length === 0) return [];
 

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -1620,6 +1620,29 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       }
     }
 
+    // ── pull_request.closed → clear/close linkedPr ───────────────────
+    // Companion to the snapshot/review/check_suite handlers above.
+    // Without this, merged PRs stay in `nodes.linked_pr` with state='open'
+    // forever and the /api/prs/open endpoint keeps reporting them, which
+    // makes Kira repeatedly try to admin-merge an already-merged PR.
+    if (
+      event === 'pull_request' &&
+      payloadAction === 'closed' &&
+      repoFullName
+    ) {
+      try {
+        const pr = payload.pull_request as PrSync.GhPrPayload | undefined;
+        if (pr) {
+          await PrSync.handlePrClosed(repoFullName, pr);
+        }
+      } catch (err) {
+        console.warn(
+          '[pr-sync] handlePrClosed failed:',
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
     // ── pull_request: closed + merged=true → transition linked nodes ─
     //
     // #152 — when a PR merges with `Closes #N` references in title or


### PR DESCRIPTION
Without this, merged PRs stay in linkedPr forever and Kira keeps trying to merge them every tick (observed live with #2345 after auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)