### PR TITLE
feat(sync): heartbeat-push helper now supports Gatus external endpoints

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -110,13 +110,23 @@ NODE_ENV=production
 # SMTP_PASS=CHANGE-ME
 # MAIL_FROM=MindBlown <noreply@example.com>
 
-# Optional — Uptime-Kuma push URLs for GitHub-sync observability.
+# Optional — Heartbeat-push URLs for GitHub-sync observability.
 # Without these, the API still runs the catchup loop + drift audit,
 # but silent failures have no external alarm. See below.
-# KUMA_GITHUB_CATCHUP_PUSH_URL=https://kuma.example.com/api/push/<token>
-# KUMA_GITHUB_DRIFT_PUSH_URL=https://kuma.example.com/api/push/<token>
-# KUMA_GITHUB_AUTH_FAILURE_PUSH_URL=https://kuma.example.com/api/push/<token>
-# KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL=https://kuma.example.com/api/push/<token>
+#
+# The helper `pushKumaHeartbeat` accepts EITHER shape:
+#   - Gatus  (preferred): http://<host>/api/v1/endpoints/push_<name>/external
+#     Requires GATUS_PUSH_TOKEN set with the matching bearer.
+#   - Kuma (legacy):      https://kuma.example.com/api/push/<token>
+#     No bearer needed; token is embedded in the path.
+#
+# Env var names are kept as KUMA_* for minimum-diff compatibility.
+# Migration target as of 2026-06-12: Gatus (see crm#2620).
+# KUMA_GITHUB_CATCHUP_PUSH_URL=http://10.0.20.14:8080/api/v1/endpoints/push_mindblown-github-catchup/external
+# KUMA_GITHUB_DRIFT_PUSH_URL=http://10.0.20.14:8080/api/v1/endpoints/push_mindblown-github-drift/external
+# KUMA_GITHUB_AUTH_FAILURE_PUSH_URL=http://10.0.20.14:8080/api/v1/endpoints/push_mindblown-github-auth-failure/external
+# KUMA_WEBHOOK_AUTH_FAILURE_PUSH_URL=http://10.0.20.14:8080/api/v1/endpoints/push_mindblown-webhook-auth/external
+# GATUS_PUSH_TOKEN=<bearer from /opt/gatus/.env on CT 124>
 
 # Optional — consecutive GH 401 ticks per repo before the catchup
 # fires `status=down msg=auth_failed:owner/repo` on the auth-failure
@@ -124,10 +134,11 @@ NODE_ENV=production
 # bridge. Default 3 (≈ 15 min on a 5-min catchup tick).
 # CATCHUP_AUTH_FAILURE_THRESHOLD=3
 
-# Optional — Uptime-Kuma push URL for the weekly Pushover-canary
+# Optional — Heartbeat-push URL for the weekly Pushover-canary
 # (alarm-chain liveness probe). Unset = canary is disabled. See the
 # "Pushover canary" section below for the full operator runbook.
-# KUMA_ALARM_CANARY_PUSH_URL=https://kuma.example.com/api/push/<token>
+# Same dual-mode (Gatus or Kuma) as the other 4 push URLs above.
+# KUMA_ALARM_CANARY_PUSH_URL=http://10.0.20.14:8080/api/v1/endpoints/push_mindblown-alarm-canary/external
 
 # Optional — drift-audit cadence in milliseconds. Default 21600000
 # (6h). Minimum 3600000 (1h) — values below the minimum (incl. zero

--- a/packages/server/src/sync/__tests__/kumaPush.test.ts
+++ b/packages/server/src/sync/__tests__/kumaPush.test.ts
@@ -205,4 +205,90 @@ describe('pushKumaHeartbeat', () => {
     // And the status param must remain a clean separate key/value.
     expect(calledUrl).toMatch(/[?&]status=down(&|$)/);
   });
+
+  describe('Gatus mode (URL contains /api/v1/endpoints/)', () => {
+    const ORIGINAL_TOKEN = process.env.GATUS_PUSH_TOKEN;
+
+    beforeEach(() => {
+      process.env.GATUS_PUSH_TOKEN = 'test-bearer-abc';
+    });
+
+    afterEach(() => {
+      if (ORIGINAL_TOKEN === undefined) delete process.env.GATUS_PUSH_TOKEN;
+      else process.env.GATUS_PUSH_TOKEN = ORIGINAL_TOKEN;
+    });
+
+    it('POSTs with bearer auth + success=true on status="up"', async () => {
+      const fetchMock = vi.fn(
+        async (_input: unknown, _init?: unknown) =>
+          ({ ok: true, status: 200 }) as Response,
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await pushKumaHeartbeat(
+        'http://gatus.example/api/v1/endpoints/push_foo/external',
+        'up',
+        'tick ok',
+        '[gatus-push] foo',
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [calledUrl, calledInit] = fetchMock.mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      expect(String(calledUrl)).toContain('success=true');
+      expect(String(calledUrl)).toContain('duration=');
+      // Healthy push must NOT include error=, since Gatus surfaces error
+      // text verbatim in the alert body and "tick ok" would land there.
+      expect(String(calledUrl)).not.toContain('error=');
+      expect(calledInit.method).toBe('POST');
+      expect(
+        (calledInit.headers as Record<string, string>).Authorization,
+      ).toBe('Bearer test-bearer-abc');
+    });
+
+    it('POSTs success=false + error=<msg> on status="down"', async () => {
+      const fetchMock = vi.fn(
+        async (_input: unknown, _init?: unknown) =>
+          ({ ok: true, status: 200 }) as Response,
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await pushKumaHeartbeat(
+        'http://gatus.example/api/v1/endpoints/push_foo/external',
+        'down',
+        'auth check failed: 3 webhooks unauthenticated',
+        '[gatus-push] foo',
+      );
+
+      const calledUrl = String(fetchMock.mock.calls[0][0]);
+      expect(calledUrl).toContain('success=false');
+      // msg goes into error= and is URL-encoded.
+      expect(calledUrl).toContain(
+        'error=auth%20check%20failed%3A%203%20webhooks%20unauthenticated',
+      );
+    });
+
+    it('omits Authorization header when GATUS_PUSH_TOKEN is unset', async () => {
+      delete process.env.GATUS_PUSH_TOKEN;
+
+      const fetchMock = vi.fn(
+        async (_input: unknown, _init?: unknown) =>
+          ({ ok: true, status: 200 }) as Response,
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await pushKumaHeartbeat(
+        'http://gatus.example/api/v1/endpoints/push_foo/external',
+        'up',
+        'ok',
+        '[gatus-push] foo',
+      );
+
+      const calledInit = fetchMock.mock.calls[0][1] as RequestInit;
+      const headers = (calledInit.headers as Record<string, string>) ?? {};
+      expect(headers.Authorization).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/sync/kumaPush.ts
+++ b/packages/server/src/sync/kumaPush.ts
@@ -1,33 +1,36 @@
 /**
- * Uptime-Kuma push-monitor helper.
+ * Heartbeat push helper. Supports both legacy Uptime-Kuma push monitors
+ * AND the newer Gatus external-endpoint API.
  *
- * Kuma "push" monitors are passive endpoints: you GET/POST a per-monitor
- * URL like `https://kuma.example/api/push/<token>?status=up&msg=...` and
- * Kuma alarms (Pushover, Telegram, email, ...) when those pushes stop
- * for longer than the monitor's configured threshold.
+ * URL shape detection (zero config flag needed):
+ *   - `/api/v1/endpoints/<key>/external` → Gatus. POST with
+ *      Authorization: Bearer ${process.env.GATUS_PUSH_TOKEN}.
+ *      Query params: success=true|false, duration=10ms[, error=<msg>].
+ *   - `/api/push/<token>` → Kuma. GET with status=up|down&msg=<msg>&ping=...
+ *      Token is embedded in the path; no bearer header.
  *
- * This module wraps the GET so callers can do
- *   `await pushKumaHeartbeat(url, status, msg)`
- * without worrying about timeouts or Kuma being temporarily unreachable.
  * Failed pushes are logged at `warn` and swallowed — the caller's main
  * flow MUST NOT fail because a heartbeat couldn't be delivered.
  *
- * The pattern mirrors the CRM infra's existing Kuma push usage (see
- * `reference_kuma_state.md`): catchup heartbeat + daily drift audit each
- * own a distinct monitor URL set via env vars.
+ * Migration: as of 2026-06-12 the production senders point at Gatus URLs
+ * (Kuma's Pushover provider was disabled). The Kuma branch is kept so
+ * the helper still works in environments still on Kuma (e.g. legacy
+ * dev configs, CI fixtures) without a config flag flip.
+ *
+ * The function name `pushKumaHeartbeat` is preserved for callers'
+ * minimal-diff compatibility — the helper does both Kuma and Gatus now.
  */
 
-/** Maximum time we wait for Kuma to acknowledge a push. */
-const KUMA_PUSH_TIMEOUT_MS = 5000;
+/** Maximum time we wait for the heartbeat receiver to acknowledge a push. */
+const HEARTBEAT_PUSH_TIMEOUT_MS = 5000;
 
 export type KumaStatus = 'up' | 'down';
 
 /**
  * Per-`logTag` memo of the last failure signature we already warned
- * about. Used to collapse repeating identical failures (e.g. Kuma
- * returning `404` every 5 minutes because the operator deleted the
- * monitor on Kuma's side) into a single warn line + a single recovery
- * warn line when the failure clears.
+ * about. Used to collapse repeating identical failures (e.g. 404 every
+ * 5 minutes because the operator deleted the monitor) into a single warn
+ * line + a single recovery warn line when the failure clears.
  *
  * Keyed by `logTag` (which is unique per call site, e.g. catchup vs
  * drift audit vs auth failure), so concurrent monitors don't suppress
@@ -48,17 +51,66 @@ export function _resetKumaSuppressionForTests(): void {
   lastFailureByTag.clear();
 }
 
+/** Detect Gatus external endpoint URL by path shape. */
+function isGatusUrl(url: string): boolean {
+  return url.includes('/api/v1/endpoints/');
+}
+
+interface PreparedRequest {
+  url: string;
+  init: RequestInit;
+}
+
 /**
- * GET the Kuma push URL with status + msg query params. Errors (timeout,
- * non-2xx, network) are swallowed — the caller's main flow never fails
- * because of a heartbeat hiccup.
+ * Build the fetch URL + init for the heartbeat receiver based on URL shape.
+ */
+function prepareRequest(
+  rawUrl: string,
+  status: KumaStatus,
+  msg: string,
+): PreparedRequest {
+  const sep = rawUrl.includes('?') ? '&' : '?';
+
+  if (isGatusUrl(rawUrl)) {
+    const success = status === 'up';
+    const parts = [`success=${success}`, `duration=10ms`];
+    if (!success && msg) parts.push(`error=${encodeURIComponent(msg)}`);
+    const url = `${rawUrl}${sep}${parts.join('&')}`;
+    const token = process.env.GATUS_PUSH_TOKEN ?? '';
+    return {
+      url,
+      init: {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal: AbortSignal.timeout(HEARTBEAT_PUSH_TIMEOUT_MS),
+      },
+    };
+  }
+
+  // Legacy Kuma push monitor. GET with status/msg in query, plus a ping
+  // marker so each push is unique even with proxies that dedupe GETs.
+  const url = `${rawUrl}${sep}status=${encodeURIComponent(
+    status,
+  )}&msg=${encodeURIComponent(msg)}&ping=${Date.now()}`;
+  return {
+    url,
+    init: {
+      method: 'GET',
+      signal: AbortSignal.timeout(HEARTBEAT_PUSH_TIMEOUT_MS),
+    },
+  };
+}
+
+/**
+ * Push a heartbeat to either a Kuma push-monitor or a Gatus external
+ * endpoint. Errors (timeout, non-2xx, network) are swallowed — the
+ * caller's main flow never fails because of a heartbeat hiccup.
  *
  * Logging policy: warn the FIRST time a given failure signature is seen
  * for a given `logTag`, then stay silent on every subsequent identical
  * tick. When the signature changes (recovery to 2xx, or a new error
- * kind), log once more. This keeps a misconfigured Kuma monitor from
- * spamming the journal every 5 minutes while still surfacing real
- * incidents.
+ * kind), log once more. This keeps a misconfigured monitor from spamming
+ * the journal every 5 minutes while still surfacing real incidents.
  *
  * `logTag` is the prefix used in the warn log so multiple call sites are
  * easy to distinguish ("[kuma-push] catchup heartbeat" vs
@@ -72,24 +124,16 @@ export async function pushKumaHeartbeat(
 ): Promise<void> {
   // Defence-in-depth: callers already guard `if (url)` before invoking
   // us, but treat a falsy URL as a hard no-op here too so a config
-  // regression can't accidentally fire a malformed GET against `?…`.
+  // regression can't accidentally fire a malformed request against `?…`.
   if (!url) return;
 
-  // Append status/msg/ping as query params. We deliberately don't try to
-  // be clever about an existing `?` — Kuma push URLs are vanilla, and the
-  // ping marker is included so each push is unique even with proxies that
-  // dedupe identical GETs.
-  const sep = url.includes('?') ? '&' : '?';
-  const fullUrl = `${url}${sep}status=${encodeURIComponent(status)}&msg=${encodeURIComponent(msg)}&ping=${Date.now()}`;
+  const { url: fullUrl, init } = prepareRequest(url, status, msg);
 
   let signature: string;
   let logLine: string | null = null;
 
   try {
-    const res = await fetch(fullUrl, {
-      method: 'GET',
-      signal: AbortSignal.timeout(KUMA_PUSH_TIMEOUT_MS),
-    });
+    const res = await fetch(fullUrl, init);
     if (!res.ok) {
       signature = `http:${res.status}`;
       logLine = `${logTag} HTTP ${res.status}`;


### PR DESCRIPTION
## Why

CRM-side PR #2608 stood up Gatus side-by-side with Kuma on CT 124. Kuma's Pushover provider is now disabled. The 5 mindblown push monitors (catchup, drift, alarm-canary, github-auth-failure, webhook-auth) still post to Kuma URLs that go nowhere. This PR makes the helper dual-mode so we can flip env-var values on CT 106 from Kuma URLs to Gatus URLs without touching call sites.

Tracking ticket: [crm#2620](https://github.com/FulcrumCRM/crm/issues/2620).

## What

`packages/server/src/sync/kumaPush.ts` auto-detects URL shape:

| URL contains | Verb | Auth | Query params |
|---|---|---|---|
| `/api/v1/endpoints/.../external` (Gatus) | POST | `Authorization: Bearer ${GATUS_PUSH_TOKEN}` | `success=<bool>&duration=10ms[&error=<msg>]` |
| `/api/push/<token>` (Kuma — legacy) | GET | none (token in path) | `status=up\|down&msg=<msg>&ping=<unix-ms>` |

Function name and env-var names are deliberately unchanged for minimum-diff compatibility. Callers (catchup, drift, canary, auth-failure, webhook-auth-check) don't touch this PR.

## Tests

11/11 pass (3 new):
- `POSTs with bearer auth + success=true on status="up"`
- `POSTs success=false + error=<msg> on status="down"`
- `omits Authorization header when GATUS_PUSH_TOKEN is unset`

Pre-existing 8 Kuma-mode tests still pass — no behavior change for URLs that don't match the Gatus pattern.

The 2 failing tests on master in `triage-routes.test.ts` (bulk-confirm 400 expected, got 200) are pre-existing and unrelated.

## Deploy plan (CT 106)

1. `git pull` on `/opt/mindblown`
2. Edit `/opt/mindblown/.env`:
   - Flip 5 `KUMA_*_PUSH_URL` values to the matching Gatus external-endpoint URLs (see `deploy/README.md`)
   - Add `GATUS_PUSH_TOKEN=<shared bearer from /opt/gatus/.env on CT 124>`
3. `systemctl restart mindblown-api`
4. Watch Gatus UI within 7 min — catchup heartbeat should land at `push_mindblown-github-catchup`

## Test plan

- [x] `pnpm test src/sync/__tests__/kumaPush.test.ts` — 11/11 green
- [ ] Deploy to CT 106 + verify catchup heartbeat in Gatus UI within 7 min
- [ ] (passive) other 4 monitors land on their natural cadence; alarm-canary fires next Sunday

🤖 Generated with [Claude Code](https://claude.com/claude-code)