### PR TITLE
fix(webhook): only transition issue→done when PR merges to default branch

### DIFF
--- a/packages/integrations/src/github.ts
+++ b/packages/integrations/src/github.ts
@@ -376,29 +376,19 @@ export function processWebhook(
     }
   }
 
-  // pull_request events — check if PR references a linked issue
-  if (event === 'pull_request' && payload.action === 'closed' && payload.pull_request?.merged) {
-    // Try to extract linked issue references from PR body
-    // Common patterns: "Closes #42", "Fixes #42", "Resolves #42"
-    const prBody = payload.pull_request.body ?? '';
-    const prTitle = payload.pull_request.title ?? '';
-    const text = `${prTitle} ${prBody}`;
-    const repoName = payload.repository?.full_name ?? '';
-
-    const issueRefs = extractClosingIssueRefs(text);
-    if (issueRefs.length > 0) {
-      // Return update for the first referenced issue
-      const issueNumber = issueRefs[0];
-      return {
-        action: 'pull_request.merged',
-        externalId: `${repoName}#${issueNumber}`,
-        nodeUpdates: {
-          percentComplete: 100,
-          status: 'done',
-        },
-      };
-    }
-  }
+  // NOTE: the legacy pull_request → done branch lived here. Removed
+  // 2026-06-11 because the canonical handler in
+  // @mindblown/server (routes/integrations.ts, around the
+  // `pull_request: closed + merged=true` block) is a strict superset:
+  //   - iterates ALL `Closes #N` refs, not just the first
+  //   - is idempotent on replay
+  //   - gates on the PR's base branch matching the repo's default branch,
+  //     mirroring GitHub's own auto-close behaviour (#199)
+  // The legacy single-ref + branch-agnostic version here was reachable
+  // via the `processWebhook` fall-through after the canonical handler
+  // skipped on the default-branch gate, which caused V1-hotfix PRs
+  // (base=release/v1) to still transition their linked nodes to done —
+  // exactly the bug #199 was meant to fix.
 
   return { action: `${event}.${payload.action}`, nodeUpdates: null, externalId: null };
 }

--- a/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
+++ b/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
@@ -152,7 +152,16 @@ async function buildApp(logger = false): Promise<FastifyInstance> {
   return app;
 }
 
-function prMergedPayload(opts: { number: number; title: string; body: string | null }): Record<string, unknown> {
+function prMergedPayload(opts: {
+  number: number;
+  title: string;
+  body: string | null;
+  baseRef?: string;
+  defaultBranch?: string;
+}): Record<string, unknown> {
+  // Default to base=main + default_branch=main so existing single-arg
+  // calls (which predate the default-branch gate added 2026-06-11)
+  // still exercise the success path.
   return {
     action: 'closed',
     pull_request: {
@@ -161,8 +170,9 @@ function prMergedPayload(opts: { number: number; title: string; body: string | n
       html_url: `https://github.com/owner/repo/pull/${opts.number}`,
       title: opts.title,
       body: opts.body,
+      base: { ref: opts.baseRef ?? 'main' },
     },
-    repository: { full_name: 'owner/repo' },
+    repository: { full_name: 'owner/repo', default_branch: opts.defaultBranch ?? 'main' },
   };
 }
 
@@ -279,7 +289,14 @@ describe('webhook: pull_request.closed merged=true (#152)', () => {
     await app.close();
 
     expect(res.statusCode).toBe(200);
-    expect(mocks.updateNodeMock).toHaveBeenCalledTimes(2);
+    // handlePrClosed (linkedPr cleanup) ALSO fires once per node, so
+    // the total updateNode count is 4 (2 linkedPr clears + 2 status
+    // transitions). Filter to the status=done calls to assert on the
+    // transition-specific behaviour this test cares about.
+    const doneTransitionCalls = mocks.updateNodeMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown> | undefined)?.status === 'done',
+    );
+    expect(doneTransitionCalls).toHaveLength(2);
     const transitioned = res.json().transitions as Array<{ externalId: string; status: string }>;
     expect(transitioned).toHaveLength(2);
     expect(transitioned.every((t) => t.status === 'transitioned')).toBe(true);
@@ -395,5 +412,95 @@ describe('webhook: pull_request.closed merged=true (#152)', () => {
     expect(mocks.updateNodeMock).not.toHaveBeenCalled();
     // Falls through to processWebhook mock (which returns a noop).
     expect(mocks.processWebhookMock).toHaveBeenCalled();
+  });
+
+  it('PR merged to a NON-default branch (V1-hotfix flow) does NOT transition', async () => {
+    // Regression for the 2026-06-11 drift on crm #2291 / #2292: a
+    // PR targeting `release/v1` (V1 hotfix) merged with `Fixes #2291`
+    // in the body. GitHub does NOT auto-close issues when a PR merges
+    // to anything other than the default branch, but this handler used
+    // to transition the linked node to `done` anyway — desyncing
+    // MindBlown ("done") from GitHub ("open") and blocking re-dispatch
+    // on `main` until the forward-port PR landed.
+    //
+    // The default-branch gate mirrors GitHub's own judgement: only
+    // transition when base.ref === repository.default_branch.
+    const node = seedLinkedNode({ nodeId: 'n-2291', externalId: 'owner/repo#2291' });
+    mocks.selectNodesMock.mockResolvedValue([{ id: node.id, externalLinks: node.externalLinks }]);
+    mocks.getNodeMock.mockResolvedValue(node);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: prMergedPayload({
+        number: 2346,
+        title: 'fix(#2291): sanitize LLM upstream errors',
+        body: '## Summary\n\nFixes #2291. Raw error messages were leaking internal hostnames.',
+        baseRef: 'release/v1',
+        defaultBranch: 'main',
+      }),
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    // handlePrClosed (separate handler) legitimately fires for ANY
+    // merged PR to clear `linkedPr` — that's correct regardless of base
+    // branch since the PR really is closed. What MUST NOT happen on a
+    // non-default-branch merge is the status → done transition.
+    const doneTransitionCalls = mocks.updateNodeMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown> | undefined)?.status === 'done',
+    );
+    expect(doneTransitionCalls).toHaveLength(0);
+    expect(mocks.broadcastMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ source: 'github_webhook_pr_merge' }),
+    );
+    // Falls through to processWebhook mock.
+    expect(mocks.processWebhookMock).toHaveBeenCalled();
+  });
+
+  it('PR with missing base.ref does NOT transition status to done (fail-safe)', async () => {
+    // Malformed or legacy payloads with no base.ref should NOT trigger
+    // the status transition. Better to drop a real merge than to
+    // wrongly transition a hotfix one — the drift audit (catchup) will
+    // pick up any genuinely closed issue within 5min anyway.
+    // handlePrClosed may still fire to clear linkedPr — that's fine.
+    const node = seedLinkedNode({ nodeId: 'n-99', externalId: 'owner/repo#99' });
+    mocks.selectNodesMock.mockResolvedValue([{ id: node.id, externalLinks: node.externalLinks }]);
+    mocks.getNodeMock.mockResolvedValue(node);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/webhooks/github',
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-hub-signature-256': 'sha256=anything',
+      },
+      payload: {
+        action: 'closed',
+        pull_request: {
+          number: 99,
+          merged: true,
+          html_url: 'https://github.com/owner/repo/pull/99',
+          title: 'Closes #99',
+          body: null,
+          // base intentionally omitted
+        },
+        repository: { full_name: 'owner/repo', default_branch: 'main' },
+      },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const doneTransitionCalls = mocks.updateNodeMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown> | undefined)?.status === 'done',
+    );
+    expect(doneTransitionCalls).toHaveLength(0);
   });
 });

--- a/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
+++ b/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
@@ -57,30 +57,49 @@ const mocks = vi.hoisted(() => {
     selectNodesMock: vi.fn(),
     broadcastMock: vi.fn(),
     verifySignatureMock: vi.fn(async () => true),
-    processWebhookMock: vi.fn(() => ({ action: 'noop', nodeUpdates: null, externalId: null })),
+    // Initial implementation is a placeholder; the mock factory below
+    // rewires this to delegate to the real processWebhook so the
+    // tests exercise production behaviour. The signature is widened
+    // to accept the real (payload, event) shape from @mindblown/integrations.
+    processWebhookMock: vi.fn(
+      (...args: unknown[]): unknown => ({ action: 'noop', nodeUpdates: null, externalId: null }),
+    ),
   };
 });
 
-vi.mock('@mindblown/integrations', () => ({
-  createGitHubIssue: vi.fn(),
-  getGitHubIssue: vi.fn(),
-  importGitHubIssues: vi.fn(),
-  extractVersionFromMilestone: vi.fn(),
-  // Real implementation — the regex is the unit under test for ref extraction.
-  extractClosingIssueRefs: (text: string): number[] => {
-    const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
-    const refs = new Set<number>();
-    let match: RegExpExecArray | null;
-    while ((match = pattern.exec(text)) !== null) {
-      refs.add(parseInt(match[1], 10));
-    }
-    return [...refs];
-  },
-  processWebhook: mocks.processWebhookMock,
-  verifyWebhookSignature: mocks.verifySignatureMock,
-  mintInstallationToken: vi.fn(),
-  isGitHubAppConfigured: vi.fn(() => true),
-}));
+vi.mock('@mindblown/integrations', async () => {
+  // Use REAL implementations of the pure functions (processWebhook,
+  // extractClosingIssueRefs) so the tests assert against the
+  // production code path — not against a noop mock that would hide
+  // the legacy PR-merge → done branch (#199 review caught exactly
+  // this masking bug). Side-effect functions (GitHub API,
+  // signature verification) stay mocked.
+  //
+  // processWebhook is wrapped in a spy so per-test `.mock.calls`
+  // assertions still work, but the spy delegates to the real
+  // implementation by default. Individual tests may override the
+  // return value with `mocks.processWebhookMock.mockReturnValueOnce(...)`.
+  const actual = await vi.importActual<typeof import('@mindblown/integrations')>(
+    '@mindblown/integrations',
+  );
+  // Cast through `unknown` to satisfy the `vi.fn(...)` parameter widening.
+  // The runtime contract — "delegate every call to the real
+  // implementation" — matches the production wiring.
+  mocks.processWebhookMock.mockImplementation(
+    actual.processWebhook as unknown as (...args: unknown[]) => unknown,
+  );
+  return {
+    ...actual,
+    createGitHubIssue: vi.fn(),
+    getGitHubIssue: vi.fn(),
+    importGitHubIssues: vi.fn(),
+    extractVersionFromMilestone: vi.fn(),
+    verifyWebhookSignature: mocks.verifySignatureMock,
+    mintInstallationToken: vi.fn(),
+    isGitHubAppConfigured: vi.fn(() => true),
+    processWebhook: mocks.processWebhookMock,
+  };
+});
 
 vi.mock('../../db/connection.js', () => ({
   db: {
@@ -211,8 +230,11 @@ beforeEach(() => {
   mocks.broadcastMock.mockReset();
   mocks.verifySignatureMock.mockReset();
   mocks.verifySignatureMock.mockResolvedValue(true);
-  mocks.processWebhookMock.mockReset();
-  mocks.processWebhookMock.mockReturnValue({ action: 'noop', nodeUpdates: null, externalId: null });
+  // Clear call history but PRESERVE the implementation set in the
+  // module-mock factory above — the spy delegates to real
+  // processWebhook so the new V1-hotfix / missing-base.ref tests
+  // exercise the production fall-through, not a noop stub.
+  mocks.processWebhookMock.mockClear();
   process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-secret';
 });
 

--- a/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
+++ b/packages/server/src/routes/__tests__/pr-merge-webhook.test.ts
@@ -1,8 +1,8 @@
 /**
  * #152 — pull_request: closed (merged=true) → linked nodes transition to done.
  *
- * Covers the new branch in routes/integrations.ts that subscribes to PR
- * merge events for repos that don't send `issues` webhooks (e.g.
+ * Covers the canonical handler in routes/integrations.ts that subscribes
+ * to PR merge events for repos that don't send `issues` webhooks (e.g.
  * FulcrumCRM/crm). Verifies:
  *
  *   1. Multi-issue: PR body with "Closes #1, fixes #2" transitions BOTH
@@ -15,10 +15,17 @@
  *      through unchanged.
  *   5. References to issues with no linked MindBlown node are reported
  *      as `not_linked` (not an error).
+ *   6. (#199) PR merged to a NON-default branch (V1-hotfix flow targeting
+ *      `release/v1`) does NOT transition the linked node, mirroring
+ *      GitHub's auto-close semantics.
+ *   7. (#199) PR with missing `base.ref` does NOT transition (fail-safe).
  *
  * Signature verification is stubbed to pass; HMAC plumbing is covered
  * by separate tests in `webhookAuthCheck.test.ts`. The processWebhook
- * fallthrough is mocked to a no-op so we can isolate the new branch.
+ * spy delegates to the REAL implementation (see the @mindblown/integrations
+ * mock factory below) so the tests exercise the production fall-through —
+ * a noop stub would have masked the legacy PR-merge bypass that #199
+ * fixes.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -1660,11 +1660,34 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     // Idempotent: a second webhook for the same PR (replay or
     // misconfigured retry) finds the node already at status='done' +
     // percentComplete=100 and emits no second transition.
+    //
+    // Default-branch gate (2026-06-11): GitHub itself only auto-closes
+    // referenced issues when a PR merges to the repo's default branch.
+    // V1-hotfix PRs target `release/v1`; they merge but the linked GH
+    // issue stays OPEN until the forward-port to `main` lands. Without
+    // this gate we'd transition the node to `done` on the V1-hotfix
+    // merge, blocking re-dispatch on `main` and creating drift between
+    // MindBlown ("done") and GitHub ("open"). Observed on crm #2291 /
+    // #2292 — both v1-hotfix tickets whose nodes got prematurely
+    // transitioned by PRs targeting `release/v1`. Mirror GitHub's
+    // judgement: only transition when the PR's base ref matches the
+    // repository's default branch.
+    const prPayload = payload.pull_request as
+      | { merged?: boolean; base?: { ref?: string } }
+      | undefined;
+    const repoPayload = payload.repository as
+      | { default_branch?: string }
+      | undefined;
+    const baseBranch = prPayload?.base?.ref;
+    const defaultBranch = repoPayload?.default_branch;
     if (
       event === 'pull_request' &&
       payloadAction === 'closed' &&
-      (payload.pull_request as { merged?: boolean } | undefined)?.merged === true &&
-      repoFullName
+      prPayload?.merged === true &&
+      repoFullName &&
+      baseBranch != null &&
+      defaultBranch != null &&
+      baseBranch === defaultBranch
     ) {
       const pr = payload.pull_request as {
         number: number;

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -1649,10 +1649,11 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     // #152 — when a PR merges with `Closes #N` references in title or
     // body, transition every referenced issue's linked node to done.
     // Cuts the up-to-5min lag of the catchup loop (`runCatchup` in
-    // index.ts, every 5min) which reconciles state from GH issues
-    // but only catches a close once it's already happened on GH and
-    // requires the `issues` event subscription. This branch handles
-    // the PR-only-subscription path.
+    // index.ts, every 5min) which reconciles state by polling the
+    // GitHub API and is the unconditional safety net. This branch
+    // handles the PR-only-subscription path — repos subscribed to
+    // `pull_request` events but not `issues` events still need
+    // immediate transitions on PR merge without waiting for catchup.
     //
     // Iterates ALL refs (PR title + body). The legacy single-ref
     // PR-merge branch in @mindblown/integrations processWebhook was

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -1648,14 +1648,17 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     //
     // #152 — when a PR merges with `Closes #N` references in title or
     // body, transition every referenced issue's linked node to done.
-    // Cuts the up-to-6h lag that the drift audit catches (catchup runs
-    // every 5min but only flips state on issue-close webhooks, which
-    // require the `issues` event subscription — not every repo has it).
+    // Cuts the up-to-5min lag of the catchup loop (`runCatchup` in
+    // index.ts, every 5min) which reconciles state from GH issues
+    // but only catches a close once it's already happened on GH and
+    // requires the `issues` event subscription. This branch handles
+    // the PR-only-subscription path.
     //
-    // Iterates ALL refs (PR title + body), unlike the legacy
-    // processWebhook PR branch which only returned the first. The
-    // existing issues.closed handler still runs for repos subscribed
-    // to that event — this branch is the PR-only-subscription path.
+    // Iterates ALL refs (PR title + body). The legacy single-ref
+    // PR-merge branch in @mindblown/integrations processWebhook was
+    // deleted on 2026-06-11 (#199 review) — it bypassed the
+    // default-branch gate below, so a V1-hotfix merge fell through
+    // to it and still wrongly transitioned the linked node.
     //
     // Idempotent: a second webhook for the same PR (replay or
     // misconfigured retry) finds the node already at status='done' +


### PR DESCRIPTION
## Summary

`pull_request.closed + merged=true` webhook handler at `routes/integrations.ts:1663` now only fires the linked-issue status transition when the PR's base ref matches the repository's default branch. Mirrors GitHub's own auto-close behaviour.

## Why

FulcrumCRM/crm #2291 + #2292 (V1 hotfix tickets) were marked `status=done` in MindBlown on 2026-06-09 by PRs that merged to `release/v1`. GitHub correctly left the issues OPEN. MindBlown ignored this and ran `extractClosingIssueRefs()` on the PR body anyway, transitioning the nodes. Result: Kira's dispatcher refused to re-dispatch the tickets on `main` (it saw `status=done` and skipped), creating a hidden drift between MindBlown and GitHub that only surfaced when investigating why kira-tick wouldn't pick up obvious hotfix work.

Pattern hits **every V1 hotfix** — they all target `release/v1`, all merge before the forward-port lands, and all incorrectly close their MindBlown nodes.

## What changes

- `routes/integrations.ts`: pulls `base.ref` and `repository.default_branch` from the webhook payload, gates the transition block on `baseBranch === defaultBranch`. handlePrClosed (which clears `linkedPr` for the merged PR) still runs unconditionally — correct, since the PR really is closed.
- `__tests__/pr-merge-webhook.test.ts`: 2 new regression cases + updated fixture to default `base.ref` and `default_branch` to `main`. Multi-issue test assertion narrowed to count `status=done` calls only (handlePrClosed adds linkedPr-clear writes that aren't the transition semantics being tested).

## Test plan

- [x] `pnpm --filter @mindblown/server test pr-merge-webhook` — 8 tests pass.
- [x] `pnpm --filter @mindblown/server typecheck` — clean.
- [ ] Manual: after merge + deploy, reset crm #2291 and #2292 node status from `done` → `todo` (or `in_progress` if the forward-port PR is already open), then verify kira-tick picks them up. Manual reset because the existing wrong-state nodes won't auto-correct.

## Follow-up

- The 2 affected nodes (crm #2291, #2292) need manual status reset post-deploy. Bug-fix doesn't auto-heal existing drift.
- Drift audit (`runDriftAudit`) catches divergence via the catchup loop every 5min; consider whether it should also check this specific MindBlown-done + GH-open case and self-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)