### PR TITLE
feat(mcp): parentId filter on search_nodes

### DIFF
--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -9,9 +9,9 @@
 
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
-import { createNodeTool, updateNodeTool, restoreNodeTool, listRecentlyDeletedTool } from '../node.js';
+import { createNodeTool, updateNodeTool, restoreNodeTool, listRecentlyDeletedTool, searchNodesTool } from '../node.js';
 import type { ToolBackend } from '../../backend.js';
-import type { NodeWithComputed } from '../../types.js';
+import type { MapDetail, NodeWithComputed } from '../../types.js';
 
 /**
  * Minimal ToolBackend that records the last call to createNode / updateNode
@@ -287,5 +287,93 @@ describe('list_recently_deleted tool', () => {
       limit: 100,
     } as never);
     expect(seen[0]).toEqual({ mapId: 'm1', opts: { sinceDays: 7, limit: 100 } });
+  });
+});
+
+describe('search_nodes tool — parentId filter', () => {
+  function buildBucketMap(): MapDetail {
+    const node = (id: string, parentId: string | null, childrenIds: string[]): NodeWithComputed =>
+      ({
+        id,
+        mapId: 'm1',
+        parentId,
+        childrenIds,
+        text: id,
+        description: null,
+        effortEstimate: null,
+        actualEffort: null,
+        percentComplete: null,
+        status: null,
+        assigneeIds: [],
+        priority: null,
+        dueDate: null,
+        startDate: null,
+        tags: [],
+        dependencies: [],
+        versionId: null,
+        cycleId: null,
+        externalLinks: [],
+        collapsed: false,
+        createdAt: '2026-06-10T00:00:00Z',
+        updatedAt: '2026-06-10T00:00:00Z',
+        claimedBySession: null,
+        claimedAt: null,
+        computedEffort: 0,
+        computedProgress: 0,
+        healthSignal: 'on_track',
+      }) as unknown as NodeWithComputed;
+    return {
+      map: { id: 'm1', rootNodeId: 'root' } as unknown as MapDetail['map'],
+      nodes: [
+        node('root', null, ['bucket-a', 'bucket-b']),
+        node('bucket-a', 'root', ['a-leaf-1', 'a-leaf-2']),
+        node('a-leaf-1', 'bucket-a', []),
+        node('a-leaf-2', 'bucket-a', []),
+        node('bucket-b', 'root', ['b-leaf']),
+        node('b-leaf', 'bucket-b', []),
+      ],
+    };
+  }
+
+  it('returns only the direct children of the given parent', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildBucketMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      parentId: 'bucket-a',
+    } as never);
+    expect(out).toContain('Found 2 node(s)');
+    expect(out).toContain('id: a-leaf-1');
+    expect(out).toContain('id: a-leaf-2');
+    expect(out).not.toContain('id: b-leaf');
+    expect(out).not.toContain('id: bucket-b');
+    expect(out).not.toContain('id: bucket-a');
+  });
+
+  it('composes with leavesOnly (children of a parent that are themselves leaves)', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildBucketMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      parentId: 'root',
+      leavesOnly: true,
+    } as never);
+    expect(out).toContain('No nodes');
+    expect(out).toContain('parentId=root');
+    expect(out).toContain('leavesOnly=true');
+  });
+
+  it('reports child count on non-leaf result lines', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildBucketMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      parentId: 'root',
+    } as never);
+    expect(out).toMatch(/bucket-a[^\n]*\(2 children\)/);
+    expect(out).toMatch(/bucket-b[^\n]*\(1 child\)/);
   });
 });

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -209,7 +209,7 @@ export const clearBlockerTool = defineTool({
 export const searchNodesTool = defineTool({
   name: 'search_nodes',
   description:
-    'Search nodes by text across a map, with optional structured filters. Pass an empty string or "*" as query to match all nodes and filter by status/priority/tag/unestimated/leavesOnly/versionId only. Common pre-flight check: query="*", unestimated:true, versionId:"<id>" to find any V-N leaves still missing estimates.',
+    'Search nodes by text across a map, with optional structured filters. Pass an empty string or "*" as query to match all nodes and filter by status/priority/tag/unestimated/leavesOnly/versionId/parentId only. Use parentId to enumerate the direct children of a specific node (e.g. before merging duplicate buckets or flattening a wrapper chain): query="*", parentId:"<id>". Common pre-flight check: query="*", unestimated:true, versionId:"<id>" to find any V-N leaves still missing estimates.',
   schema: {
     mapId: z.string().describe('The map ID'),
     query: z
@@ -230,8 +230,12 @@ export const searchNodesTool = defineTool({
       .string()
       .optional()
       .describe('Filter by version. Matches nodes whose own versionId is this OR any ancestor on the path inherits it.'),
+    parentId: z
+      .string()
+      .optional()
+      .describe('Filter to direct children of this node id. Combine with query="*" to enumerate the contents of a specific bucket — the only way to do so, since get_map truncates on large maps.'),
   },
-  handler: async (backend, { mapId, query, status, priority, tag, unestimated, leavesOnly, versionId }) => {
+  handler: async (backend, { mapId, query, status, priority, tag, unestimated, leavesOnly, versionId, parentId }) => {
     const data = await backend.getMap(mapId);
     const trimmedQ = query.trim();
     const matchAll = trimmedQ === '' || trimmedQ === '*';
@@ -247,6 +251,7 @@ export const searchNodesTool = defineTool({
     if (priority) matches = matches.filter((n) => n.priority === priority);
     if (tag) matches = matches.filter((n) => n.tags.includes(tag));
     if (leavesOnly) matches = matches.filter((n) => (n.childrenIds?.length ?? 0) === 0);
+    if (parentId) matches = matches.filter((n) => n.parentId === parentId);
     if (unestimated === true) matches = matches.filter((n) => n.effortEstimate == null);
     else if (unestimated === false) matches = matches.filter((n) => n.effortEstimate != null);
     if (versionId) {
@@ -270,6 +275,7 @@ export const searchNodesTool = defineTool({
         unestimated !== undefined && `unestimated=${unestimated}`,
         leavesOnly && `leavesOnly=true`,
         versionId && `versionId=${versionId}`,
+        parentId && `parentId=${parentId}`,
       ].filter(Boolean);
       const filterStr = filters.length > 0 ? ` (filters: ${filters.join(', ')})` : '';
       const subject = matchAll ? 'nodes' : `nodes matching "${query}"`;
@@ -284,7 +290,9 @@ export const searchNodesTool = defineTool({
         ? ' ' + n.externalLinks.map((l) => `[${l.externalId}]`).join(' ')
         : '';
       const claim = ' ' + formatClaim(n.claimedBySession, n.claimedAt);
-      return `- "${n.text}" (id: ${n.id}) — ${progress}% ${health}${n.status ? ` [${n.status}]` : ''}${n.priority ? ` ${n.priority}` : ''}${links}${claim}`;
+      const kids = n.childrenIds?.length ?? 0;
+      const kidsStr = kids > 0 ? ` (${kids} child${kids === 1 ? '' : 'ren'})` : '';
+      return `- "${n.text}" (id: ${n.id}) — ${progress}% ${health}${n.status ? ` [${n.status}]` : ''}${n.priority ? ` ${n.priority}` : ''}${kidsStr}${links}${claim}`;
     });
 
     return `Found ${matches.length} node(s) matching "${query}":\n${lines.join('\n')}`;


### PR DESCRIPTION
## Summary
- Adds optional `parentId` to `search_nodes` so MCP agents can enumerate the direct children of a specific node — closes the gap where get_map can truncate, semantic_search returns ranked matches, and search_nodes filtered on every dimension except parent.
- Result lines suffix `(N child[ren])` for non-leaf matches so the caller can tell at a glance which results are themselves buckets before drilling in.

## Test plan
- [x] `pnpm --filter @mindblown/tool-kit test` — 17 node tests pass (3 new)
- [x] `pnpm --filter @mindblown/tool-kit typecheck`
- [ ] After deploy: `search_nodes({ query: "*", parentId: "<bucket>" })` returns only direct children with child-count suffixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)