### PR TITLE
feat(requirements): requirements register — fields, view, MCP surface

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -39,6 +39,8 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     autoProgress: 'off',
     priorityRank: null,
     completedAt: null,
+    requirementId: null,
+    requirementPriority: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -37,6 +37,8 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     autoProgress: 'off',
     priorityRank: null,
     completedAt: null,
+    requirementId: null,
+    requirementPriority: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -40,6 +40,8 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     autoProgress: 'off',
     priorityRank: null,
     completedAt: null,
+    requirementId: null,
+    requirementPriority: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -210,6 +210,20 @@ export interface Node {
    */
   linkedPr?: LinkedPrState | null;
 
+  // ── Requirements register ─────────────────────────────────
+  /**
+   * Stable business requirement ID (e.g. "MAN-01"). Non-null marks this
+   * node as a requirement: it appears in the Requirements view and the
+   * `requirements_overview` MCP register. Unique per map (application-
+   * level check in the DB layer). The requirement's status is never
+   * stored — it derives from progress rollup (100 → done, >0 → partial,
+   * else open).
+   */
+  requirementId: string | null;
+
+  /** MoSCoW-style requirement priority (Muss/Soll/Kann). */
+  requirementPriority: 'must' | 'should' | 'could' | null;
+
   // ── Auto-progress (parent-epic rollup) ────────────────────
   /**
    * When set to `'children'`, the server auto-computes percentComplete on this

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -130,6 +130,9 @@ export interface NodeWithComputed {
   collapsed: boolean;
   createdAt: string;
   updatedAt: string;
+  // Requirements register — non-null requirementId marks a requirement.
+  requirementId: string | null;
+  requirementPriority: 'must' | 'should' | 'could' | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -487,6 +487,149 @@ server.tool(
 );
 
 server.tool(
+  'requirements_overview',
+  'Business-facing requirements register: every node carrying a requirementId, grouped by top-level branch (chapter). Per requirement: MoSCoW priority, derived status (done ≙ Umgesetzt / partial ≙ Teilweise / open ≙ Offen — from progress rollup, never stored), progress %, remaining effort, and linked GitHub issues. Answers "which requirements exist and where do they stand?" without the full get_map dump.',
+  {
+    mapId: z.string().describe('The map ID'),
+    status: z
+      .enum(['open', 'partial', 'done'])
+      .optional()
+      .describe('Only requirements in this derived status'),
+    requirementPriority: z
+      .enum(['must', 'should', 'could'])
+      .optional()
+      .describe('Only requirements with this MoSCoW priority'),
+  },
+  async ({ mapId, status, requirementPriority }) => {
+    try {
+      const data = await api.getMap(mapId);
+      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+      const rootId = data.map.rootNodeId;
+      const unit = data.map.effortUnit ?? 'units';
+
+      const requirements = data.nodes.filter((n) => n.requirementId != null);
+      if (requirements.length === 0) {
+        return toolResult(
+          `No requirements in map ${mapId}. Mark nodes as requirements by setting requirementId via update_node (e.g. "MAN-01").`,
+        );
+      }
+
+      // Top-level chapter = the child-of-root ancestor. Requirements that
+      // are themselves children of root (or the root) group under their
+      // own text.
+      const chapterOf = (id: string): string => {
+        let cur = nodeById.get(id);
+        while (cur && cur.parentId && cur.parentId !== rootId) {
+          cur = nodeById.get(cur.parentId);
+        }
+        return cur?.text ?? '(unknown)';
+      };
+
+      // Progress: rollup for parents, own percentComplete for leaves.
+      const progressOf = (n: (typeof requirements)[number]): number =>
+        (n.childrenIds?.length ?? 0) > 0 ? n.computedProgress : (n.percentComplete ?? 0);
+
+      const statusOf = (progress: number): 'open' | 'partial' | 'done' =>
+        progress >= 100 ? 'done' : progress > 0 ? 'partial' : 'open';
+
+      // Unestimated leaves in a requirement's subtree — flags where the
+      // effort/remaining numbers under-count (null leaves carry 0 effort
+      // in computedEffort).
+      const unestimatedLeaves = (id: string): number => {
+        let count = 0;
+        const stack = [id];
+        while (stack.length) {
+          const n = nodeById.get(stack.pop()!);
+          if (!n) continue;
+          if ((n.childrenIds?.length ?? 0) === 0) {
+            if (n.effortEstimate == null) count++;
+          } else {
+            stack.push(...n.childrenIds);
+          }
+        }
+        return count;
+      };
+
+      let rows = requirements.map((n) => {
+        const progress = progressOf(n);
+        return {
+          node: n,
+          chapter: chapterOf(n.id),
+          progress,
+          status: statusOf(progress),
+          remaining: n.computedEffort * (1 - progress / 100),
+          unestimated: unestimatedLeaves(n.id),
+          ghLinks: (n.externalLinks ?? [])
+            .filter((l) => l.provider === 'github')
+            .map((l) => l.externalId),
+        };
+      });
+
+      const totalByStatus = { done: 0, partial: 0, open: 0 };
+      for (const r of rows) totalByStatus[r.status]++;
+
+      if (status) rows = rows.filter((r) => r.status === status);
+      if (requirementPriority) {
+        rows = rows.filter((r) => r.node.requirementPriority === requirementPriority);
+      }
+
+      const byId = (a: (typeof rows)[number], b: (typeof rows)[number]) =>
+        (a.node.requirementId ?? '').localeCompare(b.node.requirementId ?? '', undefined, {
+          numeric: true,
+        });
+
+      const chapters = new Map<string, typeof rows>();
+      for (const r of [...rows].sort(byId)) {
+        const list = chapters.get(r.chapter) ?? [];
+        list.push(r);
+        chapters.set(r.chapter, list);
+      }
+
+      const lines: string[] = [];
+      lines.push(`Requirements register — ${data.map.name}`);
+      lines.push(
+        `${requirements.length} requirement(s): ${totalByStatus.done} done / ${totalByStatus.partial} partial / ${totalByStatus.open} open`,
+      );
+      if (status || requirementPriority) {
+        const filters = [
+          status ? `status=${status}` : null,
+          requirementPriority ? `requirementPriority=${requirementPriority}` : null,
+        ].filter(Boolean);
+        lines.push(`Showing ${rows.length} after filter (${filters.join(', ')})`);
+      }
+
+      const statusMark = { done: '✓ done', partial: '◐ partial', open: '○ open' } as const;
+      for (const [chapter, list] of chapters) {
+        const doneCount = list.filter((r) => r.status === 'done').length;
+        lines.push('');
+        lines.push(`## ${chapter} (${list.length} req, ${doneCount} done)`);
+        for (const r of list) {
+          const prio = r.node.requirementPriority ? ` [${r.node.requirementPriority}]` : '';
+          const parts = [
+            `${r.node.requirementId}${prio} ${statusMark[r.status]} ${r.progress.toFixed(0)}%`,
+            `— ${r.node.text} (id: ${r.node.id})`,
+          ];
+          if (r.status !== 'done' && r.remaining > 0) {
+            parts.push(`· ${r.remaining.toFixed(1)} ${unit} remaining`);
+          }
+          if (r.unestimated > 0) {
+            parts.push(`· ⚠ ${r.unestimated} unestimated leaf(s) — effort under-counts`);
+          }
+          if (r.ghLinks.length > 0) {
+            parts.push(`· gh: ${r.ghLinks.join(', ')}`);
+          }
+          lines.push(`  ${parts.join(' ')}`);
+        }
+      }
+
+      return toolResult(lines.join('\n'));
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
   'completion_forecast',
   'Forecast "when will it be done?" for a node/subtree/version. Reports: planned finish date (scheduler-based, respects dependencies), velocity-adjusted finish date (scales by past estimation accuracy from get_estimation_accuracy), target date (from version or node dueDates), and slip vs target. Scope with one of nodeId or versionId; omit both to forecast the whole map.',
   {

--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -16,6 +16,7 @@ import { QuickAdd } from './QuickAdd.js';
 import { HillChart } from './HillChart.js';
 import { WorkloadView } from './WorkloadView.js';
 import { ReleasesView } from './ReleasesView.js';
+import { RequirementsView } from './RequirementsView.js';
 import { ImportExport } from './ImportExport.js';
 import { AuthScreen } from './AuthScreen.js';
 import { ShareDialog } from './ShareDialog.js';
@@ -856,6 +857,7 @@ const VIEW_TABS: { id: ActiveView; label: string; enabled: boolean }[] = [
   { id: 'kanban', label: 'Kanban', enabled: true },
   { id: 'gantt', label: 'Gantt', enabled: true },
   { id: 'releases', label: 'Releases', enabled: true },
+  { id: 'requirements', label: 'Requirements', enabled: true },
   { id: 'list', label: 'List', enabled: false },
   { id: 'calendar', label: 'Calendar', enabled: true },
   { id: 'hill', label: 'Hill Chart', enabled: true },
@@ -2113,6 +2115,7 @@ export function App() {
           {activeView === 'kanban' && <KanbanView />}
           {activeView === 'gantt' && <GanttView />}
           {activeView === 'releases' && <ReleasesView />}
+          {activeView === 'requirements' && <RequirementsView />}
           {activeView === 'list' && <ListView />}
           {activeView === 'calendar' && <CalendarView />}
           {activeView === 'hill' && <HillChart />}

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -202,6 +202,7 @@ function PropertyPanelInner({
   const [dueDate, setDueDate] = useState(node.dueDate ?? '');
   const [startDate, setStartDate] = useState(node.startDate ?? '');
   const [blockedReason, setBlockedReason] = useState(node.blockedReason ?? '');
+  const [requirementId, setRequirementId] = useState(node.requirementId ?? '');
 
   // Sync local state when node changes externally
   useEffect(() => { setTitle(node.text); }, [node.text]);
@@ -212,6 +213,7 @@ function PropertyPanelInner({
   useEffect(() => { setDueDate(node.dueDate ?? ''); }, [node.dueDate]);
   useEffect(() => { setStartDate(node.startDate ?? ''); }, [node.startDate]);
   useEffect(() => { setBlockedReason(node.blockedReason ?? ''); }, [node.blockedReason]);
+  useEffect(() => { setRequirementId(node.requirementId ?? ''); }, [node.requirementId]);
 
   const allNodes = useMindmapStore((s) => s.nodes);
   const predecessorTitles = (computedValues?.blockedBy?.predecessorIds ?? [])
@@ -412,6 +414,45 @@ function PropertyPanelInner({
             ))}
           </select>
         </Field>
+
+        {/* Requirement ID — marks this node as a business requirement */}
+        <Field label="Requirement ID">
+          <input
+            value={requirementId}
+            onChange={(e) => setRequirementId(e.target.value)}
+            onBlur={() => {
+              const trimmed = requirementId.trim();
+              const persisted = node.requirementId ?? '';
+              if (trimmed !== persisted) {
+                directUpdate(nodeId, { requirementId: trimmed || null });
+              }
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            style={inputStyle}
+            placeholder="e.g. MAN-01 (marks node as requirement)"
+          />
+        </Field>
+
+        {/* Requirement priority (MoSCoW) — only relevant with an ID */}
+        {(node.requirementId != null || requirementId.trim() !== '') && (
+          <Field label="Req. Priority">
+            <select
+              value={node.requirementPriority ?? ''}
+              onChange={(e) => {
+                directUpdate(nodeId, {
+                  requirementPriority: (e.target.value || null) as Node['requirementPriority'],
+                });
+              }}
+              onKeyDown={(e) => e.stopPropagation()}
+              style={selectStyle}
+            >
+              <option value="">None</option>
+              <option value="must">Must (Muss)</option>
+              <option value="should">Should (Soll)</option>
+              <option value="could">Could (Kann)</option>
+            </select>
+          </Field>
+        )}
 
         {/* Effort estimate */}
         <Field label="Effort Estimate" computed={hasChildren}>

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,0 +1,731 @@
+import { useMemo, useState } from 'react';
+import type { Node } from '@mindblown/core';
+import { useMindmapStore } from './store.js';
+
+// ── Derived requirement status ───────────────────────────────────
+//
+// Never stored — always derived from progress rollup so the register
+// can't drift from the plan (the whole point of the feature).
+
+type ReqStatus = 'open' | 'partial' | 'done';
+
+const STATUS_LABEL: Record<ReqStatus, string> = {
+  done: 'Done',
+  partial: 'Partial',
+  open: 'Open',
+};
+
+const STATUS_COLOR: Record<ReqStatus, { bg: string; fg: string }> = {
+  done: { bg: '#d1fae5', fg: '#065f46' },
+  partial: { bg: '#fef3c7', fg: '#92400e' },
+  open: { bg: '#f1f5f9', fg: '#475569' },
+};
+
+const HEALTH_COLOR: Record<string, string> = {
+  on_track: '#10b981',
+  at_risk: '#f59e0b',
+  behind: '#ef4444',
+};
+
+const PRIORITY_LABEL: Record<string, string> = {
+  must: 'Must',
+  should: 'Should',
+  could: 'Could',
+};
+
+interface ReqRow {
+  node: Node;
+  chapterId: string | null;
+  chapterText: string;
+  isLeaf: boolean;
+  progress: number;
+  status: ReqStatus;
+  remaining: number;
+  unestimated: number;
+  health: string;
+  ghLinks: Array<{ id: string; url: string }>;
+}
+
+function statusOf(progress: number): ReqStatus {
+  return progress >= 100 ? 'done' : progress > 0 ? 'partial' : 'open';
+}
+
+function compareReqIds(a: ReqRow, b: ReqRow): number {
+  return (a.node.requirementId ?? '').localeCompare(b.node.requirementId ?? '', undefined, {
+    numeric: true,
+  });
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function RequirementsView() {
+  const nodes = useMindmapStore((s) => s.nodes);
+  const rootNodeId = useMindmapStore((s) => s.rootNodeId);
+  const computed = useMindmapStore((s) => s.computed);
+  const updateNode = useMindmapStore((s) => s.updateNode);
+  const addNode = useMindmapStore((s) => s.addNode);
+  const selectNode = useMindmapStore((s) => s.selectNode);
+  const setFocusNode = useMindmapStore((s) => s.setFocusNode);
+  const setActiveView = useMindmapStore((s) => s.setActiveView);
+  const getTopLevelAncestor = useMindmapStore((s) => s.getTopLevelAncestor);
+  const effortUnit = useMindmapStore((s) => s.currentMap?.effortUnit ?? 'days');
+
+  const [statusFilter, setStatusFilter] = useState<'' | ReqStatus>('');
+  const [priorityFilter, setPriorityFilter] = useState<'' | 'must' | 'should' | 'could'>('');
+  const [editingCell, setEditingCell] = useState<{ nodeId: string; field: string } | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [createFields, setCreateFields] = useState({
+    chapterId: '',
+    requirementId: '',
+    text: '',
+    requirementPriority: '' as '' | 'must' | 'should' | 'could',
+  });
+
+  // Deliberately NOT getVisibleNodes(): the register must show every
+  // requirement regardless of canvas focus / collapse / depth limit.
+  const allRows = useMemo<ReqRow[]>(() => {
+    const countUnestimatedLeaves = (id: string): number => {
+      let count = 0;
+      const stack = [id];
+      while (stack.length) {
+        const n = nodes[stack.pop()!];
+        if (!n) continue;
+        if (n.childrenIds.length === 0) {
+          if (n.effortEstimate == null) count++;
+        } else {
+          stack.push(...n.childrenIds);
+        }
+      }
+      return count;
+    };
+
+    return Object.values(nodes)
+      .filter((n) => n.requirementId != null)
+      .map((node) => {
+        const cv = computed.get(node.id);
+        const isLeaf = node.childrenIds.length === 0;
+        const progress = isLeaf ? (node.percentComplete ?? 0) : (cv?.computedProgress ?? 0);
+        const chapter = getTopLevelAncestor(node.id);
+        return {
+          node,
+          chapterId: chapter?.id ?? null,
+          chapterText: chapter?.text ?? '(root)',
+          isLeaf,
+          progress,
+          status: statusOf(progress),
+          remaining: (cv?.computedEffort ?? 0) * (1 - progress / 100),
+          unestimated: countUnestimatedLeaves(node.id),
+          health: cv?.healthSignal ?? 'on_track',
+          ghLinks: node.externalLinks
+            .filter((l) => l.provider === 'github')
+            .map((l) => ({ id: l.externalId, url: l.url })),
+        };
+      });
+  }, [nodes, computed, getTopLevelAncestor]);
+
+  const totals = useMemo(() => {
+    const t = { done: 0, partial: 0, open: 0 };
+    for (const r of allRows) t[r.status]++;
+    return t;
+  }, [allRows]);
+
+  const filteredRows = useMemo(
+    () =>
+      allRows.filter(
+        (r) =>
+          (!statusFilter || r.status === statusFilter) &&
+          (!priorityFilter || r.node.requirementPriority === priorityFilter),
+      ),
+    [allRows, statusFilter, priorityFilter],
+  );
+
+  // Group by chapter, chapters in tree order (root's childrenIds),
+  // requirements within a chapter in REQ-ID order.
+  const grouped = useMemo(() => {
+    const byChapter = new Map<string, ReqRow[]>();
+    for (const r of [...filteredRows].sort(compareReqIds)) {
+      const key = r.chapterId ?? '(root)';
+      const list = byChapter.get(key) ?? [];
+      list.push(r);
+      byChapter.set(key, list);
+    }
+    const chapterOrder = rootNodeId ? (nodes[rootNodeId]?.childrenIds ?? []) : [];
+    return [...byChapter.entries()].sort(
+      (a, b) => chapterOrder.indexOf(a[0]) - chapterOrder.indexOf(b[0]),
+    );
+  }, [filteredRows, nodes, rootNodeId]);
+
+  const chapters = useMemo(
+    () =>
+      rootNodeId
+        ? (nodes[rootNodeId]?.childrenIds ?? []).map((id) => nodes[id]).filter(Boolean)
+        : [],
+    [nodes, rootNodeId],
+  );
+
+  const jumpToNode = (node: Node) => {
+    setActiveView('mindmap');
+    selectNode(node.id);
+    const targetFocus = node.parentId && node.parentId !== rootNodeId ? node.parentId : null;
+    setFocusNode(targetFocus);
+    (window as unknown as { __mindmapPanToNode?: (id: string) => void }).__mindmapPanToNode?.(
+      node.id,
+    );
+  };
+
+  const submitCreate = () => {
+    const { chapterId, requirementId, text, requirementPriority } = createFields;
+    if (!chapterId || !requirementId.trim() || !text.trim()) return;
+    addNode(chapterId, text.trim(), false, undefined, {
+      requirementId: requirementId.trim(),
+      requirementPriority: requirementPriority || null,
+    });
+    setCreateFields({ chapterId, requirementId: '', text: '', requirementPriority: '' });
+    setShowCreate(false);
+  };
+
+  const isEditing = (nodeId: string, field: string) =>
+    editingCell?.nodeId === nodeId && editingCell.field === field;
+
+  if (!rootNodeId) {
+    return (
+      <div style={containerStyle}>
+        <EmptyState title="No map open" message="Open a map to see its requirements." />
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={headerStyle}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 16, color: '#1e293b' }}>Requirements</h2>
+          <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>
+            {allRows.length} requirement{allRows.length === 1 ? '' : 's'} · {totals.done} done ·{' '}
+            {totals.partial} partial · {totals.open} open
+            {(statusFilter || priorityFilter) && ` · showing ${filteredRows.length} (filtered)`}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as '' | ReqStatus)}
+            style={filterSelectStyle}
+          >
+            <option value="">All statuses</option>
+            <option value="open">Open</option>
+            <option value="partial">Partial</option>
+            <option value="done">Done</option>
+          </select>
+          <select
+            value={priorityFilter}
+            onChange={(e) =>
+              setPriorityFilter(e.target.value as '' | 'must' | 'should' | 'could')
+            }
+            style={filterSelectStyle}
+          >
+            <option value="">All priorities</option>
+            <option value="must">Must</option>
+            <option value="should">Should</option>
+            <option value="could">Could</option>
+          </select>
+          <button
+            onClick={() => setShowCreate((v) => !v)}
+            style={primaryButtonStyle(false)}
+          >
+            + New requirement
+          </button>
+        </div>
+      </div>
+
+      {showCreate && (
+        <div style={createFormStyle}>
+          <select
+            value={createFields.chapterId}
+            onChange={(e) => setCreateFields((f) => ({ ...f, chapterId: e.target.value }))}
+            style={{ ...inputStyle, width: 200 }}
+          >
+            <option value="">Chapter…</option>
+            {chapters.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.text}
+              </option>
+            ))}
+          </select>
+          <input
+            placeholder="REQ-ID (e.g. MAN-01)"
+            value={createFields.requirementId}
+            onChange={(e) => setCreateFields((f) => ({ ...f, requirementId: e.target.value }))}
+            style={{ ...inputStyle, width: 150 }}
+          />
+          <input
+            placeholder="Requirement title"
+            value={createFields.text}
+            onChange={(e) => setCreateFields((f) => ({ ...f, text: e.target.value }))}
+            onKeyDown={(e) => e.key === 'Enter' && submitCreate()}
+            style={{ ...inputStyle, flex: 1 }}
+          />
+          <select
+            value={createFields.requirementPriority}
+            onChange={(e) =>
+              setCreateFields((f) => ({
+                ...f,
+                requirementPriority: e.target.value as '' | 'must' | 'should' | 'could',
+              }))
+            }
+            style={{ ...inputStyle, width: 110 }}
+          >
+            <option value="">Priority…</option>
+            <option value="must">Must</option>
+            <option value="should">Should</option>
+            <option value="could">Could</option>
+          </select>
+          <button
+            onClick={submitCreate}
+            disabled={
+              !createFields.chapterId ||
+              !createFields.requirementId.trim() ||
+              !createFields.text.trim()
+            }
+            style={primaryButtonStyle(
+              !createFields.chapterId ||
+                !createFields.requirementId.trim() ||
+                !createFields.text.trim(),
+            )}
+          >
+            Create
+          </button>
+          <button onClick={() => setShowCreate(false)} style={secondaryButtonStyle(false)}>
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {allRows.length === 0 ? (
+        <EmptyState
+          title="No requirements yet"
+          message='Mark a node as a requirement by giving it a Requirement ID (property panel), or click "+ New requirement".'
+        />
+      ) : (
+        <div style={{ overflow: 'auto', flex: 1 }}>
+          <table style={tableStyle}>
+            <thead>
+              <tr>
+                <th style={{ ...thStyle, width: 110 }}>ID</th>
+                <th style={thStyle}>Requirement</th>
+                <th style={{ ...thStyle, width: 80 }}>Priority</th>
+                <th style={{ ...thStyle, width: 80 }}>Status</th>
+                <th style={{ ...thStyle, width: 130 }}>Progress</th>
+                <th style={{ ...thStyle, width: 130, textAlign: 'right' }}>Remaining</th>
+                <th style={{ ...thStyle, width: 140 }}>GitHub</th>
+              </tr>
+            </thead>
+            <tbody>
+              {grouped.map(([chapterKey, rows]) => (
+                <ChapterGroup
+                  key={chapterKey}
+                  chapterText={rows[0].chapterText}
+                  rows={rows}
+                  effortUnit={effortUnit}
+                  isEditing={isEditing}
+                  setEditingCell={setEditingCell}
+                  updateNode={updateNode}
+                  jumpToNode={jumpToNode}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Chapter group (header row + requirement rows) ────────────────
+
+function ChapterGroup({
+  chapterText,
+  rows,
+  effortUnit,
+  isEditing,
+  setEditingCell,
+  updateNode,
+  jumpToNode,
+}: {
+  chapterText: string;
+  rows: ReqRow[];
+  effortUnit: string;
+  isEditing: (nodeId: string, field: string) => boolean;
+  setEditingCell: (cell: { nodeId: string; field: string } | null) => void;
+  updateNode: (id: string, updates: Partial<Node>) => void;
+  jumpToNode: (node: Node) => void;
+}) {
+  const done = rows.filter((r) => r.status === 'done').length;
+  return (
+    <>
+      <tr>
+        <td colSpan={7} style={groupHeaderStyle}>
+          {chapterText}
+          <span style={{ fontWeight: 400, color: '#64748b', marginLeft: 8 }}>
+            {rows.length} req · {done} done
+          </span>
+        </td>
+      </tr>
+      {rows.map((r) => (
+        <tr key={r.node.id} style={{ borderBottom: '1px solid #f1f5f9' }}>
+          {/* REQ-ID — inline editable */}
+          <td style={tdStyle} onClick={() => setEditingCell({ nodeId: r.node.id, field: 'requirementId' })}>
+            {isEditing(r.node.id, 'requirementId') ? (
+              <input
+                autoFocus
+                defaultValue={r.node.requirementId ?? ''}
+                onBlur={(e) => {
+                  const v = e.target.value.trim();
+                  if (v !== r.node.requirementId) {
+                    updateNode(r.node.id, { requirementId: v || null });
+                  }
+                  setEditingCell(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                  if (e.key === 'Escape') setEditingCell(null);
+                  e.stopPropagation();
+                }}
+                style={{ ...inputStyle, width: 90, padding: '2px 6px' }}
+              />
+            ) : (
+              <span style={{ fontWeight: 600, color: '#334155', cursor: 'text' }}>
+                {r.node.requirementId}
+              </span>
+            )}
+          </td>
+
+          {/* Title — inline editable, with jump-to-map affordance */}
+          <td style={tdStyle} onClick={() => setEditingCell({ nodeId: r.node.id, field: 'text' })}>
+            {isEditing(r.node.id, 'text') ? (
+              <input
+                autoFocus
+                defaultValue={r.node.text}
+                onBlur={(e) => {
+                  const v = e.target.value.trim();
+                  if (v && v !== r.node.text) updateNode(r.node.id, { text: v });
+                  setEditingCell(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                  if (e.key === 'Escape') setEditingCell(null);
+                  e.stopPropagation();
+                }}
+                style={{ ...inputStyle, width: '100%', padding: '2px 6px' }}
+              />
+            ) : (
+              <span style={{ cursor: 'text' }}>
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: 7,
+                    height: 7,
+                    borderRadius: '50%',
+                    background: HEALTH_COLOR[r.health] ?? '#94a3b8',
+                    marginRight: 8,
+                  }}
+                  title={`Health: ${r.health}`}
+                />
+                {r.node.text}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    jumpToNode(r.node);
+                  }}
+                  title="Show in mindmap"
+                  style={jumpButtonStyle}
+                >
+                  ↗
+                </button>
+              </span>
+            )}
+          </td>
+
+          {/* MoSCoW priority — inline select */}
+          <td style={tdStyle}>
+            <select
+              value={r.node.requirementPriority ?? ''}
+              onChange={(e) =>
+                updateNode(r.node.id, {
+                  requirementPriority: (e.target.value || null) as Node['requirementPriority'],
+                })
+              }
+              onKeyDown={(e) => e.stopPropagation()}
+              style={inlineSelectStyle}
+            >
+              <option value="">—</option>
+              <option value="must">Must</option>
+              <option value="should">Should</option>
+              <option value="could">Could</option>
+            </select>
+          </td>
+
+          {/* Derived status — read-only by design */}
+          <td style={tdStyle}>
+            <span
+              title="Derived from progress rollup — complete the underlying work to change it"
+              style={{
+                padding: '2px 8px',
+                borderRadius: 10,
+                fontSize: 11,
+                fontWeight: 600,
+                background: STATUS_COLOR[r.status].bg,
+                color: STATUS_COLOR[r.status].fg,
+              }}
+            >
+              {STATUS_LABEL[r.status]}
+            </span>
+          </td>
+
+          {/* Progress — editable on leaves only (parents roll up) */}
+          <td
+            style={tdStyle}
+            onClick={() =>
+              r.isLeaf && setEditingCell({ nodeId: r.node.id, field: 'percentComplete' })
+            }
+          >
+            {r.isLeaf && isEditing(r.node.id, 'percentComplete') ? (
+              <input
+                autoFocus
+                type="number"
+                min={0}
+                max={100}
+                defaultValue={r.node.percentComplete ?? 0}
+                onBlur={(e) => {
+                  const v = e.target.value === '' ? null : Number(e.target.value);
+                  updateNode(r.node.id, {
+                    percentComplete: v != null ? Math.min(100, Math.max(0, v)) : null,
+                  });
+                  setEditingCell(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                  if (e.key === 'Escape') setEditingCell(null);
+                  e.stopPropagation();
+                }}
+                style={{ ...inputStyle, width: 60, padding: '2px 6px' }}
+              />
+            ) : (
+              <ProgressBar percent={r.progress} editable={r.isLeaf} />
+            )}
+          </td>
+
+          {/* Remaining effort + unestimated warning */}
+          <td style={{ ...tdStyle, textAlign: 'right', whiteSpace: 'nowrap' }}>
+            {r.status === 'done' ? (
+              <span style={{ color: '#94a3b8' }}>—</span>
+            ) : (
+              `${r.remaining.toFixed(1)} ${effortUnit}`
+            )}
+            {r.unestimated > 0 && (
+              <span
+                title={`${r.unestimated} unestimated leaf/leaves under this requirement — remaining under-counts`}
+                style={{ color: '#d97706', marginLeft: 6, cursor: 'help' }}
+              >
+                ⚠{r.unestimated}
+              </span>
+            )}
+          </td>
+
+          {/* GitHub links */}
+          <td style={{ ...tdStyle, whiteSpace: 'nowrap' }}>
+            {r.ghLinks.length === 0 ? (
+              <span style={{ color: '#cbd5e1' }}>—</span>
+            ) : (
+              r.ghLinks.map((l, i) => (
+                <a
+                  key={l.id}
+                  href={l.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ color: '#3b82f6', textDecoration: 'none', marginLeft: i > 0 ? 6 : 0 }}
+                >
+                  {l.id.includes('#') ? `#${l.id.split('#')[1]}` : l.id}
+                </a>
+              ))
+            )}
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ── Small pieces ─────────────────────────────────────────────────
+
+function ProgressBar({ percent, editable }: { percent: number; editable: boolean }) {
+  const clamped = Math.min(100, Math.max(0, Math.round(percent)));
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: editable ? 'text' : 'default' }}
+      title={editable ? 'Click to edit (leaf)' : 'Rolled up from children'}
+    >
+      <div style={{ flex: 1, height: 6, background: '#f1f5f9', borderRadius: 3, minWidth: 50 }}>
+        <div
+          style={{
+            width: `${clamped}%`,
+            height: '100%',
+            borderRadius: 3,
+            background: clamped >= 100 ? '#10b981' : '#3b82f6',
+          }}
+        />
+      </div>
+      <span style={{ fontSize: 11, color: '#64748b', minWidth: 32, textAlign: 'right' }}>
+        {clamped}%
+      </span>
+    </div>
+  );
+}
+
+function EmptyState({ title, message }: { title: string; message: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 1,
+        padding: 40,
+        color: '#64748b',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: 14, fontWeight: 600, color: '#1e293b', marginBottom: 4 }}>{title}</div>
+      <div style={{ fontSize: 12, maxWidth: 420 }}>{message}</div>
+    </div>
+  );
+}
+
+// ── Styles ───────────────────────────────────────────────────────
+
+const containerStyle: React.CSSProperties = {
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  background: '#ffffff',
+  fontFamily: 'inherit',
+};
+
+const headerStyle: React.CSSProperties = {
+  padding: '16px 24px',
+  borderBottom: '1px solid #e2e8f0',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+};
+
+const createFormStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 8,
+  padding: '12px 24px',
+  borderBottom: '1px solid #e2e8f0',
+  background: '#f8fafc',
+  alignItems: 'center',
+};
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 12,
+};
+
+const thStyle: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '10px 16px',
+  fontSize: 10,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+  color: '#64748b',
+  borderBottom: '1px solid #e2e8f0',
+  background: '#f8fafc',
+  position: 'sticky',
+  top: 0,
+  zIndex: 1,
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '8px 16px',
+  fontSize: 12,
+  color: '#334155',
+  verticalAlign: 'middle',
+};
+
+const groupHeaderStyle: React.CSSProperties = {
+  padding: '10px 16px',
+  fontSize: 12,
+  fontWeight: 600,
+  color: '#3730a3',
+  background: '#eef2ff',
+  borderBottom: '1px solid #e0e7ff',
+};
+
+const inputStyle: React.CSSProperties = {
+  boxSizing: 'border-box',
+  padding: '6px 10px',
+  fontSize: 12,
+  fontFamily: 'inherit',
+  border: '1px solid #cbd5e1',
+  borderRadius: 6,
+  background: '#fff',
+  color: '#1e293b',
+};
+
+const filterSelectStyle: React.CSSProperties = {
+  ...inputStyle,
+  padding: '5px 8px',
+};
+
+const inlineSelectStyle: React.CSSProperties = {
+  border: '1px solid transparent',
+  borderRadius: 4,
+  background: 'transparent',
+  fontSize: 12,
+  fontFamily: 'inherit',
+  color: '#334155',
+  cursor: 'pointer',
+};
+
+const jumpButtonStyle: React.CSSProperties = {
+  marginLeft: 8,
+  border: 'none',
+  background: 'transparent',
+  color: '#94a3b8',
+  cursor: 'pointer',
+  fontSize: 12,
+  padding: 0,
+};
+
+function primaryButtonStyle(disabled: boolean): React.CSSProperties {
+  return {
+    padding: '6px 12px',
+    borderRadius: 6,
+    border: '1px solid #3b82f6',
+    background: disabled ? '#93c5fd' : '#3b82f6',
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 500,
+    fontFamily: 'inherit',
+    cursor: disabled ? 'default' : 'pointer',
+  };
+}
+
+function secondaryButtonStyle(disabled: boolean): React.CSSProperties {
+  return {
+    padding: '6px 12px',
+    borderRadius: 6,
+    border: '1px solid #e2e8f0',
+    background: disabled ? '#f1f5f9' : '#fff',
+    color: disabled ? '#94a3b8' : '#1e293b',
+    fontSize: 12,
+    fontWeight: 500,
+    fontFamily: 'inherit',
+    cursor: disabled ? 'default' : 'pointer',
+  };
+}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -542,10 +542,18 @@ export function createNode(
   text: string,
   position?: number,
   coords?: { x: number; y: number },
+  /**
+   * Extra node fields to set atomically at create time (e.g.
+   * requirementId). Preferred over a follow-up updateNode when the
+   * caller only has a temp id — the store skips the API for temp ids,
+   * so post-create enrichment can silently fail to persist.
+   */
+  fields?: Partial<Node>,
 ): Promise<Node> {
   return request<Node>(`/api/maps/${mapId}/nodes`, {
     method: 'POST',
     body: JSON.stringify({
+      ...(fields ?? {}),
       parentId,
       text,
       createdBy: 'current-user',

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -16,7 +16,7 @@ function recomputeValues(nodes: Record<string, Node>): Map<NodeId, ComputedNodeV
 
 // ── Store types ────────────────────────────────────────────────
 
-export type ActiveView = 'mindmap' | 'kanban' | 'gantt' | 'list' | 'calendar' | 'hill' | 'workload' | 'releases';
+export type ActiveView = 'mindmap' | 'kanban' | 'gantt' | 'list' | 'calendar' | 'hill' | 'workload' | 'releases' | 'requirements';
 
 export interface VisibleNode {
   node: Node;
@@ -126,7 +126,7 @@ export interface MindmapState {
   selectAllNodes: () => void;
   clearSelection: () => void;
   startEditing: (id: string | null) => void;
-  addNode: (parentId: string, text?: string, asSibling?: boolean, position?: { x: number; y: number }) => string;
+  addNode: (parentId: string, text?: string, asSibling?: boolean, position?: { x: number; y: number }, fields?: Partial<Node>) => string;
   updateNode: (id: string, updates: Partial<Node>) => void;
   deleteNode: (id: string) => void;
   moveNode: (nodeId: string, newParentId: string, index: number) => void;
@@ -153,6 +153,7 @@ export interface MindmapState {
   // Helpers
   getLeafNodes: () => Node[];
   getNodeBreadcrumb: (nodeId: NodeId) => string;
+  getTopLevelAncestor: (nodeId: NodeId) => Node | null;
 }
 
 // ── WebSocket connection ───────────────────────────────────────
@@ -757,6 +758,20 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
     return parts.join(' > ');
   },
 
+  getTopLevelAncestor: (nodeId: NodeId) => {
+    const { nodes, rootNodeId } = get();
+    let current = nodes[nodeId];
+    if (!current) return null;
+    // The root has no chapter; a child of root is its own chapter.
+    if (current.id === rootNodeId) return null;
+    while (current.parentId && current.parentId !== rootNodeId) {
+      const parent = nodes[current.parentId];
+      if (!parent) break;
+      current = parent;
+    }
+    return current;
+  },
+
   // ── Node actions ─────────────────────────────────────────────
 
   // ── Layout actions ────────────────────────────────────────────
@@ -789,7 +804,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
 
   startEditing: (id) => set({ editingNodeId: id }),
 
-  addNode: (parentId, text = 'New node', asSibling = false, position) => {
+  addNode: (parentId, text = 'New node', asSibling = false, position, fields) => {
     const state = get();
     const mapId = state.currentMapId;
     let targetParentId = parentId;
@@ -839,6 +854,8 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       autoProgress: 'off',
       priorityRank: null,
     completedAt: null,
+      requirementId: null,
+      requirementPriority: null,
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,
@@ -848,6 +865,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       createdBy: state.user?.id ?? 'user-001',
       revision: 1,
       deletedAt: null,
+      ...(fields ?? {}),
     };
 
     // Optimistic local update
@@ -874,7 +892,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
 
     // Sync to API
     if (mapId) {
-      api.createNode(mapId, targetParentId, text, insertIndex >= 0 ? insertIndex : undefined, position)
+      api.createNode(mapId, targetParentId, text, insertIndex >= 0 ? insertIndex : undefined, position, fields)
         .then((serverNode) => {
           // Replace temp node with server node
           const current = get();

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -73,6 +73,8 @@ function toNodeWithComputed(
     collapsed: node.collapsed,
     createdAt: toIsoString((node as unknown as { createdAt: unknown }).createdAt),
     updatedAt: toIsoString((node as unknown as { updatedAt: unknown }).updatedAt),
+    requirementId: node.requirementId,
+    requirementPriority: node.requirementPriority,
     claimedBySession: node.claimedBySession,
     claimedAt: node.claimedAt,
     computedEffort: computed?.computedEffort ?? 0,

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -38,6 +38,9 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     completedAt: (get('completedAt', 'completed_at') instanceof Date
       ? (get('completedAt', 'completed_at') as Date).toISOString()
       : (get('completedAt', 'completed_at') as string)) ?? null,
+    requirementId: (get('requirementId', 'requirement_id') as string) ?? null,
+    requirementPriority:
+      (get('requirementPriority', 'requirement_priority') as CoreNode['requirementPriority']) ?? null,
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -761,5 +761,28 @@ export async function runMigrations(): Promise<void> {
     ALTER TABLE nodes ADD COLUMN IF NOT EXISTS linked_pr JSONB
   `);
 
+  // ── Requirements register ──────────────────────────────────────
+  // requirement_id: stable business requirement ID (e.g. 'MAN-01');
+  // non-null marks the node as a requirement. requirement_priority:
+  // MoSCoW 'must' | 'should' | 'could'. Per-map uniqueness of
+  // requirement_id is enforced application-level in db/nodes.ts.
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS requirement_id TEXT
+  `);
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS requirement_priority TEXT
+  `);
+  // DB-level backstop for per-map requirement_id uniqueness. The
+  // application-level precheck in db/nodes.ts gives friendly errors on
+  // the sequential path, but concurrent creates (MCP pipelines tool
+  // calls) can both pass the precheck — observed in verification. The
+  // partial index closes that race; 23505 on this index is mapped back
+  // to RequirementIdConflictError in db/nodes.ts.
+  await db.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS nodes_map_requirement_id_unique
+      ON nodes (map_id, requirement_id)
+      WHERE requirement_id IS NOT NULL AND deleted_at IS NULL
+  `);
+
   console.log('[db] Migrations complete.');
 }

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 import { db } from './connection.js';
 import { nodes, maps, changeEvents } from './schema.js';
 import { dbNodeToCore } from './helpers.js';
@@ -51,6 +51,60 @@ export class TagsModeConflictError extends Error {
     super('Cannot combine `tags` (replace) with `tagsAppend`/`tagsRemove` (merge) in the same update.');
     this.name = 'TagsModeConflictError';
   }
+}
+
+/**
+ * Thrown when a create/update would give a node a requirementId that
+ * another (non-deleted) node in the same map already carries. Requirement
+ * IDs are stable business identifiers (e.g. 'MAN-01') — two nodes with
+ * the same ID would make the requirements register ambiguous.
+ */
+export class RequirementIdConflictError extends Error {
+  constructor(requirementId: string, existingNodeId?: string) {
+    super(
+      existingNodeId
+        ? `Requirement ID "${requirementId}" is already used by node ${existingNodeId} in this map.`
+        : `Requirement ID "${requirementId}" is already used by another node in this map.`,
+    );
+    this.name = 'RequirementIdConflictError';
+  }
+}
+
+/**
+ * True when a thrown pg error is a unique-violation (23505) on the
+ * per-map requirement_id partial index. The app-level precheck catches
+ * the sequential case with a friendlier message; this catches the
+ * concurrent-create race the precheck can't see.
+ */
+function isRequirementIdUniqueViolation(err: unknown): boolean {
+  const e = err as { code?: string; constraint?: string } | null;
+  return e?.code === '23505' && e?.constraint === 'nodes_map_requirement_id_unique';
+}
+
+/**
+ * Per-map uniqueness guard for requirementId. Application-level (no DB
+ * constraint) — modeled on the dependency-duplicate guard below. Throws
+ * RequirementIdConflictError when another non-deleted node in the map
+ * already carries the ID.
+ */
+async function assertRequirementIdAvailable(
+  handle: DbHandle,
+  mapId: string,
+  requirementId: string,
+  excludeNodeId?: string,
+): Promise<void> {
+  const conditions = [
+    eq(nodes.mapId, mapId),
+    eq(nodes.requirementId, requirementId),
+    notDeleted,
+  ];
+  if (excludeNodeId) conditions.push(ne(nodes.id, excludeNodeId));
+  const [existing] = await handle
+    .select({ id: nodes.id })
+    .from(nodes)
+    .where(and(...conditions))
+    .limit(1);
+  if (existing) throw new RequirementIdConflictError(requirementId, existing.id as string);
 }
 
 // ── Tag merge math (exported for unit tests) ──────────────────────
@@ -147,6 +201,8 @@ export interface CreateNodeInput {
   autoProgress?: 'off' | 'children';
   priorityRank?: number | null;
   completedAt?: string | null;
+  requirementId?: string | null;
+  requirementPriority?: 'must' | 'should' | 'could' | null;
 }
 
 export async function createNode(
@@ -162,33 +218,47 @@ export async function createNode(
   const handle: DbHandle = txHandle ?? db;
   const now = new Date();
 
+  if (input.requirementId != null) {
+    await assertRequirementIdAvailable(handle, input.mapId, input.requirementId);
+  }
+
   // Create the node
-  const [row] = await handle.insert(nodes).values({
-    mapId: input.mapId,
-    parentId: input.parentId,
-    childrenOrder: [],
-    text: input.text,
-    collapsed: false,
-    x: input.x ?? null,
-    y: input.y ?? null,
-    effortEstimate: input.effortEstimate ?? null,
-    percentComplete: input.percentComplete ?? null,
-    status: input.status ?? null,
-    priority: input.priority ?? null,
-    startDate: input.startDate ?? null,
-    dueDate: input.dueDate ?? null,
-    autoProgress: input.autoProgress ?? 'off',
-    priorityRank: input.priorityRank ?? null,
-    completedAt: input.completedAt ? new Date(input.completedAt) : null,
-    assigneeIds: [],
-    tags: [],
-    customFields: {},
-    dependencies: [],
-    externalLinks: [],
-    createdAt: now,
-    updatedAt: now,
-    createdBy: input.createdBy,
-  }).returning();
+  let row;
+  try {
+    [row] = await handle.insert(nodes).values({
+      mapId: input.mapId,
+      parentId: input.parentId,
+      childrenOrder: [],
+      text: input.text,
+      collapsed: false,
+      x: input.x ?? null,
+      y: input.y ?? null,
+      effortEstimate: input.effortEstimate ?? null,
+      percentComplete: input.percentComplete ?? null,
+      status: input.status ?? null,
+      priority: input.priority ?? null,
+      startDate: input.startDate ?? null,
+      dueDate: input.dueDate ?? null,
+      autoProgress: input.autoProgress ?? 'off',
+      priorityRank: input.priorityRank ?? null,
+      completedAt: input.completedAt ? new Date(input.completedAt) : null,
+      requirementId: input.requirementId ?? null,
+      requirementPriority: input.requirementPriority ?? null,
+      assigneeIds: [],
+      tags: [],
+      customFields: {},
+      dependencies: [],
+      externalLinks: [],
+      createdAt: now,
+      updatedAt: now,
+      createdBy: input.createdBy,
+    }).returning();
+  } catch (err) {
+    if (isRequirementIdUniqueViolation(err)) {
+      throw new RequirementIdConflictError(input.requirementId as string);
+    }
+    throw err;
+  }
 
   // Add to parent's children_order
   const [parent] = await handle
@@ -263,6 +333,8 @@ export interface UpdateNodeInput {
   autoProgress?: 'off' | 'children';
   priorityRank?: number | null;
   completedAt?: string | null;
+  requirementId?: string | null;
+  requirementPriority?: 'must' | 'should' | 'could' | null;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -311,6 +383,17 @@ export async function updateNode(
     delete input.tagsRemove;
   }
 
+  // Per-map uniqueness of requirementId (application-level guard).
+  if (input.requirementId != null) {
+    const [row] = await handle
+      .select({ mapId: nodes.mapId })
+      .from(nodes)
+      .where(and(eq(nodes.id, nodeId), notDeleted));
+    if (row) {
+      await assertRequirementIdAvailable(handle, row.mapId as string, input.requirementId, nodeId);
+    }
+  }
+
   // Auto-derive status from percentComplete when status is not explicitly set
   // in this update. See deriveAutoStatus for the exact rules.
   if (input.percentComplete !== undefined && input.status === undefined) {
@@ -356,6 +439,8 @@ export async function updateNode(
   if (input.externalLinks !== undefined) updates.externalLinks = input.externalLinks;
   if (input.autoProgress !== undefined) updates.autoProgress = input.autoProgress;
   if (input.priorityRank !== undefined) updates.priorityRank = input.priorityRank;
+  if (input.requirementId !== undefined) updates.requirementId = input.requirementId;
+  if (input.requirementPriority !== undefined) updates.requirementPriority = input.requirementPriority;
   // Orchestration substrate (#111)
   if (input.claimedBySession !== undefined) updates.claimedBySession = input.claimedBySession;
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;
@@ -433,7 +518,15 @@ export async function updateNode(
       ? and(eq(nodes.id, nodeId), notDeleted)
       : and(eq(nodes.id, nodeId), eq(nodes.revision, expectedRevision), notDeleted);
 
-  const [row] = await handle.update(nodes).set(updates).where(where).returning();
+  let row;
+  try {
+    [row] = await handle.update(nodes).set(updates).where(where).returning();
+  } catch (err) {
+    if (isRequirementIdUniqueViolation(err)) {
+      throw new RequirementIdConflictError(input.requirementId as string);
+    }
+    throw err;
+  }
   if (row) {
     // Triage cache invalidation (#92, #93). Same rationale as createNode —
     // a depth-1 node's title/description may have just changed, which

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -187,6 +187,14 @@ export const nodes = pgTable('nodes', {
   // the past instead of piling them on the today line.
   completedAt: timestamp('completed_at', { withTimezone: true }),
 
+  // ── Requirements register ─────────────────────────────────────
+  // requirement_id: stable business requirement ID (e.g. 'MAN-01').
+  //   Non-null marks the node as a requirement. Unique per map,
+  //   enforced application-level in nodes.ts (no DB constraint).
+  // requirement_priority: MoSCoW priority — 'must' | 'should' | 'could'.
+  requirementId: text('requirement_id'),
+  requirementPriority: text('requirement_priority'),
+
   // ── Orchestration substrate (#111) ───────────────────────────
   // claimed_by_session: session ID that owns this node for active work.
   //   null = unclaimed / available.

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -388,6 +388,8 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           autoProgress: 'off',
           priorityRank: null,
           completedAt: null,
+          requirementId: null,
+          requirementPriority: null,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import * as nodeDb from '../db/nodes.js';
-import { DependencyValidationError, RevisionConflictError, TagsModeConflictError } from '../db/nodes.js';
+import { DependencyValidationError, RequirementIdConflictError, RevisionConflictError, TagsModeConflictError } from '../db/nodes.js';
 import * as mapDb from '../db/maps.js';
 import * as events from '../db/events.js';
 import { broadcast } from '../ws.js';
@@ -168,6 +168,8 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       dueDate?: string;
       autoProgress?: 'off' | 'children';
       priorityRank?: number | null;
+      requirementId?: string | null;
+      requirementPriority?: 'must' | 'should' | 'could' | null;
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`
        * auto-link backstop (#58). Useful when the leading `#NNNN` is
@@ -187,11 +189,21 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
     // `skipAutoLink` is not a column on the nodes table — strip it before
     // forwarding to the DB layer.
     const { skipAutoLink, ...nodeFields } = body;
-    const node = await nodeDb.createNode({
-      ...nodeFields,
-      mapId: req.params.id,
-      createdBy: userId,
-    });
+    let node: CoreNode;
+    try {
+      node = await nodeDb.createNode({
+        ...nodeFields,
+        mapId: req.params.id,
+        createdBy: userId,
+      });
+    } catch (err) {
+      if (err instanceof RequirementIdConflictError) {
+        return reply.status(400).send({
+          error: { code: 'REQUIREMENT_ID_CONFLICT', message: err.message },
+        });
+      }
+      throw err;
+    }
 
     // Broadcast to connected clients
     broadcast(req.params.id, { type: 'node:created', node });
@@ -286,6 +298,11 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
         if (err instanceof TagsModeConflictError) {
           return reply.status(400).send({
             error: { code: 'TAGS_MODE_CONFLICT', message: err.message },
+          });
+        }
+        if (err instanceof RequirementIdConflictError) {
+          return reply.status(400).send({
+            error: { code: 'REQUIREMENT_ID_CONFLICT', message: err.message },
           });
         }
         if (err instanceof RevisionConflictError) {

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -510,6 +510,83 @@ describe('search_nodes tool — versionId ancestor-walk', () => {
   });
 });
 
+// Requirements register — requirementId marks a node as a business
+// requirement (unique per map); requirementPriority is MoSCoW. Both must
+// round-trip through create_node AND update_node or the register is
+// invisible to MCP agents (the CLAUDE.md layer-6 failure mode).
+describe('requirement fields', () => {
+  it('accepts requirementId + requirementPriority on update_node', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      nodeId: 'n1',
+      requirementId: 'MAN-01',
+      requirementPriority: 'must',
+    });
+    expect(parsed.requirementId).toBe('MAN-01');
+    expect(parsed.requirementPriority).toBe('must');
+  });
+
+  it('rejects unknown requirementPriority values', () => {
+    const schema = z.object(updateNodeTool.schema);
+    expect(() =>
+      schema.parse({ mapId: 'm1', nodeId: 'n1', requirementPriority: 'urgent' }),
+    ).toThrow();
+  });
+
+  it('accepts null to clear both fields', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      nodeId: 'n1',
+      requirementId: null,
+      requirementPriority: null,
+    });
+    expect(parsed.requirementId).toBeNull();
+    expect(parsed.requirementPriority).toBeNull();
+  });
+
+  it('forwards requirement fields to the backend on update', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      requirementId: 'DOK-08',
+      requirementPriority: 'should',
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({
+      requirementId: 'DOK-08',
+      requirementPriority: 'should',
+    });
+  });
+
+  it('forwards requirement fields to the backend on create', async () => {
+    const recorder = makeRecordingBackend();
+    await createNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'Mandate können liquidiert werden',
+      requirementId: 'MAN-15',
+      requirementPriority: 'could',
+    } as never);
+    expect(recorder.lastCreate?.fields).toMatchObject({
+      requirementId: 'MAN-15',
+      requirementPriority: 'could',
+    });
+  });
+
+  it('omits requirement fields from the backend call when not provided', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      text: 'rename me',
+    } as never);
+    expect('requirementId' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+    expect('requirementPriority' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+  });
+});
+
 // Jenna housekeeping digest 2026-06-11 (§8.6) — `unestimated:true`
 // without a status-exclusion filter returns thousands of done leaves
 // whose effortEstimate is null, drowning out the actionable subset.

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -28,6 +28,18 @@ export const createNodeTool = defineTool({
       .describe(
         'Fractional rank for sibling ordering within the same parent (Gantt slice 1). Lower numbers appear earlier. Use (A.rank + B.rank) / 2 for midpoint insertion. null = no explicit rank (sorts after ranked siblings).',
       ),
+    requirementId: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Stable business requirement ID (e.g. "MAN-01"). Setting this marks the node as a requirement: it appears in the Requirements view and requirements_overview. Unique per map — creating a duplicate is rejected with REQUIREMENT_ID_CONFLICT.',
+      ),
+    requirementPriority: z
+      .enum(['must', 'should', 'could'])
+      .nullable()
+      .optional()
+      .describe('MoSCoW requirement priority (Muss/Soll/Kann). Only meaningful alongside requirementId.'),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -97,6 +109,18 @@ export const updateNodeTool = defineTool({
       .describe(
         'Fractional rank for sibling ordering within the same parent (Gantt slice 1). Lower numbers appear first. Use (A.rank + B.rank) / 2 to insert between two nodes. null clears the rank.',
       ),
+    requirementId: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Stable business requirement ID (e.g. "MAN-01"). Setting this marks the node as a requirement: it appears in the Requirements view and requirements_overview. Unique per map — a duplicate is rejected with REQUIREMENT_ID_CONFLICT. null clears the requirement marker.',
+      ),
+    requirementPriority: z
+      .enum(['must', 'should', 'could'])
+      .nullable()
+      .optional()
+      .describe('MoSCoW requirement priority (Muss/Soll/Kann). null clears it.'),
     // Orchestration substrate (#111)
     scopes: z
       .array(z.string())

--- a/packages/tool-kit/src/types.ts
+++ b/packages/tool-kit/src/types.ts
@@ -46,6 +46,9 @@ export interface NodeWithComputed {
   collapsed: boolean;
   createdAt: string;
   updatedAt: string;
+  // Requirements register — non-null requirementId marks a requirement.
+  requirementId: string | null;
+  requirementPriority: 'must' | 'should' | 'could' | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;


### PR DESCRIPTION
## What

The Anforderungsdokument workflow (166 hand-maintained business requirements for Fulcrum CRM) moves into MindBlown as **Model B**: a node IS a requirement when it carries a `requirementId`. The requirement's status (done ≙ Umgesetzt / partial ≙ Teilweise / open ≙ Offen) is **derived from progress rollup, never stored** — the register can't drift from the plan.

## Layers (per the Definition of Done — all 8 in this PR)

| Layer | Change |
|---|---|
| core types | `Node.requirementId: string \| null`, `Node.requirementPriority: 'must' \| 'should' \| 'could' \| null` |
| DB schema | `requirement_id`, `requirement_priority` text columns |
| migration | idempotent `ADD COLUMN IF NOT EXISTS` ×2 + partial unique index `(map_id, requirement_id) WHERE requirement_id IS NOT NULL AND deleted_at IS NULL` |
| DB mapping | `dbNodeToCore` round-trip, create insert, update allow-list |
| REST | create body accepts the fields (update inherits via `UpdateNodeInput`); `REQUIREMENT_ID_CONFLICT` → 400 on both routes |
| tool-kit | zod on **both** `create_node` and `update_node` |
| frontend store | stub literals, `ActiveView` union, `getTopLevelAncestor` helper, `addNode`/`api.createNode` optional `fields` param |
| tests | 6 new tool-kit round-trip/schema tests; core test helpers extended |

Plus:
- **`requirements_overview` MCP tool** — compact register grouped by top-level chapter: derived status, remaining effort, ⚠ unestimated-leaves warnings (rollup gotcha), GitHub links; `status` / `requirementPriority` filters. Answers the register question without the 442 KB `get_map` dump.
- **Requirements view** (9th view tab) — chapter-grouped table, derived status badges (read-only by design), inline edit (title / REQ-ID / MoSCoW / leaf progress), add-requirement form (creates the node under the chosen chapter with fields set atomically at create time — a follow-up `updateNode` on a temp id silently no-ops), jump-to-mindmap, filters.
- **PropertyPanel** — Requirement ID field + MoSCoW select.

## Uniqueness: precheck + DB backstop

App-level precheck gives a friendly 400 on the sequential path. Verification caught the TOCTOU race: **two concurrent `create_node` calls with the same new requirementId both passed the precheck and both inserted** (the MCP server pipelines tool calls). The partial unique index closes it; a 23505 on that index maps back to the same `REQUIREMENT_ID_CONFLICT` 400. Re-drive after the fix: one create wins, the loser gets the clean 400.

## Verified end-to-end (scratch DB + headless Chromium)

- REST: create/update round-trips, null-clear, self-update no-conflict, duplicate → 400 (sequential and concurrent)
- Migration idempotency across two server boots
- MCP over stdio: register output with derived statuses, filters, ⚠ warnings; duplicate create → clean error string
- UI: register renders grouped with badges/progress/warnings; add SPG-16 via form → **survives full reload** (persistence via create-path threading); status filter works
- `pnpm turbo typecheck` clean ×11 packages; tests 515/516 — the 1 failure is `triage-routes.test.ts` peakActive, **pre-existing and failing on clean master** (timing-flaky, unrelated)

## Known limits (deliberate)

- Raw REST accepts any string for `requirementPriority` (no route-level enum validation — same as existing `priority`); zod guards the MCP surface, the UI uses selects.
- Doc export (Markdown/docx Anforderungsdokument), dedupe/epic-close data-quality fixes, and seeding the 166 crm REQ-IDs are agreed follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn