### PR TITLE
fix(drift-audit): manual-pending stays Kuma=up (queue, not infra)

### DIFF
--- a/packages/server/src/sync/__tests__/runDriftAudit.test.ts
+++ b/packages/server/src/sync/__tests__/runDriftAudit.test.ts
@@ -273,25 +273,32 @@ describe('runDriftAudit', () => {
     expect(msg).toBe('auto-backfilled-3');
   });
 
-  it('drift partially auto-healed → Kuma status=down msg=auto-backfilled-X,manual-Y', async () => {
+  it('drift partially auto-healed → Kuma status=up msg=auto-backfilled-X,manual-Y (queue, not infra)', async () => {
+    // 2026-06-10 scope clarification: manual-pending is a triage queue
+    // waiting on human eyes, not an infra failure. Kuma stays UP; the
+    // operator gets a daily email from Jenna's housekeeping sweep
+    // instead. Only `audit_failed` and no-heartbeat-in-24h trip the
+    // monitor now.
     setupDriftyMap('m1', 'Mixed', 4);
     runAutoBackfillMock.mockResolvedValue(summary(2, 100));
 
     await runDriftAudit();
 
     const [, status, msg] = pushKumaMock.mock.calls[0];
-    expect(status).toBe('down');
+    expect(status).toBe('up');
     expect(msg).toBe('auto-backfilled-2,manual-100');
   });
 
-  it('drift all over cap → Kuma status=down msg=manual-N', async () => {
+  it('drift all over cap → Kuma status=up msg=manual-N (queue, not infra)', async () => {
+    // Same scope clarification as the partially-healed case above:
+    // over-cap drift is a backlog, not an infra problem.
     setupDriftyMap('m1', 'Over Cap', 75);
     runAutoBackfillMock.mockResolvedValue(summary(0, 75));
 
     await runDriftAudit();
 
     const [, status, msg] = pushKumaMock.mock.calls[0];
-    expect(status).toBe('down');
+    expect(status).toBe('up');
     expect(msg).toBe('manual-75');
   });
 

--- a/packages/server/src/sync/autoBackfill.ts
+++ b/packages/server/src/sync/autoBackfill.ts
@@ -21,13 +21,18 @@
  * Kuma push semantics (set by `runDriftAudit` in `./driftAudit.ts`):
  *   - No drift → status=up, msg="no-drift"
  *   - Drift fully auto-healed → status=up, msg="auto-backfilled-N"
- *   - Drift partially healed → status=down, msg="auto-backfilled-N,manual-M"
- *   - Drift all over cap → status=down, msg="manual-N"
+ *   - Drift partially healed → status=up, msg="auto-backfilled-N,manual-M"
+ *   - Drift all over cap → status=up, msg="manual-N"
  *   - Backfill threw entirely → status=down, msg="audit_failed:<reason>"
  *
- * The `up` for full auto-heal means the operator never gets a page when
- * the system recovers itself; the message field carries the receipt so
- * Kuma's history shows what self-healing did.
+ * `up` for full auto-heal means the operator never gets a page when the
+ * system recovers itself. `up` for the manual-pending branches reflects
+ * a 2026-06-10 scope clarification: a triage queue waiting on human
+ * eyes is not an infra failure — operators get a daily email from
+ * Jenna's housekeeping sweep instead. Kuma only fires for true infra
+ * failures (audit threw, no heartbeat in 24h). The message field still
+ * carries the manual-N receipt so the Kuma dashboard shows the
+ * backlog; it just doesn't page.
  */
 
 import type { DriftReport } from './driftAudit.js';

--- a/packages/server/src/sync/driftAudit.ts
+++ b/packages/server/src/sync/driftAudit.ts
@@ -434,8 +434,16 @@ export async function runDriftAudit(): Promise<DriftAuditRunResult> {
   }
 
   // Build the Kuma message and status.
+  //
+  // Manual-pending is a triage QUEUE state, not an infra failure —
+  // operators get a daily email from Jenna's housekeeping sweep telling
+  // them what to confirm. Kuma's job here shrinks to "did the audit run
+  // and not throw"; only `audit_failed` (catch block above) and the
+  // no-heartbeat-in-24h Kuma-side timeout trip the monitor. Background:
+  // 2026-06-10 incident — woke Dan at 00:45 CEST on an 8-item backlog
+  // that wasn't infra, just a triage queue waiting on human eyes.
   const msg = `${formatAutoBackfillMsg(autoBackfill)}${tokenSuffix}`.slice(0, 200);
-  const status = autoBackfill.totalManualPending > 0 ? 'down' : 'up';
+  const status = 'up';
 
   if (url) {
     try {

--- a/packages/server/src/sync/driftAudit.ts
+++ b/packages/server/src/sync/driftAudit.ts
@@ -195,9 +195,12 @@ async function resolveTargets(): Promise<ResolvedTargets> {
  * `ensureNodeForIssue` → `findNodesByExternalIds` is globally-scoped
  * — a backfill won't re-create a node for an issue already linked
  * elsewhere. A per-map "linked" check here would flag drift that
- * backfill can't heal, producing the "imported 0/N (0 errored)" loop
- * that pushes `status=down` for phantom drift and pages the operator
- * at 3am for nothing. Keep this aligned with backfill's reality.
+ * backfill can't heal, producing the "imported 0/N (0 errored)" loop.
+ * Pre-2026-06-10 that loop also pushed Kuma `status=down` and paged
+ * the operator at 3am for nothing; the rescope to up-on-manual-pending
+ * removed the page, but the phantom-drift waste (LLM tokens spent on
+ * triage retries) is still real. Keep this aligned with backfill's
+ * reality.
  *
  * Returns null if no genuinely-missing issues. Returns a DriftReport
  * with `onlyInGitHub > 0` otherwise.
@@ -328,9 +331,14 @@ export function formatAutoBackfillMsg(summary: AutoBackfillSummary): string {
  * Pushes:
  *   - No drift                       → status=up, msg="no-drift"
  *   - Drift fully auto-healed        → status=up, msg="auto-backfilled-N"
- *   - Drift partially auto-healed    → status=down, msg="auto-backfilled-X,manual-Y"
- *   - All drift over cap / killed    → status=down, msg="manual-N"
+ *   - Drift partially auto-healed    → status=up, msg="auto-backfilled-X,manual-Y"
+ *   - All drift over cap / killed    → status=up, msg="manual-N"
  *   - Audit itself threw             → status=down, msg="audit_failed:<reason>"
+ *
+ * The manual-pending branches return `up` (not `down`) since 2026-06-10:
+ * a triage queue waiting on human eyes is not infra failure; operators
+ * get a daily email from Jenna's housekeeping sweep. Kuma stays scoped
+ * to true infra problems (audit threw, no-heartbeat-in-24h).
  *
  * If any maps had token errors, `,token-errors-N` is appended to the
  * msg (e.g. `no-drift,token-errors-2`). Token errors alone do not flip


### PR DESCRIPTION
## Summary

- Scope clarification: a non-empty triage queue is NOT an infra failure. Re-scope `mindblown-github-drift` Kuma signal to true infra problems only.
- After this change, the monitor flips DOWN only on `audit_failed:<reason>` (audit threw) or no-heartbeat-in-24h. Manual-pending of any size pushes `up` with `manual-N` in the msg so the dashboard still surfaces the backlog.
- Operators get a daily action email from Jenna's housekeeping sweep on the CRM side (separate PR / JD update). Pushover is no longer the surface for "human, please triage".

## Why

2026-06-10 00:45 CEST: Kuma paged on `mindblown-github-drift` DOWN. Root cause: 8 unreviewed auto-decisions sitting in the queue (3 Fulcrum CRM Roadmap `place@70` below the auto-apply threshold of 75, 5 MindBlown `auto-skip@75-95`). Nothing was broken — Claude's triage had landed correctly and was waiting on operator review.

Background detail: the previous `manual-pending > 0 → down` rule was conflating "Claude couldn't auto-confirm without a human" with "infra needs immediate attention". Pushover-at-midnight for a queue depth of 8 is exactly the wrong escalation shape.

## Test plan

- [x] Updated `runDriftAudit.test.ts`: the partially-healed and over-cap cases now assert `status='up'` (msg unchanged).
- [x] `audit_failed` case still asserts `status='down'` — that's the only path that pages now.
- [x] Pre-existing failures on `master` (`pr-merge-webhook` and `triage-routes bulk-confirm`) are unrelated — confirmed by re-running against `origin/master` before this branch.

## Operator-side follow-up (separate PR on `FulcrumCRM/crm`)

Jenna's hourly housekeeping gets a new sweep (§8.10): query `list_triage_decisions(reviewed=false, decidedBy=auto)` for the triage-enabled maps, email Dan once daily when the backlog is non-empty with a per-map breakdown + suggested actions + the "Not in MindBlown" tab link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)