### PR TITLE
fix(sync): per-repo GitHub auth failures no longer starve the watchdog

### DIFF
--- a/packages/server/src/sync/__tests__/githubCatchup.test.ts
+++ b/packages/server/src/sync/__tests__/githubCatchup.test.ts
@@ -256,6 +256,35 @@ describe('pushCatchupHeartbeat (direct helper)', () => {
     const [, status] = pushKumaMock.mock.calls[0];
     expect(status).toBe('down');
   });
+
+  it('pushes status=up when the only error is an auth failure — the auth_failed alarm owns that signal', async () => {
+    process.env.KUMA_GITHUB_CATCHUP_PUSH_URL = 'https://k/api/push/x';
+    await pushCatchupHeartbeat([
+      makeResult({ fetched: 2, applied: 1 }),
+      makeResult({
+        repo: 'b/c',
+        error: 'fetch: GitHub API 401: Bad credentials',
+        authFailure: true,
+      }),
+    ]);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('up');
+    expect(msg).toMatch(/authFailed=1/);
+  });
+
+  it('still pushes status=down when an auth failure coexists with a real error', async () => {
+    process.env.KUMA_GITHUB_CATCHUP_PUSH_URL = 'https://k/api/push/x';
+    await pushCatchupHeartbeat([
+      makeResult({
+        error: 'fetch: GitHub API 401: Bad credentials',
+        authFailure: true,
+      }),
+      makeResult({ repo: 'b/c', error: 'fetch: 503' }),
+    ]);
+    const [, status, msg] = pushKumaMock.mock.calls[0];
+    expect(status).toBe('down');
+    expect(msg).toMatch(/authFailed=1/);
+  });
 });
 
 describe('runAllCatchups → systemd watchdog', () => {
@@ -316,6 +345,31 @@ describe('isHealthyTick', () => {
       isHealthyTick([makeResult({ error: 'fetch: 503' })]),
     ).toBe(false);
   });
+
+  it('returns true when the only error is a per-repo auth failure (dead tenant token must not starve the watchdog)', () => {
+    expect(
+      isHealthyTick([
+        makeResult({ fetched: 3, applied: 2 }),
+        makeResult({
+          repo: 'b/c',
+          error: 'fetch: GitHub API 401: Bad credentials',
+          authFailure: true,
+        }),
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns false when an auth-failure repo coexists with a real error elsewhere', () => {
+    expect(
+      isHealthyTick([
+        makeResult({
+          error: 'fetch: GitHub API 401: Bad credentials',
+          authFailure: true,
+        }),
+        makeResult({ repo: 'b/c', ingestErrored: 1 }),
+      ]),
+    ).toBe(false);
+  });
 });
 
 // ── 401-escalation tests (#75) ───────────────────────────────────
@@ -359,6 +413,7 @@ describe('reconcileRepo → 401 auth-failure escalation (#75)', () => {
     const result = await reconcileRepo(makeTarget('o', 'r'));
 
     expect(result.error).toMatch(/^fetch: GitHub API 401/);
+    expect(result.authFailure).toBe(true);
     expect(pushKumaMock).not.toHaveBeenCalled();
     expect(_getAuthFailureCountForTests('o/r')).toBe(1);
   });
@@ -477,11 +532,14 @@ describe('reconcileRepo → 401 auth-failure escalation (#75)', () => {
     process.env.KUMA_GITHUB_AUTH_FAILURE_PUSH_URL = 'https://kuma/api/push/auth';
     fetchChangedIssuesMock.mockRejectedValue(new MockGitHubApiError(503, 'Service Unavailable'));
 
-    await reconcileRepo(makeTarget('o', 'r'));
+    const result = await reconcileRepo(makeTarget('o', 'r'));
     await reconcileRepo(makeTarget('o', 'r'));
     await reconcileRepo(makeTarget('o', 'r'));
     await reconcileRepo(makeTarget('o', 'r'));
 
+    // A 5xx is a real (possibly transient) failure, not an auth
+    // failure — it must NOT get the tick-health carve-out.
+    expect(result.authFailure).toBeUndefined();
     expect(pushKumaMock).not.toHaveBeenCalled();
     expect(_getAuthFailureCountForTests('o/r')).toBe(0);
   });
@@ -545,6 +603,9 @@ describe('reconcileRepo → 401 auth-failure escalation, token-resolution path (
     expect(result1.error).toMatch(/^token: /);
     expect(result2.error).toMatch(/^token: /);
     expect(result3.error).toMatch(/^token: /);
+    // Mint-401 is an auth failure too — same tick-health carve-out
+    // as the fetch-401 path.
+    expect(result1.authFailure).toBe(true);
 
     // Counter ticks on every 401, pushes on the threshold-crossing tick.
     expect(_getAuthFailureCountForTests('o/r')).toBe(3);

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -135,6 +135,15 @@ export interface ReconcileResult {
   durationMs: number;
   since: string | null;
   error?: string;          // present when reconcile failed before completion
+  /**
+   * True when `error` is a GitHub 401 (revoked PAT, suspended App
+   * install). Auth failures are excluded from tick health — they have
+   * their own escalation channel (`pushAuthFailureAlarm`), and one
+   * tenant's dead credential must not starve the watchdog/heartbeat
+   * for the whole service (see incident 2026-07-10: a stale demo PAT
+   * restart-looped prod every ~24 min for two weeks).
+   */
+  authFailure?: boolean;
 }
 
 // ── State helper (idempotent transition logic) ───────────────────
@@ -282,7 +291,8 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
     // errors (PAT lookup throwing for non-401 reasons, etc.) stay on
     // the "no counter bump" path — they're transient and shouldn't
     // pin the escalation.
-    if (err instanceof GitHubApiError && err.status === 401) {
+    const isAuthFailure = err instanceof GitHubApiError && err.status === 401;
+    if (isAuthFailure) {
       const next = (consecutiveAuthFailures.get(repoLabel) ?? 0) + 1;
       consecutiveAuthFailures.set(repoLabel, next);
       const threshold = getAuthFailureThreshold();
@@ -296,6 +306,7 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
       durationMs: Date.now() - startedAt.getTime(),
       since,
       error: `token: ${err instanceof Error ? err.message : String(err)}`,
+      ...(isAuthFailure && { authFailure: true }),
     };
   }
 
@@ -310,7 +321,8 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
     // fire a dedicated Kuma alarm once we've crossed the threshold,
     // so the operator gets `auth_failed:owner/repo` instead of a
     // generic "catchup is broken".
-    if (err instanceof GitHubApiError && err.status === 401) {
+    const isAuthFailure = err instanceof GitHubApiError && err.status === 401;
+    if (isAuthFailure) {
       const next = (consecutiveAuthFailures.get(repoLabel) ?? 0) + 1;
       consecutiveAuthFailures.set(repoLabel, next);
       const threshold = getAuthFailureThreshold();
@@ -333,6 +345,7 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
       durationMs: Date.now() - startedAt.getTime(),
       since,
       error: `fetch: ${err instanceof Error ? err.message : String(err)}`,
+      ...(isAuthFailure && { authFailure: true }),
     };
   }
 
@@ -650,6 +663,14 @@ export function getLastHealthyTickAt(): number {
  * entirely; pinging on a partial-failure path would defeat its
  * purpose by hiding exactly those incidents from systemd.
  *
+ * Exception: per-repo GitHub auth failures (`authFailure`) do NOT
+ * make a tick unhealthy. A revoked PAT or suspended App install is a
+ * credential problem on one repo, not a frozen loop — it already has
+ * its own escalation channel (the `auth_failed` alarm monitor).
+ * Before this carve-out, a single tenant's dead token suppressed the
+ * watchdog ping forever and systemd restart-looped the whole service
+ * every ~24 min (incident 2026-07-10, `meheav1-stack/proptechdev`).
+ *
  * An empty `results` array (no repos discovered, no work done) counts
  * as healthy — the sweep completed without crashing, which is what
  * the watchdog actually measures.
@@ -658,7 +679,10 @@ export function getLastHealthyTickAt(): number {
  */
 export function isHealthyTick(results: ReconcileResult[]): boolean {
   return results.every(
-    (r) => !r.error && r.ingestErrored === 0 && r.stateSyncErrored === 0,
+    (r) =>
+      (!r.error || r.authFailure) &&
+      r.ingestErrored === 0 &&
+      r.stateSyncErrored === 0,
   );
 }
 
@@ -673,6 +697,12 @@ export function isHealthyTick(results: ReconcileResult[]): boolean {
  * so the Kuma monitor's history shows whether catchup is actually
  * making progress, not just whether it's running.
  *
+ * Per-repo auth failures do NOT flip the status to `down` — same
+ * rationale as `isHealthyTick`: the `auth_failed` alarm monitor owns
+ * that signal, and this heartbeat measures whether the loop is alive.
+ * They still surface in the message as `authFailed=N` so the monitor
+ * history shows the degradation.
+ *
  * Exported for unit-test access — production callers go through
  * `runAllCatchups` which invokes this at end of sweep.
  */
@@ -684,10 +714,11 @@ export async function pushCatchupHeartbeat(results: ReconcileResult[]): Promise<
     results.reduce((acc, r) => acc + pick(r), 0);
 
   const hasError = results.some(
-    (r) => r.error || r.ingestErrored > 0 || r.stateSyncErrored > 0,
+    (r) => (r.error && !r.authFailure) || r.ingestErrored > 0 || r.stateSyncErrored > 0,
   );
+  const authFailed = results.filter((r) => r.authFailure).length;
   const status = hasError ? 'down' : 'up';
-  const msg = `repos=${results.length} fetched=${sum((r) => r.fetched)} ingested=${sum((r) => r.ingested)} applied=${sum((r) => r.applied)} errored=${sum((r) => r.ingestErrored + r.stateSyncErrored)}`;
+  const msg = `repos=${results.length} fetched=${sum((r) => r.fetched)} ingested=${sum((r) => r.ingested)} applied=${sum((r) => r.applied)} errored=${sum((r) => r.ingestErrored + r.stateSyncErrored)} authFailed=${authFailed}`;
 
   await pushKumaHeartbeat(url, status, msg, '[kuma-push] catchup heartbeat');
 }


### PR DESCRIPTION
## Problem

`isHealthyTick` requires every repo in the catchup sweep to succeed. One tenant's dead GitHub credential (401) therefore suppressed the systemd watchdog ping and pushed `status=down` on the catchup heartbeat — systemd restart-looped the entire prod API every ~24 minutes.

**Incident 2026-07-10:** the Demo-Workspace PAT integration for `meheav1-stack/proptechdev` had been 401ing since at least 2026-06-26. Prod restart-looped for two weeks, unnoticed until #202 wired Gatus alerting. Contained operationally by disabling the integration row.

## Fix

Auth failures already have their own escalation channel — the `auth_failed` alarm monitor (#75, #86). This PR stops them from also poisoning liveness signals:

- `ReconcileResult` gains `authFailure: true`, stamped on both 401 paths (token mint + fetch)
- `isHealthyTick` treats authFailure-only errors as healthy — the watchdog measures "is the loop alive", not "is every tenant's token valid"
- `pushCatchupHeartbeat` keeps `status=up` for authFailure-only ticks and surfaces `authFailed=N` in the message

Non-401 errors (5xx, network, ingest/state-sync) still mark the tick unhealthy exactly as before.

## Tests

- `isHealthyTick`: authFailure-only → healthy; authFailure + real error elsewhere → unhealthy
- `pushCatchupHeartbeat`: authFailure-only → `up` + `authFailed=1`; mixed → `down`
- `reconcileRepo`: 401 (fetch + mint paths) stamps `authFailure`; 503 does not
- 31/31 pass in `githubCatchup.test.ts`; `turbo typecheck` clean. Note: `triage-routes.test.ts` has 2 pre-existing flaky failures on master, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRT3eFiRxFqVxVCJkkkMqb