### PR TITLE
perf(mobile): slim map payload + optimistic edits with debounced rollup refetch

### DIFF
--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -510,8 +510,24 @@ export function fetchMaps(): Promise<MapSummary[]> {
   return request<MapSummary[]>('/api/maps');
 }
 
-export function fetchMap(id: string): Promise<MapDetail> {
-  return request<MapDetail>(`/api/maps/${id}`);
+export function fetchMap(
+  id: string,
+  opts?: {
+    /**
+     * Heavy display-only fields to strip from every node in the payload
+     * (server allowlist: 'description', 'externalLinks'). Used by the
+     * mobile app; omitted fields are absent from the JSON, so consumers
+     * must fetch the full node (fetchNode) before rendering them.
+     */
+    omit?: Array<'description' | 'externalLinks'>;
+  },
+): Promise<MapDetail> {
+  const q = opts?.omit?.length ? `?omit=${opts.omit.join(',')}` : '';
+  return request<MapDetail>(`/api/maps/${id}${q}`);
+}
+
+export function fetchNode(mapId: string, nodeId: string): Promise<Node> {
+  return request<Node>(`/api/maps/${mapId}/nodes/${nodeId}`);
 }
 
 export function createMap(name: string): Promise<MindMap> {

--- a/packages/mindmap/src/mobile/MobileAddNodeSheet.tsx
+++ b/packages/mindmap/src/mobile/MobileAddNodeSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { MindMap } from '@mindblown/core';
+import type { MindMap, Node } from '@mindblown/core';
 import * as api from '../api.js';
 import type { NodeWithComputed } from '../api.js';
 
@@ -7,8 +7,8 @@ interface Props {
   nodes: NodeWithComputed[];
   map: MindMap;
   onClose: () => void;
-  /** Called after each successful create so the owner can re-fetch. */
-  onCreated: () => void;
+  /** Called with the created node so the owner can patch it in locally. */
+  onCreated: (created: Node) => void;
 }
 
 interface ParentOption {
@@ -57,8 +57,8 @@ export function MobileAddNodeSheet({ nodes, map, onClose, onCreated }: Props) {
     setSaving(true);
     setError(null);
     try {
-      await api.createNode(map.id, parentId, t);
-      onCreated();
+      const created = await api.createNode(map.id, parentId, t);
+      onCreated(created);
       setText('');
       setAddedCount((c) => c + 1);
       inputRef.current?.focus();

--- a/packages/mindmap/src/mobile/MobileNodeDetailSheet.tsx
+++ b/packages/mindmap/src/mobile/MobileNodeDetailSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import type { MindMap, StatusDef } from '@mindblown/core';
+import type { MindMap, Node, StatusDef } from '@mindblown/core';
 import * as api from '../api.js';
 import type { NodeWithComputed } from '../api.js';
 
@@ -8,8 +8,8 @@ interface Props {
   map: MindMap;
   byId: Map<string, NodeWithComputed>;
   onClose: () => void;
-  /** Called after any successful edit so the owner can re-fetch rollups. */
-  onChanged: () => void;
+  /** Called with the server's updated node after any successful edit. */
+  onChanged: (updated: Node) => void;
 }
 
 const PRIORITIES = ['P0', 'P1', 'P2', 'P3'] as const;
@@ -65,12 +65,39 @@ export function MobileNodeDetailSheet({ node, map, byId, onClose, onChanged }: P
     if (blockerDraft !== null) blockerInputRef.current?.focus();
   }, [blockerDraft !== null]);
 
+  // The map payload arrives without description/externalLinks (see
+  // OMIT_FIELDS in MobileViewer) — fetch the full node once on open.
+  const [full, setFull] = useState<Node | null>(null);
+  // Widened view: the slim map payload physically lacks these keys even
+  // though the Node type declares them.
+  const slim = node as Partial<Node>;
+  const needsFull = slim.description === undefined || slim.externalLinks === undefined;
+  useEffect(() => {
+    let cancelled = false;
+    setFull(null);
+    if (needsFull) {
+      api
+        .fetchNode(map.id, node.id)
+        .then((n) => {
+          if (!cancelled) setFull(n);
+        })
+        .catch(() => {
+          // Sheet still works without the tail fields.
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [map.id, node.id]);
+  const description = node.description ?? full?.description ?? null;
+  const externalLinks = node.externalLinks ?? full?.externalLinks ?? [];
+
   const save = async (fields: Record<string, unknown>) => {
     setSaving(true);
     setSaveError(null);
     try {
-      await api.updateNode(map.id, node.id, fields);
-      onChanged();
+      const updated = await api.updateNode(map.id, node.id, fields);
+      onChanged(updated);
     } catch (e) {
       setSaveError((e as Error).message ?? 'Save failed');
     } finally {
@@ -304,10 +331,10 @@ export function MobileNodeDetailSheet({ node, map, byId, onClose, onChanged }: P
             </div>
           )}
 
-          {node.externalLinks.length > 0 && (
+          {externalLinks.length > 0 && (
             <div className="mb-detail-section">
               <div className="mb-detail-label">Links</div>
-              {node.externalLinks.map((l, i) => (
+              {externalLinks.map((l, i) => (
                 <div key={i} className="mb-detail-row-soft">
                   <a href={l.url} target="_blank" rel="noopener noreferrer" style={{ color: '#4f46e5' }}>
                     {l.provider}: {l.externalId}
@@ -317,11 +344,11 @@ export function MobileNodeDetailSheet({ node, map, byId, onClose, onChanged }: P
             </div>
           )}
 
-          {node.description && (
+          {description && (
             <div className="mb-detail-section">
               <div className="mb-detail-label">Description</div>
               <div style={{ whiteSpace: 'pre-wrap', fontSize: 14, lineHeight: 1.5 }}>
-                {node.description}
+                {description}
               </div>
             </div>
           )}

--- a/packages/mindmap/src/mobile/MobileViewer.tsx
+++ b/packages/mindmap/src/mobile/MobileViewer.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Node } from '@mindblown/core';
 import * as api from '../api.js';
 import type { MapDetail, MapSummary, NodeWithComputed } from '../api.js';
 import { MobileListView } from './MobileListView.js';
@@ -33,6 +34,11 @@ interface Props {
   map: MapSummary;
 }
 
+// Heavy fields stripped from the mobile map payload — on large synced
+// maps descriptions alone are >half the JSON. The detail sheet fetches
+// the full node on demand.
+const OMIT_FIELDS: Array<'description' | 'externalLinks'> = ['description', 'externalLinks'];
+
 export function MobileViewer({ map }: Props) {
   const [detail, setDetail] = useState<MapDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -45,7 +51,7 @@ export function MobileViewer({ map }: Props) {
     setDetail(null);
     setError(null);
     api
-      .fetchMap(map.id)
+      .fetchMap(map.id, { omit: OMIT_FIELDS })
       .then((d) => {
         if (!cancelled) setDetail(d);
       })
@@ -61,12 +67,65 @@ export function MobileViewer({ map }: Props) {
   // node sheet update rollups in place instead of flashing "Loading map…".
   const silentReload = useCallback(() => {
     api
-      .fetchMap(map.id)
+      .fetchMap(map.id, { omit: OMIT_FIELDS })
       .then(setDetail)
       .catch(() => {
         // Keep showing the stale tree; the next manual refresh surfaces errors.
       });
   }, [map.id]);
+
+  // Edits patch the returned node into local state immediately; the full
+  // re-fetch that refreshes ancestor rollups is debounced so a burst of
+  // edits (slider drags, rapid-add) costs one download, not one each.
+  const reloadTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleReload = useCallback(() => {
+    if (reloadTimer.current) clearTimeout(reloadTimer.current);
+    reloadTimer.current = setTimeout(silentReload, 1500);
+  }, [silentReload]);
+  useEffect(
+    () => () => {
+      if (reloadTimer.current) clearTimeout(reloadTimer.current);
+    },
+    [],
+  );
+
+  const patchNode = useCallback(
+    (updated: Node) => {
+      setDetail((d) =>
+        d
+          ? { ...d, nodes: d.nodes.map((n) => (n.id === updated.id ? { ...n, ...updated } : n)) }
+          : d,
+      );
+      scheduleReload();
+    },
+    [scheduleReload],
+  );
+
+  const insertNode = useCallback(
+    (created: Node) => {
+      setDetail((d) => {
+        if (!d) return d;
+        const asComputed: NodeWithComputed = {
+          ...created,
+          computedEffort: created.effortEstimate ?? 0,
+          computedProgress: created.percentComplete ?? 0,
+          healthSignal: 'on_track',
+        };
+        return {
+          ...d,
+          nodes: d.nodes
+            .map((n) =>
+              n.id === created.parentId && !n.childrenIds.includes(created.id)
+                ? { ...n, childrenIds: [...n.childrenIds, created.id] }
+                : n,
+            )
+            .concat(asComputed),
+        };
+      });
+      scheduleReload();
+    },
+    [scheduleReload],
+  );
 
   const setViewPersist = (v: ViewKey) => {
     setView(v);
@@ -169,7 +228,7 @@ export function MobileViewer({ map }: Props) {
           map={detail.map}
           byId={byId}
           onClose={() => setSelectedId(null)}
-          onChanged={silentReload}
+          onChanged={patchNode}
         />
       )}
 
@@ -178,7 +237,7 @@ export function MobileViewer({ map }: Props) {
           nodes={nodes}
           map={detail.map}
           onClose={() => setAdding(false)}
-          onCreated={silentReload}
+          onCreated={insertNode}
         />
       )}
     </>

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -173,7 +173,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ── GET /api/maps/:id — Get map with all nodes + computed fields
-  app.get<{ Params: { id: string } }>('/api/maps/:id', async (req, reply) => {
+  app.get<{ Params: { id: string }; Querystring: { omit?: string } }>('/api/maps/:id', async (req, reply) => {
     const userId = req.userId;
 
     // Check permissions if authenticated
@@ -208,6 +208,22 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
         blockedBy: cv?.blockedBy ?? { manual: false, predecessorIds: [], blockedDescendantCount: 0 },
       };
     });
+
+    // ?omit=description,externalLinks strips heavy display-only fields
+    // for low-bandwidth clients (the mobile app). On a large synced map
+    // descriptions alone are >half the payload; detail views fetch the
+    // full node on demand instead. Allowlisted so structural fields the
+    // tree depends on can never be stripped.
+    const OMITTABLE = new Set(['description', 'externalLinks']);
+    const omit = (req.query.omit ?? '')
+      .split(',')
+      .map((f) => f.trim())
+      .filter((f) => OMITTABLE.has(f));
+    if (omit.length > 0) {
+      for (const node of nodesWithComputed as Record<string, unknown>[]) {
+        for (const f of omit) delete node[f];
+      }
+    }
 
     return reply.send({
       map: data.map,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -272,6 +272,23 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
+  // ── GET /api/maps/:id/nodes/:nodeId — Fetch a single node ────
+  // Counterpart to GET /api/maps/:id?omit=…: clients that load the
+  // slimmed map payload fetch the full node (description, links) on
+  // demand when a detail view opens.
+  app.get<{ Params: { id: string; nodeId: string } }>(
+    '/api/maps/:id/nodes/:nodeId',
+    async (req, reply) => {
+      const node = await nodeDb.getNode(req.params.nodeId);
+      if (!node || node.mapId !== req.params.id) {
+        return reply.status(404).send({
+          error: { code: 'NODE_NOT_FOUND', message: `Node ${req.params.nodeId} not found` },
+        });
+      }
+      return reply.send(node);
+    },
+  );
+
   // ── PUT /api/maps/:id/nodes/:nodeId — Update a node ──────────
   app.put<{ Params: { id: string; nodeId: string } }>(
     '/api/maps/:id/nodes/:nodeId',


### PR DESCRIPTION
Follow-up to #212 — Dan reported the mobile app feels slow. Diagnosis: the server is idle and healthy; the cost is the map payload. The Fulcrum CRM Roadmap is 4.8 MB per `GET /api/maps/:id` (2187 nodes, 54% node descriptions synced from GitHub), and the mobile app re-downloaded it on open **and after every edit**.

## Server
- `GET /api/maps/:id?omit=description,externalLinks` — strips allowlisted heavy display-only fields from the nodes array (structural fields can never be stripped). On the Fulcrum map this drops ~64% of the payload.
- New `GET /api/maps/:id/nodes/:nodeId` — full single node for detail views; 404s when the node isn't in the given map.

## Mobile
- All map loads request the slim payload.
- Detail sheet lazy-fetches the full node once on open (description + links).
- Edits patch the PUT response into local state immediately; the rollup-refreshing refetch is debounced 1.5 s — an edit burst costs one download, not one per tap.
- Quick-add inserts the created node locally the same way.

Desktop and MCP surfaces are untouched (no `omit` → full payload as before).

## Verification
Playwright (iPhone 13): slim fetch on open, description lazy-loads in the sheet, status/priority pills reflect instantly, exactly **one** map refetch per 2-edit burst, added node visible before any refetch, cross-map node GET → 404. Typecheck clean; server suite green except the known pre-existing triage-routes failure (#212 notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dzh24DD86VdvrAKnb4ojv