### PR TITLE
feat(mindmap): rebase visual base at "200%" + anchor focal node on rescale

### DIFF
--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -282,33 +282,68 @@ export function MindmapEditor() {
     if (typeof window === 'undefined') return;
     window.localStorage.setItem(TEXT_SCALE_STORAGE_KEY, String(textScale));
   }, [textScale]);
-  // Bump textScale by a factor while compensating viewport pan so the
-  // current screen center stays put. Without this, raising textScale
-  // visually slides the whole tree off-center because every node's
-  // layout coord grew proportional to the new scale.
+  // Bump textScale while anchoring a focal node — the selected node when
+  // there is one, otherwise the visible node closest to the screen
+  // center. We capture that node's pre-rescale screen position, set the
+  // new scale, then on the next frame (after the layout reflows with the
+  // new constants) adjust pan so the focal node lands at the same screen
+  // coordinates. This is more reliable than the prior linear-origin
+  // approximation, especially for radial/wrap layouts where the
+  // relationship between logical-coord and scale is not strictly linear.
   const changeTextScale = useCallback((nextScale: number) => {
     const oldScale = textScaleRef.current;
     const clamped = Math.min(MAX_TEXT_SCALE, Math.max(MIN_TEXT_SCALE, nextScale));
     if (Math.abs(clamped - oldScale) < 1e-6) return;
-    const ratio = clamped / oldScale;
+
     const svg = svgRef.current;
-    if (svg) {
+    const layoutMap = layoutMapRef.current;
+    const view = viewRef.current;
+
+    let focal: { id: string; screenX: number; screenY: number } | null = null;
+    if (svg && layoutMap.size > 0) {
       const rect = svg.getBoundingClientRect();
-      setView((v) => {
-        // Logical coord under the screen center, pre-rescale.
-        const cx = (rect.width / 2 - v.panX) / v.zoom;
-        const cy = (rect.height / 2 - v.panY) / v.zoom;
-        // Layout origin is (40,40) — only the distance from origin scales.
-        const newCx = 40 + (cx - 40) * ratio;
-        const newCy = 40 + (cy - 40) * ratio;
-        return {
-          ...v,
-          panX: rect.width / 2 - newCx * v.zoom,
-          panY: rect.height / 2 - newCy * v.zoom,
+      const cx = (rect.width / 2 - view.panX) / view.zoom;
+      const cy = (rect.height / 2 - view.panY) / view.zoom;
+      let focalId: string | null = null;
+      const sel = selectedNodeIdRef.current;
+      if (sel && layoutMap.has(sel)) {
+        focalId = sel;
+      } else {
+        let best = Infinity;
+        for (const ln of layoutMap.values()) {
+          const dx = ln.x + ln.width / 2 - cx;
+          const dy = ln.y + ln.height / 2 - cy;
+          const d = dx * dx + dy * dy;
+          if (d < best) { best = d; focalId = ln.id; }
+        }
+      }
+      if (focalId) {
+        const ln = layoutMap.get(focalId)!;
+        focal = {
+          id: focalId,
+          screenX: (ln.x + ln.width / 2) * view.zoom + view.panX,
+          screenY: (ln.y + ln.height / 2) * view.zoom + view.panY,
         };
-      });
+      }
     }
+
     setTextScale(clamped);
+
+    if (!focal) return;
+    // Two rAFs — layoutMap is recomputed inside a useMemo dependent on
+    // textScale, then the ref-syncing useEffect runs after paint. One
+    // frame catches the layoutMap update; we wait a second to be safe.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const after = layoutMapRef.current.get(focal!.id);
+        if (!after) return;
+        setView((v) => ({
+          ...v,
+          panX: focal!.screenX - (after.x + after.width / 2) * v.zoom,
+          panY: focal!.screenY - (after.y + after.height / 2) * v.zoom,
+        }));
+      });
+    });
   }, []);
   const [isPanning, setIsPanning] = useState(false);
   const panStart = useRef<{ x: number; y: number; panX: number; panY: number } | null>(null);
@@ -534,9 +569,9 @@ export function MindmapEditor() {
     for (const dn of dimmedNodes) {
       // Mirror the constants used in layout.ts:measureNodeWidth so dimmed
       // siblings grow with the same textScale as the main tree.
-      const textWidth = dn.node.text.length * 7.5 * textScale + 32 * textScale;
-      const width = Math.min(260 * textScale, Math.max(100 * textScale, Math.max(160 * textScale, textWidth)));
-      const height = 40 * textScale;
+      const textWidth = dn.node.text.length * 17 * textScale + 64 * textScale;
+      const width = Math.min(520 * textScale, Math.max(200 * textScale, Math.max(320 * textScale, textWidth)));
+      const height = 80 * textScale;
       result.push({
         id: dn.node.id,
         x: mainBounds.minX - width - 80,
@@ -548,7 +583,7 @@ export function MindmapEditor() {
         hasChildren: dn.node.childrenIds.length > 0,
         collapsed: dn.node.collapsed,
       });
-      yOffset += height + 14 * textScale;
+      yOffset += height + 28 * textScale;
     }
     return result;
   }, [visibleNodes, layoutNodes, effectiveRootId, textScale]);
@@ -565,6 +600,16 @@ export function MindmapEditor() {
     }
     return map;
   }, [allLayoutNodes]);
+
+  // Mirror layoutMap, view, and selectedNodeId into refs so the textScale
+  // handler can read them without stale-closure issues — it needs the
+  // pre-rescale positions to anchor a focal node across the rescale.
+  const layoutMapRef = useRef(layoutMap);
+  useEffect(() => { layoutMapRef.current = layoutMap; }, [layoutMap]);
+  const viewRef = useRef(view);
+  useEffect(() => { viewRef.current = view; }, [view]);
+  const selectedNodeIdRef = useRef(selectedNodeId);
+  useEffect(() => { selectedNodeIdRef.current = selectedNodeId; }, [selectedNodeId]);
 
   // ── Selected node IDs as a Set for fast lookup ────────────
 

--- a/packages/mindmap/src/MindmapNode.tsx
+++ b/packages/mindmap/src/MindmapNode.tsx
@@ -89,15 +89,15 @@ function AvatarCircle({ userId, index, scale = 1 }: { userId: string; index: num
   const initials = userId.slice(-2).toUpperCase();
 
   return (
-    <g transform={`translate(${index * 14 * scale}, 0)`}>
-      <circle cx={8 * scale} cy={8 * scale} r={8 * scale} fill={color} />
+    <g transform={`translate(${index * 28 * scale}, 0)`}>
+      <circle cx={16 * scale} cy={16 * scale} r={16 * scale} fill={color} />
       <text
-        x={8 * scale}
-        y={8 * scale}
+        x={16 * scale}
+        y={16 * scale}
         textAnchor="middle"
         dominantBaseline="central"
         fill="white"
-        fontSize={7 * scale}
+        fontSize={14 * scale}
         fontWeight="600"
       >
         {initials}
@@ -122,14 +122,14 @@ function ClaimBadge({ sessionId, nodeX, nodeY, nodeWidth, nodeHeight, scale = 1 
 }) {
   // Truncate to last 8 chars so it stays readable at small sizes
   const label = sessionId.length > 8 ? '…' + sessionId.slice(-8) : sessionId;
-  const badgeWidth = (label.length * 6 + 12) * scale;
-  const badgeHeight = 13 * scale;
-  const badgeX = nodeX + nodeWidth - badgeWidth - 2 * scale;
+  const badgeWidth = (label.length * 12 + 24) * scale;
+  const badgeHeight = 26 * scale;
+  const badgeX = nodeX + nodeWidth - badgeWidth - 4 * scale;
   // #119: clamp to canvas top — if placing the badge above the node
   // would put it at y<0, flip it under the node instead so it never
   // gets clipped by the SVG viewport.
-  const ABOVE_Y = nodeY - 14 * scale;
-  const badgeY = ABOVE_Y < 0 ? nodeY + nodeHeight + 1 * scale : ABOVE_Y;
+  const ABOVE_Y = nodeY - 28 * scale;
+  const badgeY = ABOVE_Y < 0 ? nodeY + nodeHeight + 2 * scale : ABOVE_Y;
 
   return (
     <g>
@@ -139,7 +139,7 @@ function ClaimBadge({ sessionId, nodeX, nodeY, nodeWidth, nodeHeight, scale = 1 
         y={badgeY}
         width={badgeWidth}
         height={badgeHeight}
-        rx={6 * scale}
+        rx={12 * scale}
         fill="#f59e0b"
         opacity={0.92}
       />
@@ -148,7 +148,7 @@ function ClaimBadge({ sessionId, nodeX, nodeY, nodeWidth, nodeHeight, scale = 1 
         y={badgeY + badgeHeight / 2}
         textAnchor="middle"
         dominantBaseline="central"
-        fontSize={8 * scale}
+        fontSize={16 * scale}
         fontWeight={600}
         fill="#fff"
         style={{ pointerEvents: 'none', userSelect: 'none' }}
@@ -180,21 +180,21 @@ function ScopeChips({ scopes, nodeX, nodeY, nodeWidth, nodeHeight, claimedBadgeB
 }) {
   if (scopes.length === 0) return null;
 
-  const CHIP_HEIGHT = 12 * scale;
-  const CHIP_PAD_X = 5 * scale;
-  const CHIP_GAP = 4 * scale;
-  const ABOVE_Y = nodeY - 16 * scale - CHIP_HEIGHT;
+  const CHIP_HEIGHT = 24 * scale;
+  const CHIP_PAD_X = 10 * scale;
+  const CHIP_GAP = 8 * scale;
+  const ABOVE_Y = nodeY - 32 * scale - CHIP_HEIGHT;
   // #119: clamp to canvas top — when the default above-node placement
   // would render at y<0, render under the node. If the claim badge
-  // also got clamped, leave room for it (badge height ~13 + 2 gap).
-  const belowOffset = claimedBadgeBelow ? nodeHeight + (1 + 13 + 2) * scale : nodeHeight + 1 * scale;
+  // also got clamped, leave room for it (badge height ~26 + 4 gap).
+  const belowOffset = claimedBadgeBelow ? nodeHeight + (2 + 26 + 4) * scale : nodeHeight + 2 * scale;
   const CHIP_Y = ABOVE_Y < 0 ? nodeY + belowOffset : ABOVE_Y;
 
   let xCursor = nodeX;
   const chips: Array<{ label: string; x: number; width: number }> = [];
 
   for (const scope of scopes) {
-    const chipWidth = scope.length * 5.5 * scale + CHIP_PAD_X * 2;
+    const chipWidth = scope.length * 11 * scale + CHIP_PAD_X * 2;
     if (xCursor + chipWidth > nodeX + nodeWidth) break; // overflow → stop
     chips.push({ label: scope, x: xCursor, width: chipWidth });
     xCursor += chipWidth + CHIP_GAP;
@@ -212,17 +212,17 @@ function ScopeChips({ scopes, nodeX, nodeY, nodeWidth, nodeHeight, claimedBadgeB
             y={CHIP_Y}
             width={chip.width}
             height={CHIP_HEIGHT}
-            rx={5 * scale}
+            rx={10 * scale}
             fill="#e0e7ff"
             stroke="#a5b4fc"
-            strokeWidth={0.5}
+            strokeWidth={1}
           />
           <text
             x={chip.x + chip.width / 2}
             y={CHIP_Y + CHIP_HEIGHT / 2}
             textAnchor="middle"
             dominantBaseline="central"
-            fontSize={7.5 * scale}
+            fontSize={15 * scale}
             fontWeight={500}
             fill="#3730a3"
             style={{ pointerEvents: 'none', userSelect: 'none' }}
@@ -385,7 +385,7 @@ export function MindmapNode({
 
   // ── Annotations offset ────────────────────────────────────
 
-  const annotationY = y + height + 4 * textScale;
+  const annotationY = y + height + 8 * textScale;
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -457,12 +457,12 @@ export function MindmapNode({
 
       {/* Collapse indicator */}
       {collapsed && !hasHiddenChildren && (
-        <g transform={`translate(${x + width - 8 * textScale}, ${y + height / 2})`}>
-          <circle r={8 * textScale} fill="#f1f5f9" stroke="#cbd5e1" strokeWidth="1" />
+        <g transform={`translate(${x + width - 16 * textScale}, ${y + height / 2})`}>
+          <circle r={16 * textScale} fill="#f1f5f9" stroke="#cbd5e1" strokeWidth="1" />
           <text
             textAnchor="middle"
             dominantBaseline="central"
-            fontSize={11 * textScale}
+            fontSize={22 * textScale}
             fontWeight="700"
             fill="#64748b"
           >
@@ -473,16 +473,16 @@ export function MindmapNode({
 
       {/* Hidden children badge (depth limit reached) */}
       {hasHiddenChildren && hiddenDescendantCount > 0 && (() => {
-        const badgeW = (hiddenDescendantCount >= 100 ? 52 : hiddenDescendantCount >= 10 ? 46 : 40) * textScale;
-        const badgeH = 20 * textScale;
+        const badgeW = (hiddenDescendantCount >= 100 ? 104 : hiddenDescendantCount >= 10 ? 92 : 80) * textScale;
+        const badgeH = 40 * textScale;
         return (
-        <g transform={`translate(${x + width + 6 * textScale}, ${y + height / 2 - badgeH / 2})`}>
+        <g transform={`translate(${x + width + 12 * textScale}, ${y + height / 2 - badgeH / 2})`}>
           <rect
             x={0}
             y={0}
             width={badgeW}
             height={badgeH}
-            rx={10 * textScale}
+            rx={20 * textScale}
             fill="#eef2ff"
             stroke="#c7d2fe"
             strokeWidth={1}
@@ -492,7 +492,7 @@ export function MindmapNode({
             y={badgeH / 2}
             textAnchor="middle"
             dominantBaseline="central"
-            fontSize={10 * textScale}
+            fontSize={20 * textScale}
             fontWeight={600}
             fill="#4f46e5"
             style={{ pointerEvents: 'none', userSelect: 'none' }}
@@ -501,7 +501,7 @@ export function MindmapNode({
           </text>
           {/* Small expand arrow hint */}
           <polygon
-            points={`${badgeW + 2 * textScale},${7 * textScale} ${badgeW + 7 * textScale},${10 * textScale} ${badgeW + 2 * textScale},${13 * textScale}`}
+            points={`${badgeW + 4 * textScale},${14 * textScale} ${badgeW + 14 * textScale},${20 * textScale} ${badgeW + 4 * textScale},${26 * textScale}`}
             fill="#4f46e5"
             opacity={0.5}
           />
@@ -512,12 +512,12 @@ export function MindmapNode({
       {/* Strikethrough for done nodes */}
       {progress >= 100 && (
         <line
-          x1={x + 12 * textScale}
+          x1={x + 24 * textScale}
           y1={y + height / 2}
-          x2={x + width - 12 * textScale}
+          x2={x + width - 24 * textScale}
           y2={y + height / 2}
           stroke="#94a3b8"
-          strokeWidth={1.5}
+          strokeWidth={3}
           style={{ pointerEvents: 'none' }}
         />
       )}
@@ -525,9 +525,9 @@ export function MindmapNode({
       {/* Priority dot */}
       {showPriority && node.priority && (
         <circle
-          cx={x + (showProgress ? 32 : 14) * textScale}
+          cx={x + (showProgress ? 64 : 28) * textScale}
           cy={y + height / 2}
-          r={4 * textScale}
+          r={8 * textScale}
           fill={PRIORITY_COLORS[node.priority] || '#6b7280'}
         />
       )}
@@ -543,9 +543,9 @@ export function MindmapNode({
         >
           <title>{githubLink.externalId}</title>
           <OctocatIcon
-            x={x + width - 14 * textScale}
-            y={y + 3 * textScale}
-            size={11 * textScale}
+            x={x + width - 28 * textScale}
+            y={y + 6 * textScale}
+            size={22 * textScale}
             color={githubLink.syncEnabled ? '#1f2937' : '#9ca3af'}
           />
         </g>
@@ -567,19 +567,19 @@ export function MindmapNode({
             {wideFanoutCount} children — click for grouping suggestions
           </title>
           <circle
-            cx={x + 8 * textScale}
-            cy={y + 8 * textScale}
-            r={7 * textScale}
+            cx={x + 16 * textScale}
+            cy={y + 16 * textScale}
+            r={14 * textScale}
             fill="#eef2ff"
             stroke="#6366f1"
-            strokeWidth={1}
+            strokeWidth={1.5}
           />
           <text
-            x={x + 8 * textScale}
-            y={y + 8 * textScale}
+            x={x + 16 * textScale}
+            y={y + 16 * textScale}
             textAnchor="middle"
             dominantBaseline="central"
-            fontSize={9 * textScale}
+            fontSize={18 * textScale}
             fontWeight={700}
             fill="#4338ca"
             style={{ pointerEvents: 'none', userSelect: 'none' }}
@@ -594,9 +594,9 @@ export function MindmapNode({
         <g>
           <title>GitHub Inbox — auto-imported issues land here</title>
           <OctocatIcon
-            x={x + width - 14 * textScale}
-            y={y + 3 * textScale}
-            size={11 * textScale}
+            x={x + width - 28 * textScale}
+            y={y + 6 * textScale}
+            size={22 * textScale}
             color="#4f46e5"
           />
         </g>
@@ -605,10 +605,10 @@ export function MindmapNode({
       {/* Node text or edit input */}
       {isEditing ? (
         <foreignObject
-          x={x + 4 * textScale}
-          y={y + 2 * textScale}
-          width={width - 8 * textScale}
-          height={height - 4 * textScale}
+          x={x + 8 * textScale}
+          y={y + 4 * textScale}
+          width={width - 16 * textScale}
+          height={height - 8 * textScale}
         >
           <input
             ref={inputRef}
@@ -622,12 +622,12 @@ export function MindmapNode({
               border: 'none',
               outline: 'none',
               background: 'transparent',
-              fontSize: `${(depth === 0 ? 16 : 15) * textScale}px`,
+              fontSize: `${(depth === 0 ? 32 : 30) * textScale}px`,
               fontWeight: depth === 0 ? '700' : '500',
               color: textColor,
               fontFamily: 'inherit',
               textAlign: 'center',
-              padding: '0 4px',
+              padding: '0 8px',
             }}
           />
         </foreignObject>
@@ -637,7 +637,7 @@ export function MindmapNode({
           y={y + height / 2}
           textAnchor="middle"
           dominantBaseline="central"
-          fontSize={(depth === 0 ? 16 : 15) * textScale}
+          fontSize={(depth === 0 ? 32 : 30) * textScale}
           fontWeight={depth === 0 ? 700 : hasChildren ? 600 : 400}
           fill={progress >= 100 ? '#94a3b8' : textColor}
           style={{ pointerEvents: 'none', userSelect: 'none' }}
@@ -648,7 +648,7 @@ export function MindmapNode({
 
       {/* Assignee avatars (below node) */}
       {showAssignees && (
-        <g transform={`translate(${x + 4 * textScale}, ${annotationY})`}>
+        <g transform={`translate(${x + 8 * textScale}, ${annotationY})`}>
           {node.assigneeIds.slice(0, 3).map((uid, i) => (
             <AvatarCircle key={uid} userId={uid} index={i} scale={textScale} />
           ))}
@@ -658,10 +658,10 @@ export function MindmapNode({
       {/* Progress % and remaining effort (below node, right-aligned) */}
       {effort > 0 && (
         <text
-          x={x + width - 8 * textScale}
-          y={annotationY + 8 * textScale}
+          x={x + width - 16 * textScale}
+          y={annotationY + 16 * textScale}
           textAnchor="end"
-          fontSize={10 * textScale}
+          fontSize={20 * textScale}
           fill={progress >= 100 ? '#059669' : '#64748b'}
           fontWeight={500}
           style={{ pointerEvents: 'none' }}
@@ -685,7 +685,7 @@ export function MindmapNode({
           nodeY={y}
           nodeWidth={width}
           nodeHeight={height}
-          claimedBadgeBelow={!!node.claimedBySession && y - 14 * textScale < 0}
+          claimedBadgeBelow={!!node.claimedBySession && y - 28 * textScale < 0}
           scale={textScale}
         />
       )}

--- a/packages/mindmap/src/layout.ts
+++ b/packages/mindmap/src/layout.ts
@@ -19,15 +19,18 @@ export type LayoutType = 'tree-lr' | 'tree-tb' | 'radial' | 'org-chart';
 
 // ── Configuration ──────────────────────────────────────────────
 
-const NODE_BASE_WIDTH = 160;
-const NODE_PARENT_WIDTH = 180;
-const NODE_HEIGHT = 40;
-const NODE_PARENT_HEIGHT = 44;
-const HORIZONTAL_GAP = 60;
-const VERTICAL_GAP = 14;
-const CHAR_WIDTH = 8.5; // approximate px per character (calibrated for the 15/16 base label fontSize)
-const MIN_NODE_WIDTH = 100;
-const MAX_NODE_WIDTH = 260;
+// All sizes baked at the "200%" feel — the previous default was half
+// these values and felt too small at typical viewing distances. textScale
+// is now a multiplier on top, so 1.0 is the comfortable default.
+const NODE_BASE_WIDTH = 320;
+const NODE_PARENT_WIDTH = 360;
+const NODE_HEIGHT = 80;
+const NODE_PARENT_HEIGHT = 88;
+const HORIZONTAL_GAP = 120;
+const VERTICAL_GAP = 28;
+const CHAR_WIDTH = 17; // approximate px per character (calibrated for the 30/32 base label fontSize)
+const MIN_NODE_WIDTH = 200;
+const MAX_NODE_WIDTH = 520;
 
 // Wrap wide leaf-fans into multiple columns/rows. Only triggers when a node
 // has > WRAP_THRESHOLD children AND all of those children are leaves —
@@ -54,7 +57,7 @@ function computeWrapGrid(n: number): { major: number; minor: number } {
 // ── Measure node width ─────────────────────────────────────────
 
 function measureNodeWidth(text: string, hasChildren: boolean, scale: number): number {
-  const textWidth = text.length * CHAR_WIDTH * scale + 32 * scale; // 16px padding each side
+  const textWidth = text.length * CHAR_WIDTH * scale + 64 * scale; // 32px padding each side
   const baseWidth = (hasChildren ? NODE_PARENT_WIDTH : NODE_BASE_WIDTH) * scale;
   return Math.min(MAX_NODE_WIDTH * scale, Math.max(MIN_NODE_WIDTH * scale, Math.max(baseWidth, textWidth)));
 }
@@ -379,7 +382,7 @@ function assignPositionsRadial(
   if (tree.children.length === 0) return;
 
   const totalLeaves = tree.children.reduce((s, c) => s + countLeaves(c), 0);
-  const childRadius = radius + Math.max(tree.width, 180) + 40;
+  const childRadius = radius + Math.max(tree.width, 360) + 80;
 
   let currentAngle = startAngle;
 


### PR DESCRIPTION
## Summary
Two direct fixes from in-product testing:

1. **The old "200%" is the new base.** Every layout/node literal doubled — `NODE_BASE_WIDTH` 160→320, `NODE_HEIGHT` 40→80, `CHAR_WIDTH` 8.5→17, gaps, radial padding, and all in-node badge/font constants. "100%" now renders at the comfortable size the user confirmed they like; the slider still multiplies on top.
2. **Nodes no longer drift across rescale.** The previous linear-origin pan compensation was an approximation that didn't hold for radial/wrap layouts. Replaced with focal-node anchoring: pick a focal node (selected if any, else closest to screen center), capture its pre-rescale screen position, set the new scale, then on the next two rAFs pan so the focal node lands at the same screen coordinates.

## Test plan
- [x] `pnpm turbo typecheck --filter=@mindblown/mindmap` clean
- [ ] On prod: at 100% the map looks like the prior 200% — comfortable to read without zooming in
- [ ] A+/A− no longer moves the focal node visibly off-screen
- [ ] Selected node stays in place across A+ even when far from screen center

🤖 Generated with [Claude Code](https://claude.com/claude-code)