### PR TITLE
fix(tools): flag missing effort estimate on create_node and import_github_issues

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2140,6 +2140,12 @@ server.tool(
       }
       if (result.nodes.length > 0) {
         lines.push(`\n${result.nodes.length} nodes created (grouped by functional area).`);
+        // GitHub issues never carry effort estimates, so every newly created
+        // node is unestimated. Surface this so the planner sizes them before
+        // forecasts and "ready node" picks under-count.
+        lines.push(
+          `${result.nodes.length} created node(s) have no effort estimate — use bulk_set_estimate (or set_estimate per node) to size them.`,
+        );
       }
       lines.push('\nAll newly created and newly linked nodes will receive webhook updates.');
       return toolResult(lines.join('\n'));

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -171,6 +171,31 @@ describe('create_node tool', () => {
     } as never);
     expect(recorder.lastCreate?.fields).toMatchObject({ autoProgress: 'children' });
   });
+
+  // Bug 2bee313d — created nodes without an estimate were silently
+  // shipped as unestimated leaves, breaking forecasts and ready-node
+  // picks. The handler must flag missing estimates back to the caller.
+  it('flags missing estimate when none is provided', async () => {
+    const recorder = makeRecordingBackend();
+    const out = await createNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'unsized task',
+    } as never);
+    expect(out).toMatch(/no effort estimate set/i);
+    expect(out).toMatch(/set_estimate/);
+  });
+
+  it('does not flag when an estimate is provided', async () => {
+    const recorder = makeRecordingBackend();
+    const out = await createNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'sized task',
+      effortEstimate: 4,
+    } as never);
+    expect(out).not.toMatch(/no effort estimate set/i);
+  });
 });
 
 // ── Soft-delete / restore (#107) ────────────────────────────────

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -35,7 +35,13 @@ export const createNodeTool = defineTool({
       if (v !== undefined) cleanFields[k] = v;
     }
     const node = await backend.createNode(mapId, parentId, text, cleanFields);
-    return `Created node "${text}" (id: ${node.id}) under parent ${parentId}`;
+    const base = `Created node "${text}" (id: ${node.id}) under parent ${parentId}`;
+    // Flag missing estimate so agents/users don't forget to size new work —
+    // unestimated leaves under-count forecasts and "ready node" picks.
+    if (fields.effortEstimate == null) {
+      return `${base}. No effort estimate set — call set_estimate (or update_node with effortEstimate) once the size is known.`;
+    }
+    return base;
   },
 });
 


### PR DESCRIPTION
## Summary
- `create_node` now appends a flag to the success message when no `effortEstimate` was provided, pointing the caller at `set_estimate` / `update_node`.
- `import_github_issues` appends a one-liner with the count of imported nodes that have no estimate (every imported GH issue is unestimated — issues don't carry effort).

Why: unestimated leaves silently under-count forecasts and \"ready node\" picks (`computedEffort` treats them as 0). The new flag nudges planners/agents to size new work before it skews planning math.

Closes the open MindBlown map bug (node `2bee313d-301f-4cf4-8636-c339bf42dfdd` — \"GitHub import / create_node should flag missing estimate\").

## Test plan
- [x] `pnpm --filter @mindblown/tool-kit test` — 50 tests pass (2 new for create_node)
- [x] `pnpm turbo typecheck --filter=@mindblown/tool-kit --filter=@mindblown/mcp` clean
- [ ] Spot-check `create_node` (with + without estimate) and `import_github_issues` once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)