### PR TITLE
fix(ai): close the chat-provider race that 502'd ai_estimate

### DIFF
--- a/packages/server/src/ai/__tests__/aiSlot.test.ts
+++ b/packages/server/src/ai/__tests__/aiSlot.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Bug 4b82ef4f — ai_estimate 502s under parallel Ollama load.
+ *
+ * commit 0401941 added a chatCompletion/embed semaphore (AI_MAX_CONCURRENCY,
+ * default 1) so concurrent JSON-mode calls queue instead of fanning out onto
+ * Ollama's single inference slot. But the conversational chat path
+ * (`ollamaProvider.runTurn`) called `client.chat.completions.create`
+ * directly and bypassed the slot — so a chat turn racing an ai_estimate
+ * still 502'd. These tests pin the slot to both call paths.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { withAiSlot } from '../client.js';
+
+describe('withAiSlot', () => {
+  it('serializes concurrent acquirers (default AI_MAX_CONCURRENCY=1)', async () => {
+    // Track maximum concurrent in-flight callers — if the slot works it
+    // never exceeds 1 (the default cap).
+    let inFlight = 0;
+    let peak = 0;
+
+    const work = (label: string) =>
+      withAiSlot(async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        // Yield to the event loop a few times so siblings get a real
+        // chance to interleave if the slot weren't enforced.
+        await new Promise((r) => setImmediate(r));
+        await new Promise((r) => setImmediate(r));
+        inFlight -= 1;
+        return label;
+      });
+
+    const results = await Promise.all([work('a'), work('b'), work('c'), work('d')]);
+
+    expect(results).toEqual(['a', 'b', 'c', 'd']);
+    expect(peak).toBe(1);
+  });
+
+  it('releases the slot when the wrapped fn throws', async () => {
+    // If release() weren't in finally, a thrown task would leak the slot
+    // and subsequent acquirers would hang forever.
+    await expect(
+      withAiSlot(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    // This second call must complete — proves the slot was released.
+    const out = await withAiSlot(async () => 'ok');
+    expect(out).toBe('ok');
+  });
+});

--- a/packages/server/src/ai/client.ts
+++ b/packages/server/src/ai/client.ts
@@ -53,7 +53,7 @@ function release(): void {
   if (next) next();
 }
 
-async function withAiSlot<T>(fn: () => Promise<T>): Promise<T> {
+export async function withAiSlot<T>(fn: () => Promise<T>): Promise<T> {
   await acquire();
   try {
     return await fn();

--- a/packages/server/src/ai/providers/ollama.ts
+++ b/packages/server/src/ai/providers/ollama.ts
@@ -9,7 +9,7 @@
 import type OpenAI from 'openai';
 import type { ToolSpec } from '@mindblown/tool-kit';
 import { specToOpenAiTool } from '@mindblown/tool-kit';
-import { getClient } from '../client.js';
+import { getClient, withAiSlot } from '../client.js';
 import type {
   ChatProvider,
   NormalizedMessage,
@@ -71,15 +71,20 @@ export const ollamaProvider: ChatProvider = {
       (s: ToolSpec) => specToOpenAiTool(s) as unknown as OpenAI.ChatCompletionTool,
     );
 
-    const response = await client.chat.completions.create(
-      {
-        model: AI_MODEL,
-        messages: toOpenAiMessages(opts.systemPrompt, opts.messages),
-        tools,
-        temperature: 0.3,
-        max_tokens: opts.maxTokens ?? 2048,
-      },
-      opts.signal ? { signal: opts.signal } : undefined,
+    // Share the chatCompletion/embed slot so chat-panel turns can't race
+    // ai_estimate (or each other) onto Ollama's single inference slot —
+    // that race was the source of the 502s the queue was supposed to fix.
+    const response = await withAiSlot(() =>
+      client.chat.completions.create(
+        {
+          model: AI_MODEL,
+          messages: toOpenAiMessages(opts.systemPrompt, opts.messages),
+          tools,
+          temperature: 0.3,
+          max_tokens: opts.maxTokens ?? 2048,
+        },
+        opts.signal ? { signal: opts.signal } : undefined,
+      ),
     );
 
     const choice = response.choices[0];


### PR DESCRIPTION
## Summary
The semaphore added in 0401941 only governed \`chatCompletion\` and \`embed\`. The conversational chat path (\`ollamaProvider.runTurn\`) called \`client.chat.completions.create\` directly, so a chat turn could race \`ai_estimate\` onto Ollama's single inference slot — exactly the 502 condition the queue was supposed to fix.

- Export \`withAiSlot\` from \`packages/server/src/ai/client.ts\` so both call paths can share it.
- Wrap the Ollama provider's chat completion in \`withAiSlot\` so every entry into Ollama from this process serializes on \`AI_MAX_CONCURRENCY\` (default 1).
- Add a unit test for the semaphore — concurrent acquirers serialize, and the slot is released on throw.

Closes the open MindBlown map bug (node \`4b82ef4f-810f-4814-ad6e-7ac75ef0810e\` — \"ai_estimate: 502s under parallel load, no queueing on Ollama backend\", P0).

## Test plan
- [x] \`pnpm --filter @mindblown/server test -- aiSlot\` passes (2 new tests)
- [ ] Spot-check: drive ai_estimate + a chat turn at the same time once deployed; both should complete without 502 (verify by checking the new queueing path with \`AI_MAX_CONCURRENCY=1\`)

Note: master has a pre-existing typecheck error in \`maps-triage-flags.test.ts\` (TS2556) unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)