### PR TITLE
fix(mindmap): tighten distributeLeavesAroundParent for new node base

### DIFF
--- a/packages/mindmap/src/layout.ts
+++ b/packages/mindmap/src/layout.ts
@@ -479,14 +479,23 @@ export function distributeLeavesAroundParent(
   const cy = parentLayout.y + parentLayout.height / 2;
 
   // Radius must clear the parent and (for N≥2) give each chord enough room
-  // for one leaf bounding box plus a small gap.
-  const SPACING = 16;
-  const PARENT_GAP = 40;
+  // along the chord direction. SPACING/PARENT_GAP were calibrated for the
+  // pre-2x node sizes — at the new larger base they pushed leaves so far
+  // out that fit-to-screen made labels unreadably small. Two changes:
+  //   - drop SPACING/PARENT_GAP to modest absolute pixel values,
+  //   - require only ~65% of the worst-case leaf bounding box along the
+  //     chord. Adjacent leaves sit at different angles, so the *tangential*
+  //     extent that actually needs to fit on the chord is smaller than the
+  //     axis-aligned width — the leaves don't actually overlap in screen
+  //     space despite the chord allowing some bbox overlap.
+  const SPACING = 8;
+  const PARENT_GAP = 20;
+  const CHORD_FILL = 0.65;
   const radiusForParent =
     Math.max(parentLayout.width, parentLayout.height) / 2 +
     Math.max(maxLeafW, maxLeafH) / 2 +
     PARENT_GAP;
-  const minChord = Math.max(maxLeafW, maxLeafH) + SPACING;
+  const minChord = Math.max(maxLeafW, maxLeafH) * CHORD_FILL + SPACING;
   const radiusForFit = N >= 2 ? minChord / (2 * Math.sin(Math.PI / N)) : 0;
   const radius = Math.max(radiusForParent, radiusForFit);
 


### PR DESCRIPTION
## Summary
After the 2x node-size bump in #195, \`Distribute leaves around node\` placed leaves at radii large enough that fit-to-screen made labels unreadable. Two changes inside the radius math:

- **Drop the absolute constants.** \`SPACING\` 16→8, \`PARENT_GAP\` 40→20. They were calibrated for the old smaller nodes — the absolute padding doesn't need to scale.
- **Loosen the chord requirement to ~65% of the leaf bbox.** Adjacent leaves sit at different angles, so the *tangential* extent that has to fit on the chord is smaller than the axis-aligned width. Allowing the chord to "overlap" the bbox by ~35% lets leaves pack closer without actually overlapping in screen space.

## Test plan
- [x] \`pnpm turbo typecheck --filter=@mindblown/mindmap\` clean
- [ ] On prod: right-click a node with 4-12 leaf children → "Distribute leaves around node" → leaves cluster close enough that labels stay readable at fit-to-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)