### PR TITLE
feat(mcp): plan_lint — plan-quality linter, 9th MI tool

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -288,6 +288,7 @@ Once connected, the AI can fully manage your projects through natural conversati
 | `status_digest` | Markdown status digest: done / in progress / behind / changes | `mapId`, `sinceDays?` |
 | `alert_digest` | Threshold-triggered alerts (slipped milestones, overdue, unassigned P0/P1) | `mapId` |
 | `risk_scan` | Stalled WIP, no-estimate leaves, overruns, fragile critical path | `mapId`, `nodeId?`, `versionId?`, `milestoneId?`, `stalledDays?` |
+| `plan_lint` | Plan-quality coach: 8 hygiene checks (unestimated/oversized leaves, stale progress, overdue-unreplanned, calibration drift, missing done-criteria, stale plan, missing dependencies), each with a teaching why + fix | `mapId`, `nodeId?`, `versionId?`, `stalledDays?`, `rule?`, `limit?` |
 | `scope_simulate` | In-memory what-if: before/after totals for a list of add/remove/update patches | `mapId`, `patches` |
 
 ### GitHub Integration Tools

--- a/docs/plan-linter.md
+++ b/docs/plan-linter.md
@@ -1,6 +1,6 @@
 # Plan Linter — v1 Specification
 
-*Status: draft spec, not yet implemented. Companion to the "Guided Project Management" section of [product-vision.md](product-vision.md).*
+*Status: surface 1 (`plan_lint` MCP tool) implemented; UI panel and moment-of-action nudges open. Companion to the "Guided Project Management" section of [product-vision.md](product-vision.md).*
 
 ---
 

--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The shared MI-suite scoping helper: subtree scoping, inherited-version
+ * scoping, and their combination. Extracted from remaining_work /
+ * completion_forecast / risk_scan when plan_lint became its 4th consumer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { scopedLeaves } from '../scope.js';
+import type { MapDetail, NodeWithComputed } from '../api.js';
+
+function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWithComputed {
+  return {
+    mapId: 'm1',
+    parentId: null,
+    childrenIds: [],
+    text: overrides.id,
+    description: null,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    blockedReason: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    dependencies: [],
+    versionId: null,
+    cycleId: null,
+    externalLinks: [],
+    collapsed: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    requirementId: null,
+    requirementPriority: null,
+    claimedBySession: null,
+    claimedAt: null,
+    computedEffort: 0,
+    computedProgress: 0,
+    healthSignal: 'on_track',
+    isBlocked: false,
+    blockedBy: { manual: false, predecessorIds: [], blockedDescendantCount: 0 },
+    ...overrides,
+  };
+}
+
+/**
+ * Tree:
+ *   root
+ *   ├── a (versionId: v1)
+ *   │   ├── a1 (leaf)
+ *   │   └── a2 (leaf, versionId: v2)
+ *   └── b
+ *       └── b1 (leaf)
+ */
+function makeMap(): MapDetail {
+  const nodes = [
+    makeNode({ id: 'root', childrenIds: ['a', 'b'] }),
+    makeNode({ id: 'a', parentId: 'root', childrenIds: ['a1', 'a2'], versionId: 'v1' }),
+    makeNode({ id: 'a1', parentId: 'a' }),
+    makeNode({ id: 'a2', parentId: 'a', versionId: 'v2' }),
+    makeNode({ id: 'b', parentId: 'root', childrenIds: ['b1'] }),
+    makeNode({ id: 'b1', parentId: 'b' }),
+  ];
+  return { map: { id: 'm1' }, nodes } as unknown as MapDetail;
+}
+
+describe('scopedLeaves', () => {
+  it('returns all leaves for an unscoped call', () => {
+    const res = scopedLeaves(makeMap());
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.leaves.map((l) => l.id).sort()).toEqual(['a1', 'a2', 'b1']);
+    expect(res.scopeLabel).toBe('whole map');
+  });
+
+  it('scopes to a subtree via nodeId', () => {
+    const res = scopedLeaves(makeMap(), { nodeId: 'a' });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.leaves.map((l) => l.id).sort()).toEqual(['a1', 'a2']);
+    expect(res.scopeLabel).toContain('subtree');
+  });
+
+  it('treats a scoped leaf node as its own single-leaf subtree', () => {
+    const res = scopedLeaves(makeMap(), { nodeId: 'b1' });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.leaves.map((l) => l.id)).toEqual(['b1']);
+  });
+
+  it('scopes by version with ancestor inheritance', () => {
+    // a1 inherits v1 from parent a; a2 carries v2 directly but also inherits v1.
+    const v1 = scopedLeaves(makeMap(), { versionId: 'v1' });
+    expect(v1.ok).toBe(true);
+    if (!v1.ok) return;
+    expect(v1.leaves.map((l) => l.id).sort()).toEqual(['a1', 'a2']);
+
+    const v2 = scopedLeaves(makeMap(), { versionId: 'v2' });
+    expect(v2.ok).toBe(true);
+    if (!v2.ok) return;
+    expect(v2.leaves.map((l) => l.id)).toEqual(['a2']);
+  });
+
+  it('intersects nodeId and versionId scopes', () => {
+    const res = scopedLeaves(makeMap(), { nodeId: 'b', versionId: 'v1' });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.leaves).toEqual([]);
+  });
+
+  it('errors on an unknown nodeId', () => {
+    const res = scopedLeaves(makeMap(), { nodeId: 'nope' });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toContain('nope');
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -24,6 +24,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { allTools as sharedTools, type ToolSpec } from '@mindblown/tool-kit';
 import * as api from './api.js';
+import { scopedLeaves } from './scope.js';
 import { httpBackend } from './backend.js';
 import { formatMapTree, filterMapData, formatHealthReport, formatScheduleReport, formatSprintOverview, formatNodeDetail } from './formatters.js';
 
@@ -367,52 +368,9 @@ server.tool(
   async ({ mapId, nodeId, versionId }) => {
     try {
       const data = await api.getMap(mapId);
-      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
-
-      // Walk ancestor chain for a given leaf, collecting version ids
-      // encountered along the way. Used for inherited-scope matching.
-      const ancestorTags = (leafId: string): { versions: Set<string> } => {
-        const versions = new Set<string>();
-        let cur = nodeById.get(leafId);
-        while (cur) {
-          if (cur.versionId) versions.add(cur.versionId);
-          cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
-        }
-        return { versions };
-      };
-
-      // Collect the set of leaf ids in scope. Subtree scoping walks down from
-      // nodeId; version scoping filters across the whole map using
-      // inherited tags.
-      let leaves: typeof data.nodes;
-      let scopeLabel = 'whole map';
-
-      if (nodeId) {
-        const root = nodeById.get(nodeId);
-        if (!root) return toolError(`Node ${nodeId} not found in map ${mapId}.`);
-        scopeLabel = `subtree of "${root.text}" (${nodeId})`;
-        const subtreeLeaves: typeof data.nodes = [];
-        const stack = [root];
-        while (stack.length) {
-          const n = stack.pop()!;
-          if ((n.childrenIds?.length ?? 0) === 0) {
-            subtreeLeaves.push(n);
-          } else {
-            for (const cid of n.childrenIds) {
-              const c = nodeById.get(cid);
-              if (c) stack.push(c);
-            }
-          }
-        }
-        leaves = subtreeLeaves;
-      } else {
-        leaves = data.nodes.filter((n) => (n.childrenIds?.length ?? 0) === 0);
-      }
-
-      if (versionId) {
-        scopeLabel = `version ${versionId}` + (nodeId ? ` within ${scopeLabel}` : '');
-        leaves = leaves.filter((n) => ancestorTags(n.id).versions.has(versionId));
-      }
+      const scope = scopedLeaves(data, { nodeId, versionId });
+      if (!scope.ok) return toolError(scope.error);
+      const { leaves, scopeLabel } = scope;
 
       if (leaves.length === 0) {
         return toolResult(`No leaf nodes in scope (${scopeLabel}).`);
@@ -656,46 +614,9 @@ server.tool(
   async ({ mapId, nodeId, versionId }) => {
     try {
       const data = await api.getMap(mapId);
-      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
-
-      const ancestorTags = (leafId: string): { versions: Set<string> } => {
-        const versions = new Set<string>();
-        let cur = nodeById.get(leafId);
-        while (cur) {
-          if (cur.versionId) versions.add(cur.versionId);
-          cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
-        }
-        return { versions };
-      };
-
-      // ── Determine scope (same logic as remaining_work) ──
-      let leaves: typeof data.nodes;
-      let scopeLabel = 'whole map';
-      if (nodeId) {
-        const root = nodeById.get(nodeId);
-        if (!root) return toolError(`Node ${nodeId} not found in map ${mapId}.`);
-        scopeLabel = `subtree of "${root.text}" (${nodeId})`;
-        const subtreeLeaves: typeof data.nodes = [];
-        const stack = [root];
-        while (stack.length) {
-          const n = stack.pop()!;
-          if ((n.childrenIds?.length ?? 0) === 0) {
-            subtreeLeaves.push(n);
-          } else {
-            for (const cid of n.childrenIds) {
-              const c = nodeById.get(cid);
-              if (c) stack.push(c);
-            }
-          }
-        }
-        leaves = subtreeLeaves;
-      } else {
-        leaves = data.nodes.filter((n) => (n.childrenIds?.length ?? 0) === 0);
-      }
-      if (versionId) {
-        scopeLabel = `version ${versionId}` + (nodeId ? ` within ${scopeLabel}` : '');
-        leaves = leaves.filter((n) => ancestorTags(n.id).versions.has(versionId));
-      }
+      const scope = scopedLeaves(data, { nodeId, versionId });
+      if (!scope.ok) return toolError(scope.error);
+      const { leaves, scopeLabel } = scope;
 
       if (leaves.length === 0) {
         return toolResult(`No leaf nodes in scope (${scopeLabel}).`);
@@ -861,45 +782,9 @@ server.tool(
   async ({ mapId, nodeId, versionId, stalledDays, category, limit }) => {
     try {
       const data = await api.getMap(mapId);
-      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
-
-      const ancestorTags = (leafId: string): { versions: Set<string> } => {
-        const versions = new Set<string>();
-        let cur = nodeById.get(leafId);
-        while (cur) {
-          if (cur.versionId) versions.add(cur.versionId);
-          cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
-        }
-        return { versions };
-      };
-
-      let leaves: typeof data.nodes;
-      let scopeLabel = 'whole map';
-      if (nodeId) {
-        const root = nodeById.get(nodeId);
-        if (!root) return toolError(`Node ${nodeId} not found in map ${mapId}.`);
-        scopeLabel = `subtree of "${root.text}" (${nodeId})`;
-        const subtreeLeaves: typeof data.nodes = [];
-        const stack = [root];
-        while (stack.length) {
-          const n = stack.pop()!;
-          if ((n.childrenIds?.length ?? 0) === 0) {
-            subtreeLeaves.push(n);
-          } else {
-            for (const cid of n.childrenIds) {
-              const c = nodeById.get(cid);
-              if (c) stack.push(c);
-            }
-          }
-        }
-        leaves = subtreeLeaves;
-      } else {
-        leaves = data.nodes.filter((n) => (n.childrenIds?.length ?? 0) === 0);
-      }
-      if (versionId) {
-        scopeLabel = `version ${versionId}` + (nodeId ? ` within ${scopeLabel}` : '');
-        leaves = leaves.filter((n) => ancestorTags(n.id).versions.has(versionId));
-      }
+      const scope = scopedLeaves(data, { nodeId, versionId });
+      if (!scope.ok) return toolError(scope.error);
+      const { leaves, scopeLabel } = scope;
 
       if (leaves.length === 0) {
         return toolResult(`No leaf nodes in scope (${scopeLabel}).`);
@@ -1060,6 +945,331 @@ server.tool(
           }
           if (fragileCP.length > limit) lines.push(`  … and ${fragileCP.length - limit} more (raise \`limit\` or pass \`category: "fragile_cp"\` to see them)`);
         }
+      }
+
+      return toolResult(lines.join('\n'));
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+const LINT_RULES = [
+  'unestimated-leaf',
+  'oversized-leaf',
+  'stale-progress',
+  'overdue-unreplanned',
+  'calibration-drift',
+  'no-done-criteria',
+  'stale-plan',
+  'dates-without-dependencies',
+] as const;
+
+server.tool(
+  'plan_lint',
+  'Check plan QUALITY (hygiene), not execution risk — the coaching counterpart to risk_scan. Runs 8 deterministic checks ordered basics-first: unestimated leaves, oversized leaves, stale progress, overdue-but-never-replanned, calibration drift, missing done-criteria, stale plan, dates without dependencies. Every finding explains why it matters (one teaching sentence) and names the fix. Scope with nodeId (subtree) or versionId; the map-level checks (calibration-drift, stale-plan, dates-without-dependencies) always evaluate the whole map. See docs/plan-linter.md for the rule rationale.',
+  {
+    mapId: z.string().describe('The map ID'),
+    nodeId: z.string().optional().describe('Scope to this node and its descendants'),
+    versionId: z.string().optional().describe('Scope to leaves tagged with this version (directly or via an ancestor)'),
+    stalledDays: z.number().int().min(1).default(7).describe('Days without a progress update before in-progress work counts as stale (default 7)'),
+    rule: z.enum(LINT_RULES).optional().describe('Run only this one rule instead of all eight'),
+    limit: z.number().int().min(1).max(1000).default(20).describe('Max findings listed per rule (default 20)'),
+  },
+  async ({ mapId, nodeId, versionId, stalledDays, rule, limit }) => {
+    try {
+      // Opinionated defaults, deliberately not configurable (see docs/plan-linter.md).
+      const OVERSIZED_DAYS = 5; // absolute: leaf bigger than a work week
+      const OVERSIZED_MAP_SHARE = 0.15; // relative: leaf dwarfs the rest of the plan
+      const OVERSIZED_SHARE_MIN_LEAVES = 8; // share rule needs enough leaves to be meaningful
+      const DONE_CRITERIA_MIN_DAYS = 2; // small tasks may skip a written done-definition
+      const STALE_PLAN_DAYS = 14;
+      const MIN_CALIBRATION_SAMPLES = 5;
+      const CALIBRATION_LOW = 0.8;
+      const CALIBRATION_HIGH = 1.25;
+      const MIN_DATED_LEAVES_FOR_DEPS = 10;
+      const REPLAN_LOOKBACK_DAYS = 90; // how far back we look for re-plan events
+
+      const data = await api.getMap(mapId);
+      const scope = scopedLeaves(data, { nodeId, versionId });
+      if (!scope.ok) return toolError(scope.error);
+      const { leaves, scopeLabel } = scope;
+
+      if (leaves.length === 0) {
+        return toolResult(`No leaf nodes in scope (${scopeLabel}).`);
+      }
+
+      const unit = data.map.effortUnit ?? 'units';
+
+      // Units-per-day so day-based thresholds work for hour/point maps.
+      // Best-effort from the scheduler; 1 unit == 1 day as fallback.
+      let unitsPerDay = 1;
+      try {
+        const sched = await api.getSchedule(mapId);
+        if (sched.unitsPerDay > 0) unitsPerDay = sched.unitsPerDay;
+      } catch {
+        /* keep fallback */
+      }
+
+      // Change-event-backed signals (stale-progress, overdue-unreplanned,
+      // stale-plan) are best-effort: the event log may be unavailable.
+      let historyOk = true;
+      // Latest percentComplete change per node (events arrive newest-first;
+      // first hit per node wins). Nodes absent from the map have no progress
+      // change in the lookback window — with a 1000-event cap, worst case we
+      // under-record ancient changes, which only ever makes a node MORE stale.
+      const lastProgressChange = new Map<string, string>();
+      const replanEventsByNode = new Map<string, string[]>();
+      let anyRecentEvent = false;
+      try {
+        const [progress, dueChanges, startChanges, estChanges, recent] = await Promise.all([
+          api.getChangeHistory(mapId, { fieldName: 'percentComplete', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
+          api.getChangeHistory(mapId, { fieldName: 'dueDate', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
+          api.getChangeHistory(mapId, { fieldName: 'startDate', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
+          api.getChangeHistory(mapId, { fieldName: 'effortEstimate', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
+          api.getChangeHistory(mapId, { sinceDays: STALE_PLAN_DAYS, limit: 1 }),
+        ]);
+        for (const e of progress.events) {
+          if (e.nodeId && !lastProgressChange.has(e.nodeId)) {
+            lastProgressChange.set(e.nodeId, e.createdAt);
+          }
+        }
+        for (const e of [...dueChanges.events, ...startChanges.events, ...estChanges.events]) {
+          if (!e.nodeId) continue;
+          const list = replanEventsByNode.get(e.nodeId) ?? [];
+          list.push(e.createdAt);
+          replanEventsByNode.set(e.nodeId, list);
+        }
+        anyRecentEvent = recent.events.length > 0;
+      } catch {
+        historyOk = false;
+      }
+
+      const incomplete = leaves.filter((l) => (l.percentComplete ?? 0) < 100);
+      const totalEffort = leaves.reduce((s, l) => s + (l.effortEstimate ?? 0), 0);
+
+      const inProgressStatusIds = new Set(
+        (data.map.statusWorkflow ?? [])
+          .filter((s) => s.category === 'in_progress')
+          .map((s) => s.id),
+      );
+      const isInProgress = (n: (typeof leaves)[number]) =>
+        (n.status != null && inProgressStatusIds.has(n.status)) ||
+        ((n.percentComplete ?? 0) > 0 && (n.percentComplete ?? 0) < 100);
+
+      const fmtNode = (n: (typeof leaves)[number], extra?: string) => {
+        const bits: string[] = [`${n.id} ${n.text}`];
+        if (n.priority) bits.push(`[${n.priority}]`);
+        if (extra) bits.push(`— ${extra}`);
+        return bits.join(' ');
+      };
+
+      // ── Evaluate rules (basics first) ──
+      type Finding = { line: string };
+      type RuleResult = {
+        id: (typeof LINT_RULES)[number];
+        severity: 'warn' | 'info';
+        title: string;
+        why: string;
+        fix: string;
+        findings: Finding[];
+        skipped?: string;
+      };
+      const results: RuleResult[] = [];
+
+      // 1. unestimated-leaf
+      results.push({
+        id: 'unestimated-leaf',
+        severity: 'warn',
+        title: 'Leaves without an effort estimate',
+        why: 'Unestimated work is invisible to the forecast — your finish date is under-counting.',
+        fix: 'Set an estimate on each (set_estimate); ai_estimate can draft one.',
+        findings: incomplete
+          .filter((l) => l.effortEstimate == null)
+          .map((l) => ({ line: fmtNode(l) })),
+      });
+
+      // 2. oversized-leaf
+      const oversizedAbs = OVERSIZED_DAYS * unitsPerDay;
+      const shareRuleActive = totalEffort > 0 && leaves.length >= OVERSIZED_SHARE_MIN_LEAVES;
+      results.push({
+        id: 'oversized-leaf',
+        severity: 'warn',
+        title: `Oversized leaves (> ${OVERSIZED_DAYS} days${shareRuleActive ? ` or > ${OVERSIZED_MAP_SHARE * 100}% of the plan` : ''})`,
+        why: 'Small pieces get estimated far more accurately — projects built from small chunks succeed dramatically more often.',
+        fix: 'Split it into smaller children (ai_breakdown can suggest a split).',
+        findings: incomplete
+          .filter(
+            (l) =>
+              l.effortEstimate != null &&
+              (l.effortEstimate > oversizedAbs ||
+                (shareRuleActive && l.effortEstimate > OVERSIZED_MAP_SHARE * totalEffort)),
+          )
+          .sort((a, b) => (b.effortEstimate ?? 0) - (a.effortEstimate ?? 0))
+          .map((l) => ({ line: fmtNode(l, `${l.effortEstimate} ${unit}`) })),
+      });
+
+      // 3. stale-progress
+      results.push({
+        id: 'stale-progress',
+        severity: 'warn',
+        title: `In-progress work with no progress update in ${stalledDays}+ days`,
+        why: 'A task that stops moving is usually stuck, not slow — surface it before it slips the schedule.',
+        fix: 'Update its % complete (set_progress), or flag what blocks it (flag_blocker).',
+        findings: historyOk
+          ? incomplete
+              .filter((l) => {
+                if (!isInProgress(l)) return false;
+                const last = lastProgressChange.get(l.id);
+                return last == null || new Date(last).getTime() < Date.now() - stalledDays * 86_400_000;
+              })
+              .map((l) => {
+                const last = lastProgressChange.get(l.id);
+                const detail = last
+                  ? `${l.percentComplete ?? 0}%, last progress change ${last.slice(0, 10)}`
+                  : `${l.percentComplete ?? 0}%, no progress change on record`;
+                return { line: fmtNode(l, detail) };
+              })
+          : [],
+        skipped: historyOk ? undefined : 'change history unavailable',
+      });
+
+      // 4. overdue-unreplanned
+      const todayIso = new Date().toISOString().slice(0, 10);
+      results.push({
+        id: 'overdue-unreplanned',
+        severity: 'warn',
+        title: 'Overdue leaves never re-planned',
+        why: 'Plans only work if they are amended when reality diverges — an ignored overdue date makes every downstream date fiction.',
+        fix: 'Re-plan it: move the due date, split the remainder, or descope (scope_simulate previews the impact).',
+        findings: historyOk
+          ? incomplete
+              .filter((l) => {
+                if (!l.dueDate || l.dueDate.slice(0, 10) >= todayIso) return false;
+                const evs = replanEventsByNode.get(l.id) ?? [];
+                return !evs.some((ts) => ts > l.dueDate!);
+              })
+              .map((l) => ({ line: fmtNode(l, `due ${l.dueDate!.slice(0, 10)}, ${l.percentComplete ?? 0}%`) }))
+          : [],
+        skipped: historyOk ? undefined : 'change history unavailable',
+      });
+
+      // 5. calibration-drift (map-level)
+      const calibrationLeaves = data.nodes.filter(
+        (n) =>
+          (n.childrenIds?.length ?? 0) === 0 &&
+          n.effortEstimate != null &&
+          n.actualEffort != null,
+      );
+      const calibEstimate = calibrationLeaves.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
+      const calibActual = calibrationLeaves.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
+      const fudge = calibEstimate > 0 ? calibActual / calibEstimate : null;
+      const drifted =
+        fudge != null &&
+        calibrationLeaves.length >= MIN_CALIBRATION_SAMPLES &&
+        (fudge < CALIBRATION_LOW || fudge > CALIBRATION_HIGH);
+      results.push({
+        id: 'calibration-drift',
+        severity: 'info',
+        title: 'Estimation calibration drift (map-level)',
+        why: fudge != null
+          ? `Your estimates historically run ${fudge.toFixed(2)}× — the velocity-adjusted forecast already corrects for this; consider sizing new estimates accordingly.`
+          : 'Once completed leaves carry both estimate and actual, the linter watches your calibration.',
+        fix: 'See get_estimation_accuracy for the per-node breakdown.',
+        findings: drifted
+          ? [{ line: `fudge factor ${fudge!.toFixed(2)}× over ${calibrationLeaves.length} completed leaves` }]
+          : [],
+      });
+
+      // 6. no-done-criteria
+      results.push({
+        id: 'no-done-criteria',
+        severity: 'info',
+        title: `Sizeable leaves (≥ ${DONE_CRITERIA_MIN_DAYS} days) without a done-definition`,
+        why: 'A task without a definition of done tends to be 90% finished forever — one sentence of "done means…" prevents it.',
+        fix: 'Add a sentence to the description (update_node). Nodes linked to a requirement are exempt.',
+        findings: incomplete
+          .filter(
+            (l) =>
+              l.requirementId == null &&
+              l.effortEstimate != null &&
+              l.effortEstimate >= DONE_CRITERIA_MIN_DAYS * unitsPerDay &&
+              (l.description ?? '').trim() === '',
+          )
+          .map((l) => ({ line: fmtNode(l, `${l.effortEstimate} ${unit}`) })),
+      });
+
+      // 7. stale-plan (map-level)
+      const mapIncomplete = (data.map.computedProgress ?? 0) < 100;
+      results.push({
+        id: 'stale-plan',
+        severity: 'info',
+        title: `Stale plan (no changes in ${STALE_PLAN_DAYS}+ days, map-level)`,
+        why: 'A plan that is not touched weekly is a document, not a plan — a 2-minute review keeps the forecast honest.',
+        fix: 'Run status_digest, then update the progress and dates that changed.',
+        findings:
+          historyOk && mapIncomplete && !anyRecentEvent
+            ? [{ line: `map is at ${(data.map.computedProgress ?? 0).toFixed(0)}% with no recorded change in ${STALE_PLAN_DAYS} days` }]
+            : [],
+        skipped: historyOk ? undefined : 'change history unavailable',
+      });
+
+      // 8. dates-without-dependencies (map-level)
+      const datedLeaves = data.nodes.filter(
+        (n) => (n.childrenIds?.length ?? 0) === 0 && (n.dueDate || n.startDate),
+      );
+      const totalDeps = data.nodes.reduce((s, n) => s + (n.dependencies?.length ?? 0), 0);
+      results.push({
+        id: 'dates-without-dependencies',
+        severity: 'info',
+        title: 'Scheduled plan with zero dependencies (map-level)',
+        why: 'Without dependencies the schedule assumes everything can happen in parallel — the critical path is what makes a finish date real.',
+        fix: 'Add dependencies between sequential tasks (add_dependency).',
+        findings:
+          datedLeaves.length >= MIN_DATED_LEAVES_FOR_DEPS && totalDeps === 0
+            ? [{ line: `${datedLeaves.length} dated leaves, 0 dependencies` }]
+            : [],
+      });
+
+      // ── Format ──
+      const shown = rule ? results.filter((r) => r.id === rule) : results;
+      const warnCount = shown.filter((r) => r.severity === 'warn').reduce((s, r) => s + r.findings.length, 0);
+      const infoCount = shown.filter((r) => r.severity === 'info').reduce((s, r) => s + r.findings.length, 0);
+
+      const lines: string[] = [];
+      lines.push(`Plan lint — ${scopeLabel}`);
+      lines.push(`Plan health: ${warnCount} warning(s), ${infoCount} suggestion(s)`);
+      if (rule) lines.push(`Filtered to rule: ${rule}`);
+      lines.push('');
+
+      const clean: string[] = [];
+      const skippedRules: string[] = [];
+      for (const r of shown) {
+        if (r.skipped) {
+          skippedRules.push(`${r.id} (${r.skipped})`);
+          continue;
+        }
+        if (r.findings.length === 0) {
+          clean.push(r.id);
+          continue;
+        }
+        lines.push(`## [${r.severity}] ${r.id}: ${r.findings.length} — ${r.title}`);
+        lines.push(`Why: ${r.why}`);
+        lines.push(`Fix: ${r.fix}`);
+        for (const f of r.findings.slice(0, limit)) {
+          lines.push(`  - ${f.line}`);
+        }
+        if (r.findings.length > limit) {
+          lines.push(`  … and ${r.findings.length - limit} more (raise \`limit\` or pass \`rule: "${r.id}"\`)`);
+        }
+        lines.push('');
+      }
+
+      if (clean.length > 0) lines.push(`✓ Clean: ${clean.join(', ')}`);
+      if (skippedRules.length > 0) lines.push(`⚠ Skipped: ${skippedRules.join(', ')}`);
+      if (warnCount + infoCount === 0 && skippedRules.length === 0) {
+        lines.push('');
+        lines.push('The plan is in good shape — every check passed.');
       }
 
       return toolResult(lines.join('\n'));

--- a/packages/mcp/src/scope.ts
+++ b/packages/mcp/src/scope.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared leaf-scoping for the MI tool suite (remaining_work,
+ * completion_forecast, risk_scan, plan_lint).
+ *
+ * Scope rules:
+ * - `nodeId` restricts to the leaves of that subtree.
+ * - `versionId` filters by inherited tag: a leaf is in scope if it OR any
+ *   ancestor carries the version. Combines with `nodeId` (intersection).
+ * - Neither → all leaves of the map.
+ */
+import type { MapDetail, NodeWithComputed } from './api.js';
+
+export type ScopeResult =
+  | { ok: true; leaves: NodeWithComputed[]; scopeLabel: string }
+  | { ok: false; error: string };
+
+export function scopedLeaves(
+  data: MapDetail,
+  opts: { nodeId?: string; versionId?: string } = {},
+): ScopeResult {
+  const { nodeId, versionId } = opts;
+  const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+
+  const ancestorVersions = (leafId: string): Set<string> => {
+    const versions = new Set<string>();
+    let cur = nodeById.get(leafId);
+    while (cur) {
+      if (cur.versionId) versions.add(cur.versionId);
+      cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
+    }
+    return versions;
+  };
+
+  let leaves: NodeWithComputed[];
+  let scopeLabel = 'whole map';
+
+  if (nodeId) {
+    const root = nodeById.get(nodeId);
+    if (!root) return { ok: false, error: `Node ${nodeId} not found in map ${data.map.id}.` };
+    scopeLabel = `subtree of "${root.text}" (${nodeId})`;
+    const subtreeLeaves: NodeWithComputed[] = [];
+    const stack = [root];
+    while (stack.length) {
+      const n = stack.pop()!;
+      if ((n.childrenIds?.length ?? 0) === 0) {
+        subtreeLeaves.push(n);
+      } else {
+        for (const cid of n.childrenIds) {
+          const c = nodeById.get(cid);
+          if (c) stack.push(c);
+        }
+      }
+    }
+    leaves = subtreeLeaves;
+  } else {
+    leaves = data.nodes.filter((n) => (n.childrenIds?.length ?? 0) === 0);
+  }
+
+  if (versionId) {
+    scopeLabel = `version ${versionId}` + (nodeId ? ` within ${scopeLabel}` : '');
+    leaves = leaves.filter((n) => ancestorVersions(n.id).has(versionId));
+  }
+
+  return { ok: true, leaves, scopeLabel };
+}


### PR DESCRIPTION
## What

Implements **surface 1 of [docs/plan-linter.md](../blob/master/docs/plan-linter.md)** (merged in #208): the `plan_lint` MCP tool — the coaching counterpart to `risk_scan`. It checks plan *quality/hygiene* rather than execution risk, and every finding teaches the principle it enforces in one sentence plus a concrete fix pointer.

**8 checks, basics-first:**

| Rule | Severity | Signal |
|---|---|---|
| `unestimated-leaf` | warn | incomplete leaf without `effortEstimate` |
| `oversized-leaf` | warn | estimate > 5 days (unit-aware) or > 15% of plan total (≥8 leaves) |
| `stale-progress` | warn | in-progress leaf with no `percentComplete` **change event** in 7+ days |
| `overdue-unreplanned` | warn | past due, <100%, no date/estimate change since the due date passed |
| `calibration-drift` | info | fudge factor outside 0.8–1.25× with ≥5 samples |
| `no-done-criteria` | info | ≥2-day leaf with empty description (requirement-linked nodes exempt) |
| `stale-plan` | info | map <100% with zero change events in 14 days |
| `dates-without-dependencies` | info | ≥10 dated leaves, zero dependencies |

Params follow the MI-suite conventions: `mapId`, `nodeId`/`versionId` scoping (ancestor inheritance), `stalledDays`, `rule` filter, `limit` with truncation footers.

## Refactor

`plan_lint` is the 4th consumer of the leaf-scoping logic that was copy-pasted across `remaining_work` / `completion_forecast` / `risk_scan` — it now lives in `packages/mcp/src/scope.ts` with unit tests; the three existing tools are refactored onto it (behavior unchanged).

## Verification

- `pnpm turbo typecheck` clean; `@mindblown/mcp` tests 14/14 (6 new for the scope helper).
- Exercised live end-to-end via the stdio MCP from this branch against a large real map (read-only tool): full scan, rule filter, and limit truncation verified. This surfaced and fixed a display bug where stale-progress showed `updatedAt` (bumped by any edit) instead of the actual last progress-change event.
- Server test suite has 2 pre-existing failures in `triage-routes.test.ts` on master (bulk-confirm batch cap + label-write parallelism), unrelated to this change.

Change-event-backed checks degrade gracefully (reported as skipped) when the history endpoint is unavailable. Dismissals and the UI plan-health panel are the next slices per the spec's ship order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9eAuogxQ9r6TrjMGyjpTz