### PR TITLE
docs: guided PM positioning, five-layer guidance concept, plan-linter v1 spec

### DIFF
--- a/docs/market-research.md
+++ b/docs/market-research.md
@@ -642,9 +642,12 @@ Only MindManager and XMind support all 4 dependency types. Only MindManager has 
 
 ## Recommended Positioning for MindBlown
 
-**"The open-source tool where projects start as ideas and become plans — without switching apps."**
+**"The tool that makes you a good project manager without you noticing."**
+
+The mechanism pitch behind it: *the open-source tool where projects start as ideas and become plans — without switching apps.* The benefit is guided PM; the seamless mindmap→plan transition is how it's delivered.
 
 Core differentiators:
+0. **Guided PM** — the defaults are the methodology, plus a plan linter that teaches as it checks. No tool on the market coaches untrained users into PM practice (see product-vision.md → Guided Project Management)
 1. **Open source** — no competitor here
 2. **Mindmap-first, but not mindmap-only** — the map is the primary planning surface, with kanban/list/Gantt as derived views
 3. **Graceful brainstorm → execute transition** — nodes start as ideas, get promoted to tasks when ready, without breaking the visual flow

--- a/docs/plan-linter.md
+++ b/docs/plan-linter.md
@@ -1,0 +1,75 @@
+# Plan Linter — v1 Specification
+
+*Status: draft spec, not yet implemented. Companion to the "Guided Project Management" section of [product-vision.md](product-vision.md).*
+
+---
+
+## What it is
+
+A set of **deterministic, explainable checks on plan quality**, run against a map's current state and its change history. Each finding names the problem, teaches the principle behind it in one sentence, and points at a concrete fix.
+
+The linter is the productized form of "the tool guides you into good PM": it targets the four failure modes of untrained project management — no decomposition, missing/uncalibrated estimates, vague done-criteria, publish-and-forget plans — using signals the engine already computes.
+
+**Coach, not autopilot.** The linter never mutates the plan. It surfaces findings; the user (or their AI agent) fixes them.
+
+## Relationship to existing MI tools
+
+The MI suite already computes most raw signals:
+
+| Existing tool | Signals the linter reuses |
+|---|---|
+| `risk_scan` | stalled WIP, leaves without estimates, overruns, unassigned P0/P1, fragile critical path |
+| `completion_forecast` / `get_estimation_accuracy` | calibration fudge factor (sum actual / sum estimate) |
+| `remaining_work` | no-estimate count, largest remaining leaves |
+| `change_events` substrate | per-field change timestamps (progress, dates, estimates) since 2026-04-14 |
+
+The difference is intent: `risk_scan` answers *"what is at risk right now?"* (execution). The linter answers *"is this a well-formed plan, and what habit is missing?"* (hygiene + teaching). Overlapping checks share detection logic but the linter adds the **why** line, a **fix** action, and **dismissal**.
+
+## v1 checks
+
+Ordered basics-first: "when is it done / how much is left" hygiene before advanced practice. Severity is `warn` (materially distorts forecast or progress) or `info` (habit-forming nudge).
+
+| # | Rule id | Fires when | Severity | Why-line (teaching sentence) | Fix action |
+|---|---|---|---|---|---|
+| 1 | `unestimated-leaf` | Leaf has no `effortEstimate` (reuse `risk_scan` no_estimate) | warn | "Unestimated work is invisible to the forecast — your finish date is under-counting." | Prompt estimate (offer `ai_estimate` draft) |
+| 2 | `oversized-leaf` | Leaf estimate > **5 days** or > **15% of map total** | warn | "Small pieces get estimated far more accurately — projects built from small chunks succeed dramatically more often." | Suggest breakdown (offer `ai_breakdown`) |
+| 3 | `stale-progress` | In-progress leaf with no `percentComplete` change in **7 days** (change_events; reuse `risk_scan` stalled) | warn | "A task that stops moving is usually stuck, not slow — surface it before it slips the schedule." | Prompt update / flag blocker |
+| 4 | `overdue-unreplanned` | Leaf past `dueDate`, < 100%, and no date/estimate change since the due date passed | warn | "Plans only work if they're amended when reality diverges — an ignored overdue date makes every downstream date fiction." | Prompt re-plan (new date, split, or descope) |
+| 5 | `calibration-drift` | Fudge factor outside **0.8–1.25** with ≥ 5 calibration samples | info | "Your estimates historically run {X}× — the forecast already corrects for this; consider sizing new estimates accordingly." | Show `get_estimation_accuracy` detail |
+| 6 | `no-done-criteria` | Leaf with estimate ≥ 2 days and empty description | info | "A task without a definition of done tends to be 90% finished forever — one sentence of 'done means…' prevents it." | Prompt description (links to requirements register where present) |
+| 7 | `stale-plan` | Map < 100% complete and no change_events at all in **14 days** | info | "A plan that isn't touched weekly is a document, not a plan — a 2-minute review keeps the forecast honest." | Suggest review (offer `status_digest`) |
+| 8 | `dates-without-dependencies` | Map has ≥ 10 dated leaves and zero dependencies | info | "Without dependencies the schedule assumes everything can happen in parallel — the critical path is what makes a finish date real." | Point at dependency creation |
+
+Thresholds above are **opinionated defaults, not configuration**. v1 exposes only `stalledDays`-style overrides where `risk_scan` already does; no settings sprawl.
+
+## Output shape
+
+Per finding: `{ ruleId, severity, nodeId, nodeText, detail, why, fix }` plus a summary header ("Plan health: 3 warnings, 2 suggestions"). Sorted by severity, then rule order (basics first), then node effort descending. Same scoping params as the MI suite: `nodeId` subtree, `versionId`, `milestoneId` with ancestor inheritance.
+
+## Dismissals
+
+- Stored per `(mapId, nodeId, ruleId)` — dismissing `oversized-leaf` on one node never hides it elsewhere.
+- Map-level rule mute per `(mapId, ruleId)` for teams that reject a given opinion (e.g. sprints-only teams muting `dates-without-dependencies`).
+- Dismissals are permanent until the underlying value changes materially (e.g. estimate edited after dismissal → eligible to re-fire).
+- Needs a small table: `lint_dismissals (map_id, node_id nullable, rule_id, dismissed_by, dismissed_at)`.
+
+## Surfaces (in ship order)
+
+1. **MCP tool `plan_lint`** — 9th MI tool, same pattern as the suite (fetch via `api.getMap`, shared scoping helper — extract it now, this is the 4th consumer; plain-text output). This makes the linter available to AI agents and the chat panel immediately, per the standing "MCP tools first, defer dashboard UI" directive.
+2. **Mindmap UI plan-health panel** — pull-based sidebar; badge with finding count, click-through jumps to the node. No toasts, no emails.
+3. **Moment-of-action nudges** (separate, later milestone) — inline prompt when a node becomes an estimated leaf, or when the forecast slips past a target. Reuses the same rules; only the delivery differs. Strictly capped (max 1 pushed nudge per session).
+
+Per the Feature Definition of Done: surface 1 must land with whatever server endpoint it needs in the same PR; the UI panel (surface 2) is a valid follow-up because the MCP surface already makes the feature reachable by real users.
+
+## Non-goals (v1)
+
+- No AI in the detection path (AI only assists fixes, via existing `ai_estimate` / `ai_breakdown`).
+- No cross-map linting (each map lints alone; portfolio view later).
+- No custom user-defined rules.
+- No auto-fix. The linter never edits nodes.
+
+## Open questions
+
+1. `no-done-criteria` (#6): once the requirements register lands, should the check key on "has linked requirement" instead of "has description"? Probably yes — revisit after that branch merges.
+2. `stale-progress` overlap: fold `risk_scan`'s stalled detection into a shared helper, or accept ~30 lines of duplication? (The MI memory says: extract on the 4th consumer — this is the 4th.)
+3. Should dismissals sync to the change_events log for auditability? Leaning yes (`lint.dismissed` event type).

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -2,6 +2,8 @@
 
 *A mindmap-based project management tool where ideas become plans.*
 
+**The tool that makes you a good project manager without you noticing.**
+
 ---
 
 ## The Problem
@@ -73,6 +75,14 @@ This matters for:
 - Extensibility and customization
 - Community-driven development
 - Trust and transparency
+
+### 7. The method is built in
+
+Most projects are not run by trained project managers. They're run by developers, founders, designers, researchers — people who know *what* they want to build but were never taught how to plan and track it. The research on why such projects fail is remarkably consistent: no decomposition into small units, missing or never-calibrated estimates, vague done-criteria, and plans that are written once and never revisited.
+
+MindBlown's answer is that **the defaults are the methodology**. Following the tool's grain — map the work, estimate the leaves, update progress, re-plan when the forecast slips — *is* textbook project management (work breakdown structure, bottom-up estimation, earned-value tracking, continuous re-planning), without the user ever needing to learn those terms.
+
+Where defaults aren't enough, MindBlown **coaches — it never takes over**. Guidance means explainable checks and moment-of-action nudges, each teaching the principle it enforces in one sentence. It does not mean an AI that runs the project for you. (See "Guided Project Management" below.)
 
 ---
 
@@ -163,6 +173,62 @@ No existing tool does this loop well:
 - **Mindomo**: Has rollup and Gantt, but no health tracking, no projections, no "are we on track?"
 
 MindBlown is the tool where you **think in a mindmap** and get a **project plan for free**.
+
+---
+
+## Guided Project Management
+
+*The planning loop is the mechanism. This is the benefit: MindBlown makes you a good project manager without you noticing.*
+
+### The gap we're filling
+
+No tool today teaches project management in-product. The market splits into two failure poles:
+
+- **Autopilot AI** — "the AI does the PM for you" (Height 2.0's autonomous PM: auto-triage, backlog grooming, health monitoring). Height shut down in 2025 despite heavy funding. Removing the human from planning removes the reason to engage with the plan.
+- **Methodology for experts** — Linear's Method and Basecamp's Shape Up bake real opinions into the product, but both are written for already-competent, self-organized product teams. They assume you know why cycles, small batches, and appetite matter.
+
+The open lane: **coach the untrained user**, at the moment they're about to make a known mistake, in language that teaches the principle. monday.com's Risk Insights comes closest (risk flags with explanations) but is enterprise-tier, portfolio-level, and diagnostic-only — it flags risk, it doesn't help you fix the plan.
+
+### The failure modes we guard against
+
+Decades of research (PMI Pulse, Standish CHAOS, planning-fallacy literature) reduce untrained-PM failure to a short chain:
+
+1. **No decomposition** — work isn't broken into small units. Small projects with short iterations succeed dramatically more often; chunk size is the single strongest success lever.
+2. **No estimates, or uncalibrated optimism** — the planning fallacy holds even when people *know* their history. The fix is reference-class forecasting: correct new estimates by observed past accuracy.
+3. **Vague done-criteria** — inaccurate requirements are a primary cited cause in ~40% of failed projects.
+4. **Publish-and-forget plans** — the plan is written once and never amended when reality diverges.
+
+Every one of these has a computable signal in MindBlown's data model. That's the design insight: **guidance is mostly surfacing what the engine already knows.**
+
+### The plan linter
+
+Professional scheduling has had automated plan-quality checks for years (the DCMA 14-point assessment); nothing consumer-grade does. MindBlown ships a **plan linter**: a set of deterministic, explainable checks on plan hygiene — unestimated leaves, oversized chunks, stalled progress, overdue-but-never-replanned tasks, estimates contradicted by the user's own history. Each finding carries a one-sentence *why* and a one-click fix path.
+
+See [docs/plan-linter.md](plan-linter.md) for the v1 specification.
+
+### How guidance works: five layers
+
+From most passive to most active — and in roughly this ship order:
+
+1. **The rails.** The data model itself prevents the classic mistakes: estimates live only on leaves, parents compute themselves. The wrong math is impossible, not warned about. (Already built — and worth protecting: manual parent overrides would break the pedagogy, not just the math.)
+2. **Empty states that teach.** Every derived view explains what feeds it when it has nothing to show. An empty Gantt doesn't render a blank grid; it says "I build myself from estimates and a start date — you have 12 unestimated leaves, start there." Guidance that only exists at the moment it's wanted, with zero annoyance cost.
+3. **The compass.** The map's own data reveals which phase of the planning loop a project is in (brainstorming → estimating → scheduling → executing → re-planning → done). The tool offers exactly **one next action** for that phase, dismissible, never a checklist. During brainstorming it stays silent — asking for estimates mid-braindump is the wizard mistake.
+4. **The re-plan moment.** The one place the tool actively interrupts: the forecast just slipped past the target. Not a red "you're behind" banner — a structured decision: descope (here are the lowest-priority unstarted leaves), split and defer, or move the target, each option simulated so the user sees the consequence before committing. This is the moment an untrained person becomes a project manager.
+5. **Graduation.** Nudges taper once the habit is observed — a user who estimates new leaves unprompted stops being asked. The tool succeeds when it goes quiet. (This is what separates a coach from Clippy, and it gives guidance an honest success metric: time until silence.)
+
+All five layers speak **as the plan, about the plan** ("Backend starts in 2 days at 0% with nobody assigned") — never as the tool about methodology ("Tip: estimation matters!"). The user should feel the project talking to them, not a tutorial. That's the "without you noticing" in the tagline, mechanically.
+
+### Guidance design rules
+
+1. **Moment of action, not upfront wizards.** Prompt for an estimate when a node becomes a leaf; prompt a re-plan when the forecast slips. Never a multi-step project-setup wizard — onboarding research is unambiguous that wizards fatigue and get abandoned.
+2. **Every nudge teaches its own why, in one sentence.** "Break this down — smaller pieces get estimated far more accurately" beats a bare warning. Users absorb PM practice by osmosis; that's the point.
+3. **Quiet by default, dismissible forever.** Guidance lives in a pull-based plan-health surface plus a very small set of pushed nudges. Dismissed findings stay dismissed. The failure mode to avoid is Clippy / notification flood.
+4. **Deterministic first, AI optional.** The linter is rule-based on computed data. AI features (suggest a breakdown, draft estimates) can accelerate the *fix*, but the guidance mechanism itself never depends on a model.
+5. **If it needs a manual, it's wrong.** The target user is, by definition, someone who won't read one. The user-facing vocabulary stays tiny — node, estimate, % done, due date; everything else (rollup, critical path, health, calibration) is *output*, never something the user must understand to operate the tool. PM concepts are hidden behind their consequences: nobody needs to learn what "critical path" means when the tool says "this task is the one holding up your finish date." The acceptance test is literal: hand MindBlown to someone with zero instructions; they reach a useful map in 30 seconds and a finish date without help.
+
+### Coach, not autopilot
+
+The user stays the project manager. MindBlown's job is to make them a better one each week they use it — until the nudges stop firing because the habits stuck.
 
 ---
 


### PR DESCRIPTION
## What

Docs-only PR establishing the **guided project management** positioning and the design groundwork for it.

- **New tagline** (vision doc header + market-research positioning): *"The tool that makes you a good project manager without you noticing."* The previous line ("ideas become plans without switching apps") stays as the mechanism pitch behind it.
- **Core principle 7 — The method is built in**: MindBlown's defaults *are* the methodology (WBS, bottom-up estimation, earned-value tracking, continuous re-planning) for users who never learned PM.
- **New vision section "Guided Project Management"**: the market gap (Height's autopilot failure vs Linear/Shape Up's expert-only methodology), the four research-backed failure modes of untrained PM, the five guidance layers (rails → teaching empty states → phase compass → re-plan moment → graduation), and five design rules — including "if it needs a manual, it's wrong" as a literal acceptance test.
- **`docs/plan-linter.md`** — v1 spec for the plan linter: 8 deterministic checks (basics-first), each with a teaching why-line and fix action; composes with the existing MI substrate (`risk_scan`, `completion_forecast`, `change_events`) instead of duplicating it; ships MCP-tool-first per the standing MI directive.
- Market research: guided PM added as differentiator #0.

## Why

Web research (2026-07-15) found "the tool teaches you PM in-product" is an unoccupied lane: autonomous-AI PM failed commercially (Height, shut down 2025), and the methodology-opinionated tools (Linear, Basecamp) target already-trained teams. MindBlown's computed substrate makes coaching nearly free to build.

No code changes; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9eAuogxQ9r6TrjMGyjpTz