### PR TITLE
fix(requirements): register chapters group by parent (Bereich), tree-ordered

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -514,15 +514,27 @@ server.tool(
         );
       }
 
-      // Top-level chapter = the child-of-root ancestor. Requirements that
-      // are themselves children of root (or the root) group under their
-      // own text.
+      // Chapter = the requirement's parent node (the Bereich in a
+      // doc-shaped map). Chapters are ordered by depth-first tree order.
       const chapterOf = (id: string): string => {
-        let cur = nodeById.get(id);
-        while (cur && cur.parentId && cur.parentId !== rootId) {
-          cur = nodeById.get(cur.parentId);
-        }
-        return cur?.text ?? '(unknown)';
+        const parentId = nodeById.get(id)?.parentId;
+        return (parentId && nodeById.get(parentId)?.text) || '(root)';
+      };
+      const dfsOrder = new Map<string, number>();
+      {
+        let i = 0;
+        const walk = (id: string) => {
+          dfsOrder.set(id, i++);
+          for (const cid of nodeById.get(id)?.childrenIds ?? []) {
+            if (nodeById.has(cid)) walk(cid);
+          }
+        };
+        walk(rootId);
+      }
+      const chapterOrderOf = (id: string): number => {
+        const parentId = nodeById.get(id)?.parentId;
+        if (!parentId) return Infinity;
+        return dfsOrder.get(parentId) ?? Infinity;
       };
 
       // Progress: rollup for parents, own percentComplete for leaves.
@@ -555,6 +567,7 @@ server.tool(
         return {
           node: n,
           chapter: chapterOf(n.id),
+          chapterOrder: chapterOrderOf(n.id),
           progress,
           status: statusOf(progress),
           remaining: n.computedEffort * (1 - progress / 100),
@@ -579,7 +592,10 @@ server.tool(
         });
 
       const chapters = new Map<string, typeof rows>();
-      for (const r of [...rows].sort(byId)) {
+      const sorted = [...rows].sort(
+        (a, b) => a.chapterOrder - b.chapterOrder || byId(a, b),
+      );
+      for (const r of sorted) {
         const list = chapters.get(r.chapter) ?? [];
         list.push(r);
         chapters.set(r.chapter, list);

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -67,7 +67,6 @@ export function RequirementsView() {
   const selectNode = useMindmapStore((s) => s.selectNode);
   const setFocusNode = useMindmapStore((s) => s.setFocusNode);
   const setActiveView = useMindmapStore((s) => s.setActiveView);
-  const getTopLevelAncestor = useMindmapStore((s) => s.getTopLevelAncestor);
   const effortUnit = useMindmapStore((s) => s.currentMap?.effortUnit ?? 'days');
 
   const [statusFilter, setStatusFilter] = useState<'' | ReqStatus>('');
@@ -105,7 +104,10 @@ export function RequirementsView() {
         const cv = computed.get(node.id);
         const isLeaf = node.childrenIds.length === 0;
         const progress = isLeaf ? (node.percentComplete ?? 0) : (cv?.computedProgress ?? 0);
-        const chapter = getTopLevelAncestor(node.id);
+        // Chapter = the requirement's parent node. In a doc-shaped map the
+        // requirements sit directly under their Bereich node, so the parent
+        // IS the chapter; this also matches ListView's group-by-parent.
+        const chapter = node.parentId ? nodes[node.parentId] : null;
         return {
           node,
           chapterId: chapter?.id ?? null,
@@ -121,7 +123,7 @@ export function RequirementsView() {
             .map((l) => ({ id: l.externalId, url: l.url })),
         };
       });
-  }, [nodes, computed, getTopLevelAncestor]);
+  }, [nodes, computed]);
 
   const totals = useMemo(() => {
     const t = { done: 0, partial: 0, open: 0 };
@@ -139,8 +141,22 @@ export function RequirementsView() {
     [allRows, statusFilter, priorityFilter],
   );
 
-  // Group by chapter, chapters in tree order (root's childrenIds),
-  // requirements within a chapter in REQ-ID order.
+  // Depth-first tree order — used to sort chapter groups so the register
+  // follows the map's structure (Bereich order in a doc-shaped spine).
+  const dfsOrder = useMemo(() => {
+    const order = new Map<string, number>();
+    if (!rootNodeId) return order;
+    let i = 0;
+    const walk = (id: string) => {
+      order.set(id, i++);
+      for (const cid of nodes[id]?.childrenIds ?? []) if (nodes[cid]) walk(cid);
+    };
+    walk(rootNodeId);
+    return order;
+  }, [nodes, rootNodeId]);
+
+  // Group by chapter (= parent node) in tree order; requirements within a
+  // chapter in REQ-ID order.
   const grouped = useMemo(() => {
     const byChapter = new Map<string, ReqRow[]>();
     for (const r of [...filteredRows].sort(compareReqIds)) {
@@ -149,19 +165,26 @@ export function RequirementsView() {
       list.push(r);
       byChapter.set(key, list);
     }
-    const chapterOrder = rootNodeId ? (nodes[rootNodeId]?.childrenIds ?? []) : [];
     return [...byChapter.entries()].sort(
-      (a, b) => chapterOrder.indexOf(a[0]) - chapterOrder.indexOf(b[0]),
+      (a, b) => (dfsOrder.get(a[0]) ?? Infinity) - (dfsOrder.get(b[0]) ?? Infinity),
     );
-  }, [filteredRows, nodes, rootNodeId]);
+  }, [filteredRows, dfsOrder]);
 
-  const chapters = useMemo(
-    () =>
-      rootNodeId
-        ? (nodes[rootNodeId]?.childrenIds ?? []).map((id) => nodes[id]).filter(Boolean)
-        : [],
-    [nodes, rootNodeId],
-  );
+  // Add-form chapter choices: parents that already hold requirements (the
+  // Bereiche once the map is doc-shaped), falling back to root's children
+  // on a map with no requirements yet.
+  const chapters = useMemo(() => {
+    const parentIds = new Set<string>();
+    for (const r of allRows) if (r.chapterId) parentIds.add(r.chapterId);
+    const list = [...parentIds]
+      .map((id) => nodes[id])
+      .filter(Boolean)
+      .sort((a, b) => (dfsOrder.get(a.id) ?? Infinity) - (dfsOrder.get(b.id) ?? Infinity));
+    if (list.length > 0) return list;
+    return rootNodeId
+      ? (nodes[rootNodeId]?.childrenIds ?? []).map((id) => nodes[id]).filter(Boolean)
+      : [];
+  }, [allRows, nodes, rootNodeId, dfsOrder]);
 
   const jumpToNode = (node: Node) => {
     setActiveView('mindmap');

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -153,7 +153,6 @@ export interface MindmapState {
   // Helpers
   getLeafNodes: () => Node[];
   getNodeBreadcrumb: (nodeId: NodeId) => string;
-  getTopLevelAncestor: (nodeId: NodeId) => Node | null;
 }
 
 // ── WebSocket connection ───────────────────────────────────────
@@ -756,20 +755,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       current = parent;
     }
     return parts.join(' > ');
-  },
-
-  getTopLevelAncestor: (nodeId: NodeId) => {
-    const { nodes, rootNodeId } = get();
-    let current = nodes[nodeId];
-    if (!current) return null;
-    // The root has no chapter; a child of root is its own chapter.
-    if (current.id === rootNodeId) return null;
-    while (current.parentId && current.parentId !== rootNodeId) {
-      const parent = nodes[current.parentId];
-      if (!parent) break;
-      current = parent;
-    }
-    return current;
   },
 
   // ── Node actions ─────────────────────────────────────────────


### PR DESCRIPTION
Prepares the register for the doc-shaped Anforderungen spine (root → Anforderungen → 21 Bereiche → requirement nodes): with top-level-branch grouping, all 166 requirements would collapse into one chapter. Chapter = parent node now, groups sorted in DFS tree order, in both the Requirements view and `requirements_overview`. Add-form chapter select offers existing requirement parents. Removes unused `getTopLevelAncestor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn