### PR TITLE
fix(mcp): search_nodes versionId — explicit child assignment wins (Jenna #9)

### DIFF
--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -417,6 +417,99 @@ describe('search_nodes tool — parentId filter', () => {
   });
 });
 
+// Jenna housekeeping digest 2026-06-11 tick 20:38 (§8.1 beta-feedback
+// #9) — `bulk_assign_to_version` was wrongly reported as a no-op for
+// 26 leaves that survived 6 re-runs in one day. Root cause was on the
+// READ side: a leaf with an explicit versionId=V2 sat under an epic
+// parent still carrying versionId=Unversioned, and the ancestor walk
+// kept climbing past the explicit assignment. The fix lets the first
+// non-null versionId on the path decide membership.
+describe('search_nodes tool — versionId ancestor-walk', () => {
+  function buildMixedVersionMap(): MapDetail {
+    const node = (
+      id: string,
+      parentId: string | null,
+      childrenIds: string[],
+      versionId: string | null,
+    ): NodeWithComputed =>
+      ({
+        id,
+        mapId: 'm1',
+        parentId,
+        childrenIds,
+        text: id,
+        description: null,
+        effortEstimate: null,
+        actualEffort: null,
+        percentComplete: null,
+        status: null,
+        assigneeIds: [],
+        priority: null,
+        dueDate: null,
+        startDate: null,
+        tags: [],
+        dependencies: [],
+        versionId,
+        cycleId: null,
+        externalLinks: [],
+        collapsed: false,
+        createdAt: '2026-06-11T00:00:00Z',
+        updatedAt: '2026-06-11T00:00:00Z',
+        claimedBySession: null,
+        claimedAt: null,
+        computedEffort: 0,
+        computedProgress: 0,
+        healthSignal: 'on_track',
+      }) as unknown as NodeWithComputed;
+    return {
+      map: { id: 'm1', rootNodeId: 'root' } as unknown as MapDetail['map'],
+      nodes: [
+        node('root', null, ['epic'], null),
+        // The Jenna-2026-06-11 shape: epic explicitly Unversioned, leaf
+        // explicitly V2. The leaf must NOT be reported as in-Unversioned.
+        node('epic', 'root', ['leaf-v2', 'leaf-inherits', 'leaf-other'], 'unversioned-uuid'),
+        node('leaf-v2', 'epic', [], 'v2-uuid'),
+        node('leaf-inherits', 'epic', [], null),
+        node('leaf-other', 'epic', [], 'v1-uuid'),
+      ],
+    };
+  }
+
+  it("doesn't report a child with explicit versionId as belonging to the parent's version", async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildMixedVersionMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      versionId: 'unversioned-uuid',
+    } as never);
+    // Explicit-versionId children of the Unversioned epic are NOT
+    // pulled in; only the epic itself and its null-versionId child
+    // (which inherits the epic's assignment) match.
+    expect(out).not.toContain('id: leaf-v2');
+    expect(out).not.toContain('id: leaf-other');
+    expect(out).toContain('id: epic');
+    expect(out).toContain('id: leaf-inherits');
+  });
+
+  it('still inherits ancestor version when the child has no explicit assignment', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildMixedVersionMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      versionId: 'v2-uuid',
+    } as never);
+    // Only the explicitly-V2 leaf shows up — the V1-leaf doesn't,
+    // the Unversioned-epic doesn't, and the inheriting leaf
+    // (which would inherit Unversioned from its epic) doesn't.
+    expect(out).toContain('id: leaf-v2');
+    expect(out).not.toContain('id: leaf-other');
+    expect(out).not.toContain('id: epic');
+    expect(out).not.toContain('id: leaf-inherits');
+  });
+});
+
 // Jenna housekeeping digest 2026-06-11 (§8.6) — `unestimated:true`
 // without a status-exclusion filter returns thousands of done leaves
 // whose effortEstimate is null, drowning out the actionable subset.

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -280,10 +280,20 @@ export const searchNodesTool = defineTool({
     else if (unestimated === false) matches = matches.filter((n) => n.effortEstimate != null);
     if (versionId) {
       const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+      // Explicit-assignment-wins inheritance: walk up the ancestor chain
+      // and let the FIRST non-null versionId on the path decide membership.
+      // Pre-fix, the walk kept climbing past a leaf's own non-matching
+      // versionId — so a leaf explicitly assigned to V2 whose epic parent
+      // still carried the legacy `Unversioned` row would be reported as
+      // "in Unversioned" on every sweep, and Jenna's §8.1 fire would
+      // re-bulk-assign-to-V2 the same 26 leaves hour after hour (digest
+      // 2026-06-11 tick 20:38, beta-feedback #9). Now an explicit child
+      // assignment overrides the ancestor's, matching the "leaf knows
+      // best" semantics users expect.
       const inVersion = (id: string): boolean => {
         let cur = nodeById.get(id);
         while (cur) {
-          if (cur.versionId === versionId) return true;
+          if (cur.versionId != null) return cur.versionId === versionId;
           cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
         }
         return false;


### PR DESCRIPTION
## Summary

Jenna's 2026-06-11 housekeeping digest tick 20:38 confirmed the Unversioned-bucket regression is a real bug, but the root cause is NOT what we fixed in #200 (webhook ingest). DB probe of `dd4f7a9d` (#1076 Firewall rule audit) shows the write IS sticking — leaf carries `versionId = df9027bd (V2)`. The bug is on the **read side**.

The leaf's epic parent `19994a53` "DEC697 Perimeter Cutover" still carries `versionId = f72b694e (Unversioned)` from the original bulk-import path. `search_nodes`' ancestor walk previously kept climbing past the leaf's explicit V2 and hit the epic's explicit Unversioned, reporting the leaf as "in Unversioned." Jenna's §8.1 sweep re-ran `bulk_assign_to_version(V2, [26 leaves])` 6 times today — every call succeeded at the DB level and was wasted work.

Fix: first-non-null versionId on the walk decides membership. Explicit child beats ancestor. Null-versionId leaves still inherit from the nearest ancestor — the "tag an epic with V2, all its leaves come along" use case keeps working.

## Test plan

- [x] `pnpm turbo typecheck` clean
- [x] `node.test.ts` — 2 new cases under "search_nodes tool — versionId ancestor-walk" (24 tests total green)
- [ ] Manual: post-deploy, fire Jenna's housekeeping → §8.1 Unversioned bucket reports 0 net-new

🤖 Generated with [Claude Code](https://claude.com/claude-code)