### PR TITLE
feat(mobile): editing, quick capture, Requirements view, kanban/mindmap polish

### DIFF
--- a/packages/mindmap/src/mobile/MobileAddNodeSheet.tsx
+++ b/packages/mindmap/src/mobile/MobileAddNodeSheet.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { MindMap } from '@mindblown/core';
+import * as api from '../api.js';
+import type { NodeWithComputed } from '../api.js';
+
+interface Props {
+  nodes: NodeWithComputed[];
+  map: MindMap;
+  onClose: () => void;
+  /** Called after each successful create so the owner can re-fetch. */
+  onCreated: () => void;
+}
+
+interface ParentOption {
+  id: string;
+  label: string;
+}
+
+/** Depth-first walk producing an indented picker list of all nodes. */
+function parentOptions(nodes: NodeWithComputed[], rootId: string, rootText: string): ParentOption[] {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const out: ParentOption[] = [{ id: rootId, label: rootText }];
+  const walk = (id: string, depth: number) => {
+    const n = byId.get(id);
+    if (!n) return;
+    if (id !== rootId) {
+      out.push({ id, label: `${'  '.repeat(depth)}${n.text}` });
+    }
+    for (const cid of n.childrenIds) walk(cid, depth + 1);
+  };
+  const root = byId.get(rootId);
+  for (const cid of root?.childrenIds ?? []) walk(cid, 1);
+  return out;
+}
+
+export function MobileAddNodeSheet({ nodes, map, onClose, onCreated }: Props) {
+  const root = nodes.find((n) => n.id === map.rootNodeId);
+  const options = useMemo(
+    () => parentOptions(nodes, map.rootNodeId, root?.text ?? map.name),
+    [nodes, map.rootNodeId, root?.text, map.name],
+  );
+
+  const [parentId, setParentId] = useState(map.rootNodeId);
+  const [text, setText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [addedCount, setAddedCount] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const add = async () => {
+    const t = text.trim();
+    if (!t || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.createNode(map.id, parentId, t);
+      onCreated();
+      setText('');
+      setAddedCount((c) => c + 1);
+      inputRef.current?.focus();
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to add node');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="mb-sheet-backdrop" onClick={onClose} />
+      <div className="mb-sheet" role="dialog" aria-modal="true">
+        <div className="mb-sheet-header">
+          <span style={{ flex: 1 }}>Add node</span>
+          <button className="mb-link" onClick={onClose}>
+            Done
+          </button>
+        </div>
+        <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {error && <div className="mb-error">{error}</div>}
+
+          <div>
+            <div className="mb-detail-label">Under</div>
+            <select
+              className="mb-select"
+              value={parentId}
+              onChange={(e) => setParentId(e.target.value)}
+            >
+              {options.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <input
+            ref={inputRef}
+            type="text"
+            className="mb-input"
+            placeholder="What needs doing?"
+            value={text}
+            enterKeyHint="done"
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void add();
+            }}
+          />
+
+          <button
+            className="mb-btn-primary"
+            disabled={saving || !text.trim()}
+            onClick={() => void add()}
+          >
+            {saving ? 'Adding…' : 'Add'}
+          </button>
+
+          {addedCount > 0 && (
+            <div style={{ color: '#059669', fontSize: 13, textAlign: 'center' }}>
+              {addedCount} node{addedCount === 1 ? '' : 's'} added
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/mindmap/src/mobile/MobileKanbanView.tsx
+++ b/packages/mindmap/src/mobile/MobileKanbanView.tsx
@@ -32,6 +32,16 @@ interface Column {
 }
 
 export function MobileKanbanView({ nodes, map, onSelect }: Props) {
+  const breadcrumbs = useMemo(() => {
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    const out = new Map<string, string>();
+    for (const n of nodes) {
+      const parent = n.parentId ? byId.get(n.parentId) : undefined;
+      if (parent && parent.id !== map.rootNodeId) out.set(n.id, parent.text);
+    }
+    return out;
+  }, [nodes, map.rootNodeId]);
+
   const columns: Column[] = useMemo(() => {
     const workflow = [...map.statusWorkflow].sort((a, b) => a.position - b.position);
     const byStatus = new Map<string, NodeWithComputed[]>();
@@ -39,6 +49,9 @@ export function MobileKanbanView({ nodes, map, onSelect }: Props) {
 
     for (const n of nodes) {
       if (n.id === map.rootNodeId) continue;
+      // Parents are containers, not work items — a card for "Backend"
+      // next to its own children only adds noise on a phone screen.
+      if (n.childrenIds.length > 0) continue;
       if (n.status === null) {
         unstatused.push(n);
       } else {
@@ -101,7 +114,14 @@ export function MobileKanbanView({ nodes, map, onSelect }: Props) {
                         flexShrink: 0,
                       }}
                     />
-                    <div style={{ fontSize: 13, color: '#0f172a', flex: 1 }}>{n.text}</div>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ fontSize: 13, color: '#0f172a' }}>{n.text}</div>
+                      {breadcrumbs.has(n.id) && (
+                        <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 2 }}>
+                          {breadcrumbs.get(n.id)}
+                        </div>
+                      )}
+                    </div>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11, color: '#64748b' }}>
                     <span>{pct}%</span>

--- a/packages/mindmap/src/mobile/MobileListView.tsx
+++ b/packages/mindmap/src/mobile/MobileListView.tsx
@@ -64,7 +64,7 @@ export function MobileListView({ nodes, map, onSelect }: Props) {
         const s = statusOf(node, map.statusWorkflow);
         if (s?.category === 'in_progress') return true;
         const pct = node.computedProgress ?? 0;
-        return pct > 0 && pct < 1;
+        return pct > 0 && pct < 100;
       }
       return true;
     });
@@ -77,7 +77,7 @@ export function MobileListView({ nodes, map, onSelect }: Props) {
         const s = statusOf(node, map.statusWorkflow);
         if (s?.category === 'in_progress') return true;
         const pct = node.computedProgress ?? 0;
-        return pct > 0 && pct < 1;
+        return pct > 0 && pct < 100;
       }).length,
       behind: rows.filter(({ node }) => node.healthSignal === 'behind').length,
       mine: userId === null ? 0 : rows.filter(({ node }) => node.assigneeIds.includes(userId)).length,

--- a/packages/mindmap/src/mobile/MobileMindmapView.tsx
+++ b/packages/mindmap/src/mobile/MobileMindmapView.tsx
@@ -230,6 +230,13 @@ export function MobileMindmapView({ nodes, map, onSelect }: Props) {
           {layoutNodes.map((ln) => {
             const n = lookup.get(ln.id);
             const h = n?.healthSignal;
+            // Truncate to what actually fits this node's width (layout.ts
+            // measures ~7.5px per char + 16px padding each side) instead of
+            // a fixed character count.
+            const maxChars = Math.max(4, Math.floor((ln.width - 24) / 7.5));
+            const text = n?.text ?? '';
+            const label = text.length > maxChars ? `${text.slice(0, maxChars - 1)}…` : text;
+            const pct = Math.round(n?.computedProgress ?? 0);
             return (
               <g key={ln.id}>
                 <rect
@@ -243,6 +250,18 @@ export function MobileMindmapView({ nodes, map, onSelect }: Props) {
                   stroke={healthStroke(h)}
                   strokeWidth={ln.id === map.rootNodeId ? 2 : 1}
                 />
+                {pct > 0 && (
+                  <rect
+                    x={ln.x + 1}
+                    y={ln.y + ln.height - 4}
+                    width={(ln.width - 2) * (pct / 100)}
+                    height={3}
+                    rx={1.5}
+                    fill={pct >= 100 ? '#16a34a' : '#4f46e5'}
+                    opacity={0.75}
+                    style={{ pointerEvents: 'none' }}
+                  />
+                )}
                 <text
                   x={ln.x + ln.width / 2}
                   y={ln.y + ln.height / 2 + 4}
@@ -252,7 +271,7 @@ export function MobileMindmapView({ nodes, map, onSelect }: Props) {
                   fill="#0f172a"
                   style={{ pointerEvents: 'none' }}
                 >
-                  {n?.text.slice(0, 28) ?? ''}
+                  {label}
                 </text>
               </g>
             );

--- a/packages/mindmap/src/mobile/MobileNodeDetailSheet.tsx
+++ b/packages/mindmap/src/mobile/MobileNodeDetailSheet.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from 'react';
 import type { MindMap, StatusDef } from '@mindblown/core';
+import * as api from '../api.js';
 import type { NodeWithComputed } from '../api.js';
 
 interface Props {
@@ -6,15 +8,15 @@ interface Props {
   map: MindMap;
   byId: Map<string, NodeWithComputed>;
   onClose: () => void;
+  /** Called after any successful edit so the owner can re-fetch rollups. */
+  onChanged: () => void;
 }
+
+const PRIORITIES = ['P0', 'P1', 'P2', 'P3'] as const;
 
 function statusOf(node: NodeWithComputed, workflow: StatusDef[]): StatusDef | null {
   if (!node.status) return null;
   return workflow.find((s) => s.id === node.status) ?? null;
-}
-
-function priorityLabel(p: string | null): string {
-  return p ?? '—';
 }
 
 function formatDate(iso: string | null): string {
@@ -42,13 +44,41 @@ function pathTo(node: NodeWithComputed, byId: Map<string, NodeWithComputed>): No
   return out;
 }
 
-export function MobileNodeDetailSheet({ node, map, byId, onClose }: Props) {
+export function MobileNodeDetailSheet({ node, map, byId, onClose, onChanged }: Props) {
   const s = statusOf(node, map.statusWorkflow);
-  const pct = Math.round(node.computedProgress ?? 0);
+  const isLeaf = node.childrenIds.length === 0;
   const ancestors = pathTo(node, byId).slice(1); // skip the root node
 
   const deps = node.dependencies ?? [];
   const blockedBy = deps.filter((d) => d.type === 'FS' || d.type === 'SS');
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Slider state is local while dragging; committed on release.
+  const [draftPct, setDraftPct] = useState<number | null>(null);
+  const pct = draftPct ?? Math.round(isLeaf ? node.percentComplete ?? 0 : node.computedProgress ?? 0);
+
+  const [blockerDraft, setBlockerDraft] = useState<string | null>(null);
+  const blockerInputRef = useRef<HTMLTextAreaElement | null>(null);
+  useEffect(() => {
+    if (blockerDraft !== null) blockerInputRef.current?.focus();
+  }, [blockerDraft !== null]);
+
+  const save = async (fields: Record<string, unknown>) => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await api.updateNode(map.id, node.id, fields);
+      onChanged();
+    } catch (e) {
+      setSaveError((e as Error).message ?? 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const workflow = [...map.statusWorkflow].sort((a, b) => a.position - b.position);
 
   return (
     <>
@@ -74,33 +104,131 @@ export function MobileNodeDetailSheet({ node, map, byId, onClose }: Props) {
             </div>
           )}
 
-          <div className="mb-detail-grid">
-            <div className="mb-detail-cell">
-              <div className="mb-detail-label">Status</div>
-              <div>
-                {s ? (
-                  <span
-                    className="mb-status-pill"
-                    style={{ background: `${s.color}22`, color: s.color, borderColor: `${s.color}66` }}
+          {saveError && <div className="mb-error">{saveError}</div>}
+
+          <div className="mb-detail-section">
+            <div className="mb-detail-label">Status</div>
+            <div className="mb-edit-pill-row">
+              {workflow.map((w) => {
+                const active = node.status === w.id;
+                return (
+                  <button
+                    key={w.id}
+                    className="mb-status-pill mb-status-pill-tappable"
+                    aria-pressed={active}
+                    disabled={saving}
+                    style={
+                      active
+                        ? { background: w.color, color: '#fff', borderColor: w.color }
+                        : { background: `${w.color}18`, color: w.color, borderColor: `${w.color}55` }
+                    }
+                    onClick={() => void save({ status: active ? null : w.id })}
                   >
-                    {s.name}
-                  </span>
-                ) : (
-                  <span className="mb-status-pill mb-status-pill-empty">No status</span>
-                )}
+                    {w.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mb-detail-section">
+            <div className="mb-detail-label">
+              Progress · {pct}%{!isLeaf && ' (auto from children)'}
+            </div>
+            {isLeaf ? (
+              <input
+                type="range"
+                className="mb-progress-slider"
+                min={0}
+                max={100}
+                step={5}
+                value={pct}
+                disabled={saving}
+                onChange={(e) => setDraftPct(Number(e.target.value))}
+                onPointerUp={() => {
+                  if (draftPct !== null && draftPct !== (node.percentComplete ?? 0)) {
+                    void save({ percentComplete: draftPct }).then(() => setDraftPct(null));
+                  } else {
+                    setDraftPct(null);
+                  }
+                }}
+              />
+            ) : (
+              <div className="mb-progress-track">
+                <div className="mb-progress-fill" style={{ width: `${pct}%` }} />
               </div>
+            )}
+          </div>
+
+          <div className="mb-detail-section">
+            <div className="mb-detail-label">Priority</div>
+            <div className="mb-edit-pill-row">
+              {PRIORITIES.map((p) => {
+                const active = node.priority === p;
+                return (
+                  <button
+                    key={p}
+                    className="mb-status-pill mb-status-pill-tappable"
+                    aria-pressed={active}
+                    disabled={saving}
+                    onClick={() => void save({ priority: active ? null : p })}
+                  >
+                    {p}
+                  </button>
+                );
+              })}
             </div>
-            <div className="mb-detail-cell">
-              <div className="mb-detail-label">Progress</div>
-              <div>{pct}%</div>
-            </div>
+          </div>
+
+          <div className="mb-detail-section">
+            <div className="mb-detail-label">Blocked</div>
+            {node.blockedReason ? (
+              <div className="mb-blocker-box">
+                <div style={{ color: '#b91c1c', flex: 1 }}>{node.blockedReason}</div>
+                <button
+                  className="mb-link"
+                  disabled={saving}
+                  onClick={() => void save({ blockedReason: null })}
+                >
+                  Clear
+                </button>
+              </div>
+            ) : blockerDraft !== null ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <textarea
+                  ref={blockerInputRef}
+                  className="mb-textarea"
+                  rows={2}
+                  placeholder="What is blocking this?"
+                  value={blockerDraft}
+                  onChange={(e) => setBlockerDraft(e.target.value)}
+                />
+                <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                  <button className="mb-link" onClick={() => setBlockerDraft(null)}>
+                    Cancel
+                  </button>
+                  <button
+                    className="mb-btn-primary"
+                    disabled={saving || !blockerDraft.trim()}
+                    onClick={() =>
+                      void save({ blockedReason: blockerDraft.trim() }).then(() => setBlockerDraft(null))
+                    }
+                  >
+                    Flag blocker
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button className="mb-btn-soft" onClick={() => setBlockerDraft('')}>
+                Flag a blocker
+              </button>
+            )}
+          </div>
+
+          <div className="mb-detail-grid">
             <div className="mb-detail-cell">
               <div className="mb-detail-label">Health</div>
               <div>{(node.healthSignal ?? 'unknown').replace('_', ' ')}</div>
-            </div>
-            <div className="mb-detail-cell">
-              <div className="mb-detail-label">Priority</div>
-              <div>{priorityLabel(node.priority)}</div>
             </div>
             <div className="mb-detail-cell">
               <div className="mb-detail-label">Estimate</div>
@@ -119,6 +247,14 @@ export function MobileNodeDetailSheet({ node, map, byId, onClose }: Props) {
               </div>
             </div>
             <div className="mb-detail-cell">
+              <div className="mb-detail-label">Children</div>
+              <div>
+                {isLeaf
+                  ? 'Leaf node'
+                  : `${node.childrenIds.length} child${node.childrenIds.length === 1 ? '' : 'ren'}`}
+              </div>
+            </div>
+            <div className="mb-detail-cell">
               <div className="mb-detail-label">Start</div>
               <div>{formatDate(node.startDate)}</div>
             </div>
@@ -127,13 +263,6 @@ export function MobileNodeDetailSheet({ node, map, byId, onClose }: Props) {
               <div>{formatDate(node.dueDate)}</div>
             </div>
           </div>
-
-          {node.blockedReason && (
-            <div className="mb-detail-section">
-              <div className="mb-detail-label">Blocked</div>
-              <div style={{ color: '#b91c1c' }}>{node.blockedReason}</div>
-            </div>
-          )}
 
           {blockedBy.length > 0 && (
             <div className="mb-detail-section">
@@ -196,15 +325,6 @@ export function MobileNodeDetailSheet({ node, map, byId, onClose }: Props) {
               </div>
             </div>
           )}
-
-          <div className="mb-detail-section">
-            <div className="mb-detail-label">Children</div>
-            <div style={{ color: '#475569', fontSize: 13 }}>
-              {node.childrenIds.length === 0
-                ? 'Leaf node'
-                : `${node.childrenIds.length} child${node.childrenIds.length === 1 ? '' : 'ren'}`}
-            </div>
-          </div>
         </div>
       </div>
     </>

--- a/packages/mindmap/src/mobile/MobileRequirementsView.tsx
+++ b/packages/mindmap/src/mobile/MobileRequirementsView.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from 'react';
+import type { MindMap } from '@mindblown/core';
+import type { NodeWithComputed } from '../api.js';
+
+// Requirement status is never stored — always derived from the progress
+// rollup, mirroring the desktop RequirementsView.
+
+type ReqStatus = 'open' | 'partial' | 'done';
+type Filter = 'all' | ReqStatus;
+
+const STATUS_LABEL: Record<ReqStatus, string> = {
+  done: 'Done',
+  partial: 'Partial',
+  open: 'Open',
+};
+
+const STATUS_COLOR: Record<ReqStatus, { bg: string; fg: string }> = {
+  done: { bg: '#d1fae5', fg: '#065f46' },
+  partial: { bg: '#fef3c7', fg: '#92400e' },
+  open: { bg: '#f1f5f9', fg: '#475569' },
+};
+
+const PRIORITY_LABEL: Record<string, string> = {
+  must: 'Must',
+  should: 'Should',
+  could: 'Could',
+};
+
+interface Props {
+  nodes: NodeWithComputed[];
+  map: MindMap;
+  onSelect: (nodeId: string) => void;
+}
+
+interface ReqRow {
+  node: NodeWithComputed;
+  status: ReqStatus;
+  chapterText: string;
+}
+
+function statusOf(progress: number): ReqStatus {
+  return progress >= 100 ? 'done' : progress > 0 ? 'partial' : 'open';
+}
+
+export function MobileRequirementsView({ nodes, map, onSelect }: Props) {
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const rows = useMemo<ReqRow[]>(() => {
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    return nodes
+      .filter((n) => n.requirementId != null)
+      .map((n) => {
+        const parent = n.parentId ? byId.get(n.parentId) : undefined;
+        return {
+          node: n,
+          status: statusOf(n.computedProgress ?? 0),
+          chapterText: parent && parent.id !== map.rootNodeId ? parent.text : '',
+        };
+      })
+      .sort((a, b) =>
+        (a.node.requirementId ?? '').localeCompare(b.node.requirementId ?? '', undefined, {
+          numeric: true,
+        }),
+      );
+  }, [nodes, map.rootNodeId]);
+
+  const counts = useMemo(() => {
+    const c = { all: rows.length, open: 0, partial: 0, done: 0 };
+    for (const r of rows) c[r.status] += 1;
+    return c;
+  }, [rows]);
+
+  const filtered = filter === 'all' ? rows : rows.filter((r) => r.status === filter);
+
+  if (rows.length === 0) {
+    return (
+      <div className="mb-body">
+        <div style={{ color: '#64748b', textAlign: 'center', padding: 24 }}>
+          No requirements in this map yet. Tag nodes with a requirement ID from the
+          desktop Requirements view.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-body" style={{ paddingTop: 8 }}>
+      <div className="mb-filter-row">
+        {(['all', 'open', 'partial', 'done'] as const).map((f) => (
+          <button
+            key={f}
+            className="mb-filter-chip"
+            aria-pressed={filter === f}
+            onClick={() => setFilter(f)}
+          >
+            {f === 'all' ? 'All' : STATUS_LABEL[f]}
+            <span className="mb-filter-count">{counts[f]}</span>
+          </button>
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <div style={{ color: '#64748b', textAlign: 'center', padding: 24 }}>
+          Nothing matches this filter.
+        </div>
+      )}
+
+      {filtered.map(({ node, status, chapterText }) => {
+        const sc = STATUS_COLOR[status];
+        const pct = Math.round(node.computedProgress ?? 0);
+        return (
+          <button key={node.id} className="mb-req-card" onClick={() => onSelect(node.id)}>
+            <div className="mb-req-card-top">
+              <span className="mb-req-id">{node.requirementId}</span>
+              <span
+                className="mb-status-pill"
+                style={{ background: sc.bg, color: sc.fg, borderColor: sc.bg }}
+              >
+                {STATUS_LABEL[status]}
+                {status === 'partial' ? ` · ${pct}%` : ''}
+              </span>
+              {node.requirementPriority && (
+                <span className="mb-req-priority">
+                  {PRIORITY_LABEL[node.requirementPriority] ?? node.requirementPriority}
+                </span>
+              )}
+            </div>
+            <div className="mb-req-text">{node.requirementText ?? node.text}</div>
+            {chapterText && <div className="mb-req-chapter">{chapterText}</div>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/mindmap/src/mobile/MobileViewer.tsx
+++ b/packages/mindmap/src/mobile/MobileViewer.tsx
@@ -1,20 +1,30 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import * as api from '../api.js';
 import type { MapDetail, MapSummary, NodeWithComputed } from '../api.js';
 import { MobileListView } from './MobileListView.js';
 import { MobileKanbanView } from './MobileKanbanView.js';
 import { MobileGanttView } from './MobileGanttView.js';
 import { MobileMindmapView } from './MobileMindmapView.js';
+import { MobileRequirementsView } from './MobileRequirementsView.js';
 import { MobileNodeDetailSheet } from './MobileNodeDetailSheet.js';
+import { MobileAddNodeSheet } from './MobileAddNodeSheet.js';
 
-type ViewKey = 'list' | 'kanban' | 'gantt' | 'mindmap';
+type ViewKey = 'list' | 'kanban' | 'gantt' | 'mindmap' | 'requirements';
 
 const VIEW_KEY = 'mb_mobile_view';
+
+const VIEW_LABELS: Record<ViewKey, string> = {
+  list: 'List',
+  kanban: 'Kanban',
+  gantt: 'Gantt',
+  mindmap: 'Mindmap',
+  requirements: 'Reqs',
+};
 
 function readDefaultView(): ViewKey {
   try {
     const v = localStorage.getItem(VIEW_KEY);
-    if (v === 'list' || v === 'kanban' || v === 'gantt' || v === 'mindmap') return v;
+    if (v && v in VIEW_LABELS) return v as ViewKey;
   } catch {}
   return 'list';
 }
@@ -28,7 +38,7 @@ export function MobileViewer({ map }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<ViewKey>(readDefaultView);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [reloadTick, setReloadTick] = useState(0);
+  const [adding, setAdding] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -45,7 +55,18 @@ export function MobileViewer({ map }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [map.id, reloadTick]);
+  }, [map.id]);
+
+  // Re-fetch without dropping the current detail, so edits made from the
+  // node sheet update rollups in place instead of flashing "Loading map…".
+  const silentReload = useCallback(() => {
+    api
+      .fetchMap(map.id)
+      .then(setDetail)
+      .catch(() => {
+        // Keep showing the stale tree; the next manual refresh surfaces errors.
+      });
+  }, [map.id]);
 
   const setViewPersist = (v: ViewKey) => {
     setView(v);
@@ -61,7 +82,7 @@ export function MobileViewer({ map }: Props) {
   return (
     <>
       <div className="mb-view-tabs" role="tablist">
-        {(['list', 'kanban', 'gantt', 'mindmap'] as const).map((k) => (
+        {(Object.keys(VIEW_LABELS) as ViewKey[]).map((k) => (
           <button
             key={k}
             role="tab"
@@ -69,18 +90,12 @@ export function MobileViewer({ map }: Props) {
             onClick={() => setViewPersist(k)}
             className="mb-view-tab"
           >
-            {k === 'list'
-              ? 'List'
-              : k === 'kanban'
-                ? 'Kanban'
-                : k === 'gantt'
-                  ? 'Gantt'
-                  : 'Mindmap'}
+            {VIEW_LABELS[k]}
           </button>
         ))}
         <button
           className="mb-view-refresh"
-          onClick={() => setReloadTick((t) => t + 1)}
+          onClick={silentReload}
           aria-label="Refresh"
           title="Refresh"
         >
@@ -130,15 +145,40 @@ export function MobileViewer({ map }: Props) {
               onSelect={setSelectedId}
             />
           )}
+          {view === 'requirements' && (
+            <MobileRequirementsView
+              nodes={nodes}
+              map={detail.map}
+              onSelect={setSelectedId}
+            />
+          )}
+
+          <button
+            className="mb-fab"
+            aria-label="Add node"
+            onClick={() => setAdding(true)}
+          >
+            +
+          </button>
         </>
       )}
 
-      {selectedNode && (
+      {selectedNode && detail && (
         <MobileNodeDetailSheet
           node={selectedNode}
-          map={detail!.map}
+          map={detail.map}
           byId={byId}
           onClose={() => setSelectedId(null)}
+          onChanged={silentReload}
+        />
+      )}
+
+      {adding && detail && (
+        <MobileAddNodeSheet
+          nodes={nodes}
+          map={detail.map}
+          onClose={() => setAdding(false)}
+          onCreated={silentReload}
         />
       )}
     </>

--- a/packages/mindmap/src/mobile/mobile.css
+++ b/packages/mindmap/src/mobile/mobile.css
@@ -301,7 +301,9 @@ body.mobile {
 }
 
 .mb-view-tab {
-  flex: 1;
+  /* Grow to fill, but never shrink below the label — with five tabs the
+     row overflow-scrolls instead of squeezing labels illegible. */
+  flex: 1 0 auto;
   background: none;
   border: none;
   padding: 12px 8px;
@@ -758,4 +760,160 @@ body.mobile {
     order: 3;
     width: 80px;
   }
+}
+
+/* ── Editing (detail sheet) ────────────────────────────────── */
+
+.mb-edit-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mb-status-pill-tappable {
+  min-height: 36px;
+  min-width: 52px;
+  padding: 6px 14px;
+  font-size: 13px;
+  background: #f1f5f9;
+  color: #475569;
+  border: 1px solid #e2e8f0;
+}
+
+.mb-status-pill-tappable[aria-pressed='true'] {
+  background: #4f46e5;
+  color: #fff;
+  border-color: #4f46e5;
+  font-weight: 600;
+}
+
+.mb-progress-slider {
+  width: 100%;
+  min-height: 44px;
+  accent-color: #4f46e5;
+  touch-action: pan-y; /* keep vertical page scroll, own the horizontal drag */
+}
+
+.mb-progress-track {
+  height: 8px;
+  border-radius: 4px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.mb-progress-fill {
+  height: 100%;
+  background: #4f46e5;
+  border-radius: 4px;
+}
+
+.mb-blocker-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.mb-btn-primary {
+  background: #4f46e5;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 18px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.mb-btn-primary:disabled {
+  opacity: 0.5;
+}
+
+.mb-btn-soft {
+  background: #f1f5f9;
+  color: #475569;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  align-self: flex-start;
+}
+
+/* ── Quick capture ─────────────────────────────────────────── */
+
+.mb-fab {
+  position: fixed;
+  right: 20px;
+  bottom: calc(20px + env(safe-area-inset-bottom));
+  width: 56px;
+  height: 56px;
+  border-radius: 28px;
+  background: #4f46e5;
+  color: #fff;
+  border: none;
+  font-size: 28px;
+  line-height: 1;
+  box-shadow: 0 4px 12px rgba(79, 70, 229, 0.4);
+  z-index: 50;
+}
+
+.mb-input,
+.mb-select {
+  width: 100%;
+  padding: 12px;
+  font-size: 16px; /* prevents iOS zoom-on-focus */
+  font-family: inherit;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  color: #0f172a;
+}
+
+/* ── Requirements ──────────────────────────────────────────── */
+
+.mb-req-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+}
+
+.mb-req-card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.mb-req-id {
+  font-size: 12px;
+  font-weight: 700;
+  color: #4f46e5;
+  font-variant-numeric: tabular-nums;
+}
+
+.mb-req-priority {
+  font-size: 11px;
+  color: #64748b;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.mb-req-text {
+  font-size: 14px;
+  color: #0f172a;
+  line-height: 1.4;
+}
+
+.mb-req-chapter {
+  font-size: 11px;
+  color: #94a3b8;
 }


### PR DESCRIPTION
The mobile app was a pure read-only viewer — the planning loop was impossible from a phone. Scope selected by Dan from the mobile audit shortlist (all four items).

## What changed

- **Editable node detail sheet** — status pills, progress slider on leaves (parents stay auto-computed), P0–P3 priority, flag/clear blocker. Edits silently re-fetch the map so rollups update in place.
- **Quick capture** — floating "+" opens an add-node sheet with parent picker; stays open for rapid multi-add.
- **Requirements tab ("Reqs")** — register cards with derived open/partial/done status, MoSCoW priority, chapter, and filter chips. The desktop register (#204ff) was invisible on mobile.
- **Kanban polish** — parent nodes no longer appear as cards; cards show a parent breadcrumb.
- **Mindmap polish** — width-aware label truncation with ellipsis (was a hard 28-char cut); thin progress bar per node.
- **Bugfix** — list "In progress" filter compared computedProgress (0–100) against 1; partially-done unstatused nodes never matched.
- **Tab row** — tabs no longer shrink below their label; with five tabs the row overflow-scrolls (checked down to 320px).

## Verification

Playwright, iPhone 13 emulation against a local server: status/priority/progress/blocker edits round-trip and show up in the list; quick-add lands in list + kanban with breadcrumb; Reqs tab renders REQ-001…004 with correct derived statuses; all five tabs tappable at 390px and 320px.

`pnpm turbo typecheck` clean. `pnpm turbo test`: all green except 2 **pre-existing** failures in `triage-routes.test.ts` (stale 20-cap expectation vs #151's 500-cap split + a flaky parallelism assertion) — reproduced on pristine origin/master, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dzh24DD86VdvrAKnb4ojv