### PR TITLE
fix(orch): consolidate status workflow helpers; clamp chip/badge; broaden conflict gate (#119)

### DIFF
--- a/packages/core/src/__tests__/statusWorkflow.test.ts
+++ b/packages/core/src/__tests__/statusWorkflow.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the consolidated status-workflow helpers (#119).
+ *
+ * These mirror the inline test fixtures from packages/server that used
+ * to live next to each duplicate implementation — they now have one
+ * canonical home in core.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { StatusDef } from '../types.js';
+import {
+  resolveStatusDef,
+  buildIsDonePredicate,
+  buildInProgressIds,
+  buildTodoIds,
+} from '../statusWorkflow.js';
+
+const workflow: StatusDef[] = [
+  { id: 'st-todo', name: 'Todo', category: 'todo', color: '#888', position: 0 },
+  { id: 'st-wip', name: 'In Progress', category: 'in_progress', color: '#444', position: 1 },
+  { id: 'st-done', name: 'Done', category: 'done', color: '#0a0', position: 2 },
+];
+
+describe('resolveStatusDef', () => {
+  it('finds a def by exact id', () => {
+    expect(resolveStatusDef(workflow, 'st-done')?.category).toBe('done');
+  });
+
+  it('finds a def by case-insensitive name', () => {
+    expect(resolveStatusDef(workflow, 'done')?.id).toBe('st-done');
+    expect(resolveStatusDef(workflow, 'DONE')?.id).toBe('st-done');
+    expect(resolveStatusDef(workflow, 'IN PROGRESS')?.id).toBe('st-wip');
+  });
+
+  it('returns undefined for null/unknown keys', () => {
+    expect(resolveStatusDef(workflow, null)).toBeUndefined();
+    expect(resolveStatusDef(workflow, 'archived')).toBeUndefined();
+  });
+});
+
+describe('buildIsDonePredicate', () => {
+  const isDone = buildIsDonePredicate(workflow);
+
+  it('returns true for done id and name (case-insensitive)', () => {
+    expect(isDone('st-done')).toBe(true);
+    expect(isDone('done')).toBe(true);
+    expect(isDone('Done')).toBe(true);
+  });
+
+  it('returns false for null, todo, in_progress', () => {
+    expect(isDone(null)).toBe(false);
+    expect(isDone('st-todo')).toBe(false);
+    expect(isDone('In Progress')).toBe(false);
+  });
+
+  it('returns false for unknown status strings (defensive)', () => {
+    expect(isDone('archived')).toBe(false);
+  });
+});
+
+describe('buildInProgressIds / buildTodoIds', () => {
+  it('returns just the in_progress ids', () => {
+    expect(buildInProgressIds(workflow)).toEqual(new Set(['st-wip']));
+  });
+
+  it('returns just the todo ids', () => {
+    expect(buildTodoIds(workflow)).toEqual(new Set(['st-todo']));
+  });
+
+  it('handles a workflow with multiple defs in each category', () => {
+    const wf: StatusDef[] = [
+      { id: 'a', name: 'A', category: 'todo', color: '', position: 0 },
+      { id: 'b', name: 'B', category: 'todo', color: '', position: 1 },
+      { id: 'c', name: 'C', category: 'in_progress', color: '', position: 2 },
+      { id: 'd', name: 'D', category: 'done', color: '', position: 3 },
+    ];
+    expect(buildTodoIds(wf)).toEqual(new Set(['a', 'b']));
+    expect(buildInProgressIds(wf)).toEqual(new Set(['c']));
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,3 +74,11 @@ export {
   businessDaysBetween,
   hoursToBusinessDays,
 } from './calendar.js';
+
+// Status-workflow helpers (#119)
+export {
+  resolveStatusDef,
+  buildIsDonePredicate,
+  buildInProgressIds,
+  buildTodoIds,
+} from './statusWorkflow.js';

--- a/packages/core/src/statusWorkflow.ts
+++ b/packages/core/src/statusWorkflow.ts
@@ -1,0 +1,59 @@
+/**
+ * Status-workflow helpers.
+ *
+ * A map's status workflow is `StatusDef[]` (see types.ts). Multiple
+ * server modules need to answer the same questions against it — "is
+ * this status `done`?", "which IDs are in_progress?", "find the def
+ * matching this string." Until #119 these lived inline in
+ * `services/orchestration.ts` and `db/nodes.ts`, with slightly
+ * different shapes. Promoted here so there's one source of truth and
+ * future tools can import the same predicates.
+ *
+ * The string-key lookup is intentionally case-insensitive on name
+ * (callers may pass "done", "Done", "DONE") AND accepts the def's
+ * `id` directly — older callers store the id, newer ones the
+ * display name.
+ */
+
+import type { StatusDef } from './types.js';
+
+/**
+ * Find the `StatusDef` matching a status key — either its `id` or its
+ * `name` (case-insensitive). Returns undefined if no def matches; the
+ * caller decides whether that's an error or a "no status" sentinel.
+ */
+export function resolveStatusDef(
+  workflow: StatusDef[],
+  statusKey: string | null,
+): StatusDef | undefined {
+  if (statusKey == null) return undefined;
+  const lower = statusKey.toLowerCase();
+  return workflow.find((s) => s.id === statusKey || s.name.toLowerCase() === lower);
+}
+
+/**
+ * Return a predicate that maps a status key to whether it represents
+ * the `done` category. Null/missing keys are never done.
+ */
+export function buildIsDonePredicate(
+  workflow: StatusDef[],
+): (status: string | null) => boolean {
+  const doneIds = new Set(workflow.filter((s) => s.category === 'done').map((s) => s.id));
+  const doneNames = new Set(
+    workflow.filter((s) => s.category === 'done').map((s) => s.name.toLowerCase()),
+  );
+  return (status: string | null): boolean => {
+    if (!status) return false;
+    return doneIds.has(status) || doneNames.has(status.toLowerCase());
+  };
+}
+
+/** Set of status IDs whose category is `in_progress`. */
+export function buildInProgressIds(workflow: StatusDef[]): Set<string> {
+  return new Set(workflow.filter((s) => s.category === 'in_progress').map((s) => s.id));
+}
+
+/** Set of status IDs whose category is `todo`. */
+export function buildTodoIds(workflow: StatusDef[]): Set<string> {
+  return new Set(workflow.filter((s) => s.category === 'todo').map((s) => s.id));
+}

--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -384,13 +384,19 @@ export function MindmapEditor() {
   } | null>(null);
 
   // ── Orchestration conflict detection (#111) ──────────────────
-  // When hovering a todo node, compute which OTHER todo nodes have scope
-  // overlap with any in-flight (claimed or in_progress) node. These are
-  // flagged with an amber border so the operator can spot contention.
+  // When hovering a node with scopes, compute which OTHER in-flight
+  // nodes have scope overlap. The hovered node gets flagged with an
+  // amber border so the operator can spot contention.
+  //
+  // #119: dropped the `status !== null` gate — scanning from an
+  // in-progress node ("what's already competing with me?") is just as
+  // useful as scanning from a todo ("can I safely dispatch this?").
+  // Done nodes still surface conflicts (cheap and the visualisation
+  // tells the operator the overlap is already in flight).
   const conflictNodeIds = useMemo<Set<string>>(() => {
     if (!hoveredNodeId) return new Set();
     const hoveredNode = nodes[hoveredNodeId];
-    if (!hoveredNode || hoveredNode.status !== null || !hoveredNode.scopes?.length) {
+    if (!hoveredNode || !hoveredNode.scopes?.length) {
       return new Set();
     }
     // Collect in-flight scopes: any node that is claimed OR in_progress

--- a/packages/mindmap/src/MindmapNode.tsx
+++ b/packages/mindmap/src/MindmapNode.tsx
@@ -112,17 +112,22 @@ function AvatarCircle({ userId, index }: { userId: string; index: number }) {
  * Renders a small colored pill showing the claiming session ID.
  * Positioned at the top-right corner of the node rect.
  */
-function ClaimBadge({ sessionId, nodeX, nodeY, nodeWidth }: {
+function ClaimBadge({ sessionId, nodeX, nodeY, nodeWidth, nodeHeight }: {
   sessionId: string;
   nodeX: number;
   nodeY: number;
   nodeWidth: number;
+  nodeHeight: number;
 }) {
   // Truncate to last 8 chars so it stays readable at small sizes
   const label = sessionId.length > 8 ? '…' + sessionId.slice(-8) : sessionId;
   const badgeWidth = label.length * 6 + 12;
   const badgeX = nodeX + nodeWidth - badgeWidth - 2;
-  const badgeY = nodeY - 14;
+  // #119: clamp to canvas top — if placing the badge above the node
+  // would put it at y<0, flip it under the node instead so it never
+  // gets clipped by the SVG viewport.
+  const ABOVE_Y = nodeY - 14;
+  const badgeY = ABOVE_Y < 0 ? nodeY + nodeHeight + 1 : ABOVE_Y;
 
   return (
     <g>
@@ -159,18 +164,28 @@ function ClaimBadge({ sessionId, nodeX, nodeY, nodeWidth }: {
  * Chips are placed horizontally, wrapping isn't attempted — only the
  * first N chips that fit within nodeWidth are shown.
  */
-function ScopeChips({ scopes, nodeX, nodeY, nodeWidth }: {
+function ScopeChips({ scopes, nodeX, nodeY, nodeWidth, nodeHeight, claimedBadgeBelow }: {
   scopes: string[];
   nodeX: number;
   nodeY: number;
   nodeWidth: number;
+  nodeHeight: number;
+  /** True when the claim badge was clamped below the node. Chips then
+   * stack under the badge (badge first, chips below it) so the stack
+   * stays in the same visual order as the default above-node layout. */
+  claimedBadgeBelow: boolean;
 }) {
   if (scopes.length === 0) return null;
 
   const CHIP_HEIGHT = 12;
   const CHIP_PAD_X = 5;
   const CHIP_GAP = 4;
-  const CHIP_Y = nodeY - 16 - CHIP_HEIGHT; // place above claim badge row
+  const ABOVE_Y = nodeY - 16 - CHIP_HEIGHT;
+  // #119: clamp to canvas top — when the default above-node placement
+  // would render at y<0, render under the node. If the claim badge
+  // also got clamped, leave room for it (badge height ~13 + 2 gap).
+  const belowOffset = claimedBadgeBelow ? nodeHeight + 1 + 13 + 2 : nodeHeight + 1;
+  const CHIP_Y = ABOVE_Y < 0 ? nodeY + belowOffset : ABOVE_Y;
 
   let xCursor = nodeX;
   const chips: Array<{ label: string; x: number; width: number }> = [];
@@ -646,23 +661,26 @@ export function MindmapNode({
 
       {/* Orchestration substrate (#111) ─────────────────────── */}
 
-      {/* Scope chips — rendered above the node */}
+      {/* Scope chips — rendered above the node (clamped under when near canvas top) */}
       {node.scopes && node.scopes.length > 0 && (
         <ScopeChips
           scopes={node.scopes}
           nodeX={x}
           nodeY={y}
           nodeWidth={width}
+          nodeHeight={height}
+          claimedBadgeBelow={!!node.claimedBySession && y - 14 < 0}
         />
       )}
 
-      {/* Claim badge — amber pill in the top-right corner */}
+      {/* Claim badge — amber pill in the top-right corner (clamped under when near canvas top) */}
       {node.claimedBySession && (
         <ClaimBadge
           sessionId={node.claimedBySession}
           nodeX={x}
           nodeY={y}
           nodeWidth={width}
+          nodeHeight={height}
         />
       )}
     </g>

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, gte, inArray, isNotNull, isNull, sql } from 'drizzle-orm
 import { db } from './connection.js';
 import { nodes, maps, changeEvents } from './schema.js';
 import { dbNodeToCore } from './helpers.js';
-import { hasCycle } from '@mindblown/core';
+import { hasCycle, resolveStatusDef } from '@mindblown/core';
 import type { Node as CoreNode, Dependency, DependencyType, ExternalLink, LinkedPrState, Priority, CustomFieldValue, NodeMap, StatusDef } from '@mindblown/core';
 import { invalidateMapContext } from '../sync/mapContext.js';
 
@@ -325,11 +325,7 @@ export async function updateNode(
       let movingToDone = false;
       let movingFromDone = false;
       if (statusChanging && input.status !== null) {
-        const targetDef = workflow.find(
-          (s) =>
-            s.id === input.status ||
-            s.name.toLowerCase() === (input.status as string).toLowerCase(),
-        );
+        const targetDef = resolveStatusDef(workflow, input.status as string);
         if (targetDef?.category === 'done') movingToDone = true;
         else movingFromDone = true;
       } else if (statusChanging && input.status === null) {

--- a/packages/server/src/services/orchestration.ts
+++ b/packages/server/src/services/orchestration.ts
@@ -18,7 +18,14 @@ import { nodes, maps } from '../db/schema.js';
 import { dbNodeToCore } from '../db/helpers.js';
 import { notDeleted } from '../db/nodes.js';
 import { broadcast } from '../ws.js';
-import { resolvedSiblingOrder, isReady, scopeOverlap } from '@mindblown/core';
+import {
+  resolvedSiblingOrder,
+  isReady,
+  scopeOverlap,
+  buildIsDonePredicate,
+  buildInProgressIds,
+  buildTodoIds,
+} from '@mindblown/core';
 import type { Node as CoreNode, StatusDef, NodeMap } from '@mindblown/core';
 import type {
   ReadyNodesResult,
@@ -46,40 +53,12 @@ export class OrchestrationNotFoundError extends Error {
 }
 
 // ── Workflow predicate helpers ──────────────────────────────────
-
-/**
- * Build an `isDone` predicate for a given map's status workflow.
- * Returns a function that returns true when a status string (id OR
- * case-insensitive name) maps to a status with category='done'.
- */
-export function buildIsDonePredicate(
-  workflow: StatusDef[],
-): (status: string | null) => boolean {
-  const doneIds = new Set(
-    workflow.filter((s) => s.category === 'done').map((s) => s.id),
-  );
-  const doneNames = new Set(
-    workflow.filter((s) => s.category === 'done').map((s) => s.name.toLowerCase()),
-  );
-  return (status: string | null): boolean => {
-    if (!status) return false;
-    return doneIds.has(status) || doneNames.has(status.toLowerCase());
-  };
-}
-
-/** Build the set of status IDs whose category is 'in_progress'. */
-export function buildInProgressIds(workflow: StatusDef[]): Set<string> {
-  return new Set(
-    workflow.filter((s) => s.category === 'in_progress').map((s) => s.id),
-  );
-}
-
-/** Build the set of status IDs whose category is 'todo'. */
-export function buildTodoIds(workflow: StatusDef[]): Set<string> {
-  return new Set(
-    workflow.filter((s) => s.category === 'todo').map((s) => s.id),
-  );
-}
+//
+// `buildIsDonePredicate`, `buildInProgressIds`, and `buildTodoIds`
+// moved to `@mindblown/core/statusWorkflow` in #119 so the duplicate
+// id-or-name lookup in db/nodes.ts can import the same source of
+// truth. Re-exported here for back-compat with existing imports.
+export { buildIsDonePredicate, buildInProgressIds, buildTodoIds };
 
 // ── readyNodes ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Three small polish items called out in the PR #116 review (#119):

1. **isDone helper DRY** — \`buildIsDonePredicate\`, \`buildInProgressIds\`, \`buildTodoIds\`, and a new \`resolveStatusDef\` now live in \`packages/core/src/statusWorkflow.ts\`. \`services/orchestration.ts\` re-exports the predicates for back-compat. \`db/nodes.ts\` drops its own inline id-or-name lookup and uses \`resolveStatusDef\`.
2. **Top-edge clamp** — \`ClaimBadge\` and \`ScopeChips\` now accept \`nodeHeight\` and flip placement below the node when the default above-node Y would be negative (chips stack under the badge in the clamped case so the visual order stays consistent).
3. **Conflict scan from in-progress nodes** — dropped the \`hoveredNode.status !== null\` gate on \`conflictNodeIds\`. Scanning \"what's competing with this in-flight node\" is just as useful as the original todo-side use case.

Closes #119.

## Test plan
- [x] \`pnpm --filter @mindblown/core test\` — 110/110 pass (9 new statusWorkflow tests)
- [x] \`pnpm --filter @mindblown/server test -- orchestration\` — 33/33 still pass after consolidation
- [x] \`pnpm turbo typecheck --filter=@mindblown/core --filter=@mindblown/server --filter=@mindblown/mindmap\` clean
- [ ] Visually verify chip/badge clamp on a node near canvas top after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)