### PR TITLE
feat(requirements): Anforderungsdokument export + requirementText field

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -41,6 +41,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     completedAt: null,
     requirementId: null,
     requirementPriority: null,
+    requirementText: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -39,6 +39,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     completedAt: null,
     requirementId: null,
     requirementPriority: null,
+    requirementText: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -42,6 +42,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     completedAt: null,
     requirementId: null,
     requirementPriority: null,
+    requirementText: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -224,6 +224,14 @@ export interface Node {
   /** MoSCoW-style requirement priority (Muss/Soll/Kann). */
   requirementPriority: 'must' | 'should' | 'could' | null;
 
+  /**
+   * Business phrasing of the requirement for the register and doc export.
+   * Kept separate from `text` (which may be a ticket-style title synced to
+   * GitHub) and deliberately NOT in the GitHub outbound SYNC_FIELDS.
+   * null = fall back to `text`.
+   */
+  requirementText: string | null;
+
   // ── Auto-progress (parent-epic rollup) ────────────────────
   /**
    * When set to `'children'`, the server auto-computes percentComplete on this

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -133,6 +133,7 @@ export interface NodeWithComputed {
   // Requirements register — non-null requirementId marks a requirement.
   requirementId: string | null;
   requirementPriority: 'must' | 'should' | 'could' | null;
+  requirementText: string | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;
@@ -287,6 +288,33 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
   if (res.status === 204) return undefined as unknown as T;
   return res.json() as Promise<T>;
+}
+
+/**
+ * Raw-text GET for endpoints that return non-JSON bodies (e.g. the
+ * Markdown requirements export). Mirrors request()'s auth + injector
+ * fast path but returns the body verbatim.
+ */
+async function requestText(path: string): Promise<string> {
+  const ctx = getContext();
+  const headers: Record<string, string> = {};
+  if (ctx.token) headers['Authorization'] = `Bearer ${ctx.token}`;
+
+  if (ctx.injector) {
+    const res = await ctx.injector({ method: 'GET', url: path, headers });
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw new ApiError(res.statusCode, `HTTP ${res.statusCode}`);
+    }
+    return res.body ?? '';
+  }
+
+  const res = await fetch(`${ctx.baseUrl}${path}`, { headers });
+  if (!res.ok) throw new ApiError(res.status, res.statusText);
+  return res.text();
+}
+
+export function exportRequirements(mapId: string): Promise<string> {
+  return requestText(`/api/maps/${mapId}/requirements-export`);
 }
 
 // ── Maps ────────────────────────────────────────────────────────

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -487,6 +487,21 @@ server.tool(
 );
 
 server.tool(
+  'requirements_export',
+  'Export the requirements register as a Markdown Anforderungsdokument: chapter per Bereich, one table row per requirement (ID, business text, Muss/Soll/Kann, derived status, Aufwand/Rest in S/M/L/XL buckets). Returns the full Markdown document — save it to a file or convert with pandoc for docx/pdf.',
+  {
+    mapId: z.string().describe('The map ID'),
+  },
+  async ({ mapId }) => {
+    try {
+      return toolResult(await api.exportRequirements(mapId));
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
   'requirements_overview',
   'Business-facing requirements register: every node carrying a requirementId, grouped by top-level branch (chapter). Per requirement: MoSCoW priority, derived status (done ≙ Umgesetzt / partial ≙ Teilweise / open ≙ Offen — from progress rollup, never stored), progress %, remaining effort, and linked GitHub issues. Answers "which requirements exist and where do they stand?" without the full get_map dump.',
   {

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import type { Node } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
+import * as api from './api.js';
 
 // ── Derived requirement status ───────────────────────────────────
 //
@@ -60,6 +61,7 @@ function compareReqIds(a: ReqRow, b: ReqRow): number {
 
 export function RequirementsView() {
   const nodes = useMindmapStore((s) => s.nodes);
+  const currentMapId = useMindmapStore((s) => s.currentMapId);
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
   const computed = useMindmapStore((s) => s.computed);
   const updateNode = useMindmapStore((s) => s.updateNode);
@@ -69,6 +71,7 @@ export function RequirementsView() {
   const setActiveView = useMindmapStore((s) => s.setActiveView);
   const effortUnit = useMindmapStore((s) => s.currentMap?.effortUnit ?? 'days');
 
+  const [exporting, setExporting] = useState(false);
   const [statusFilter, setStatusFilter] = useState<'' | ReqStatus>('');
   const [priorityFilter, setPriorityFilter] = useState<'' | 'must' | 'should' | 'could'>('');
   const [editingCell, setEditingCell] = useState<{ nodeId: string; field: string } | null>(null);
@@ -257,6 +260,28 @@ export function RequirementsView() {
             style={primaryButtonStyle(false)}
           >
             + New requirement
+          </button>
+          <button
+            onClick={async () => {
+              if (!currentMapId || exporting) return;
+              setExporting(true);
+              try {
+                const md = await api.exportRequirements(currentMapId);
+                const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+                const a = document.createElement('a');
+                a.href = URL.createObjectURL(blob);
+                a.download = `anforderungsdokument-${new Date().toISOString().slice(0, 10)}.md`;
+                a.click();
+                URL.revokeObjectURL(a.href);
+              } finally {
+                setExporting(false);
+              }
+            }}
+            disabled={exporting}
+            title="Als Anforderungsdokument (Markdown) exportieren"
+            style={secondaryButtonStyle(exporting)}
+          >
+            {exporting ? 'Exporting…' : 'Export'}
           </button>
         </div>
       </div>
@@ -447,10 +472,18 @@ function ChapterGroup({
             {isEditing(r.node.id, 'text') ? (
               <input
                 autoFocus
-                defaultValue={r.node.text}
+                defaultValue={r.node.requirementText ?? r.node.text}
                 onBlur={(e) => {
                   const v = e.target.value.trim();
-                  if (v && v !== r.node.text) updateNode(r.node.id, { text: v });
+                  // Business phrasing edits go to requirementText when one is
+                  // set — never touching the (GitHub-synced) node text.
+                  if (r.node.requirementText != null) {
+                    if (v !== r.node.requirementText) {
+                      updateNode(r.node.id, { requirementText: v || null });
+                    }
+                  } else if (v && v !== r.node.text) {
+                    updateNode(r.node.id, { text: v });
+                  }
                   setEditingCell(null);
                 }}
                 onKeyDown={(e) => {
@@ -473,7 +506,15 @@ function ChapterGroup({
                   }}
                   title={`Health: ${r.health}`}
                 />
-                {r.node.text}
+                <span
+                  title={
+                    r.node.requirementText != null && r.node.requirementText !== r.node.text
+                      ? `Node: ${r.node.text}`
+                      : undefined
+                  }
+                >
+                  {r.node.requirementText ?? r.node.text}
+                </span>
                 <button
                   onClick={(e) => {
                     e.stopPropagation();

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -534,6 +534,19 @@ export function updateMap(id: string, fields: Record<string, unknown>): Promise<
   });
 }
 
+/**
+ * Fetch the requirements register rendered as a Markdown
+ * Anforderungsdokument. Raw text — not JSON.
+ */
+export async function exportRequirements(mapId: string): Promise<string> {
+  const token = getToken();
+  const res = await fetch(`${BASE_URL}/api/maps/${mapId}/requirements-export`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error(`Export failed: HTTP ${res.status}`);
+  return res.text();
+}
+
 // ── Nodes ────────────────────────────────────────────────────────
 
 export function createNode(

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -841,6 +841,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
     completedAt: null,
       requirementId: null,
       requirementPriority: null,
+      requirementText: null,
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -75,6 +75,7 @@ function toNodeWithComputed(
     updatedAt: toIsoString((node as unknown as { updatedAt: unknown }).updatedAt),
     requirementId: node.requirementId,
     requirementPriority: node.requirementPriority,
+    requirementText: node.requirementText,
     claimedBySession: node.claimedBySession,
     claimedAt: node.claimedAt,
     computedEffort: computed?.computedEffort ?? 0,

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -41,6 +41,7 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     requirementId: (get('requirementId', 'requirement_id') as string) ?? null,
     requirementPriority:
       (get('requirementPriority', 'requirement_priority') as CoreNode['requirementPriority']) ?? null,
+    requirementText: (get('requirementText', 'requirement_text') as string) ?? null,
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -779,6 +779,9 @@ export async function runMigrations(): Promise<void> {
   // partial index closes that race; 23505 on this index is mapped back
   // to RequirementIdConflictError in db/nodes.ts.
   await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS requirement_text TEXT
+  `);
+  await db.execute(sql`
     CREATE UNIQUE INDEX IF NOT EXISTS nodes_map_requirement_id_unique
       ON nodes (map_id, requirement_id)
       WHERE requirement_id IS NOT NULL AND deleted_at IS NULL

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -203,6 +203,7 @@ export interface CreateNodeInput {
   completedAt?: string | null;
   requirementId?: string | null;
   requirementPriority?: 'must' | 'should' | 'could' | null;
+  requirementText?: string | null;
 }
 
 export async function createNode(
@@ -244,6 +245,7 @@ export async function createNode(
       completedAt: input.completedAt ? new Date(input.completedAt) : null,
       requirementId: input.requirementId ?? null,
       requirementPriority: input.requirementPriority ?? null,
+      requirementText: input.requirementText ?? null,
       assigneeIds: [],
       tags: [],
       customFields: {},
@@ -335,6 +337,7 @@ export interface UpdateNodeInput {
   completedAt?: string | null;
   requirementId?: string | null;
   requirementPriority?: 'must' | 'should' | 'could' | null;
+  requirementText?: string | null;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -441,6 +444,7 @@ export async function updateNode(
   if (input.priorityRank !== undefined) updates.priorityRank = input.priorityRank;
   if (input.requirementId !== undefined) updates.requirementId = input.requirementId;
   if (input.requirementPriority !== undefined) updates.requirementPriority = input.requirementPriority;
+  if (input.requirementText !== undefined) updates.requirementText = input.requirementText;
   // Orchestration substrate (#111)
   if (input.claimedBySession !== undefined) updates.claimedBySession = input.claimedBySession;
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -194,6 +194,8 @@ export const nodes = pgTable('nodes', {
   // requirement_priority: MoSCoW priority — 'must' | 'should' | 'could'.
   requirementId: text('requirement_id'),
   requirementPriority: text('requirement_priority'),
+  // Business phrasing for register/doc export; NOT GitHub-synced.
+  requirementText: text('requirement_text'),
 
   // ── Orchestration substrate (#111) ───────────────────────────
   // claimed_by_session: session ID that owns this node for active work.

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -214,6 +214,117 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
+  // ── GET /api/maps/:id/requirements-export — Anforderungsdokument ──
+  //
+  // Renders the requirements register as a Markdown document mirroring
+  // the hand-maintained Anforderungsdokument format: chapters = the
+  // requirement nodes' parents (Bereiche) in depth-first tree order,
+  // one table row per requirement with derived status. Effort sizes
+  // map to the doc's S/M/L/XL buckets. text/markdown response.
+  app.get<{ Params: { id: string } }>(
+    '/api/maps/:id/requirements-export',
+    async (req, reply) => {
+      const userId = req.userId;
+      if (userId) {
+        const perm = await permDb.getPermission(req.params.id, userId);
+        if (!permDb.hasPermission(perm, 'view')) {
+          return reply.status(403).send({
+            error: { code: 'FORBIDDEN', message: 'You do not have access to this map' },
+          });
+        }
+      }
+
+      const data = await mapDb.getMap(req.params.id);
+      if (!data) {
+        return reply.status(404).send({
+          error: { code: 'MAP_NOT_FOUND', message: `Map ${req.params.id} not found` },
+        });
+      }
+
+      const computed = computeTree(data.nodes, data.map.healthThreshold);
+      const byId = new Map(data.nodes.map((n) => [n.id, n]));
+      const requirements = data.nodes.filter((n) => n.requirementId != null);
+
+      const progressOf = (n: CoreNode): number =>
+        n.childrenIds.length > 0
+          ? (computed.get(n.id)?.computedProgress ?? 0)
+          : (n.percentComplete ?? 0);
+      const statusOf = (p: number): string =>
+        p >= 99.5 ? 'Umgesetzt' : p > 0 ? 'Teilweise' : 'Offen';
+      // Doc buckets: S ≤ 2 Tage · M 3–5 · L 1–3 Wochen · XL > 3 Wochen
+      const sizeOf = (days: number): string =>
+        days <= 0 ? '—' : days <= 2 ? 'S' : days <= 5 ? 'M' : days <= 15 ? 'L' : 'XL';
+      const PRIO: Record<string, string> = { must: 'Muss', should: 'Soll', could: 'Kann' };
+
+      // Depth-first order for chapter (= parent) sorting.
+      const dfs = new Map<string, number>();
+      {
+        let i = 0;
+        const walk = (id: string) => {
+          dfs.set(id, i++);
+          for (const c of byId.get(id)?.childrenIds ?? []) if (byId.has(c)) walk(c);
+        };
+        walk(data.map.rootNodeId);
+      }
+
+      const chapters = new Map<string, CoreNode[]>();
+      for (const n of requirements) {
+        const key = n.parentId ?? data.map.rootNodeId;
+        (chapters.get(key) ?? chapters.set(key, []).get(key)!).push(n);
+      }
+      const orderedChapters = [...chapters.entries()].sort(
+        (a, b) => (dfs.get(a[0]) ?? Infinity) - (dfs.get(b[0]) ?? Infinity),
+      );
+
+      const today = new Date().toISOString().slice(0, 10);
+      const counts = { Umgesetzt: 0, Teilweise: 0, Offen: 0 };
+      for (const n of requirements) counts[statusOf(progressOf(n)) as keyof typeof counts]++;
+
+      const L: string[] = [];
+      L.push(`# ${data.map.name} — Anforderungsdokument`);
+      L.push('');
+      L.push(`*Generiert aus MindBlown am ${today} — Status abgeleitet aus dem Projektstand (Rollup), nicht manuell gepflegt.*`);
+      L.push('');
+      L.push('**Priorität:** Muss — Kernfunktion (MVP) · Soll — wichtig, nicht MVP-blockierend · Kann — wünschenswert');
+      L.push('');
+      L.push('**Status:** Umgesetzt · Teilweise · Offen (abgeleitet: 100 % / >0 % / 0 % Fortschritt)');
+      L.push('');
+      L.push('**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» bei Umgesetzt): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen');
+      L.push('');
+      L.push(`**Stand:** ${requirements.length} Anforderungen — ${counts.Umgesetzt} Umgesetzt · ${counts.Teilweise} Teilweise · ${counts.Offen} Offen`);
+      L.push('');
+      L.push('---');
+
+      let sec = 0;
+      for (const [chapterId, list] of orderedChapters) {
+        sec++;
+        const chapterName = byId.get(chapterId)?.text ?? '(Root)';
+        L.push('');
+        L.push(`## ${sec}. ${chapterName}`);
+        L.push('');
+        L.push('| ID | Anforderung | Priorität | Status | Aufwand | Rest |');
+        L.push('|---|---|---|---|---|---|');
+        list.sort((a, b) =>
+          (a.requirementId ?? '').localeCompare(b.requirementId ?? '', undefined, { numeric: true }),
+        );
+        for (const n of list) {
+          const p = progressOf(n);
+          const status = statusOf(p);
+          const effort = computed.get(n.id)?.computedEffort ?? n.effortEstimate ?? 0;
+          const remaining = effort * (1 - p / 100);
+          const text = (n.requirementText ?? n.text).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+          L.push(
+            `| ${n.requirementId} | ${text} | ${PRIO[n.requirementPriority ?? ''] ?? '—'} | ${status} | ${sizeOf(effort)} | ${status === 'Umgesetzt' ? '—' : sizeOf(remaining)} |`,
+          );
+        }
+      }
+      L.push('');
+
+      reply.header('content-type', 'text/markdown; charset=utf-8');
+      return reply.send(L.join('\n'));
+    },
+  );
+
   // ── PUT /api/maps/:id — Update map settings ──────────────────
   app.put<{ Params: { id: string } }>('/api/maps/:id', async (req, reply) => {
     const userId = req.userId!;
@@ -390,6 +501,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           completedAt: null,
           requirementId: null,
           requirementPriority: null,
+          requirementText: null,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -170,6 +170,7 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       priorityRank?: number | null;
       requirementId?: string | null;
       requirementPriority?: 'must' | 'should' | 'could' | null;
+      requirementText?: string | null;
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`
        * auto-link backstop (#58). Useful when the leading `#NNNN` is

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -575,6 +575,18 @@ describe('requirement fields', () => {
     });
   });
 
+  it('forwards requirementText on update', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      requirementText: 'Mandate können liquidiert werden.',
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({
+      requirementText: 'Mandate können liquidiert werden.',
+    });
+  });
+
   it('omits requirement fields from the backend call when not provided', async () => {
     const recorder = makeRecordingBackend();
     await updateNodeTool.handler(recorder.backend, {

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -40,6 +40,11 @@ export const createNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('MoSCoW requirement priority (Muss/Soll/Kann). Only meaningful alongside requirementId.'),
+    requirementText: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Business phrasing of the requirement for the register/doc export. Falls back to the node text when null. Not synced to GitHub.'),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -121,6 +126,11 @@ export const updateNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('MoSCoW requirement priority (Muss/Soll/Kann). null clears it.'),
+    requirementText: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Business phrasing for the register/doc export (falls back to node text). Safe to edit freely — never pushed to GitHub. null clears it.'),
     // Orchestration substrate (#111)
     scopes: z
       .array(z.string())

--- a/packages/tool-kit/src/types.ts
+++ b/packages/tool-kit/src/types.ts
@@ -49,6 +49,7 @@ export interface NodeWithComputed {
   // Requirements register — non-null requirementId marks a requirement.
   requirementId: string | null;
   requirementPriority: 'must' | 'should' | 'could' | null;
+  requirementText: string | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;


### PR DESCRIPTION
The register can now be exported as a Markdown Anforderungsdokument
mirroring the hand-maintained format (chapter per Bereich, table rows
with ID / business text / Muss-Soll-Kann / derived status / Aufwand+Rest
in S-M-L-XL buckets, legend header, generation timestamp).

- Node.requirementText: business phrasing for register + export,
  separate from the (GitHub-synced) node text and deliberately NOT in
  SYNC_FIELDS — safe for business users to edit. All 8 DoD layers.
- GET /api/maps/:id/requirements-export → text/markdown, server-side
  rendering with computeTree rollups.
- MCP tool requirements_export (raw-text api helper alongside the
  JSON request path).
- Requirements view: Export button (downloads .md), title cell shows
  requirementText ?? text; editing writes requirementText when set so
  ticket titles never get clobbered.

Verified end-to-end on a scratch DB: REST export with rollup-derived
statuses and pipe-escaping, MCP tool over stdio, migration idempotency.
Pre-existing triage-routes flake fails on clean master too.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn
