### PR TITLE
fix(triage): triage:placed requires placed_node_id; backfill heals the rest (#139, #178)

### DIFF
--- a/packages/server/src/routes/__tests__/triage-reopen.test.ts
+++ b/packages/server/src/routes/__tests__/triage-reopen.test.ts
@@ -452,6 +452,10 @@ describe('syncTriageRowsForReopen', () => {
       mapId: 'm1',
       externalId: 'o/r#42',
       decision: 'skip',
+      // #178: re-triage flipped place→skip, so reopenNewParent is
+      // null. Skip-decisions don't care about placedNodeId for the
+      // label-add gate, but the call still passes it for consistency.
+      placedNodeId: null,
     });
   });
 

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -357,6 +357,7 @@ export async function syncTriageRowsForReopen(
         mapId: row.mapId,
         externalId,
         decision: decision.decision,
+        placedNodeId: reopenNewParent,
       });
     } catch (err) {
       console.warn(

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -1061,6 +1061,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           mapId: req.params.mapId,
           externalId,
           decision: 'place',
+          placedNodeId: result.node?.id ?? null,
         });
         broadcastTriageUpdated(req.params.mapId, 'overridden', [result.decisionId]);
       }
@@ -1195,6 +1196,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           mapId: req.params.mapId,
           externalId,
           decision: 'skip',
+          placedNodeId: null,
         });
         broadcastTriageUpdated(req.params.mapId, 'overridden', [insertedId]);
       }
@@ -1348,6 +1350,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         mapId: req.params.mapId,
         externalId: row.externalId,
         decision: row.decision as 'place' | 'skip' | 'uncertain',
+        placedNodeId: row.placedNodeId ?? null,
       });
 
       // Phase 3 follow-up (#102 item 7): notify connected clients.
@@ -1544,6 +1547,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           mapId: req.params.mapId,
           externalId: row.externalId,
           decision: 'place',
+          placedNodeId,
         });
 
         // Phase 3 follow-up (#102 item 7): notify connected clients.
@@ -1670,6 +1674,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
         mapId: req.params.mapId,
         externalId: row.externalId,
         decision,
+        placedNodeId: decision === 'place' ? (createdNodeId ?? null) : null,
       });
 
       // Phase 3 follow-up (#102 item 7): notify connected clients.
@@ -1849,11 +1854,14 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       // the new decision is auto and intermediate. We still write the
       // label (the spec calls out reclassify-to-skip should flip the
       // label) — uncertain decisions are silently no-op'd inside
-      // applyTriageLabel.
+      // applyTriageLabel. `newParent` is null when reclassify cleared
+      // placedNodeId or the new decision isn't place — so the place
+      // gate inside the helper correctly suppresses a stale add.
       await applyTriageLabel({
         mapId: req.params.mapId,
         externalId: row.externalId,
         decision: decision.decision,
+        placedNodeId: newParent,
       });
 
       // Phase 3 follow-up (#102 item 7): notify connected clients.
@@ -2068,6 +2076,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
               mapId: req.params.mapId,
               externalId: row.externalId,
               decision: row.decision as 'place' | 'skip' | 'uncertain',
+              placedNodeId: row.placedNodeId ?? null,
             }),
           );
           results.push({
@@ -2298,6 +2307,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
                 mapId: req.params.mapId,
                 externalId: row.externalId,
                 decision: 'place',
+                placedNodeId,
               }),
             );
             nodeId = placedNodeId;
@@ -2373,6 +2383,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
                 mapId: req.params.mapId,
                 externalId: row.externalId,
                 decision: 'place',
+                placedNodeId: nodeId,
               }),
             );
           }
@@ -2535,6 +2546,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
               mapId: req.params.mapId,
               externalId: row.externalId,
               decision: decision.decision,
+              placedNodeId: clearPlacedNode ? null : (row.placedNodeId ?? null),
             }),
           );
           results.push({

--- a/packages/server/src/scripts/backfill-suggested-parent.ts
+++ b/packages/server/src/scripts/backfill-suggested-parent.ts
@@ -51,6 +51,8 @@ import { db, pool } from '../db/connection.js';
 import { maps, triageDecisions } from '../db/schema.js';
 import { buildMapContext } from '../sync/mapContext.js';
 import { triageIssue } from '../sync/triage.js';
+import { recordTriageHistory } from '../sync/triageHistory.js';
+import { applyTriageLabel } from '../sync/triageLabelWriteback.js';
 
 function parseIssueNumber(externalId: string): number {
   const idx = externalId.lastIndexOf('#');
@@ -73,6 +75,12 @@ interface BackfillRow {
   externalId: string;
   issueTitle: string;
   issueState: string;
+  // Previous decision body — captured so the full-refresh write (which
+  // matches /reclassify semantics) can also feed `recordTriageHistory`
+  // with accurate previous-state values.
+  previousDecision: string;
+  previousConfidence: number | null;
+  previousSuggestedParentNodeId: string | null;
 }
 
 async function main(): Promise<void> {
@@ -107,6 +115,9 @@ async function main(): Promise<void> {
       externalId: triageDecisions.externalId,
       issueTitle: triageDecisions.issueTitle,
       issueState: triageDecisions.issueState,
+      previousDecision: triageDecisions.decision,
+      previousConfidence: triageDecisions.confidence,
+      previousSuggestedParentNodeId: triageDecisions.suggestedParentNodeId,
     })
     .from(triageDecisions)
     .where(and(...filters));
@@ -183,35 +194,75 @@ async function main(): Promise<void> {
           mapContext,
         });
 
-        // Always write the new suggestion (null on skip/uncertain),
-        // because the row is by definition a stale low-confidence
-        // place — if the new LLM call decides skip, we want the
-        // suggestion column to reflect that. We do NOT rewrite
-        // `decision` / `confidence` / `placedNodeId` here, because
-        // this is a column-backfill, not a reclassify. The operator's
-        // review queue still shows the original auto-decision; the
-        // only thing that changes is the badge surfaces a usable
-        // pre-selection.
+        // #139 fix: write back the FULL new triage result so the row
+        // can't end up internally inconsistent (decision='place' from
+        // the original auto-call, but suggested_parent_node_id=null
+        // because the fresh LLM said skip/uncertain). Mirrors the
+        // /reclassify route's row-refresh semantics — see triage.ts.
+        //
+        // Bonus rule from the ticket: backfill MUST NOT auto-place.
+        // The script filter only selects rows with placedNodeId=null,
+        // and we never write a new placedNodeId here — even when the
+        // fresh decision crosses the auto-apply threshold. Auto-apply
+        // belongs to the ingest path; backfill always leaves the row
+        // pending for operator review.
         const newSuggestedParentNodeId =
           decision.decision === 'place' ? (decision.parentNodeId ?? null) : null;
 
         await db
           .update(triageDecisions)
-          .set({ suggestedParentNodeId: newSuggestedParentNodeId })
+          .set({
+            decision: decision.decision,
+            reason: decision.reason,
+            confidence: decision.confidence,
+            suggestedParentNodeId: newSuggestedParentNodeId,
+            decidedBy: 'auto',
+            decidedAt: new Date(),
+            reviewed: false,
+            reviewedAt: null,
+            reviewedBy: null,
+            lastInputHash: null,
+          })
           .where(eq(triageDecisions.id, row.id));
 
-        if (newSuggestedParentNodeId) {
+        // Audit trail — backfill is an LLM-driven row mutation, same
+        // category as /reclassify (changedBy='auto', type='reclassified').
+        await recordTriageHistory({
+          decisionId: row.id,
+          changedBy: 'auto',
+          changeType: 'reclassified',
+          previousDecision: row.previousDecision,
+          newDecision: decision.decision,
+          previousConfidence: row.previousConfidence,
+          newConfidence: decision.confidence,
+          previousParentNodeId: row.previousSuggestedParentNodeId,
+          newParentNodeId: newSuggestedParentNodeId,
+          reason: decision.reason,
+        });
+
+        // #178: re-fire the GH label writeback. Backfill never places
+        // a node, so placedNodeId is always null — the helper's gate
+        // will skip the `triage:placed` add for a fresh 'place'
+        // decision and still remove the inverse, healing rows like
+        // #117 and #110 that were labelled as placed without an
+        // actual node landing.
+        await applyTriageLabel({
+          mapId: row.mapId,
+          externalId: row.externalId,
+          decision: decision.decision,
+          placedNodeId: null,
+        });
+
+        if (decision.decision === 'place' && newSuggestedParentNodeId) {
           console.log(
-            `[backfill]   ${row.externalId}: suggested ${newSuggestedParentNodeId}`,
+            `[backfill]   ${row.externalId}: place → suggested ${newSuggestedParentNodeId} (conf ${decision.confidence})`,
           );
-          updated++;
         } else {
           console.log(
-            `[backfill]   ${row.externalId}: new decision is ${decision.decision}, no parent suggestion`,
+            `[backfill]   ${row.externalId}: ${row.previousDecision} → ${decision.decision} (conf ${decision.confidence}, no suggestion)`,
           );
-          // Still counts as updated — we wrote NULL deliberately.
-          updated++;
         }
+        updated++;
       } catch (err) {
         console.error(
           `[backfill] ${row.externalId}: failed —`,

--- a/packages/server/src/sync/__tests__/triage-label-writeback.test.ts
+++ b/packages/server/src/sync/__tests__/triage-label-writeback.test.ts
@@ -118,6 +118,7 @@ describe('applyTriageLabel — gated off', () => {
       mapId: 'm1',
       externalId: 'octocat/demo#42',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: shim.impl,
     });
     expect(shim.calls).toHaveLength(0);
@@ -143,6 +144,7 @@ describe('applyTriageLabel — gated off', () => {
       mapId: 'm1',
       externalId: 'octocat/demo#42',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: shim.impl,
     });
     expect(shim.calls).toHaveLength(0);
@@ -155,6 +157,7 @@ describe('applyTriageLabel — gated off', () => {
       mapId: 'm1',
       externalId: 'not-an-external-id',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: shim.impl,
     });
     expect(shim.calls).toHaveLength(0);
@@ -168,9 +171,68 @@ describe('applyTriageLabel — gated off', () => {
       mapId: 'm1',
       externalId: 'octocat/demo#42',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: shim.impl,
     });
     expect(shim.calls).toHaveLength(0);
+  });
+});
+
+// ── #178: place-without-placement gate ───────────────────────────
+
+describe('applyTriageLabel — #178 place gate', () => {
+  it("decision='place' with placedNodeId=null → DELETEs inverse but does NOT POST triage:placed", async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels/triage', method: 'DELETE', status: 200 },
+    ]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'place',
+      placedNodeId: null,
+      fetchImpl: shim.impl,
+    });
+    // No POST — only the inverse-label DELETE fires (1 call total).
+    expect(shim.calls).toHaveLength(1);
+    expect(shim.calls[0].method).toBe('DELETE');
+    expect(shim.calls[0].url).toContain(
+      `/repos/octocat/demo/issues/42/labels/${encodeURIComponent('triage:skipped')}`,
+    );
+  });
+
+  it("decision='place' with placedNodeId omitted → same gate (defensive)", async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels/triage', method: 'DELETE', status: 200 },
+    ]);
+    // placedNodeId intentionally omitted — proves the helper doesn't
+    // post when the caller forgot to thread the field through.
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'place',
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+  });
+
+  it("decision='skip' with placedNodeId=null still POSTs triage:skipped (gate only affects place)", async () => {
+    labelWritebackEnabled = true;
+    const shim = fetchShim([
+      { urlContains: '/labels', method: 'POST', status: 200 },
+      { urlContains: '/labels/triage', method: 'DELETE', status: 200 },
+    ]);
+    await applyTriageLabel({
+      mapId: 'm1',
+      externalId: 'octocat/demo#42',
+      decision: 'skip',
+      placedNodeId: null,
+      fetchImpl: shim.impl,
+    });
+    expect(shim.calls).toHaveLength(2);
+    expect(shim.calls[0].method).toBe('POST');
+    expect(shim.calls[0].body).toContain('triage:skipped');
   });
 });
 
@@ -187,6 +249,7 @@ describe('applyTriageLabel — active', () => {
       mapId: 'm1',
       externalId: 'octocat/demo#42',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: shim.impl,
     });
     expect(shim.calls).toHaveLength(2);
@@ -229,6 +292,7 @@ describe('applyTriageLabel — active', () => {
         mapId: 'm1',
         externalId: 'octocat/demo#42',
         decision: 'place',
+        placedNodeId: 'n42',
         fetchImpl: shim.impl,
       }),
     ).resolves.toBeUndefined();
@@ -246,6 +310,7 @@ describe('applyTriageLabel — active', () => {
         mapId: 'm1',
         externalId: 'octocat/demo#42',
         decision: 'place',
+        placedNodeId: 'n42',
         fetchImpl: shim.impl,
       }),
     ).resolves.toBeUndefined();
@@ -264,6 +329,7 @@ describe('applyTriageLabel — active', () => {
         mapId: 'm1',
         externalId: 'octocat/demo#42',
         decision: 'place',
+        placedNodeId: 'n42',
         fetchImpl: shim.impl,
       }),
     ).resolves.toBeUndefined();
@@ -283,6 +349,7 @@ describe('applyTriageLabel — active', () => {
       mapId: 'm1',
       externalId: 'octocat/demo#42',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: impl,
     });
     expect(capturedAuth).toBe('Bearer t_test');
@@ -308,6 +375,7 @@ describe('applyTriageLabel — timeout (#104 item 10)', () => {
         mapId: 'm1',
         externalId: 'octocat/demo#42',
         decision: 'place',
+        placedNodeId: 'n42',
         fetchImpl: impl,
       }),
     ).resolves.toBeUndefined();
@@ -329,6 +397,7 @@ describe('applyTriageLabel — timeout (#104 item 10)', () => {
       mapId: 'm1',
       externalId: 'octocat/demo#42',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: impl,
     });
     expect(calls).toEqual(['POST', 'DELETE']);
@@ -373,6 +442,7 @@ describe('parseExternalId regex (#104 item 13)', () => {
       mapId: 'm1',
       externalId: 'octocat/demo#42',
       decision: 'place',
+      placedNodeId: 'n42',
       fetchImpl: shim.impl,
     });
     expect(shim.calls).toHaveLength(2);

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -1037,6 +1037,7 @@ async function ensureNodeForIssueViaTriage(
       mapId,
       externalId,
       decision: decision.decision,
+      placedNodeId: result.nodeId,
     });
     return {
       status: 'created',
@@ -1071,10 +1072,14 @@ async function ensureNodeForIssueViaTriage(
     newParentNodeId: null,
     reason: decision.reason,
   });
+  // Decision-only outcomes carry no placed node — the gate inside
+  // applyTriageLabel will skip the `triage:placed` add for an auto
+  // 'place' decision that didn't auto-apply (#178).
   await applyTriageLabel({
     mapId,
     externalId,
     decision: decision.decision,
+    placedNodeId: null,
   });
   return {
     status,

--- a/packages/server/src/sync/triageLabelWriteback.ts
+++ b/packages/server/src/sync/triageLabelWriteback.ts
@@ -38,6 +38,16 @@ interface WriteLabelOpts {
   externalId: string; // "owner/repo#NNN"
   decision: FinalizedTriageDecision;
   /**
+   * The node id the decision actually placed (when `decision='place'`).
+   * Null/undefined means the decision said "place" but the placement
+   * hasn't landed yet (low-confidence auto-decision still pending
+   * operator review). In that state we skip the `triage:placed` add —
+   * the label would lie about a node that doesn't exist in the map.
+   * The label fires later when the operator confirms/overrides and a
+   * node is actually created. Ignored for skip/uncertain. See #178.
+   */
+  placedNodeId?: string | null;
+  /**
    * Test injection: replace the `githubFetch` HTTP call. Production
    * callers omit this; tests pass a mock to assert request shape.
    */
@@ -159,41 +169,52 @@ export async function applyTriageLabel(opts: WriteLabelOpts): Promise<void> {
   const removeLabel =
     opts.decision === 'place' ? TRIAGE_SKIPPED_LABEL : TRIAGE_PLACED_LABEL;
 
+  // #178: gate the ADD step for place decisions that haven't actually
+  // placed a node. Without this, the row's GH label says "we put it in
+  // the map" even though `placed_node_id IS NULL` (pending operator
+  // review). The inverse-label remove still runs — a row that flips
+  // from skip→pending-place shouldn't keep the stale skip label.
+  const shouldAddLabel =
+    opts.decision === 'skip' ||
+    (opts.decision === 'place' && opts.placedNodeId != null);
+
   const { owner, repo, issueNumber } = parsed;
 
   // 1) Add the new label. POST /repos/{owner}/{repo}/issues/{number}/labels
   //    is additive — GitHub merges with existing labels rather than
   //    replacing the set.
-  try {
-    const addUrl = `${GITHUB_API}/repos/${owner}/${repo}/issues/${issueNumber}/labels`;
-    const { status, bodyText } = await ghRequest(
-      addUrl,
-      'POST',
-      ghCtx.token,
-      { labels: [addLabel] },
-      opts.fetchImpl,
-    );
-    if (status === 422) {
-      // GitHub returns 422 when the label doesn't exist on the repo.
-      // Per spec: don't auto-create — log a warn and continue.
-      console.warn(
-        `[triage-label] label "${addLabel}" does not exist on ${owner}/${repo}; create it in your repo to enable writeback. (issue #${issueNumber})`,
+  if (shouldAddLabel) {
+    try {
+      const addUrl = `${GITHUB_API}/repos/${owner}/${repo}/issues/${issueNumber}/labels`;
+      const { status, bodyText } = await ghRequest(
+        addUrl,
+        'POST',
+        ghCtx.token,
+        { labels: [addLabel] },
+        opts.fetchImpl,
       );
-    } else if (status < 200 || status >= 300) {
-      console.warn(
-        `[triage-label] add ${addLabel} on ${owner}/${repo}#${issueNumber} returned ${status}: ${bodyText.slice(0, 200)}`,
-      );
-    }
-  } catch (err) {
-    if (err instanceof GitHubApiError) {
-      console.warn(
-        `[triage-label] add label failed on ${owner}/${repo}#${issueNumber}: ${err.message}`,
-      );
-    } else {
-      console.warn(
-        `[triage-label] add label network error on ${owner}/${repo}#${issueNumber}:`,
-        err instanceof Error ? err.message : err,
-      );
+      if (status === 422) {
+        // GitHub returns 422 when the label doesn't exist on the repo.
+        // Per spec: don't auto-create — log a warn and continue.
+        console.warn(
+          `[triage-label] label "${addLabel}" does not exist on ${owner}/${repo}; create it in your repo to enable writeback. (issue #${issueNumber})`,
+        );
+      } else if (status < 200 || status >= 300) {
+        console.warn(
+          `[triage-label] add ${addLabel} on ${owner}/${repo}#${issueNumber} returned ${status}: ${bodyText.slice(0, 200)}`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof GitHubApiError) {
+        console.warn(
+          `[triage-label] add label failed on ${owner}/${repo}#${issueNumber}: ${err.message}`,
+        );
+      } else {
+        console.warn(
+          `[triage-label] add label network error on ${owner}/${repo}#${issueNumber}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Closes two related bugs that produced ghost \`triage:placed\` labels on GH issues with no corresponding node in the map (today: #117, #110).

### #139 — backfill-suggested-parent.ts left stale decision/reason/confidence

When re-triage flipped to \`skip\` or \`uncertain\`, the script cleared \`suggested_parent_node_id\` but kept the previous \`decision='place'\` / stale reason / stale confidence. Triage UI showed a 'place' verdict with no usable suggestion, operator overrides found the parent picker empty.

The script now writes the full new triage result (matches \`/reclassify\` semantics), records a history row, and fires the corrected \`applyTriageLabel\` so re-running it heals affected rows. Backfill is **forbidden from auto-placing** — even when the new confidence crosses the auto-apply threshold, the row stays pending operator review.

### #178 — \`applyTriageLabel\` wrote triage:placed on AI verdict, not on actual placement

\`triageLabelWriteback.ts:157\` keyed the label on \`decision\` alone, so a low-confidence auto 'place' decision (\`placed_node_id IS NULL\`) still got \`triage:placed\`. \`placed_node_id\` is now part of \`WriteLabelOpts\`; the add-label step is gated on \`(decision='place' && placedNodeId != null) || decision='skip'\`. The inverse-label remove still runs unconditionally so a row flipping skip→pending-place can't keep a stale skip label. All 14 call sites updated (ingest auto-triage, single + bulk override/confirm/reclassify, reopen re-triage, manual create-skip / create-place via /triage-decisions, the #139 backfill).

## Test plan
- [x] \`pnpm --filter @mindblown/server test -- triage-label-writeback triage-reopen\` — 29/29 pass (3 new gate tests)
- [x] \`pnpm turbo typecheck --filter=@mindblown/server\` clean
- [ ] Deploy, run the backfill on the self-map (\`tsx packages/server/src/scripts/backfill-suggested-parent.ts --map-id df1d3294-…\`), confirm #117 and #110 lose \`triage:placed\` on GH.

Note: master has 2 pre-existing test failures unrelated to this PR (pr-merge-webhook multi-issue, bulk-confirm batch-size). Verified by running them on master HEAD before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)