### PR TITLE
feat(requirements): native Word export (?format=docx)

### DIFF
--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -34,6 +34,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     updatedAt: '2026-01-01T00:00:00Z',
     requirementId: null,
     requirementPriority: null,
+    requirementText: null,
     claimedBySession: null,
     claimedAt: null,
     computedEffort: 0,

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -266,11 +266,12 @@ export function RequirementsView() {
               if (!currentMapId || exporting) return;
               setExporting(true);
               try {
-                const md = await api.exportRequirements(currentMapId);
-                const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+                // Word is what business consumers open — the Markdown
+                // variant stays available via ?format=md and the MCP tool.
+                const blob = await api.exportRequirementsDocx(currentMapId);
                 const a = document.createElement('a');
                 a.href = URL.createObjectURL(blob);
-                a.download = `anforderungsdokument-${new Date().toISOString().slice(0, 10)}.md`;
+                a.download = `anforderungsdokument-${new Date().toISOString().slice(0, 10)}.docx`;
                 a.click();
                 URL.revokeObjectURL(a.href);
               } finally {
@@ -278,10 +279,10 @@ export function RequirementsView() {
               }
             }}
             disabled={exporting}
-            title="Als Anforderungsdokument (Markdown) exportieren"
+            title="Als Anforderungsdokument (Word) exportieren"
             style={secondaryButtonStyle(exporting)}
           >
-            {exporting ? 'Exporting…' : 'Export'}
+            {exporting ? 'Exporting…' : 'Export Word'}
           </button>
         </div>
       </div>

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -538,6 +538,19 @@ export function updateMap(id: string, fields: Record<string, unknown>): Promise<
  * Fetch the requirements register rendered as a Markdown
  * Anforderungsdokument. Raw text — not JSON.
  */
+/**
+ * Fetch the requirements register as a Word document (docx) — the
+ * format business consumers actually open. Returns a Blob for download.
+ */
+export async function exportRequirementsDocx(mapId: string): Promise<Blob> {
+  const token = getToken();
+  const res = await fetch(`${BASE_URL}/api/maps/${mapId}/requirements-export?format=docx`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error(`Export failed: HTTP ${res.status}`);
+  return res.blob();
+}
+
 export async function exportRequirements(mapId: string): Promise<string> {
   const token = getToken();
   const res = await fetch(`${BASE_URL}/api/maps/${mapId}/requirements-export`, {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,6 +31,7 @@
     "@mindblown/mcp": "workspace:*",
     "@mindblown/tool-kit": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "docx": "^9.7.1",
     "drizzle-orm": "^0.39.3",
     "fastify": "^5.2.2",
     "jsonwebtoken": "^9.0.2",

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -1,0 +1,259 @@
+import type { Node as CoreNode, MindMap, ComputedNodeValues, NodeId } from '@mindblown/core';
+import {
+  Document,
+  HeadingLevel,
+  Packer,
+  Paragraph,
+  Table,
+  TableCell,
+  TableRow,
+  TextRun,
+  WidthType,
+  BorderStyle,
+} from 'docx';
+
+// ── Register data (shared by both renderers) ─────────────────────
+
+export interface RegisterRow {
+  id: string;
+  text: string;
+  prio: string;
+  status: string;
+  aufwand: string;
+  rest: string;
+}
+
+export interface RegisterData {
+  title: string;
+  generatedAt: string; // YYYY-MM-DD
+  total: number;
+  counts: { Umgesetzt: number; Teilweise: number; Offen: number };
+  chapters: Array<{ name: string; rows: RegisterRow[] }>;
+}
+
+const PRIO: Record<string, string> = { must: 'Muss', should: 'Soll', could: 'Kann' };
+
+// Doc buckets: S ≤ 2 Tage · M 3–5 · L 1–3 Wochen · XL > 3 Wochen
+function sizeOf(days: number): string {
+  return days <= 0 ? '—' : days <= 2 ? 'S' : days <= 5 ? 'M' : days <= 15 ? 'L' : 'XL';
+}
+
+export function buildRegisterData(
+  map: MindMap,
+  nodes: CoreNode[],
+  computed: Map<NodeId, ComputedNodeValues>,
+): RegisterData {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const requirements = nodes.filter((n) => n.requirementId != null);
+
+  const progressOf = (n: CoreNode): number =>
+    n.childrenIds.length > 0
+      ? (computed.get(n.id)?.computedProgress ?? 0)
+      : (n.percentComplete ?? 0);
+  const statusOf = (p: number): string =>
+    p >= 99.5 ? 'Umgesetzt' : p > 0 ? 'Teilweise' : 'Offen';
+
+  // Depth-first order for chapter (= parent) sorting.
+  const dfs = new Map<string, number>();
+  {
+    let i = 0;
+    const walk = (id: string) => {
+      dfs.set(id, i++);
+      for (const c of byId.get(id)?.childrenIds ?? []) if (byId.has(c)) walk(c);
+    };
+    walk(map.rootNodeId);
+  }
+
+  const chapters = new Map<string, CoreNode[]>();
+  for (const n of requirements) {
+    const key = n.parentId ?? map.rootNodeId;
+    (chapters.get(key) ?? chapters.set(key, []).get(key)!).push(n);
+  }
+
+  const counts = { Umgesetzt: 0, Teilweise: 0, Offen: 0 };
+  for (const n of requirements) counts[statusOf(progressOf(n)) as keyof typeof counts]++;
+
+  const orderedChapters = [...chapters.entries()]
+    .sort((a, b) => (dfs.get(a[0]) ?? Infinity) - (dfs.get(b[0]) ?? Infinity))
+    .map(([chapterId, list]) => ({
+      name: byId.get(chapterId)?.text ?? '(Root)',
+      rows: list
+        .sort((a, b) =>
+          (a.requirementId ?? '').localeCompare(b.requirementId ?? '', undefined, {
+            numeric: true,
+          }),
+        )
+        .map((n) => {
+          const p = progressOf(n);
+          const status = statusOf(p);
+          const effort = computed.get(n.id)?.computedEffort ?? n.effortEstimate ?? 0;
+          return {
+            id: n.requirementId ?? '',
+            text: (n.requirementText ?? n.text).replace(/\n/g, ' '),
+            prio: PRIO[n.requirementPriority ?? ''] ?? '—',
+            status,
+            aufwand: sizeOf(effort),
+            rest: status === 'Umgesetzt' ? '—' : sizeOf(effort * (1 - p / 100)),
+          };
+        }),
+    }));
+
+  return {
+    title: `${map.name} — Anforderungsdokument`,
+    generatedAt: new Date().toISOString().slice(0, 10),
+    total: requirements.length,
+    counts,
+    chapters: orderedChapters,
+  };
+}
+
+// ── Markdown renderer ─────────────────────────────────────────────
+
+const LEGEND = [
+  '**Priorität:** Muss — Kernfunktion (MVP) · Soll — wichtig, nicht MVP-blockierend · Kann — wünschenswert',
+  '**Status:** Umgesetzt · Teilweise · Offen (abgeleitet: 100 % / >0 % / 0 % Fortschritt)',
+  '**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» bei Umgesetzt): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen',
+];
+
+export function renderMarkdown(data: RegisterData): string {
+  const L: string[] = [];
+  L.push(`# ${data.title}`);
+  L.push('');
+  L.push(
+    `*Generiert aus MindBlown am ${data.generatedAt} — Status abgeleitet aus dem Projektstand (Rollup), nicht manuell gepflegt.*`,
+  );
+  for (const line of LEGEND) {
+    L.push('');
+    L.push(line);
+  }
+  L.push('');
+  L.push(
+    `**Stand:** ${data.total} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
+  );
+  L.push('');
+  L.push('---');
+  data.chapters.forEach((ch, i) => {
+    L.push('');
+    L.push(`## ${i + 1}. ${ch.name}`);
+    L.push('');
+    L.push('| ID | Anforderung | Priorität | Status | Aufwand | Rest |');
+    L.push('|---|---|---|---|---|---|');
+    for (const r of ch.rows) {
+      L.push(
+        `| ${r.id} | ${r.text.replace(/\|/g, '\\|')} | ${r.prio} | ${r.status} | ${r.aufwand} | ${r.rest} |`,
+      );
+    }
+  });
+  L.push('');
+  return L.join('\n');
+}
+
+// ── DOCX renderer ─────────────────────────────────────────────────
+
+const STATUS_FILL: Record<string, string> = {
+  Umgesetzt: 'd1fae5',
+  Teilweise: 'fef3c7',
+  Offen: 'f1f5f9',
+};
+
+function cell(text: string, opts: { bold?: boolean; fill?: string; width?: number } = {}): TableCell {
+  return new TableCell({
+    shading: opts.fill ? { fill: opts.fill } : undefined,
+    width: opts.width ? { size: opts.width, type: WidthType.PERCENTAGE } : undefined,
+    margins: { top: 60, bottom: 60, left: 100, right: 100 },
+    children: [
+      new Paragraph({
+        children: [new TextRun({ text, bold: opts.bold ?? false, size: 18 })],
+      }),
+    ],
+  });
+}
+
+export async function renderDocx(data: RegisterData): Promise<Buffer> {
+  const children: Array<Paragraph | Table> = [];
+
+  children.push(
+    new Paragraph({ heading: HeadingLevel.TITLE, children: [new TextRun(data.title)] }),
+    new Paragraph({
+      children: [
+        new TextRun({
+          text: `Generiert aus MindBlown am ${data.generatedAt} — Status abgeleitet aus dem Projektstand (Rollup), nicht manuell gepflegt.`,
+          italics: true,
+          size: 18,
+        }),
+      ],
+    }),
+  );
+  for (const line of LEGEND) {
+    // Strip the markdown bold markers for the docx paragraphs.
+    children.push(
+      new Paragraph({
+        children: [new TextRun({ text: line.replace(/\*\*/g, ''), size: 18 })],
+        spacing: { before: 120 },
+      }),
+    );
+  }
+  children.push(
+    new Paragraph({
+      spacing: { before: 160, after: 240 },
+      children: [
+        new TextRun({
+          text: `Stand: ${data.total} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
+          bold: true,
+          size: 20,
+        }),
+      ],
+    }),
+  );
+
+  data.chapters.forEach((ch, i) => {
+    children.push(
+      new Paragraph({
+        heading: HeadingLevel.HEADING_1,
+        spacing: { before: 320, after: 120 },
+        children: [new TextRun(`${i + 1}. ${ch.name}`)],
+      }),
+    );
+    const header = new TableRow({
+      tableHeader: true,
+      children: [
+        cell('ID', { bold: true, fill: 'e2e8f0', width: 9 }),
+        cell('Anforderung', { bold: true, fill: 'e2e8f0', width: 55 }),
+        cell('Priorität', { bold: true, fill: 'e2e8f0', width: 9 }),
+        cell('Status', { bold: true, fill: 'e2e8f0', width: 11 }),
+        cell('Aufwand', { bold: true, fill: 'e2e8f0', width: 8 }),
+        cell('Rest', { bold: true, fill: 'e2e8f0', width: 8 }),
+      ],
+    });
+    const rows = ch.rows.map(
+      (r) =>
+        new TableRow({
+          children: [
+            cell(r.id, { bold: true }),
+            cell(r.text),
+            cell(r.prio),
+            cell(r.status, { fill: STATUS_FILL[r.status] }),
+            cell(r.aufwand),
+            cell(r.rest),
+          ],
+        }),
+    );
+    children.push(
+      new Table({
+        width: { size: 100, type: WidthType.PERCENTAGE },
+        borders: {
+          top: { style: BorderStyle.SINGLE, size: 2, color: 'cbd5e1' },
+          bottom: { style: BorderStyle.SINGLE, size: 2, color: 'cbd5e1' },
+          left: { style: BorderStyle.SINGLE, size: 2, color: 'cbd5e1' },
+          right: { style: BorderStyle.SINGLE, size: 2, color: 'cbd5e1' },
+          insideHorizontal: { style: BorderStyle.SINGLE, size: 2, color: 'e2e8f0' },
+          insideVertical: { style: BorderStyle.SINGLE, size: 2, color: 'e2e8f0' },
+        },
+        rows: [header, ...rows],
+      }),
+    );
+  });
+
+  const doc = new Document({ sections: [{ children }] });
+  return Packer.toBuffer(doc);
+}

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
 import { computeTree, schedule, criticalPath } from '@mindblown/core';
+import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
 import * as mapDb from '../db/maps.js';
 import * as permDb from '../db/permissions.js';
@@ -216,12 +217,14 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
 
   // ── GET /api/maps/:id/requirements-export — Anforderungsdokument ──
   //
-  // Renders the requirements register as a Markdown document mirroring
-  // the hand-maintained Anforderungsdokument format: chapters = the
+  // Renders the requirements register as a document mirroring the
+  // hand-maintained Anforderungsdokument format: chapters = the
   // requirement nodes' parents (Bereiche) in depth-first tree order,
-  // one table row per requirement with derived status. Effort sizes
-  // map to the doc's S/M/L/XL buckets. text/markdown response.
-  app.get<{ Params: { id: string } }>(
+  // one table row per requirement with derived status, S/M/L/XL effort
+  // buckets. ?format=md (default, text/markdown) or ?format=docx
+  // (Word download for business consumers). Rendering lives in
+  // ../export/requirementsDoc.ts.
+  app.get<{ Params: { id: string }; Querystring: { format?: string } }>(
     '/api/maps/:id/requirements-export',
     async (req, reply) => {
       const userId = req.userId;
@@ -242,86 +245,28 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const computed = computeTree(data.nodes, data.map.healthThreshold);
-      const byId = new Map(data.nodes.map((n) => [n.id, n]));
-      const requirements = data.nodes.filter((n) => n.requirementId != null);
+      const register = buildRegisterData(data.map, data.nodes, computed);
+      const format = (req.query as { format?: string }).format ?? 'md';
 
-      const progressOf = (n: CoreNode): number =>
-        n.childrenIds.length > 0
-          ? (computed.get(n.id)?.computedProgress ?? 0)
-          : (n.percentComplete ?? 0);
-      const statusOf = (p: number): string =>
-        p >= 99.5 ? 'Umgesetzt' : p > 0 ? 'Teilweise' : 'Offen';
-      // Doc buckets: S ≤ 2 Tage · M 3–5 · L 1–3 Wochen · XL > 3 Wochen
-      const sizeOf = (days: number): string =>
-        days <= 0 ? '—' : days <= 2 ? 'S' : days <= 5 ? 'M' : days <= 15 ? 'L' : 'XL';
-      const PRIO: Record<string, string> = { must: 'Muss', should: 'Soll', could: 'Kann' };
-
-      // Depth-first order for chapter (= parent) sorting.
-      const dfs = new Map<string, number>();
-      {
-        let i = 0;
-        const walk = (id: string) => {
-          dfs.set(id, i++);
-          for (const c of byId.get(id)?.childrenIds ?? []) if (byId.has(c)) walk(c);
-        };
-        walk(data.map.rootNodeId);
-      }
-
-      const chapters = new Map<string, CoreNode[]>();
-      for (const n of requirements) {
-        const key = n.parentId ?? data.map.rootNodeId;
-        (chapters.get(key) ?? chapters.set(key, []).get(key)!).push(n);
-      }
-      const orderedChapters = [...chapters.entries()].sort(
-        (a, b) => (dfs.get(a[0]) ?? Infinity) - (dfs.get(b[0]) ?? Infinity),
-      );
-
-      const today = new Date().toISOString().slice(0, 10);
-      const counts = { Umgesetzt: 0, Teilweise: 0, Offen: 0 };
-      for (const n of requirements) counts[statusOf(progressOf(n)) as keyof typeof counts]++;
-
-      const L: string[] = [];
-      L.push(`# ${data.map.name} — Anforderungsdokument`);
-      L.push('');
-      L.push(`*Generiert aus MindBlown am ${today} — Status abgeleitet aus dem Projektstand (Rollup), nicht manuell gepflegt.*`);
-      L.push('');
-      L.push('**Priorität:** Muss — Kernfunktion (MVP) · Soll — wichtig, nicht MVP-blockierend · Kann — wünschenswert');
-      L.push('');
-      L.push('**Status:** Umgesetzt · Teilweise · Offen (abgeleitet: 100 % / >0 % / 0 % Fortschritt)');
-      L.push('');
-      L.push('**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» bei Umgesetzt): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen');
-      L.push('');
-      L.push(`**Stand:** ${requirements.length} Anforderungen — ${counts.Umgesetzt} Umgesetzt · ${counts.Teilweise} Teilweise · ${counts.Offen} Offen`);
-      L.push('');
-      L.push('---');
-
-      let sec = 0;
-      for (const [chapterId, list] of orderedChapters) {
-        sec++;
-        const chapterName = byId.get(chapterId)?.text ?? '(Root)';
-        L.push('');
-        L.push(`## ${sec}. ${chapterName}`);
-        L.push('');
-        L.push('| ID | Anforderung | Priorität | Status | Aufwand | Rest |');
-        L.push('|---|---|---|---|---|---|');
-        list.sort((a, b) =>
-          (a.requirementId ?? '').localeCompare(b.requirementId ?? '', undefined, { numeric: true }),
+      if (format === 'docx') {
+        const buf = await renderDocx(register);
+        reply.header(
+          'content-type',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         );
-        for (const n of list) {
-          const p = progressOf(n);
-          const status = statusOf(p);
-          const effort = computed.get(n.id)?.computedEffort ?? n.effortEstimate ?? 0;
-          const remaining = effort * (1 - p / 100);
-          const text = (n.requirementText ?? n.text).replace(/\|/g, '\\|').replace(/\n/g, ' ');
-          L.push(
-            `| ${n.requirementId} | ${text} | ${PRIO[n.requirementPriority ?? ''] ?? '—'} | ${status} | ${sizeOf(effort)} | ${status === 'Umgesetzt' ? '—' : sizeOf(remaining)} |`,
-          );
-        }
+        reply.header(
+          'content-disposition',
+          `attachment; filename="anforderungsdokument-${register.generatedAt}.docx"`,
+        );
+        return reply.send(buf);
       }
-      L.push('');
-
+      if (format !== 'md') {
+        return reply.status(400).send({
+          error: { code: 'VALIDATION_ERROR', message: `Unknown format "${format}" — use md or docx` },
+        });
+      }
       reply.header('content-type', 'text/markdown; charset=utf-8');
-      return reply.send(L.join('\n'));
+      return reply.send(renderMarkdown(register));
     },
   );
 


### PR DESCRIPTION
Rendering extracted to packages/server/src/export/requirementsDoc.ts:
buildRegisterData (shared) + renderMarkdown + renderDocx (docx npm
package — real Word tables, status-colored cells, legend header).
Route gains ?format=md|docx (default md, unknown → 400); docx responds
with proper content-type + content-disposition. The Requirements-view
Export button now downloads .docx; Markdown stays for the MCP tool and
?format=md. Also adds requirementText to the new scope.test.ts stub.

Verified on a scratch DB: valid OOXML (pandoc round-trip, umlauts),
md default byte-identical shape, 400 on unknown format.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn
