### PR TITLE
fix(test): type vi.fn mocks so spread args satisfy tsc

### DIFF
--- a/packages/server/src/routes/__tests__/maps-triage-flags.test.ts
+++ b/packages/server/src/routes/__tests__/maps-triage-flags.test.ts
@@ -20,7 +20,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 
 const updateMapMock = vi.fn();
 const getMapMock = vi.fn();
-const listMapsForUserMock = vi.fn(async () => []);
+const listMapsForUserMock = vi.fn<(...args: unknown[]) => Promise<unknown[]>>(async () => []);
 const createBaselineMock = vi.fn();
 const deleteMapMock = vi.fn();
 const createMapMock = vi.fn();
@@ -34,7 +34,7 @@ vi.mock('../../db/maps.js', () => ({
   createMap: (...args: unknown[]) => createMapMock(...args),
 }));
 
-const getPermissionMock = vi.fn(async () => 'edit' as 'view' | 'edit' | 'admin' | null);
+const getPermissionMock = vi.fn<(...args: unknown[]) => Promise<'view' | 'edit' | 'admin' | null>>(async () => 'edit');
 vi.mock('../../db/permissions.js', () => ({
   getPermission: (...args: unknown[]) => getPermissionMock(...args),
   hasPermission: (actual: string | null, required: string) => {


### PR DESCRIPTION
## Summary
\`vi.fn(async () => [])\` infers a strict \`() => Promise<never[]>\` signature, so the \`(...args: unknown[]) => mock(...args)\` wrappers tripped TS2556 at typecheck (the spread didn't match the no-arg signature). Annotate the generic on both mocks so the spread is accepted.

This was pre-existing on master — surfaced while typechecking during the ai-slot bug fix. Runtime behaviour is unchanged.

## Test plan
- [x] \`pnpm turbo typecheck --filter=@mindblown/server\` clean
- [x] \`pnpm --filter @mindblown/server test -- maps-triage-flags\` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)