### PR TITLE
fix(triage): backfill --include-suggested flag covers stale-place rows with a non-null suggestion

### DIFF
--- a/packages/server/src/scripts/backfill-suggested-parent.ts
+++ b/packages/server/src/scripts/backfill-suggested-parent.ts
@@ -90,12 +90,26 @@ async function main(): Promise<void> {
     mapIdFlagIdx >= 0 && args[mapIdFlagIdx + 1] ? args[mapIdFlagIdx + 1] : null;
 
   const dryRun = args.includes('--dry-run');
+  // #178: the script's original purpose was "fill the suggestion
+  // column," so it only touched rows with suggested_parent_node_id IS
+  // NULL. Now that the script also writes the full new triage result
+  // and re-fires the GH label writeback, the natural definition of
+  // "stale" expanded to any decision='place' / placed_node_id IS NULL
+  // row — regardless of whether a suggestion was previously written.
+  // Pass --include-suggested to broaden the filter (catches rows like
+  // #117/#110 where the AI placed-label leaked onto GitHub but no node
+  // ever landed). Default stays narrow for back-compat.
+  const includeSuggested = args.includes('--include-suggested');
 
   console.log('[backfill] starting suggested_parent_node_id retro-fill');
   if (targetMapId) console.log(`[backfill]   filter: map_id=${targetMapId}`);
+  if (includeSuggested)
+    console.log(
+      '[backfill]   --include-suggested: also re-triaging rows with a non-null suggestion (#178 label-heal)',
+    );
   if (dryRun) console.log('[backfill]   DRY RUN — no writes, no LLM calls');
 
-  // Find every row that needs backfilling. Strict filter set: place
+  // Find every row that needs backfilling. Default filter: place
   // decision, no placed node, no existing suggestion. We DON'T touch
   // skip/uncertain rows (suggestion is irrelevant) or already-placed
   // rows (auto-apply already happened — suggestion ≠ placed but the
@@ -103,8 +117,10 @@ async function main(): Promise<void> {
   const filters = [
     eq(triageDecisions.decision, 'place'),
     isNull(triageDecisions.placedNodeId),
-    isNull(triageDecisions.suggestedParentNodeId),
   ];
+  if (!includeSuggested) {
+    filters.push(isNull(triageDecisions.suggestedParentNodeId));
+  }
   if (targetMapId) {
     filters.push(eq(triageDecisions.mapId, targetMapId));
   }


### PR DESCRIPTION
## Summary
Follow-up to #179. The default backfill filter (\`suggested_parent_node_id IS NULL\`) misses rows where the AI wrote a suggestion in a previous run but the placement still never landed — exactly the shape of #117 and #110 on the MindBlown self-map. Without this flag the operator has to delete labels by hand or trigger \`/reclassify\` through the UI.

Default behaviour unchanged. Pass \`--include-suggested\` to broaden the filter when the goal is to heal stale \`triage:placed\` labels (#178 follow-up).

## Test plan
- [x] \`pnpm turbo typecheck --filter=@mindblown/server\` clean
- [ ] Deploy + run \`tsx packages/server/src/scripts/backfill-suggested-parent.ts --map-id df1d3294-… --include-suggested\` on prod; confirm #117 and #110 lose \`triage:placed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)