### PR TITLE
feat(lint): plan-health panel — server lint engine, dismissals, UI dock

### DIFF
--- a/docs/plan-linter.md
+++ b/docs/plan-linter.md
@@ -1,6 +1,6 @@
 # Plan Linter — v1 Specification
 
-*Status: surface 1 (`plan_lint` MCP tool) implemented; UI panel and moment-of-action nudges open. Companion to the "Guided Project Management" section of [product-vision.md](product-vision.md).*
+*Status: surfaces 1 (`plan_lint` MCP tool) and 2 (plan-health panel + dismissals) implemented; the engine lives server-side (`packages/server/src/lint/engine.ts`) and both surfaces consume `GET /api/maps/:id/lint`. Moment-of-action nudges (surface 3) open. Companion to the "Guided Project Management" section of [product-vision.md](product-vision.md).*
 
 ---
 
@@ -50,8 +50,8 @@ Per finding: `{ ruleId, severity, nodeId, nodeText, detail, why, fix }` plus a s
 
 - Stored per `(mapId, nodeId, ruleId)` — dismissing `oversized-leaf` on one node never hides it elsewhere.
 - Map-level rule mute per `(mapId, ruleId)` for teams that reject a given opinion (e.g. sprints-only teams muting `dates-without-dependencies`).
-- Dismissals are permanent until the underlying value changes materially (e.g. estimate edited after dismissal → eligible to re-fire).
-- Needs a small table: `lint_dismissals (map_id, node_id nullable, rule_id, dismissed_by, dismissed_at)`.
+- v1 semantics: dismissals are permanent until explicitly undone (the panel offers undo/unmute; re-firing on material change of the underlying value is a possible v2 refinement).
+- Table: `lint_dismissals (map_id, node_id nullable, rule_id, dismissed_by, created_at)` — uniqueness enforced app-level (nullable node_id + pre-PG15).
 
 ## Surfaces (in ship order)
 

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -686,6 +686,49 @@ export function getChangeHistory(
   return request<{ events: ChangeEvent[] }>(`/api/maps/${mapId}/changes${qs ? `?${qs}` : ''}`);
 }
 
+// ── Plan lint ─────────────────────────────────────────────────
+
+export interface LintFinding {
+  nodeId: string | null;
+  nodeText: string | null;
+  priority: string | null;
+  detail: string;
+  dismissed: boolean;
+}
+
+export interface LintRuleReport {
+  ruleId: string;
+  severity: 'warn' | 'info';
+  title: string;
+  why: string;
+  fix: string;
+  findings: LintFinding[];
+  activeCount: number;
+  dismissedCount: number;
+  ruleMuted: boolean;
+  skipped?: string;
+}
+
+export interface LintReport {
+  scopeLabel: string;
+  warnCount: number;
+  infoCount: number;
+  rules: LintRuleReport[];
+}
+
+export function getLint(
+  mapId: string,
+  opts: { nodeId?: string; versionId?: string; stalledDays?: number; rule?: string } = {},
+): Promise<LintReport> {
+  const params = new URLSearchParams();
+  if (opts.nodeId) params.set('nodeId', opts.nodeId);
+  if (opts.versionId) params.set('versionId', opts.versionId);
+  if (opts.stalledDays != null) params.set('stalledDays', String(opts.stalledDays));
+  if (opts.rule) params.set('rule', opts.rule);
+  const qs = params.toString();
+  return request<LintReport>(`/api/maps/${mapId}/lint${qs ? `?${qs}` : ''}`);
+}
+
 // ── Versions ──────────────────────────────────────────────────
 
 export function listVersions(mapId: string): Promise<VersionInfo[]> {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1062,296 +1062,56 @@ server.tool(
   },
   async ({ mapId, nodeId, versionId, stalledDays, rule, limit }) => {
     try {
-      // Opinionated defaults, deliberately not configurable (see docs/plan-linter.md).
-      const OVERSIZED_DAYS = 5; // absolute: leaf bigger than a work week
-      const OVERSIZED_MAP_SHARE = 0.15; // relative: leaf dwarfs the rest of the plan
-      const OVERSIZED_SHARE_MIN_LEAVES = 8; // share rule needs enough leaves to be meaningful
-      const DONE_CRITERIA_MIN_DAYS = 2; // small tasks may skip a written done-definition
-      const STALE_PLAN_DAYS = 14;
-      const MIN_CALIBRATION_SAMPLES = 5;
-      const CALIBRATION_LOW = 0.8;
-      const CALIBRATION_HIGH = 1.25;
-      const MIN_DATED_LEAVES_FOR_DEPS = 10;
-      const REPLAN_LOOKBACK_DAYS = 90; // how far back we look for re-plan events
-
-      const data = await api.getMap(mapId);
-      const scope = scopedLeaves(data, { nodeId, versionId });
-      if (!scope.ok) return toolError(scope.error);
-      const { leaves, scopeLabel } = scope;
-
-      if (leaves.length === 0) {
-        return toolResult(`No leaf nodes in scope (${scopeLabel}).`);
-      }
-
-      const unit = data.map.effortUnit ?? 'units';
-
-      // Units-per-day so day-based thresholds work for hour/point maps.
-      // Best-effort from the scheduler; 1 unit == 1 day as fallback.
-      let unitsPerDay = 1;
-      try {
-        const sched = await api.getSchedule(mapId);
-        if (sched.unitsPerDay > 0) unitsPerDay = sched.unitsPerDay;
-      } catch {
-        /* keep fallback */
-      }
-
-      // Change-event-backed signals (stale-progress, overdue-unreplanned,
-      // stale-plan) are best-effort: the event log may be unavailable.
-      let historyOk = true;
-      // Latest percentComplete change per node (events arrive newest-first;
-      // first hit per node wins). Nodes absent from the map have no progress
-      // change in the lookback window — with a 1000-event cap, worst case we
-      // under-record ancient changes, which only ever makes a node MORE stale.
-      const lastProgressChange = new Map<string, string>();
-      const replanEventsByNode = new Map<string, string[]>();
-      let anyRecentEvent = false;
-      try {
-        const [progress, dueChanges, startChanges, estChanges, recent] = await Promise.all([
-          api.getChangeHistory(mapId, { fieldName: 'percentComplete', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
-          api.getChangeHistory(mapId, { fieldName: 'dueDate', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
-          api.getChangeHistory(mapId, { fieldName: 'startDate', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
-          api.getChangeHistory(mapId, { fieldName: 'effortEstimate', sinceDays: REPLAN_LOOKBACK_DAYS, limit: 1000 }),
-          api.getChangeHistory(mapId, { sinceDays: STALE_PLAN_DAYS, limit: 1 }),
-        ]);
-        for (const e of progress.events) {
-          if (e.nodeId && !lastProgressChange.has(e.nodeId)) {
-            lastProgressChange.set(e.nodeId, e.createdAt);
-          }
-        }
-        for (const e of [...dueChanges.events, ...startChanges.events, ...estChanges.events]) {
-          if (!e.nodeId) continue;
-          const list = replanEventsByNode.get(e.nodeId) ?? [];
-          list.push(e.createdAt);
-          replanEventsByNode.set(e.nodeId, list);
-        }
-        anyRecentEvent = recent.events.length > 0;
-      } catch {
-        historyOk = false;
-      }
-
-      const incomplete = leaves.filter((l) => (l.percentComplete ?? 0) < 100);
-      const totalEffort = leaves.reduce((s, l) => s + (l.effortEstimate ?? 0), 0);
-
-      const inProgressStatusIds = new Set(
-        (data.map.statusWorkflow ?? [])
-          .filter((s) => s.category === 'in_progress')
-          .map((s) => s.id),
-      );
-      const isInProgress = (n: (typeof leaves)[number]) =>
-        (n.status != null && inProgressStatusIds.has(n.status)) ||
-        ((n.percentComplete ?? 0) > 0 && (n.percentComplete ?? 0) < 100);
-
-      const fmtNode = (n: (typeof leaves)[number], extra?: string) => {
-        const bits: string[] = [`${n.id} ${n.text}`];
-        if (n.priority) bits.push(`[${n.priority}]`);
-        if (extra) bits.push(`— ${extra}`);
-        return bits.join(' ');
-      };
-
-      // ── Evaluate rules (basics first) ──
-      type Finding = { line: string };
-      type RuleResult = {
-        id: (typeof LINT_RULES)[number];
-        severity: 'warn' | 'info';
-        title: string;
-        why: string;
-        fix: string;
-        findings: Finding[];
-        skipped?: string;
-      };
-      const results: RuleResult[] = [];
-
-      // 1. unestimated-leaf
-      results.push({
-        id: 'unestimated-leaf',
-        severity: 'warn',
-        title: 'Leaves without an effort estimate',
-        why: 'Unestimated work is invisible to the forecast — your finish date is under-counting.',
-        fix: 'Set an estimate on each (set_estimate); ai_estimate can draft one.',
-        findings: incomplete
-          .filter((l) => l.effortEstimate == null)
-          .map((l) => ({ line: fmtNode(l) })),
-      });
-
-      // 2. oversized-leaf
-      const oversizedAbs = OVERSIZED_DAYS * unitsPerDay;
-      const shareRuleActive = totalEffort > 0 && leaves.length >= OVERSIZED_SHARE_MIN_LEAVES;
-      results.push({
-        id: 'oversized-leaf',
-        severity: 'warn',
-        title: `Oversized leaves (> ${OVERSIZED_DAYS} days${shareRuleActive ? ` or > ${OVERSIZED_MAP_SHARE * 100}% of the plan` : ''})`,
-        why: 'Small pieces get estimated far more accurately — projects built from small chunks succeed dramatically more often.',
-        fix: 'Split it into smaller children (ai_breakdown can suggest a split).',
-        findings: incomplete
-          .filter(
-            (l) =>
-              l.effortEstimate != null &&
-              (l.effortEstimate > oversizedAbs ||
-                (shareRuleActive && l.effortEstimate > OVERSIZED_MAP_SHARE * totalEffort)),
-          )
-          .sort((a, b) => (b.effortEstimate ?? 0) - (a.effortEstimate ?? 0))
-          .map((l) => ({ line: fmtNode(l, `${l.effortEstimate} ${unit}`) })),
-      });
-
-      // 3. stale-progress
-      results.push({
-        id: 'stale-progress',
-        severity: 'warn',
-        title: `In-progress work with no progress update in ${stalledDays}+ days`,
-        why: 'A task that stops moving is usually stuck, not slow — surface it before it slips the schedule.',
-        fix: 'Update its % complete (set_progress), or flag what blocks it (flag_blocker).',
-        findings: historyOk
-          ? incomplete
-              .filter((l) => {
-                if (!isInProgress(l)) return false;
-                const last = lastProgressChange.get(l.id);
-                return last == null || new Date(last).getTime() < Date.now() - stalledDays * 86_400_000;
-              })
-              .map((l) => {
-                const last = lastProgressChange.get(l.id);
-                const detail = last
-                  ? `${l.percentComplete ?? 0}%, last progress change ${last.slice(0, 10)}`
-                  : `${l.percentComplete ?? 0}%, no progress change on record`;
-                return { line: fmtNode(l, detail) };
-              })
-          : [],
-        skipped: historyOk ? undefined : 'change history unavailable',
-      });
-
-      // 4. overdue-unreplanned
-      const todayIso = new Date().toISOString().slice(0, 10);
-      results.push({
-        id: 'overdue-unreplanned',
-        severity: 'warn',
-        title: 'Overdue leaves never re-planned',
-        why: 'Plans only work if they are amended when reality diverges — an ignored overdue date makes every downstream date fiction.',
-        fix: 'Re-plan it: move the due date, split the remainder, or descope (scope_simulate previews the impact).',
-        findings: historyOk
-          ? incomplete
-              .filter((l) => {
-                if (!l.dueDate || l.dueDate.slice(0, 10) >= todayIso) return false;
-                const evs = replanEventsByNode.get(l.id) ?? [];
-                return !evs.some((ts) => ts > l.dueDate!);
-              })
-              .map((l) => ({ line: fmtNode(l, `due ${l.dueDate!.slice(0, 10)}, ${l.percentComplete ?? 0}%`) }))
-          : [],
-        skipped: historyOk ? undefined : 'change history unavailable',
-      });
-
-      // 5. calibration-drift (map-level)
-      const calibrationLeaves = data.nodes.filter(
-        (n) =>
-          (n.childrenIds?.length ?? 0) === 0 &&
-          n.effortEstimate != null &&
-          n.actualEffort != null,
-      );
-      const calibEstimate = calibrationLeaves.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
-      const calibActual = calibrationLeaves.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
-      const fudge = calibEstimate > 0 ? calibActual / calibEstimate : null;
-      const drifted =
-        fudge != null &&
-        calibrationLeaves.length >= MIN_CALIBRATION_SAMPLES &&
-        (fudge < CALIBRATION_LOW || fudge > CALIBRATION_HIGH);
-      results.push({
-        id: 'calibration-drift',
-        severity: 'info',
-        title: 'Estimation calibration drift (map-level)',
-        why: fudge != null
-          ? `Your estimates historically run ${fudge.toFixed(2)}× — the velocity-adjusted forecast already corrects for this; consider sizing new estimates accordingly.`
-          : 'Once completed leaves carry both estimate and actual, the linter watches your calibration.',
-        fix: 'See get_estimation_accuracy for the per-node breakdown.',
-        findings: drifted
-          ? [{ line: `fudge factor ${fudge!.toFixed(2)}× over ${calibrationLeaves.length} completed leaves` }]
-          : [],
-      });
-
-      // 6. no-done-criteria
-      results.push({
-        id: 'no-done-criteria',
-        severity: 'info',
-        title: `Sizeable leaves (≥ ${DONE_CRITERIA_MIN_DAYS} days) without a done-definition`,
-        why: 'A task without a definition of done tends to be 90% finished forever — one sentence of "done means…" prevents it.',
-        fix: 'Add a sentence to the description (update_node). Nodes linked to a requirement are exempt.',
-        findings: incomplete
-          .filter(
-            (l) =>
-              l.requirementId == null &&
-              l.effortEstimate != null &&
-              l.effortEstimate >= DONE_CRITERIA_MIN_DAYS * unitsPerDay &&
-              (l.description ?? '').trim() === '',
-          )
-          .map((l) => ({ line: fmtNode(l, `${l.effortEstimate} ${unit}`) })),
-      });
-
-      // 7. stale-plan (map-level)
-      const mapIncomplete = (data.map.computedProgress ?? 0) < 100;
-      results.push({
-        id: 'stale-plan',
-        severity: 'info',
-        title: `Stale plan (no changes in ${STALE_PLAN_DAYS}+ days, map-level)`,
-        why: 'A plan that is not touched weekly is a document, not a plan — a 2-minute review keeps the forecast honest.',
-        fix: 'Run status_digest, then update the progress and dates that changed.',
-        findings:
-          historyOk && mapIncomplete && !anyRecentEvent
-            ? [{ line: `map is at ${(data.map.computedProgress ?? 0).toFixed(0)}% with no recorded change in ${STALE_PLAN_DAYS} days` }]
-            : [],
-        skipped: historyOk ? undefined : 'change history unavailable',
-      });
-
-      // 8. dates-without-dependencies (map-level)
-      const datedLeaves = data.nodes.filter(
-        (n) => (n.childrenIds?.length ?? 0) === 0 && (n.dueDate || n.startDate),
-      );
-      const totalDeps = data.nodes.reduce((s, n) => s + (n.dependencies?.length ?? 0), 0);
-      results.push({
-        id: 'dates-without-dependencies',
-        severity: 'info',
-        title: 'Scheduled plan with zero dependencies (map-level)',
-        why: 'Without dependencies the schedule assumes everything can happen in parallel — the critical path is what makes a finish date real.',
-        fix: 'Add dependencies between sequential tasks (add_dependency).',
-        findings:
-          datedLeaves.length >= MIN_DATED_LEAVES_FOR_DEPS && totalDeps === 0
-            ? [{ line: `${datedLeaves.length} dated leaves, 0 dependencies` }]
-            : [],
-      });
-
-      // ── Format ──
-      const shown = rule ? results.filter((r) => r.id === rule) : results;
-      const warnCount = shown.filter((r) => r.severity === 'warn').reduce((s, r) => s + r.findings.length, 0);
-      const infoCount = shown.filter((r) => r.severity === 'info').reduce((s, r) => s + r.findings.length, 0);
+      // The rules run server-side (packages/server/src/lint/engine.ts) so
+      // the MCP tool and the plan-health panel share one engine; this
+      // handler only formats. Dismissed findings (panel) are excluded
+      // from counts and listings but summarized per rule.
+      const report = await api.getLint(mapId, { nodeId, versionId, stalledDays, rule });
 
       const lines: string[] = [];
-      lines.push(`Plan lint — ${scopeLabel}`);
-      lines.push(`Plan health: ${warnCount} warning(s), ${infoCount} suggestion(s)`);
+      lines.push(`Plan lint — ${report.scopeLabel}`);
+      lines.push(`Plan health: ${report.warnCount} warning(s), ${report.infoCount} suggestion(s)`);
       if (rule) lines.push(`Filtered to rule: ${rule}`);
       lines.push('');
 
       const clean: string[] = [];
+      const muted: string[] = [];
       const skippedRules: string[] = [];
-      for (const r of shown) {
+      for (const r of report.rules) {
         if (r.skipped) {
-          skippedRules.push(`${r.id} (${r.skipped})`);
+          skippedRules.push(`${r.ruleId} (${r.skipped})`);
           continue;
         }
-        if (r.findings.length === 0) {
-          clean.push(r.id);
+        if (r.ruleMuted) {
+          muted.push(r.ruleId);
           continue;
         }
-        lines.push(`## [${r.severity}] ${r.id}: ${r.findings.length} — ${r.title}`);
+        const active = r.findings.filter((f) => !f.dismissed);
+        if (active.length === 0) {
+          clean.push(r.dismissedCount > 0 ? `${r.ruleId} (${r.dismissedCount} dismissed)` : r.ruleId);
+          continue;
+        }
+        lines.push(
+          `## [${r.severity}] ${r.ruleId}: ${active.length}${r.dismissedCount > 0 ? ` (+${r.dismissedCount} dismissed)` : ''} — ${r.title}`,
+        );
         lines.push(`Why: ${r.why}`);
         lines.push(`Fix: ${r.fix}`);
-        for (const f of r.findings.slice(0, limit)) {
-          lines.push(`  - ${f.line}`);
+        for (const f of active.slice(0, limit)) {
+          const bits: string[] = [f.nodeId ? `${f.nodeId} ${f.nodeText}` : '(map-level)'];
+          if (f.priority) bits.push(`[${f.priority}]`);
+          bits.push(`— ${f.detail}`);
+          lines.push(`  - ${bits.join(' ')}`);
         }
-        if (r.findings.length > limit) {
-          lines.push(`  … and ${r.findings.length - limit} more (raise \`limit\` or pass \`rule: "${r.id}"\`)`);
+        if (active.length > limit) {
+          lines.push(`  … and ${active.length - limit} more (raise \`limit\` or pass \`rule: "${r.ruleId}"\`)`);
         }
         lines.push('');
       }
 
       if (clean.length > 0) lines.push(`✓ Clean: ${clean.join(', ')}`);
+      if (muted.length > 0) lines.push(`🔕 Muted on this map: ${muted.join(', ')}`);
       if (skippedRules.length > 0) lines.push(`⚠ Skipped: ${skippedRules.join(', ')}`);
-      if (warnCount + infoCount === 0 && skippedRules.length === 0) {
+      if (report.warnCount + report.infoCount === 0 && skippedRules.length === 0) {
         lines.push('');
         lines.push('The plan is in good shape — every check passed.');
       }

--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -10,6 +10,7 @@ import { CalendarView } from './CalendarView.js';
 import { SprintPanel } from './SprintPanel.js';
 import { BlockedPanel } from './BlockedPanel.js';
 import { TriagePanel } from './TriagePanel.js';
+import { PlanHealthPanel } from './PlanHealthPanel.js';
 import { listTriageDecisions } from './api.js';
 import { CommandPalette } from './CommandPalette.js';
 import { QuickAdd } from './QuickAdd.js';
@@ -1400,6 +1401,7 @@ export function App() {
   const [sprintPanelOpen, setSprintPanelOpen] = useState(false);
   const [blockedPanelOpen, setBlockedPanelOpen] = useState(false);
   const [triagePanelOpen, setTriagePanelOpen] = useState(false);
+  const [planHealthPanelOpen, setPlanHealthPanelOpen] = useState(false);
   const [triagePendingCount, setTriagePendingCount] = useState(0);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -1872,6 +1874,7 @@ export function App() {
                 // close Triage on open (symmetric with the Blocked/Triage
                 // handlers below).
                 setTriagePanelOpen(false);
+                setPlanHealthPanelOpen(false);
               }
             }}
             style={{
@@ -1901,6 +1904,7 @@ export function App() {
               if (!blockedPanelOpen) {
                 setSprintPanelOpen(false);
                 setTriagePanelOpen(false);
+                setPlanHealthPanelOpen(false);
               }
             }}
           />
@@ -1916,9 +1920,39 @@ export function App() {
               if (!triagePanelOpen) {
                 setSprintPanelOpen(false);
                 setBlockedPanelOpen(false);
+                setPlanHealthPanelOpen(false);
               }
             }}
           />
+
+          <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
+
+          {/* Plan-health panel toggle (pull-based lint, docs/plan-linter.md) */}
+          <button
+            onClick={() => {
+              setPlanHealthPanelOpen(!planHealthPanelOpen);
+              if (!planHealthPanelOpen) {
+                setSprintPanelOpen(false);
+                setBlockedPanelOpen(false);
+                setTriagePanelOpen(false);
+              }
+            }}
+            title="Check the plan's hygiene: estimates, chunk size, stale progress, overdue re-planning"
+            style={{
+              padding: '3px 10px',
+              borderRadius: 4,
+              border: planHealthPanelOpen ? '1px solid #4f46e5' : '1px solid #e2e8f0',
+              fontSize: 11,
+              fontWeight: 600,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+              background: planHealthPanelOpen ? '#eef2ff' : '#fff',
+              color: planHealthPanelOpen ? '#4f46e5' : '#64748b',
+              transition: 'all 0.15s',
+            }}
+          >
+            🩺 Plan health
+          </button>
 
           <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
 
@@ -2129,6 +2163,11 @@ export function App() {
           <TriagePanel
             mapId={currentMapId}
             onClose={() => setTriagePanelOpen(false)}
+          />
+        ) : planHealthPanelOpen && currentMapId ? (
+          <PlanHealthPanel
+            mapId={currentMapId}
+            onClose={() => setPlanHealthPanelOpen(false)}
           />
         ) : (
           <PropertyPanel />

--- a/packages/mindmap/src/PlanHealthPanel.tsx
+++ b/packages/mindmap/src/PlanHealthPanel.tsx
@@ -1,0 +1,360 @@
+/**
+ * Plan-health panel — surface 2 of the plan linter (docs/plan-linter.md).
+ *
+ * Pull-based coaching: fetched when the panel opens, never pushed. Each
+ * finding teaches the principle it enforces (the "why" line) and links
+ * back to the node on the map. Dismissals are per-(node, rule); a whole
+ * rule can be muted for the map. Quiet by default — no toasts, no badges
+ * until the user asks.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import * as api from './api.js';
+import { useMindmapStore } from './store.js';
+
+const PANEL_WIDTH = 380;
+
+const SEVERITY_STYLE: Record<'warn' | 'info', { label: string; color: string; bg: string }> = {
+  warn: { label: 'warning', color: '#b45309', bg: '#fef3c7' },
+  info: { label: 'suggestion', color: '#1d4ed8', bg: '#dbeafe' },
+};
+
+export function PlanHealthPanel({ mapId, onClose }: { mapId: string; onClose: () => void }) {
+  const selectNode = useMindmapStore((s) => s.selectNode);
+  const setFocusNode = useMindmapStore((s) => s.setFocusNode);
+  const setActiveView = useMindmapStore((s) => s.setActiveView);
+  const nodes = useMindmapStore((s) => s.nodes);
+  const rootNodeId = useMindmapStore((s) => s.rootNodeId);
+
+  const [report, setReport] = useState<api.LintReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showDismissed, setShowDismissed] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setReport(await api.fetchLint(mapId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to run the plan check');
+    } finally {
+      setLoading(false);
+    }
+  }, [mapId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const jumpToNode = (nodeId: string) => {
+    const node = nodes[nodeId];
+    setActiveView('mindmap');
+    selectNode(nodeId);
+    setFocusNode(node?.parentId && node.parentId !== rootNodeId ? node.parentId : null);
+    (window as unknown as { __mindmapPanToNode?: (id: string) => void }).__mindmapPanToNode?.(nodeId);
+  };
+
+  const dismiss = async (ruleId: string, nodeId: string | null) => {
+    await api.dismissLintFinding(mapId, ruleId, nodeId);
+    await load();
+  };
+  const undismiss = async (ruleId: string, nodeId: string | null) => {
+    await api.undismissLintFinding(mapId, ruleId, nodeId);
+    await load();
+  };
+
+  const activeRules = (report?.rules ?? []).filter(
+    (r) => !r.skipped && !r.ruleMuted && (r.activeCount > 0 || (showDismissed && r.dismissedCount > 0)),
+  );
+  const cleanRules = (report?.rules ?? []).filter(
+    (r) => !r.skipped && !r.ruleMuted && r.activeCount === 0 && !(showDismissed && r.dismissedCount > 0),
+  );
+  const mutedRules = (report?.rules ?? []).filter((r) => r.ruleMuted);
+  const skippedRules = (report?.rules ?? []).filter((r) => r.skipped);
+  const allClear = report != null && report.warnCount + report.infoCount === 0;
+
+  return (
+    <div
+      style={{
+        width: PANEL_WIDTH,
+        height: '100%',
+        borderLeft: '1px solid #e2e8f0',
+        background: '#ffffff',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid #e2e8f0',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <span style={{ fontSize: 16 }}>🩺</span>
+        <span style={{ fontSize: 14, fontWeight: 700, color: '#1e293b', flex: 1 }}>
+          Plan health
+          {report && (
+            <span style={{ marginLeft: 8, fontSize: 12, color: '#94a3b8', fontWeight: 500 }}>
+              {report.warnCount} warning{report.warnCount === 1 ? '' : 's'} · {report.infoCount}{' '}
+              suggestion{report.infoCount === 1 ? '' : 's'}
+            </span>
+          )}
+        </span>
+        <button
+          onClick={() => void load()}
+          disabled={loading}
+          title="Re-run the checks"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: loading ? 'default' : 'pointer',
+            padding: 4,
+            color: '#94a3b8',
+            fontSize: 14,
+            fontFamily: 'inherit',
+            lineHeight: 1,
+          }}
+        >
+          ↻
+        </button>
+        <button
+          onClick={onClose}
+          title="Close"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: 4,
+            color: '#94a3b8',
+            fontSize: 16,
+            fontFamily: 'inherit',
+            lineHeight: 1,
+          }}
+        >
+          x
+        </button>
+      </div>
+
+      {/* Body */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '12px 16px' }}>
+        {loading && !report && (
+          <div style={{ fontSize: 12, color: '#94a3b8' }}>Checking the plan…</div>
+        )}
+        {error && (
+          <div style={{ fontSize: 12, color: '#dc2626' }}>
+            {error}{' '}
+            <button
+              onClick={() => void load()}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: '#4f46e5',
+                cursor: 'pointer',
+                fontSize: 12,
+                fontFamily: 'inherit',
+                padding: 0,
+                textDecoration: 'underline',
+              }}
+            >
+              retry
+            </button>
+          </div>
+        )}
+
+        {allClear && !loading && !error && (
+          <div style={{ fontSize: 13, color: '#16a34a', padding: '8px 0' }}>
+            ✓ The plan is in good shape — every check passed.
+          </div>
+        )}
+
+        {activeRules.map((r) => {
+          const sev = SEVERITY_STYLE[r.severity];
+          const visible = r.findings.filter((f) => (showDismissed ? true : !f.dismissed));
+          return (
+            <div key={r.ruleId} style={{ marginBottom: 16 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                <span
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    color: sev.color,
+                    background: sev.bg,
+                    borderRadius: 3,
+                    padding: '1px 6px',
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.4,
+                  }}
+                >
+                  {sev.label}
+                </span>
+                <span style={{ fontSize: 12, fontWeight: 700, color: '#1e293b', flex: 1 }}>
+                  {r.title}
+                  <span style={{ marginLeft: 6, color: '#94a3b8', fontWeight: 500 }}>
+                    {r.activeCount}
+                  </span>
+                </span>
+                <button
+                  onClick={() => void dismiss(r.ruleId, null)}
+                  title="Mute this check for this map"
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#cbd5e1',
+                    fontSize: 12,
+                    fontFamily: 'inherit',
+                    padding: 2,
+                  }}
+                >
+                  🔕
+                </button>
+              </div>
+              <div style={{ fontSize: 11, color: '#64748b', fontStyle: 'italic', marginBottom: 2 }}>
+                {r.why}
+              </div>
+              <div style={{ fontSize: 11, color: '#64748b', marginBottom: 6 }}>Fix: {r.fix}</div>
+              {visible.map((f, i) => (
+                <div
+                  key={`${f.nodeId ?? 'map'}-${i}`}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'baseline',
+                    gap: 6,
+                    padding: '3px 0',
+                    opacity: f.dismissed ? 0.45 : 1,
+                  }}
+                >
+                  {f.nodeId ? (
+                    <button
+                      onClick={() => jumpToNode(f.nodeId!)}
+                      title="Show on the map"
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: '#4f46e5',
+                        fontSize: 12,
+                        fontFamily: 'inherit',
+                        padding: 0,
+                        textAlign: 'left',
+                        flex: 1,
+                        textDecoration: f.dismissed ? 'line-through' : 'none',
+                      }}
+                    >
+                      {f.nodeText ?? f.nodeId}
+                      {f.priority && (
+                        <span style={{ color: '#94a3b8', marginLeft: 4 }}>[{f.priority}]</span>
+                      )}
+                      <span style={{ color: '#94a3b8', marginLeft: 4 }}>— {f.detail}</span>
+                    </button>
+                  ) : (
+                    <span style={{ fontSize: 12, color: '#334155', flex: 1 }}>{f.detail}</span>
+                  )}
+                  {f.dismissed ? (
+                    <button
+                      onClick={() => void undismiss(r.ruleId, f.nodeId)}
+                      title="Restore this finding"
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: '#94a3b8',
+                        fontSize: 11,
+                        fontFamily: 'inherit',
+                        padding: 0,
+                      }}
+                    >
+                      undo
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => void dismiss(r.ruleId, f.nodeId)}
+                      title="Dismiss this finding"
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: '#cbd5e1',
+                        fontSize: 12,
+                        fontFamily: 'inherit',
+                        padding: 0,
+                        lineHeight: 1,
+                      }}
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+
+        {/* Footer chips: clean / muted / skipped */}
+        {report && cleanRules.length > 0 && (
+          <div style={{ fontSize: 11, color: '#16a34a', marginTop: 8 }}>
+            ✓ Clean: {cleanRules.map((r) => r.ruleId).join(', ')}
+          </div>
+        )}
+        {mutedRules.length > 0 && (
+          <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 6 }}>
+            🔕 Muted:{' '}
+            {mutedRules.map((r, i) => (
+              <span key={r.ruleId}>
+                {i > 0 && ', '}
+                {r.ruleId}{' '}
+                <button
+                  onClick={() => void undismiss(r.ruleId, null)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: '#4f46e5',
+                    cursor: 'pointer',
+                    fontSize: 11,
+                    fontFamily: 'inherit',
+                    padding: 0,
+                    textDecoration: 'underline',
+                  }}
+                >
+                  unmute
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        {skippedRules.length > 0 && (
+          <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 6 }}>
+            ⚠ Skipped: {skippedRules.map((r) => `${r.ruleId} (${r.skipped})`).join(', ')}
+          </div>
+        )}
+
+        {report && (report.rules.some((r) => r.dismissedCount > 0) || showDismissed) && (
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 11,
+              color: '#94a3b8',
+              marginTop: 12,
+              cursor: 'pointer',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={showDismissed}
+              onChange={(e) => setShowDismissed(e.target.checked)}
+              style={{ margin: 0 }}
+            />
+            Show dismissed findings
+          </label>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -1639,3 +1639,59 @@ export function listNotInMindBlown(
     `/api/maps/${mapId}/triage-decisions/not-in-mindblown${q ? `?${q}` : ''}`,
   );
 }
+
+// ── Plan lint (plan-health panel, docs/plan-linter.md) ────────────
+
+export interface LintFinding {
+  nodeId: string | null;
+  nodeText: string | null;
+  priority: string | null;
+  detail: string;
+  dismissed: boolean;
+}
+
+export interface LintRuleReport {
+  ruleId: string;
+  severity: 'warn' | 'info';
+  title: string;
+  why: string;
+  fix: string;
+  findings: LintFinding[];
+  activeCount: number;
+  dismissedCount: number;
+  ruleMuted: boolean;
+  skipped?: string;
+}
+
+export interface LintReport {
+  scopeLabel: string;
+  warnCount: number;
+  infoCount: number;
+  rules: LintRuleReport[];
+}
+
+export function fetchLint(mapId: string): Promise<LintReport> {
+  return request<LintReport>(`/api/maps/${mapId}/lint`);
+}
+
+/** nodeId null mutes the rule for the whole map. */
+export function dismissLintFinding(
+  mapId: string,
+  ruleId: string,
+  nodeId: string | null,
+): Promise<unknown> {
+  return request(`/api/maps/${mapId}/lint/dismissals`, {
+    method: 'POST',
+    body: JSON.stringify({ ruleId, nodeId }),
+  });
+}
+
+export function undismissLintFinding(
+  mapId: string,
+  ruleId: string,
+  nodeId: string | null,
+): Promise<unknown> {
+  const params = new URLSearchParams({ ruleId });
+  if (nodeId) params.set('nodeId', nodeId);
+  return request(`/api/maps/${mapId}/lint/dismissals?${params}`, { method: 'DELETE' });
+}

--- a/packages/server/src/db/lint.ts
+++ b/packages/server/src/db/lint.ts
@@ -1,0 +1,53 @@
+/**
+ * Lint-dismissal persistence (plan-health panel, docs/plan-linter.md).
+ * nodeId NULL = rule muted for the whole map.
+ */
+import { and, eq, isNull } from 'drizzle-orm';
+import { db } from './connection.js';
+import { lintDismissals } from './schema.js';
+
+export interface DismissalRow {
+  id: string;
+  mapId: string;
+  nodeId: string | null;
+  ruleId: string;
+  dismissedBy: string | null;
+  createdAt: Date;
+}
+
+export async function listDismissals(mapId: string): Promise<DismissalRow[]> {
+  return db.select().from(lintDismissals).where(eq(lintDismissals.mapId, mapId));
+}
+
+function matchClause(mapId: string, ruleId: string, nodeId: string | null) {
+  return and(
+    eq(lintDismissals.mapId, mapId),
+    eq(lintDismissals.ruleId, ruleId),
+    nodeId == null ? isNull(lintDismissals.nodeId) : eq(lintDismissals.nodeId, nodeId),
+  );
+}
+
+/**
+ * Idempotent dismiss: returns the existing row when the same
+ * (map, rule, node) dismissal already exists. Uniqueness is app-level —
+ * a nullable node_id makes a DB unique constraint awkward pre-PG15, and
+ * a lost race here just produces a duplicate row with identical effect.
+ */
+export async function upsertDismissal(
+  mapId: string,
+  ruleId: string,
+  nodeId: string | null,
+  dismissedBy: string | null,
+): Promise<{ row: DismissalRow; created: boolean }> {
+  const existing = await db.select().from(lintDismissals).where(matchClause(mapId, ruleId, nodeId));
+  if (existing.length > 0) return { row: existing[0], created: false };
+  const inserted = await db
+    .insert(lintDismissals)
+    .values({ mapId, nodeId, ruleId, dismissedBy })
+    .returning();
+  return { row: inserted[0], created: true };
+}
+
+export async function deleteDismissal(mapId: string, ruleId: string, nodeId: string | null): Promise<void> {
+  await db.delete(lintDismissals).where(matchClause(mapId, ruleId, nodeId));
+}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -814,5 +814,23 @@ export async function runMigrations(): Promise<void> {
       ON requirement_acceptances (map_id)
   `);
 
+  // ── Lint dismissals (plan-health panel) ────────────────────────
+  // node_id NULL = rule muted map-wide. Non-FK node_id by convention
+  // (see triage_decisions.placed_node_id) so node deletion leaves the
+  // dismissal row inert rather than cascading.
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS lint_dismissals (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      map_id UUID NOT NULL REFERENCES maps(id) ON DELETE CASCADE,
+      node_id UUID,
+      rule_id TEXT NOT NULL,
+      dismissed_by UUID REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS lint_dismissals_map_idx ON lint_dismissals (map_id)
+  `);
+
   console.log('[db] Migrations complete.');
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -467,3 +467,19 @@ export const requirementAcceptances = pgTable('requirement_acceptances', {
   nodeRevisionAtAcceptance: integer('node_revision_at_acceptance').notNull(),
   revokedAt: timestamp('revoked_at', { withTimezone: true }),
 });
+
+// ── Lint dismissals (plan-health panel, docs/plan-linter.md) ───────
+// One row = "stop showing this lint finding". node_id NULL mutes the
+// rule for the whole map. node_id is non-FK on purpose (same convention
+// as triage_decisions.placed_node_id): when the node is deleted the
+// dismissal simply becomes inert instead of cascading. Uniqueness of
+// (map_id, node_id, rule_id) is enforced application-level in the
+// route (NULL node_id makes a DB unique constraint awkward pre-PG15).
+export const lintDismissals = pgTable('lint_dismissals', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  mapId: uuid('map_id').notNull().references(() => maps.id, { onDelete: 'cascade' }),
+  nodeId: uuid('node_id'),
+  ruleId: text('rule_id').notNull(),
+  dismissedBy: uuid('dismissed_by').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -16,6 +16,7 @@ import { authRoutes } from './auth.js';
 import { systemRoutes } from './routes/system.js';
 import { registerAuthMiddleware } from './middleware/auth.js';
 import { mapRoutes } from './routes/maps.js';
+import { lintRoutes } from './routes/lint.js';
 import { nodeRoutes } from './routes/nodes.js';
 import { cycleRoutes } from './routes/cycles.js';
 import { versionRoutes } from './routes/versions.js';
@@ -80,6 +81,7 @@ async function main(): Promise<void> {
 
   // ── Protected Routes ───────────────────────────────────────────
   await app.register(mapRoutes);
+  await app.register(lintRoutes);
   await app.register(nodeRoutes);
   await app.register(cycleRoutes);
   await app.register(versionRoutes);

--- a/packages/server/src/lint/__tests__/engine.test.ts
+++ b/packages/server/src/lint/__tests__/engine.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Pure-engine tests for the plan linter (docs/plan-linter.md).
+ * Rule firing conditions, scoping, and dismissal application — no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@mindblown/core';
+import { computePlanLint, type LintHistory, type LintReport } from '../engine.js';
+
+let seq = 0;
+function makeNode(overrides: Partial<Node> & { id: string }): Node {
+  seq++;
+  return {
+    mapId: 'm1',
+    parentId: null,
+    childrenIds: [],
+    text: overrides.id,
+    description: null,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    blockedReason: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    dependencies: [],
+    versionId: null,
+    cycleId: null,
+    externalLinks: [],
+    collapsed: false,
+    x: seq,
+    y: seq,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    requirementId: null,
+    requirementPriority: null,
+    requirementText: null,
+    claimedBySession: null,
+    claimedAt: null,
+    ...overrides,
+  } as Node;
+}
+
+const NOW = new Date('2026-07-16T12:00:00Z');
+const emptyHistory = (): LintHistory => ({
+  ok: true,
+  lastProgressChange: new Map(),
+  replanEvents: new Map(),
+  anyRecentEvent: true, // suppress stale-plan unless a test opts in
+});
+
+function lint(nodes: Node[], opts: Partial<Parameters<typeof computePlanLint>[0]> = {}) {
+  const result = computePlanLint({
+    map: { effortUnit: 'days', statusWorkflow: [{ id: 'wip', category: 'in_progress' }] },
+    nodes,
+    unitsPerDay: 1,
+    history: emptyHistory(),
+    dismissals: [],
+    now: NOW,
+    ...opts,
+  });
+  if ('error' in result) throw new Error(result.error);
+  return result;
+}
+
+function rule(report: LintReport, id: string) {
+  const r = report.rules.find((r) => r.ruleId === id);
+  if (!r) throw new Error(`rule ${id} missing from report`);
+  return r;
+}
+
+describe('computePlanLint — rules', () => {
+  it('unestimated-leaf fires on incomplete leaves without estimate, not on complete ones', () => {
+    const report = lint([
+      makeNode({ id: 'root', childrenIds: ['a', 'b', 'c'] }),
+      makeNode({ id: 'a', parentId: 'root' }), // no estimate, incomplete → fires
+      makeNode({ id: 'b', parentId: 'root', percentComplete: 100 }), // complete → exempt
+      makeNode({ id: 'c', parentId: 'root', effortEstimate: 3 }), // estimated → clean
+    ]);
+    expect(rule(report, 'unestimated-leaf').findings.map((f) => f.nodeId)).toEqual(['a']);
+    expect(report.warnCount).toBe(1);
+  });
+
+  it('oversized-leaf fires above the 5-day absolute threshold, unit-aware', () => {
+    const nodes = [
+      makeNode({ id: 'root', childrenIds: ['a', 'b'] }),
+      makeNode({ id: 'a', parentId: 'root', effortEstimate: 48 }), // 6 days at 8h/day
+      makeNode({ id: 'b', parentId: 'root', effortEstimate: 8 }), // 1 day
+    ];
+    const report = lint(nodes, {
+      map: { effortUnit: 'hours', statusWorkflow: [] },
+      unitsPerDay: 8,
+    });
+    expect(rule(report, 'oversized-leaf').findings.map((f) => f.nodeId)).toEqual(['a']);
+  });
+
+  it('oversized-leaf share rule only activates with ≥8 leaves', () => {
+    // 3 leaves, one is 40% of the total but under 5 days → must NOT fire.
+    const small = lint([
+      makeNode({ id: 'root', childrenIds: ['a', 'b', 'c'] }),
+      makeNode({ id: 'a', parentId: 'root', effortEstimate: 4 }),
+      makeNode({ id: 'b', parentId: 'root', effortEstimate: 3 }),
+      makeNode({ id: 'c', parentId: 'root', effortEstimate: 3 }),
+    ]);
+    expect(rule(small, 'oversized-leaf').findings).toEqual([]);
+
+    // 9 leaves: a 4-day leaf that is >15% of total fires via the share rule.
+    const ids = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    const many = lint([
+      makeNode({ id: 'root', childrenIds: ['big', ...ids] }),
+      makeNode({ id: 'big', parentId: 'root', effortEstimate: 4 }),
+      ...ids.map((id) => makeNode({ id, parentId: 'root', effortEstimate: 0.5 })),
+    ]);
+    expect(rule(many, 'oversized-leaf').findings.map((f) => f.nodeId)).toEqual(['big']);
+  });
+
+  it('stale-progress keys on progress change events, not other edits', () => {
+    const history = emptyHistory();
+    history.lastProgressChange.set('fresh', '2026-07-15T00:00:00Z'); // 1 day ago
+    history.lastProgressChange.set('old', '2026-06-01T00:00:00Z'); // 45 days ago
+    const report = lint(
+      [
+        makeNode({ id: 'root', childrenIds: ['fresh', 'old', 'norec'] }),
+        makeNode({ id: 'fresh', parentId: 'root', percentComplete: 50 }),
+        makeNode({ id: 'old', parentId: 'root', percentComplete: 50 }),
+        makeNode({ id: 'norec', parentId: 'root', status: 'wip' }), // in-progress by status, no event
+      ],
+      { history },
+    );
+    const found = rule(report, 'stale-progress').findings;
+    expect(found.map((f) => f.nodeId).sort()).toEqual(['norec', 'old']);
+    expect(found.find((f) => f.nodeId === 'norec')!.detail).toContain('no progress change on record');
+  });
+
+  it('overdue-unreplanned exempts leaves with a re-plan event after the due date', () => {
+    const history = emptyHistory();
+    history.replanEvents.set('replanned', ['2026-07-10T00:00:00Z']); // after due
+    history.replanEvents.set('touched-early', ['2026-06-01T00:00:00Z']); // before due
+    const report = lint(
+      [
+        makeNode({ id: 'root', childrenIds: ['ignored', 'replanned', 'touched-early'] }),
+        makeNode({ id: 'ignored', parentId: 'root', dueDate: '2026-07-01', percentComplete: 20 }),
+        makeNode({ id: 'replanned', parentId: 'root', dueDate: '2026-07-01', percentComplete: 20 }),
+        makeNode({ id: 'touched-early', parentId: 'root', dueDate: '2026-06-15', percentComplete: 20 }),
+      ],
+      { history },
+    );
+    expect(rule(report, 'overdue-unreplanned').findings.map((f) => f.nodeId).sort()).toEqual([
+      'ignored',
+      'touched-early',
+    ]);
+  });
+
+  it('history-backed rules are skipped (not empty-passed) when history is unavailable', () => {
+    const report = lint(
+      [makeNode({ id: 'root', childrenIds: ['a'] }), makeNode({ id: 'a', parentId: 'root', status: 'wip' })],
+      { history: { ok: false, lastProgressChange: new Map(), replanEvents: new Map(), anyRecentEvent: false } },
+    );
+    expect(rule(report, 'stale-progress').skipped).toBeTruthy();
+    expect(rule(report, 'overdue-unreplanned').skipped).toBeTruthy();
+    expect(rule(report, 'stale-plan').skipped).toBeTruthy();
+  });
+
+  it('calibration-drift needs ≥5 samples and fudge outside 0.8–1.25', () => {
+    const drifted = Array.from({ length: 5 }, (_, i) =>
+      makeNode({ id: `c${i}`, parentId: 'root', effortEstimate: 2, actualEffort: 3, percentComplete: 100 }),
+    );
+    const report = lint([makeNode({ id: 'root', childrenIds: drifted.map((n) => n.id) }), ...drifted]);
+    const r = rule(report, 'calibration-drift');
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].detail).toContain('1.50×');
+    expect(r.why).toContain('1.50×');
+
+    const few = drifted.slice(0, 4);
+    const quiet = lint([makeNode({ id: 'root', childrenIds: few.map((n) => n.id) }), ...few]);
+    expect(rule(quiet, 'calibration-drift').findings).toEqual([]);
+  });
+
+  it('no-done-criteria exempts requirement-linked nodes and small leaves', () => {
+    const report = lint([
+      makeNode({ id: 'root', childrenIds: ['bare', 'req', 'small', 'documented'] }),
+      makeNode({ id: 'bare', parentId: 'root', effortEstimate: 3 }),
+      makeNode({ id: 'req', parentId: 'root', effortEstimate: 3, requirementId: 'REQ-1' }),
+      makeNode({ id: 'small', parentId: 'root', effortEstimate: 1 }),
+      makeNode({ id: 'documented', parentId: 'root', effortEstimate: 3, description: 'done means X' }),
+    ]);
+    expect(rule(report, 'no-done-criteria').findings.map((f) => f.nodeId)).toEqual(['bare']);
+  });
+
+  it('stale-plan fires only when incomplete and no recent events', () => {
+    const nodes = [
+      makeNode({ id: 'root', childrenIds: ['a'] }),
+      makeNode({ id: 'a', parentId: 'root', percentComplete: 50 }),
+    ];
+    const history = emptyHistory();
+    history.anyRecentEvent = false;
+    expect(rule(lint(nodes, { history }), 'stale-plan').findings).toHaveLength(1);
+    expect(rule(lint(nodes), 'stale-plan').findings).toEqual([]);
+  });
+
+  it('dates-without-dependencies needs ≥10 dated leaves and zero dependencies', () => {
+    const dated = Array.from({ length: 10 }, (_, i) =>
+      makeNode({ id: `d${i}`, parentId: 'root', dueDate: '2026-08-01' }),
+    );
+    const root = makeNode({ id: 'root', childrenIds: dated.map((n) => n.id) });
+    expect(rule(lint([root, ...dated]), 'dates-without-dependencies').findings).toHaveLength(1);
+
+    const withDep = [...dated];
+    withDep[0] = makeNode({
+      id: 'd0',
+      parentId: 'root',
+      dueDate: '2026-08-01',
+      dependencies: [{ targetNodeId: 'd1', type: 'FS', lag: 0 }],
+    });
+    expect(rule(lint([root, ...withDep]), 'dates-without-dependencies').findings).toEqual([]);
+  });
+});
+
+describe('computePlanLint — scoping and dismissals', () => {
+  const tree = () => [
+    makeNode({ id: 'root', childrenIds: ['epicA', 'epicB'] }),
+    makeNode({ id: 'epicA', parentId: 'root', childrenIds: ['a1', 'a2'], versionId: 'v1' }),
+    makeNode({ id: 'a1', parentId: 'epicA' }),
+    makeNode({ id: 'a2', parentId: 'epicA' }),
+    makeNode({ id: 'epicB', parentId: 'root', childrenIds: ['b1'] }),
+    makeNode({ id: 'b1', parentId: 'epicB' }),
+  ];
+
+  it('nodeId scopes leaf rules to the subtree', () => {
+    const report = lint(tree(), { nodeId: 'epicB' });
+    expect(rule(report, 'unestimated-leaf').findings.map((f) => f.nodeId)).toEqual(['b1']);
+    expect(report.scopeLabel).toContain('epicB');
+  });
+
+  it('versionId scopes with ancestor inheritance', () => {
+    const report = lint(tree(), { versionId: 'v1' });
+    expect(rule(report, 'unestimated-leaf').findings.map((f) => f.nodeId).sort()).toEqual(['a1', 'a2']);
+  });
+
+  it('unknown nodeId returns an error, not a report', () => {
+    const result = computePlanLint({
+      map: {},
+      nodes: tree(),
+      unitsPerDay: 1,
+      history: emptyHistory(),
+      dismissals: [],
+      nodeId: 'nope',
+      now: NOW,
+    });
+    expect('error' in result).toBe(true);
+  });
+
+  it('node dismissal hides one finding; rule mute hides them all — counts follow', () => {
+    const nodes = tree();
+    const undismissed = lint(nodes);
+    expect(rule(undismissed, 'unestimated-leaf').activeCount).toBe(3);
+
+    const oneOff = lint(nodes, { dismissals: [{ ruleId: 'unestimated-leaf', nodeId: 'a1' }] });
+    const r1 = rule(oneOff, 'unestimated-leaf');
+    expect(r1.activeCount).toBe(2);
+    expect(r1.dismissedCount).toBe(1);
+    expect(r1.findings.find((f) => f.nodeId === 'a1')!.dismissed).toBe(true);
+    expect(oneOff.warnCount).toBe(2);
+
+    const muted = lint(nodes, { dismissals: [{ ruleId: 'unestimated-leaf', nodeId: null }] });
+    const r2 = rule(muted, 'unestimated-leaf');
+    expect(r2.ruleMuted).toBe(true);
+    expect(r2.activeCount).toBe(0);
+    expect(muted.warnCount).toBe(0);
+  });
+
+  it('dismissals on one rule do not bleed into another', () => {
+    const nodes = [
+      makeNode({ id: 'root', childrenIds: ['a'] }),
+      makeNode({ id: 'a', parentId: 'root', effortEstimate: 10 }), // oversized, has estimate
+    ];
+    const report = lint(nodes, { dismissals: [{ ruleId: 'unestimated-leaf', nodeId: 'a' }] });
+    expect(rule(report, 'oversized-leaf').findings[0].dismissed).toBe(false);
+  });
+});

--- a/packages/server/src/lint/engine.ts
+++ b/packages/server/src/lint/engine.ts
@@ -1,0 +1,358 @@
+/**
+ * Plan-lint engine — the 8 plan-quality checks behind the plan_lint MCP
+ * tool and the mindmap plan-health panel (docs/plan-linter.md).
+ *
+ * Pure function: callers supply nodes, change-history digests, and
+ * dismissals; no DB or clock access in here (`now` is a parameter).
+ * Thresholds are opinionated defaults, deliberately not configurable.
+ */
+import type { Node } from '@mindblown/core';
+
+export const LINT_RULE_IDS = [
+  'unestimated-leaf',
+  'oversized-leaf',
+  'stale-progress',
+  'overdue-unreplanned',
+  'calibration-drift',
+  'no-done-criteria',
+  'stale-plan',
+  'dates-without-dependencies',
+] as const;
+export type LintRuleId = (typeof LINT_RULE_IDS)[number];
+export type LintSeverity = 'warn' | 'info';
+
+export interface LintFinding {
+  nodeId: string | null; // null for map-level findings
+  nodeText: string | null;
+  priority: string | null;
+  detail: string;
+  dismissed: boolean;
+}
+
+export interface LintRuleReport {
+  ruleId: LintRuleId;
+  severity: LintSeverity;
+  title: string;
+  why: string;
+  fix: string;
+  findings: LintFinding[];
+  activeCount: number; // findings not dismissed
+  dismissedCount: number;
+  ruleMuted: boolean; // map-level mute (dismissal with nodeId = null)
+  skipped?: string; // set when the rule couldn't run (e.g. no change history)
+}
+
+export interface LintReport {
+  scopeLabel: string;
+  warnCount: number; // active warn findings across rules
+  infoCount: number; // active info findings across rules
+  rules: LintRuleReport[];
+}
+
+/** Digest of change_events the history-backed rules need. */
+export interface LintHistory {
+  ok: boolean;
+  /** nodeId → ISO timestamp of the latest percentComplete change. */
+  lastProgressChange: Map<string, string>;
+  /** nodeId → ISO timestamps of dueDate/startDate/effortEstimate changes. */
+  replanEvents: Map<string, string[]>;
+  /** Whether ANY change event exists in the stale-plan window. */
+  anyRecentEvent: boolean;
+}
+
+export interface LintDismissal {
+  nodeId: string | null; // null = mute the whole rule on this map
+  ruleId: string;
+}
+
+export interface LintOptions {
+  map: {
+    statusWorkflow?: Array<{ id: string; category: string }> | null;
+    effortUnit?: string | null;
+  };
+  nodes: Node[];
+  unitsPerDay: number;
+  history: LintHistory;
+  dismissals: LintDismissal[];
+  nodeId?: string;
+  versionId?: string;
+  stalledDays?: number;
+  now?: Date;
+}
+
+// Opinionated defaults (docs/plan-linter.md — not configuration).
+const OVERSIZED_DAYS = 5;
+const OVERSIZED_MAP_SHARE = 0.15;
+const OVERSIZED_SHARE_MIN_LEAVES = 8;
+const DONE_CRITERIA_MIN_DAYS = 2;
+export const STALE_PLAN_DAYS = 14;
+const MIN_CALIBRATION_SAMPLES = 5;
+const CALIBRATION_LOW = 0.8;
+const CALIBRATION_HIGH = 1.25;
+const MIN_DATED_LEAVES_FOR_DEPS = 10;
+export const REPLAN_LOOKBACK_DAYS = 90;
+export const DEFAULT_STALLED_DAYS = 7;
+
+const isLeaf = (n: Node) => (n.childrenIds?.length ?? 0) === 0;
+
+/** Subtree + inherited-version scoping (same semantics as the MI suite). */
+function scopeLeaves(
+  nodes: Node[],
+  opts: { nodeId?: string; versionId?: string },
+): { leaves: Node[]; scopeLabel: string } | { error: string } {
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  let leaves: Node[];
+  let scopeLabel = 'whole map';
+
+  if (opts.nodeId) {
+    const root = nodeById.get(opts.nodeId);
+    if (!root) return { error: `Node ${opts.nodeId} not found` };
+    scopeLabel = `subtree of "${root.text}" (${opts.nodeId})`;
+    leaves = [];
+    const stack = [root];
+    while (stack.length) {
+      const n = stack.pop()!;
+      if (isLeaf(n)) leaves.push(n);
+      else for (const cid of n.childrenIds) {
+        const c = nodeById.get(cid);
+        if (c) stack.push(c);
+      }
+    }
+  } else {
+    leaves = nodes.filter(isLeaf);
+  }
+
+  if (opts.versionId) {
+    scopeLabel = `version ${opts.versionId}` + (opts.nodeId ? ` within ${scopeLabel}` : '');
+    const inherits = (leaf: Node): boolean => {
+      let cur: Node | undefined = leaf;
+      while (cur) {
+        if (cur.versionId === opts.versionId) return true;
+        cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
+      }
+      return false;
+    };
+    leaves = leaves.filter(inherits);
+  }
+
+  return { leaves, scopeLabel };
+}
+
+export function computePlanLint(opts: LintOptions): LintReport | { error: string } {
+  const { map, nodes, unitsPerDay, history, dismissals } = opts;
+  const stalledDays = opts.stalledDays ?? DEFAULT_STALLED_DAYS;
+  const now = opts.now ?? new Date();
+
+  const scoped = scopeLeaves(nodes, { nodeId: opts.nodeId, versionId: opts.versionId });
+  if ('error' in scoped) return { error: scoped.error };
+  const { leaves, scopeLabel } = scoped;
+
+  const unit = map.effortUnit ?? 'units';
+  const incomplete = leaves.filter((l) => (l.percentComplete ?? 0) < 100);
+  const totalEffort = leaves.reduce((s, l) => s + (l.effortEstimate ?? 0), 0);
+
+  const inProgressStatusIds = new Set(
+    (map.statusWorkflow ?? []).filter((s) => s.category === 'in_progress').map((s) => s.id),
+  );
+  const isInProgress = (n: Node) =>
+    (n.status != null && inProgressStatusIds.has(n.status)) ||
+    ((n.percentComplete ?? 0) > 0 && (n.percentComplete ?? 0) < 100);
+
+  const finding = (n: Node, detail: string): LintFinding => ({
+    nodeId: n.id,
+    nodeText: n.text,
+    priority: n.priority ?? null,
+    detail,
+    dismissed: false,
+  });
+  const mapFinding = (detail: string): LintFinding => ({
+    nodeId: null,
+    nodeText: null,
+    priority: null,
+    detail,
+    dismissed: false,
+  });
+
+  type RawRule = Omit<LintRuleReport, 'activeCount' | 'dismissedCount' | 'ruleMuted'>;
+  const rules: RawRule[] = [];
+
+  // 1. unestimated-leaf
+  rules.push({
+    ruleId: 'unestimated-leaf',
+    severity: 'warn',
+    title: 'Leaves without an effort estimate',
+    why: 'Unestimated work is invisible to the forecast — your finish date is under-counting.',
+    fix: 'Set an estimate on each; the AI estimator can draft one.',
+    findings: incomplete.filter((l) => l.effortEstimate == null).map((l) => finding(l, 'no estimate')),
+  });
+
+  // 2. oversized-leaf
+  const oversizedAbs = OVERSIZED_DAYS * unitsPerDay;
+  const shareRuleActive = totalEffort > 0 && leaves.length >= OVERSIZED_SHARE_MIN_LEAVES;
+  rules.push({
+    ruleId: 'oversized-leaf',
+    severity: 'warn',
+    title: `Oversized leaves (> ${OVERSIZED_DAYS} days${shareRuleActive ? ` or > ${OVERSIZED_MAP_SHARE * 100}% of the plan` : ''})`,
+    why: 'Small pieces get estimated far more accurately — projects built from small chunks succeed dramatically more often.',
+    fix: 'Split it into smaller children; the AI breakdown can suggest a split.',
+    findings: incomplete
+      .filter(
+        (l) =>
+          l.effortEstimate != null &&
+          (l.effortEstimate > oversizedAbs ||
+            (shareRuleActive && l.effortEstimate > OVERSIZED_MAP_SHARE * totalEffort)),
+      )
+      .sort((a, b) => (b.effortEstimate ?? 0) - (a.effortEstimate ?? 0))
+      .map((l) => finding(l, `${l.effortEstimate} ${unit}`)),
+  });
+
+  // 3. stale-progress
+  const staleCutoff = now.getTime() - stalledDays * 86_400_000;
+  rules.push({
+    ruleId: 'stale-progress',
+    severity: 'warn',
+    title: `In-progress work with no progress update in ${stalledDays}+ days`,
+    why: 'A task that stops moving is usually stuck, not slow — surface it before it slips the schedule.',
+    fix: 'Update its % complete, or flag what blocks it.',
+    findings: history.ok
+      ? incomplete
+          .filter((l) => {
+            if (!isInProgress(l)) return false;
+            const last = history.lastProgressChange.get(l.id);
+            return last == null || new Date(last).getTime() < staleCutoff;
+          })
+          .map((l) => {
+            const last = history.lastProgressChange.get(l.id);
+            return finding(
+              l,
+              last
+                ? `${l.percentComplete ?? 0}%, last progress change ${last.slice(0, 10)}`
+                : `${l.percentComplete ?? 0}%, no progress change on record`,
+            );
+          })
+      : [],
+    skipped: history.ok ? undefined : 'change history unavailable',
+  });
+
+  // 4. overdue-unreplanned
+  const todayIso = now.toISOString().slice(0, 10);
+  rules.push({
+    ruleId: 'overdue-unreplanned',
+    severity: 'warn',
+    title: 'Overdue leaves never re-planned',
+    why: 'Plans only work if they are amended when reality diverges — an ignored overdue date makes every downstream date fiction.',
+    fix: 'Re-plan it: move the due date, split the remainder, or descope.',
+    findings: history.ok
+      ? incomplete
+          .filter((l) => {
+            if (!l.dueDate || l.dueDate.slice(0, 10) >= todayIso) return false;
+            const evs = history.replanEvents.get(l.id) ?? [];
+            return !evs.some((ts) => ts > l.dueDate!);
+          })
+          .map((l) => finding(l, `due ${l.dueDate!.slice(0, 10)}, ${l.percentComplete ?? 0}%`))
+      : [],
+    skipped: history.ok ? undefined : 'change history unavailable',
+  });
+
+  // 5. calibration-drift (map-level — always evaluated on the whole map)
+  const calibrationLeaves = nodes.filter(
+    (n) => isLeaf(n) && n.effortEstimate != null && n.actualEffort != null,
+  );
+  const calibEstimate = calibrationLeaves.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
+  const calibActual = calibrationLeaves.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
+  const fudge = calibEstimate > 0 ? calibActual / calibEstimate : null;
+  const drifted =
+    fudge != null &&
+    calibrationLeaves.length >= MIN_CALIBRATION_SAMPLES &&
+    (fudge < CALIBRATION_LOW || fudge > CALIBRATION_HIGH);
+  rules.push({
+    ruleId: 'calibration-drift',
+    severity: 'info',
+    title: 'Estimation calibration drift (map-level)',
+    why:
+      fudge != null
+        ? `Your estimates historically run ${fudge.toFixed(2)}× — the velocity-adjusted forecast already corrects for this; consider sizing new estimates accordingly.`
+        : 'Once completed leaves carry both estimate and actual, the linter watches your calibration.',
+    fix: 'See the estimation-accuracy breakdown for per-node detail.',
+    findings: drifted
+      ? [mapFinding(`fudge factor ${fudge!.toFixed(2)}× over ${calibrationLeaves.length} completed leaves`)]
+      : [],
+  });
+
+  // 6. no-done-criteria
+  rules.push({
+    ruleId: 'no-done-criteria',
+    severity: 'info',
+    title: `Sizeable leaves (≥ ${DONE_CRITERIA_MIN_DAYS} days) without a done-definition`,
+    why: 'A task without a definition of done tends to be 90% finished forever — one sentence of "done means…" prevents it.',
+    fix: 'Add a sentence to the description. Nodes linked to a requirement are exempt.',
+    findings: incomplete
+      .filter(
+        (l) =>
+          l.requirementId == null &&
+          l.effortEstimate != null &&
+          l.effortEstimate >= DONE_CRITERIA_MIN_DAYS * unitsPerDay &&
+          (l.description ?? '').trim() === '',
+      )
+      .map((l) => finding(l, `${l.effortEstimate} ${unit}`)),
+  });
+
+  // 7. stale-plan (map-level)
+  const mapIncomplete = nodes.filter(isLeaf).some((l) => (l.percentComplete ?? 0) < 100);
+  rules.push({
+    ruleId: 'stale-plan',
+    severity: 'info',
+    title: `Stale plan (no changes in ${STALE_PLAN_DAYS}+ days, map-level)`,
+    why: 'A plan that is not touched weekly is a document, not a plan — a 2-minute review keeps the forecast honest.',
+    fix: 'Do a short review: update the progress and dates that changed.',
+    findings:
+      history.ok && mapIncomplete && !history.anyRecentEvent
+        ? [mapFinding(`map is incomplete with no recorded change in ${STALE_PLAN_DAYS} days`)]
+        : [],
+    skipped: history.ok ? undefined : 'change history unavailable',
+  });
+
+  // 8. dates-without-dependencies (map-level)
+  const datedLeaves = nodes.filter((n) => isLeaf(n) && (n.dueDate || n.startDate));
+  const totalDeps = nodes.reduce((s, n) => s + (n.dependencies?.length ?? 0), 0);
+  rules.push({
+    ruleId: 'dates-without-dependencies',
+    severity: 'info',
+    title: 'Scheduled plan with zero dependencies (map-level)',
+    why: 'Without dependencies the schedule assumes everything can happen in parallel — the critical path is what makes a finish date real.',
+    fix: 'Add dependencies between sequential tasks.',
+    findings:
+      datedLeaves.length >= MIN_DATED_LEAVES_FOR_DEPS && totalDeps === 0
+        ? [mapFinding(`${datedLeaves.length} dated leaves, 0 dependencies`)]
+        : [],
+  });
+
+  // ── Apply dismissals ──
+  const mutedRules = new Set(dismissals.filter((d) => d.nodeId == null).map((d) => d.ruleId));
+  const nodeDismissals = new Set(
+    dismissals.filter((d) => d.nodeId != null).map((d) => `${d.ruleId}:${d.nodeId}`),
+  );
+
+  const reports: LintRuleReport[] = rules.map((r) => {
+    const ruleMuted = mutedRules.has(r.ruleId);
+    const findings = r.findings.map((f) => ({
+      ...f,
+      dismissed: ruleMuted || (f.nodeId != null && nodeDismissals.has(`${r.ruleId}:${f.nodeId}`)),
+    }));
+    const dismissedCount = findings.filter((f) => f.dismissed).length;
+    return {
+      ...r,
+      findings,
+      dismissedCount,
+      activeCount: findings.length - dismissedCount,
+      ruleMuted,
+    };
+  });
+
+  return {
+    scopeLabel,
+    warnCount: reports.filter((r) => r.severity === 'warn').reduce((s, r) => s + r.activeCount, 0),
+    infoCount: reports.filter((r) => r.severity === 'info').reduce((s, r) => s + r.activeCount, 0),
+    rules: reports,
+  };
+}

--- a/packages/server/src/routes/__tests__/lint-routes.test.ts
+++ b/packages/server/src/routes/__tests__/lint-routes.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Route-wiring tests for /api/maps/:id/lint (+ dismissals). The engine
+ * has its own pure tests (../../lint/__tests__/engine.test.ts); here we
+ * pin permission gates, param validation, and the dismissal round-trip.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+let permissionLevel: 'view' | 'edit' | 'admin' | null = 'edit';
+
+vi.mock('../../db/permissions.js', () => ({
+  getPermission: vi.fn(async () => permissionLevel),
+  hasPermission: (perm: string | null, level: 'view' | 'edit' | 'admin') => {
+    if (!perm) return false;
+    const order = { view: 0, edit: 1, admin: 2 } as const;
+    return order[perm as keyof typeof order] >= order[level];
+  },
+}));
+
+const mapData = {
+  map: {
+    id: 'map-1',
+    effortUnit: 'days',
+    hoursPerDay: 8,
+    statusWorkflow: [{ id: 'wip', category: 'in_progress' }],
+  },
+  nodes: [
+    {
+      id: 'root',
+      parentId: null,
+      childrenIds: ['leaf-1'],
+      text: 'Root',
+      effortEstimate: null,
+      percentComplete: null,
+      dependencies: [],
+    },
+    {
+      id: 'leaf-1',
+      parentId: 'root',
+      childrenIds: [],
+      text: 'Unestimated task',
+      effortEstimate: null,
+      actualEffort: null,
+      percentComplete: 0,
+      status: null,
+      priority: null,
+      dueDate: null,
+      startDate: null,
+      description: null,
+      requirementId: null,
+      versionId: null,
+      dependencies: [],
+    },
+  ],
+};
+
+vi.mock('../../db/maps.js', () => ({
+  getMap: vi.fn(async (id: string) => (id === 'map-1' ? mapData : null)),
+}));
+
+vi.mock('../../db/events.js', () => ({
+  listEvents: vi.fn(async () => []),
+}));
+
+interface DismissalRow {
+  id: string;
+  mapId: string;
+  nodeId: string | null;
+  ruleId: string;
+  dismissedBy: string | null;
+  createdAt: Date;
+}
+const dismissals: DismissalRow[] = [];
+
+vi.mock('../../db/lint.js', () => ({
+  listDismissals: vi.fn(async (mapId: string) => dismissals.filter((d) => d.mapId === mapId)),
+  upsertDismissal: vi.fn(async (mapId: string, ruleId: string, nodeId: string | null, by: string | null) => {
+    const existing = dismissals.find((d) => d.mapId === mapId && d.ruleId === ruleId && d.nodeId === nodeId);
+    if (existing) return { row: existing, created: false };
+    const row: DismissalRow = {
+      id: `dis-${dismissals.length + 1}`,
+      mapId,
+      nodeId,
+      ruleId,
+      dismissedBy: by,
+      createdAt: new Date(),
+    };
+    dismissals.push(row);
+    return { row, created: true };
+  }),
+  deleteDismissal: vi.fn(async (mapId: string, ruleId: string, nodeId: string | null) => {
+    const idx = dismissals.findIndex(
+      (d) => d.mapId === mapId && d.ruleId === ruleId && d.nodeId === nodeId,
+    );
+    if (idx >= 0) dismissals.splice(idx, 1);
+  }),
+}));
+
+import { lintRoutes } from '../lint.js';
+
+async function buildApp(userId: string | null = 'user-1'): Promise<FastifyInstance> {
+  const app = Fastify();
+  app.addHook('preHandler', async (req) => {
+    (req as unknown as { userId: string | null }).userId = userId;
+  });
+  await app.register(lintRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  permissionLevel = 'edit';
+  dismissals.length = 0;
+});
+
+describe('GET /api/maps/:id/lint', () => {
+  it('returns a structured report with the unestimated leaf flagged', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/maps/map-1/lint' });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.warnCount).toBeGreaterThanOrEqual(1);
+    const unest = body.rules.find((r: { ruleId: string }) => r.ruleId === 'unestimated-leaf');
+    expect(unest.findings).toHaveLength(1);
+    expect(unest.findings[0].nodeId).toBe('leaf-1');
+    expect(unest.why).toBeTruthy();
+    expect(unest.fix).toBeTruthy();
+  });
+
+  it('403 without view permission', async () => {
+    permissionLevel = null;
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/maps/map-1/lint' });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('404 for an unknown map, 404 for an unknown scope node, 400 for an unknown rule', async () => {
+    const app = await buildApp();
+    expect((await app.inject({ method: 'GET', url: '/api/maps/nope/lint' })).statusCode).toBe(404);
+    expect(
+      (await app.inject({ method: 'GET', url: '/api/maps/map-1/lint?nodeId=nope' })).statusCode,
+    ).toBe(404);
+    expect(
+      (await app.inject({ method: 'GET', url: '/api/maps/map-1/lint?rule=bogus' })).statusCode,
+    ).toBe(400);
+    await app.close();
+  });
+
+  it('rule filter narrows the report and recomputes counts', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/maps/map-1/lint?rule=stale-plan' });
+    await app.close();
+    const body = res.json();
+    expect(body.rules).toHaveLength(1);
+    expect(body.rules[0].ruleId).toBe('stale-plan');
+    expect(body.warnCount).toBe(0);
+  });
+
+  it('dismissed findings are flagged and excluded from counts', async () => {
+    dismissals.push({
+      id: 'dis-x',
+      mapId: 'map-1',
+      nodeId: 'leaf-1',
+      ruleId: 'unestimated-leaf',
+      dismissedBy: 'user-1',
+      createdAt: new Date(),
+    });
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/api/maps/map-1/lint' });
+    await app.close();
+    const unest = res.json().rules.find((r: { ruleId: string }) => r.ruleId === 'unestimated-leaf');
+    expect(unest.findings[0].dismissed).toBe(true);
+    expect(unest.activeCount).toBe(0);
+  });
+});
+
+describe('dismissal endpoints', () => {
+  it('POST creates (201), repeat POST is idempotent (200 same row)', async () => {
+    const app = await buildApp();
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/lint/dismissals',
+      payload: { ruleId: 'unestimated-leaf', nodeId: 'leaf-1' },
+    });
+    expect(first.statusCode).toBe(201);
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/lint/dismissals',
+      payload: { ruleId: 'unestimated-leaf', nodeId: 'leaf-1' },
+    });
+    await app.close();
+    expect(second.statusCode).toBe(200);
+    expect(second.json().id).toBe(first.json().id);
+  });
+
+  it('POST without nodeId records a map-wide rule mute', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/lint/dismissals',
+      payload: { ruleId: 'oversized-leaf' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(201);
+    expect(res.json().nodeId).toBeNull();
+  });
+
+  it('POST validates ruleId', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/lint/dismissals',
+      payload: { ruleId: 'bogus' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('POST/DELETE require edit permission (view-only is 403)', async () => {
+    permissionLevel = 'view';
+    const app = await buildApp();
+    const post = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/lint/dismissals',
+      payload: { ruleId: 'stale-plan' },
+    });
+    const del = await app.inject({
+      method: 'DELETE',
+      url: '/api/maps/map-1/lint/dismissals?ruleId=stale-plan',
+    });
+    await app.close();
+    expect(post.statusCode).toBe(403);
+    expect(del.statusCode).toBe(403);
+  });
+
+  it('DELETE undoes a dismissal so the finding becomes active again', async () => {
+    const app = await buildApp();
+    await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/lint/dismissals',
+      payload: { ruleId: 'unestimated-leaf', nodeId: 'leaf-1' },
+    });
+    const del = await app.inject({
+      method: 'DELETE',
+      url: '/api/maps/map-1/lint/dismissals?ruleId=unestimated-leaf&nodeId=leaf-1',
+    });
+    expect(del.statusCode).toBe(204);
+    const res = await app.inject({ method: 'GET', url: '/api/maps/map-1/lint' });
+    await app.close();
+    const unest = res.json().rules.find((r: { ruleId: string }) => r.ruleId === 'unestimated-leaf');
+    expect(unest.findings[0].dismissed).toBe(false);
+    expect(unest.activeCount).toBe(1);
+  });
+});

--- a/packages/server/src/routes/lint.ts
+++ b/packages/server/src/routes/lint.ts
@@ -1,0 +1,193 @@
+/**
+ * Plan-lint routes — the REST surface behind the plan-health panel and
+ * the plan_lint MCP tool (docs/plan-linter.md).
+ *
+ *   GET    /api/maps/:id/lint              — run the linter, structured report
+ *   POST   /api/maps/:id/lint/dismissals   — dismiss a finding / mute a rule
+ *   DELETE /api/maps/:id/lint/dismissals   — undo a dismissal (querystring)
+ *
+ * The engine itself is pure (../lint/engine.ts); this file supplies data:
+ * nodes from the map, change-event digests, dismissals, unitsPerDay.
+ */
+import type { FastifyInstance } from 'fastify';
+import * as mapDb from '../db/maps.js';
+import * as permDb from '../db/permissions.js';
+import * as lintDb from '../db/lint.js';
+import { listEvents } from '../db/events.js';
+import {
+  computePlanLint,
+  LINT_RULE_IDS,
+  REPLAN_LOOKBACK_DAYS,
+  STALE_PLAN_DAYS,
+  type LintHistory,
+  type LintRuleId,
+} from '../lint/engine.js';
+
+const MS_PER_DAY = 86_400_000;
+
+async function loadHistory(mapId: string, now: Date): Promise<LintHistory> {
+  try {
+    const replanSince = new Date(now.getTime() - REPLAN_LOOKBACK_DAYS * MS_PER_DAY);
+    const staleSince = new Date(now.getTime() - STALE_PLAN_DAYS * MS_PER_DAY);
+    const [progress, due, start, est, recent] = await Promise.all([
+      listEvents({ mapId, fieldName: 'percentComplete', since: replanSince, limit: 1000 }),
+      listEvents({ mapId, fieldName: 'dueDate', since: replanSince, limit: 1000 }),
+      listEvents({ mapId, fieldName: 'startDate', since: replanSince, limit: 1000 }),
+      listEvents({ mapId, fieldName: 'effortEstimate', since: replanSince, limit: 1000 }),
+      listEvents({ mapId, since: staleSince, limit: 1 }),
+    ]);
+    // Events arrive newest-first; first hit per node is its latest change.
+    const lastProgressChange = new Map<string, string>();
+    for (const e of progress) {
+      if (e.nodeId && !lastProgressChange.has(e.nodeId)) lastProgressChange.set(e.nodeId, e.createdAt);
+    }
+    const replanEvents = new Map<string, string[]>();
+    for (const e of [...due, ...start, ...est]) {
+      if (!e.nodeId) continue;
+      const list = replanEvents.get(e.nodeId) ?? [];
+      list.push(e.createdAt);
+      replanEvents.set(e.nodeId, list);
+    }
+    return { ok: true, lastProgressChange, replanEvents, anyRecentEvent: recent.length > 0 };
+  } catch {
+    return { ok: false, lastProgressChange: new Map(), replanEvents: new Map(), anyRecentEvent: false };
+  }
+}
+
+export async function lintRoutes(app: FastifyInstance) {
+  // ── GET /api/maps/:id/lint ─────────────────────────────────────
+  app.get<{
+    Params: { id: string };
+    Querystring: { nodeId?: string; versionId?: string; stalledDays?: string; rule?: string };
+  }>('/api/maps/:id/lint', async (req, reply) => {
+    const userId = req.userId;
+    if (userId) {
+      const perm = await permDb.getPermission(req.params.id, userId);
+      if (!permDb.hasPermission(perm, 'view')) {
+        return reply.status(403).send({
+          error: { code: 'FORBIDDEN', message: 'You do not have access to this map' },
+        });
+      }
+    }
+
+    const data = await mapDb.getMap(req.params.id);
+    if (!data) {
+      return reply.status(404).send({
+        error: { code: 'MAP_NOT_FOUND', message: `Map ${req.params.id} not found` },
+      });
+    }
+
+    const rule = req.query.rule as LintRuleId | undefined;
+    if (rule && !LINT_RULE_IDS.includes(rule)) {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: `Unknown rule "${rule}"` },
+      });
+    }
+    const stalledDays = req.query.stalledDays ? Number(req.query.stalledDays) : undefined;
+    if (stalledDays != null && (!Number.isInteger(stalledDays) || stalledDays < 1)) {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: 'stalledDays must be a positive integer' },
+      });
+    }
+
+    // Same effort-unit → days conversion as GET /:id/schedule.
+    const unitsPerDay = data.map.effortUnit === 'hours' ? (data.map.hoursPerDay ?? 8) : 1;
+
+    const now = new Date();
+    const [history, dismissalRows] = await Promise.all([
+      loadHistory(req.params.id, now),
+      lintDb.listDismissals(req.params.id),
+    ]);
+
+    const report = computePlanLint({
+      map: data.map,
+      nodes: data.nodes,
+      unitsPerDay,
+      history,
+      dismissals: dismissalRows.map((d) => ({ nodeId: d.nodeId, ruleId: d.ruleId })),
+      nodeId: req.query.nodeId,
+      versionId: req.query.versionId,
+      stalledDays,
+      now,
+    });
+    if ('error' in report) {
+      return reply.status(404).send({ error: { code: 'NODE_NOT_FOUND', message: report.error } });
+    }
+
+    if (rule) {
+      const filtered = report.rules.filter((r) => r.ruleId === rule);
+      return reply.send({
+        ...report,
+        rules: filtered,
+        warnCount: filtered.filter((r) => r.severity === 'warn').reduce((s, r) => s + r.activeCount, 0),
+        infoCount: filtered.filter((r) => r.severity === 'info').reduce((s, r) => s + r.activeCount, 0),
+      });
+    }
+    return reply.send(report);
+  });
+
+  // ── POST /api/maps/:id/lint/dismissals ─────────────────────────
+  // Body: { ruleId, nodeId? } — nodeId omitted/null mutes the rule
+  // map-wide. Idempotent: re-dismissing returns the existing row.
+  app.post<{
+    Params: { id: string };
+    Body: { ruleId?: unknown; nodeId?: unknown };
+  }>('/api/maps/:id/lint/dismissals', async (req, reply) => {
+    const userId = req.userId;
+    if (userId) {
+      const perm = await permDb.getPermission(req.params.id, userId);
+      if (!permDb.hasPermission(perm, 'edit')) {
+        return reply.status(403).send({
+          error: { code: 'FORBIDDEN', message: 'Edit permission required' },
+        });
+      }
+    }
+
+    const ruleId = req.body?.ruleId;
+    const nodeId = req.body?.nodeId ?? null;
+    if (typeof ruleId !== 'string' || !LINT_RULE_IDS.includes(ruleId as LintRuleId)) {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: `ruleId must be one of: ${LINT_RULE_IDS.join(', ')}` },
+      });
+    }
+    if (nodeId != null && typeof nodeId !== 'string') {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: 'nodeId must be a string or omitted' },
+      });
+    }
+
+    const { row, created } = await lintDb.upsertDismissal(
+      req.params.id,
+      ruleId,
+      nodeId as string | null,
+      userId ?? null,
+    );
+    return reply.status(created ? 201 : 200).send(row);
+  });
+
+  // ── DELETE /api/maps/:id/lint/dismissals?ruleId=…&nodeId=… ─────
+  // nodeId omitted = undo the map-wide rule mute.
+  app.delete<{
+    Params: { id: string };
+    Querystring: { ruleId?: string; nodeId?: string };
+  }>('/api/maps/:id/lint/dismissals', async (req, reply) => {
+    const userId = req.userId;
+    if (userId) {
+      const perm = await permDb.getPermission(req.params.id, userId);
+      if (!permDb.hasPermission(perm, 'edit')) {
+        return reply.status(403).send({
+          error: { code: 'FORBIDDEN', message: 'Edit permission required' },
+        });
+      }
+    }
+
+    const { ruleId, nodeId } = req.query;
+    if (!ruleId) {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: 'ruleId query parameter is required' },
+      });
+    }
+    await lintDb.deleteDismissal(req.params.id, ruleId, nodeId ?? null);
+    return reply.status(204).send();
+  });
+}


### PR DESCRIPTION
## What

**Surface 2 of [docs/plan-linter.md](../blob/master/docs/plan-linter.md)** — the plan linter becomes visible to humans.

### One engine, two surfaces
The 8 lint rules move out of the MCP tool into a pure server-side engine (`packages/server/src/lint/engine.ts`), exposed as `GET /api/maps/:id/lint` (structured findings, view-gated). The `plan_lint` MCP tool is refactored into a thin text formatter over that endpoint — no more parallel implementations to drift. The engine no longer needs a scheduler run (`unitsPerDay` derives from the map row), so the endpoint is cheap.

### Dismissals
`lint_dismissals` table + idempotent POST / DELETE endpoints (edit-gated). Node-level dismiss, or map-wide rule mute via `NULL node_id`. Dismissed findings stay in the payload flagged `dismissed: true` but leave the counts. v1 semantics: permanent until undone (re-fire-on-material-change is a possible v2; spec updated to match).

### The panel
Right-dock toggle in the toolbar, mutually exclusive with the Sprint/Blocked/Triage panels. Per the guidance design rules: pull-based (fetched when opened, nothing pushed), each rule shows its teaching why-line + fix hint, findings click through to the map (same focus/select/pan mechanism as the requirements register), ✕ dismisses, 🔕 mutes a rule, both undoable, dismissed findings viewable via a checkbox.

## Tests & verification

- 15 pure engine tests (rule firing, unit-awareness, scoping, dismissal application) + 10 route tests (permission gates, validation, dismissal round-trip). `pnpm turbo typecheck test` fully green.
- Driven end-to-end on a scratch DB: REST round-trip verified with curl (201/200 idempotency, 204 undo, counts recompute); `plan_lint` MCP over stdio against the same server shows the shared engine (including "(1 dismissed)" in its clean-list); panel driven in a real Chromium via Playwright — login → map → panel (screenshot verified), click-through focuses + selects the node, dismiss drops the warning count 20→19, rule-mute shows the muted footer.
- Ride-along: `pnpm-lock.yaml` entry for `docx` (added to `package.json` in #214 without the lockfile — fresh installs currently fail on master).

One pre-existing quirk noticed while testing (not addressed here): toolbar panel buttons (all of them, incl. Sprints) swallow clicks during a brief re-render window right after map load.

Deploy note: the `lint_dismissals` migration is idempotent and runs on systemd restart as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9eAuogxQ9r6TrjMGyjpTz