### PR TITLE
feat(mindmap): text-size control decoupled from zoom

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -33,6 +33,23 @@ const MIN_ZOOM = 0.15;
 const MAX_ZOOM = 3;
 const DRAG_THRESHOLD = 5; // px of movement before drag starts
 
+// Text-size pref: multiplies node label fonts and the underlying layout
+// dimensions so labels grow without requiring the user to zoom in (which
+// loses overview). Persisted in localStorage so it survives reloads.
+const MIN_TEXT_SCALE = 0.8;
+const MAX_TEXT_SCALE = 2.0;
+const TEXT_SCALE_STEP = 1.15;
+const TEXT_SCALE_STORAGE_KEY = 'mindmap.textScale';
+
+function loadTextScale(): number {
+  if (typeof window === 'undefined') return 1;
+  const raw = window.localStorage.getItem(TEXT_SCALE_STORAGE_KEY);
+  if (!raw) return 1;
+  const n = parseFloat(raw);
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(MAX_TEXT_SCALE, Math.max(MIN_TEXT_SCALE, n));
+}
+
 // ── Drag state ────────────────────────────────────────────────
 
 interface DragState {
@@ -258,6 +275,11 @@ const DEPTH_OPTIONS = [
 export function MindmapEditor() {
   const svgRef = useRef<SVGSVGElement>(null);
   const [view, setView] = useState<ViewState>({ panX: 0, panY: 0, zoom: 1 });
+  const [textScale, setTextScale] = useState<number>(() => loadTextScale());
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(TEXT_SCALE_STORAGE_KEY, String(textScale));
+  }, [textScale]);
   const [isPanning, setIsPanning] = useState(false);
   const panStart = useRef<{ x: number; y: number; panX: number; panY: number } | null>(null);
 
@@ -465,8 +487,8 @@ export function MindmapEditor() {
   const effectiveRootId = focusNodeId ?? rootNodeId;
 
   const layoutNodes = useMemo(
-    () => effectiveRootId ? computeLayout(effectiveRootId, visibleNodesRecord, layoutType) : [],
-    [effectiveRootId, visibleNodesRecord, layoutType],
+    () => effectiveRootId ? computeLayout(effectiveRootId, visibleNodesRecord, layoutType, textScale) : [],
+    [effectiveRootId, visibleNodesRecord, layoutType, textScale],
   );
 
   // Also layout dimmed sibling nodes (simple positioning beside the main tree)
@@ -480,9 +502,11 @@ export function MindmapEditor() {
     let yOffset = mainBounds.minY;
 
     for (const dn of dimmedNodes) {
-      const textWidth = dn.node.text.length * 7.5 + 32;
-      const width = Math.min(260, Math.max(100, Math.max(160, textWidth)));
-      const height = 40;
+      // Mirror the constants used in layout.ts:measureNodeWidth so dimmed
+      // siblings grow with the same textScale as the main tree.
+      const textWidth = dn.node.text.length * 7.5 * textScale + 32 * textScale;
+      const width = Math.min(260 * textScale, Math.max(100 * textScale, Math.max(160 * textScale, textWidth)));
+      const height = 40 * textScale;
       result.push({
         id: dn.node.id,
         x: mainBounds.minX - width - 80,
@@ -494,10 +518,10 @@ export function MindmapEditor() {
         hasChildren: dn.node.childrenIds.length > 0,
         collapsed: dn.node.collapsed,
       });
-      yOffset += height + 14;
+      yOffset += height + 14 * textScale;
     }
     return result;
-  }, [visibleNodes, layoutNodes, effectiveRootId]);
+  }, [visibleNodes, layoutNodes, effectiveRootId, textScale]);
 
   const allLayoutNodes = useMemo(
     () => [...layoutNodes, ...dimmedLayoutNodes],
@@ -1439,6 +1463,7 @@ export function MindmapEditor() {
                   layout={ln}
                   node={nodeData}
                   computedValues={computed.get(ln.id)}
+                  textScale={textScale}
                   isSelected={selectedSet.has(ln.id)}
                   isEditing={ln.id === editingNodeId}
                   isDragging={isBeingDragged ?? false}
@@ -1657,6 +1682,47 @@ export function MindmapEditor() {
             lineHeight: 1,
           }}
         >⛶</button>
+      </div>
+
+      {/* Text-size controls — deliberately a separate floating column so
+          users see it as orthogonal to zoom (zoom changes how much fits,
+          text size changes label legibility). */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 60,
+          bottom: 12,
+          zIndex: 15,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'stretch',
+          background: '#fff',
+          border: '1px solid #e2e8f0',
+          borderRadius: 8,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+          overflow: 'hidden',
+          fontFamily: 'inherit',
+          minWidth: 44,
+        }}
+      >
+        <button
+          onClick={() => setTextScale((s) => Math.min(MAX_TEXT_SCALE, s * TEXT_SCALE_STEP))}
+          title="Increase text size"
+          aria-label="Increase text size"
+          style={{ ...zoomCtrlBtnStyle, fontSize: 16 }}
+        >A+</button>
+        <button
+          onClick={() => setTextScale(1)}
+          title="Reset text size to 100%"
+          aria-label="Reset text size"
+          style={{ ...zoomCtrlBtnStyle, fontSize: 11, fontWeight: 600, color: '#64748b' }}
+        >{Math.round(textScale * 100)}%</button>
+        <button
+          onClick={() => setTextScale((s) => Math.max(MIN_TEXT_SCALE, s / TEXT_SCALE_STEP))}
+          title="Decrease text size"
+          aria-label="Decrease text size"
+          style={{ ...zoomCtrlBtnStyle, fontSize: 12 }}
+        >A−</button>
       </div>
 
       {/* Bulk action bar */}

--- a/packages/mindmap/src/MindmapNode.tsx
+++ b/packages/mindmap/src/MindmapNode.tsx
@@ -264,6 +264,14 @@ interface MindmapNodeProps {
    * the threshold; the click handler opens RefineModal.
    */
   wideFanoutCount?: number;
+  /**
+   * Multiplier applied to label font sizes (and the inline-edit input).
+   * Defaults to 1; the editor wires this from the user's text-size pref so
+   * label legibility scales without changing the viewport zoom. Layout
+   * already grew node boxes by the same factor (see computeLayout(scale)),
+   * so the text fits.
+   */
+  textScale?: number;
   onRefineClick?: () => void;
   onSelect: (shiftKey: boolean) => void;
   onDoubleClick: () => void;
@@ -287,6 +295,7 @@ export function MindmapNode({
   isGithubInbox = false,
   hasConflict = false,
   wideFanoutCount,
+  textScale = 1,
   onRefineClick,
   onSelect,
   onDoubleClick,
@@ -606,7 +615,7 @@ export function MindmapNode({
               border: 'none',
               outline: 'none',
               background: 'transparent',
-              fontSize: depth === 0 ? '14px' : '13px',
+              fontSize: `${(depth === 0 ? 14 : 13) * textScale}px`,
               fontWeight: depth === 0 ? '700' : '500',
               color: textColor,
               fontFamily: 'inherit',
@@ -621,7 +630,7 @@ export function MindmapNode({
           y={y + height / 2}
           textAnchor="middle"
           dominantBaseline="central"
-          fontSize={depth === 0 ? 14 : 13}
+          fontSize={(depth === 0 ? 14 : 13) * textScale}
           fontWeight={depth === 0 ? 700 : hasChildren ? 600 : 400}
           fill={progress >= 100 ? '#94a3b8' : textColor}
           style={{ pointerEvents: 'none', userSelect: 'none' }}

--- a/packages/mindmap/src/layout.ts
+++ b/packages/mindmap/src/layout.ts
@@ -53,10 +53,10 @@ function computeWrapGrid(n: number): { major: number; minor: number } {
 
 // ── Measure node width ─────────────────────────────────────────
 
-function measureNodeWidth(text: string, hasChildren: boolean): number {
-  const textWidth = text.length * CHAR_WIDTH + 32; // 16px padding each side
-  const baseWidth = hasChildren ? NODE_PARENT_WIDTH : NODE_BASE_WIDTH;
-  return Math.min(MAX_NODE_WIDTH, Math.max(MIN_NODE_WIDTH, Math.max(baseWidth, textWidth)));
+function measureNodeWidth(text: string, hasChildren: boolean, scale: number): number {
+  const textWidth = text.length * CHAR_WIDTH * scale + 32 * scale; // 16px padding each side
+  const baseWidth = (hasChildren ? NODE_PARENT_WIDTH : NODE_BASE_WIDTH) * scale;
+  return Math.min(MAX_NODE_WIDTH * scale, Math.max(MIN_NODE_WIDTH * scale, Math.max(baseWidth, textWidth)));
 }
 
 // ── Internal tree node ────────────────────────────────────────
@@ -78,18 +78,19 @@ function buildTree(
   nodeId: string,
   nodes: Record<string, Node>,
   depth: number = 0,
+  scale: number = 1,
 ): TreeNode | null {
   const node = nodes[nodeId];
   if (!node) return null;
 
   const hasChildren = node.childrenIds.length > 0;
-  const width = measureNodeWidth(node.text, hasChildren);
-  const height = hasChildren ? NODE_PARENT_HEIGHT : NODE_HEIGHT;
+  const width = measureNodeWidth(node.text, hasChildren, scale);
+  const height = (hasChildren ? NODE_PARENT_HEIGHT : NODE_HEIGHT) * scale;
 
   const children: TreeNode[] = [];
   if (!node.collapsed) {
     for (const childId of node.childrenIds) {
-      const child = buildTree(childId, nodes, depth + 1);
+      const child = buildTree(childId, nodes, depth + 1, scale);
       if (child) children.push(child);
     }
   }
@@ -138,17 +139,17 @@ function flatten(tree: TreeNode): LayoutNode[] {
 // Tree Left-to-Right layout
 // ══════════════════════════════════════════════════════════════
 
-function computeSubtreeHeightLR(tree: TreeNode): number {
+function computeSubtreeHeightLR(tree: TreeNode, scale: number): number {
   if (tree.children.length === 0) {
     tree.subtreeHeight = tree.height;
     return tree.subtreeHeight;
   }
 
-  for (const c of tree.children) computeSubtreeHeightLR(c);
+  for (const c of tree.children) computeSubtreeHeightLR(c, scale);
 
   if (shouldWrapChildren(tree)) {
     const { minor } = computeWrapGrid(tree.children.length);
-    const colHeight = minor * NODE_HEIGHT + (minor - 1) * VERTICAL_GAP;
+    const colHeight = minor * NODE_HEIGHT * scale + (minor - 1) * VERTICAL_GAP * scale;
     tree.subtreeHeight = Math.max(tree.height, colHeight);
     return tree.subtreeHeight;
   }
@@ -157,7 +158,7 @@ function computeSubtreeHeightLR(tree: TreeNode): number {
   for (let i = 0; i < tree.children.length; i++) {
     totalChildrenHeight += tree.children[i].subtreeHeight;
     if (i < tree.children.length - 1) {
-      totalChildrenHeight += VERTICAL_GAP;
+      totalChildrenHeight += VERTICAL_GAP * scale;
     }
   }
 
@@ -165,7 +166,7 @@ function computeSubtreeHeightLR(tree: TreeNode): number {
   return tree.subtreeHeight;
 }
 
-function assignPositionsLR(tree: TreeNode, x: number, yStart: number): void {
+function assignPositionsLR(tree: TreeNode, x: number, yStart: number, scale: number): void {
   tree.x = x;
   tree.y = yStart + tree.subtreeHeight / 2 - tree.height / 2;
 
@@ -174,19 +175,19 @@ function assignPositionsLR(tree: TreeNode, x: number, yStart: number): void {
   if (shouldWrapChildren(tree)) {
     const { major, minor } = computeWrapGrid(tree.children.length);
     const colWidth = Math.max(...tree.children.map((c) => c.width));
-    const firstColX = x + tree.width + HORIZONTAL_GAP;
+    const firstColX = x + tree.width + HORIZONTAL_GAP * scale;
 
     for (let i = 0; i < tree.children.length; i++) {
       const colIdx = Math.floor(i / minor);
       const rowIdx = i % minor;
       const child = tree.children[i];
       const itemsInCol = colIdx === major - 1 ? tree.children.length - colIdx * minor : minor;
-      const thisColHeight = itemsInCol * NODE_HEIGHT + (itemsInCol - 1) * VERTICAL_GAP;
+      const thisColHeight = itemsInCol * NODE_HEIGHT * scale + (itemsInCol - 1) * VERTICAL_GAP * scale;
       // Center each column vertically inside the parent's subtreeHeight so
       // the trailing (shorter) column doesn't look stuck to the top.
       const colYTop = yStart + (tree.subtreeHeight - thisColHeight) / 2;
-      child.x = firstColX + colIdx * (colWidth + WRAP_COLUMN_GAP) + (colWidth - child.width) / 2;
-      child.y = colYTop + rowIdx * (NODE_HEIGHT + VERTICAL_GAP);
+      child.x = firstColX + colIdx * (colWidth + WRAP_COLUMN_GAP * scale) + (colWidth - child.width) / 2;
+      child.y = colYTop + rowIdx * (NODE_HEIGHT * scale + VERTICAL_GAP * scale);
     }
     return;
   }
@@ -195,24 +196,24 @@ function assignPositionsLR(tree: TreeNode, x: number, yStart: number): void {
   for (let i = 0; i < tree.children.length; i++) {
     totalChildrenHeight += tree.children[i].subtreeHeight;
     if (i < tree.children.length - 1) {
-      totalChildrenHeight += VERTICAL_GAP;
+      totalChildrenHeight += VERTICAL_GAP * scale;
     }
   }
 
   let childY = yStart + (tree.subtreeHeight - totalChildrenHeight) / 2;
-  const childX = x + tree.width + HORIZONTAL_GAP;
+  const childX = x + tree.width + HORIZONTAL_GAP * scale;
 
   for (const child of tree.children) {
-    assignPositionsLR(child, childX, childY);
-    childY += child.subtreeHeight + VERTICAL_GAP;
+    assignPositionsLR(child, childX, childY, scale);
+    childY += child.subtreeHeight + VERTICAL_GAP * scale;
   }
 }
 
-function layoutTreeLR(rootId: string, nodes: Record<string, Node>): LayoutNode[] {
-  const tree = buildTree(rootId, nodes);
+function layoutTreeLR(rootId: string, nodes: Record<string, Node>, scale: number): LayoutNode[] {
+  const tree = buildTree(rootId, nodes, 0, scale);
   if (!tree) return [];
-  computeSubtreeHeightLR(tree);
-  assignPositionsLR(tree, 40, 40);
+  computeSubtreeHeightLR(tree, scale);
+  assignPositionsLR(tree, 40, 40, scale);
   return flatten(tree);
 }
 
@@ -220,18 +221,18 @@ function layoutTreeLR(rootId: string, nodes: Record<string, Node>): LayoutNode[]
 // Tree Top-to-Bottom layout
 // ══════════════════════════════════════════════════════════════
 
-function computeSubtreeWidthTB(tree: TreeNode): number {
+function computeSubtreeWidthTB(tree: TreeNode, scale: number): number {
   if (tree.children.length === 0) {
     tree.subtreeWidth = tree.width;
     return tree.subtreeWidth;
   }
 
-  for (const c of tree.children) computeSubtreeWidthTB(c);
+  for (const c of tree.children) computeSubtreeWidthTB(c, scale);
 
   if (shouldWrapChildren(tree)) {
     const { minor } = computeWrapGrid(tree.children.length);
     const childWidth = Math.max(...tree.children.map((c) => c.width));
-    const rowWidth = minor * childWidth + (minor - 1) * (HORIZONTAL_GAP / 2);
+    const rowWidth = minor * childWidth + (minor - 1) * (HORIZONTAL_GAP * scale / 2);
     tree.subtreeWidth = Math.max(tree.width, rowWidth);
     return tree.subtreeWidth;
   }
@@ -240,7 +241,7 @@ function computeSubtreeWidthTB(tree: TreeNode): number {
   for (let i = 0; i < tree.children.length; i++) {
     totalChildrenWidth += tree.children[i].subtreeWidth;
     if (i < tree.children.length - 1) {
-      totalChildrenWidth += HORIZONTAL_GAP / 2;
+      totalChildrenWidth += HORIZONTAL_GAP * scale / 2;
     }
   }
 
@@ -248,7 +249,7 @@ function computeSubtreeWidthTB(tree: TreeNode): number {
   return tree.subtreeWidth;
 }
 
-function assignPositionsTB(tree: TreeNode, xStart: number, y: number): void {
+function assignPositionsTB(tree: TreeNode, xStart: number, y: number, scale: number): void {
   tree.x = xStart + tree.subtreeWidth / 2 - tree.width / 2;
   tree.y = y;
 
@@ -257,17 +258,17 @@ function assignPositionsTB(tree: TreeNode, xStart: number, y: number): void {
   if (shouldWrapChildren(tree)) {
     const { major, minor } = computeWrapGrid(tree.children.length);
     const childWidth = Math.max(...tree.children.map((c) => c.width));
-    const firstRowY = y + tree.height + WRAP_ROW_GAP;
-    const rowStep = NODE_HEIGHT + WRAP_ROW_GAP;
+    const firstRowY = y + tree.height + WRAP_ROW_GAP * scale;
+    const rowStep = NODE_HEIGHT * scale + WRAP_ROW_GAP * scale;
 
     for (let i = 0; i < tree.children.length; i++) {
       const rowIdx = Math.floor(i / minor);
       const colIdx = i % minor;
       const child = tree.children[i];
       const itemsInRow = rowIdx === major - 1 ? tree.children.length - rowIdx * minor : minor;
-      const thisRowWidth = itemsInRow * childWidth + (itemsInRow - 1) * (HORIZONTAL_GAP / 2);
+      const thisRowWidth = itemsInRow * childWidth + (itemsInRow - 1) * (HORIZONTAL_GAP * scale / 2);
       const rowXStart = xStart + (tree.subtreeWidth - thisRowWidth) / 2;
-      child.x = rowXStart + colIdx * (childWidth + HORIZONTAL_GAP / 2) + (childWidth - child.width) / 2;
+      child.x = rowXStart + colIdx * (childWidth + HORIZONTAL_GAP * scale / 2) + (childWidth - child.width) / 2;
       child.y = firstRowY + rowIdx * rowStep;
     }
     return;
@@ -277,24 +278,24 @@ function assignPositionsTB(tree: TreeNode, xStart: number, y: number): void {
   for (let i = 0; i < tree.children.length; i++) {
     totalChildrenWidth += tree.children[i].subtreeWidth;
     if (i < tree.children.length - 1) {
-      totalChildrenWidth += HORIZONTAL_GAP / 2;
+      totalChildrenWidth += HORIZONTAL_GAP * scale / 2;
     }
   }
 
   let childX = xStart + (tree.subtreeWidth - totalChildrenWidth) / 2;
-  const childY = y + tree.height + VERTICAL_GAP * 3;
+  const childY = y + tree.height + VERTICAL_GAP * scale * 3;
 
   for (const child of tree.children) {
-    assignPositionsTB(child, childX, childY);
-    childX += child.subtreeWidth + HORIZONTAL_GAP / 2;
+    assignPositionsTB(child, childX, childY, scale);
+    childX += child.subtreeWidth + HORIZONTAL_GAP * scale / 2;
   }
 }
 
-function layoutTreeTB(rootId: string, nodes: Record<string, Node>): LayoutNode[] {
-  const tree = buildTree(rootId, nodes);
+function layoutTreeTB(rootId: string, nodes: Record<string, Node>, scale: number): LayoutNode[] {
+  const tree = buildTree(rootId, nodes, 0, scale);
   if (!tree) return [];
-  computeSubtreeWidthTB(tree);
-  assignPositionsTB(tree, 40, 40);
+  computeSubtreeWidthTB(tree, scale);
+  assignPositionsTB(tree, 40, 40, scale);
   return flatten(tree);
 }
 
@@ -302,15 +303,15 @@ function layoutTreeTB(rootId: string, nodes: Record<string, Node>): LayoutNode[]
 // Org Chart layout (top-to-bottom, wider spacing)
 // ══════════════════════════════════════════════════════════════
 
-function layoutOrgChart(rootId: string, nodes: Record<string, Node>): LayoutNode[] {
-  const tree = buildTree(rootId, nodes);
+function layoutOrgChart(rootId: string, nodes: Record<string, Node>, scale: number): LayoutNode[] {
+  const tree = buildTree(rootId, nodes, 0, scale);
   if (!tree) return [];
-  computeSubtreeWidthOC(tree);
-  assignPositionsOC(tree, 40, 40);
+  computeSubtreeWidthOC(tree, scale);
+  assignPositionsOC(tree, 40, 40, scale);
   return flatten(tree);
 }
 
-function computeSubtreeWidthOC(tree: TreeNode): number {
+function computeSubtreeWidthOC(tree: TreeNode, scale: number): number {
   if (tree.children.length === 0) {
     tree.subtreeWidth = tree.width;
     return tree.subtreeWidth;
@@ -318,9 +319,9 @@ function computeSubtreeWidthOC(tree: TreeNode): number {
 
   let totalChildrenWidth = 0;
   for (let i = 0; i < tree.children.length; i++) {
-    totalChildrenWidth += computeSubtreeWidthOC(tree.children[i]);
+    totalChildrenWidth += computeSubtreeWidthOC(tree.children[i], scale);
     if (i < tree.children.length - 1) {
-      totalChildrenWidth += HORIZONTAL_GAP;
+      totalChildrenWidth += HORIZONTAL_GAP * scale;
     }
   }
 
@@ -328,7 +329,7 @@ function computeSubtreeWidthOC(tree: TreeNode): number {
   return tree.subtreeWidth;
 }
 
-function assignPositionsOC(tree: TreeNode, xStart: number, y: number): void {
+function assignPositionsOC(tree: TreeNode, xStart: number, y: number, scale: number): void {
   tree.x = xStart + tree.subtreeWidth / 2 - tree.width / 2;
   tree.y = y;
 
@@ -338,16 +339,16 @@ function assignPositionsOC(tree: TreeNode, xStart: number, y: number): void {
   for (let i = 0; i < tree.children.length; i++) {
     totalChildrenWidth += tree.children[i].subtreeWidth;
     if (i < tree.children.length - 1) {
-      totalChildrenWidth += HORIZONTAL_GAP;
+      totalChildrenWidth += HORIZONTAL_GAP * scale;
     }
   }
 
   let childX = xStart + (tree.subtreeWidth - totalChildrenWidth) / 2;
-  const childY = y + tree.height + VERTICAL_GAP * 5;
+  const childY = y + tree.height + VERTICAL_GAP * scale * 5;
 
   for (const child of tree.children) {
-    assignPositionsOC(child, childX, childY);
-    childX += child.subtreeWidth + HORIZONTAL_GAP;
+    assignPositionsOC(child, childX, childY, scale);
+    childX += child.subtreeWidth + HORIZONTAL_GAP * scale;
   }
 }
 
@@ -395,8 +396,8 @@ function assignPositionsRadial(
   }
 }
 
-function layoutRadial(rootId: string, nodes: Record<string, Node>): LayoutNode[] {
-  const tree = buildTree(rootId, nodes);
+function layoutRadial(rootId: string, nodes: Record<string, Node>, scale: number): LayoutNode[] {
+  const tree = buildTree(rootId, nodes, 0, scale);
   if (!tree) return [];
 
   const cx = 400;
@@ -417,18 +418,19 @@ export function computeLayout(
   rootId: string,
   nodes: Record<string, Node>,
   layoutType: LayoutType = 'tree-lr',
+  textScale: number = 1,
 ): LayoutNode[] {
   switch (layoutType) {
     case 'tree-lr':
-      return layoutTreeLR(rootId, nodes);
+      return layoutTreeLR(rootId, nodes, textScale);
     case 'tree-tb':
-      return layoutTreeTB(rootId, nodes);
+      return layoutTreeTB(rootId, nodes, textScale);
     case 'radial':
-      return layoutRadial(rootId, nodes);
+      return layoutRadial(rootId, nodes, textScale);
     case 'org-chart':
-      return layoutOrgChart(rootId, nodes);
+      return layoutOrgChart(rootId, nodes, textScale);
     default:
-      return layoutTreeLR(rootId, nodes);
+      return layoutTreeLR(rootId, nodes, textScale);
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds floating **A+ / nnn% / A−** controls beside the zoom column so users can grow node label text without zooming in (which loses overview).
- `computeLayout` takes an optional `textScale` arg (default 1, backward compatible) and threads it through every layout function so node widths/heights/gaps scale proportionally — labels never overflow their boxes.
- Preference persists in `localStorage` (`mindmap.textScale`), clamped 0.8–2.0, 1.15× per step.

## Test plan
- [x] `pnpm turbo typecheck --filter=@mindblown/mindmap` clean
- [ ] On prod: click A+ a few times — node text grows, layout reflows, viewport zoom unchanged
- [ ] Reload — chosen scale persists
- [ ] A− back to 100% restores original sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)