### PR TITLE
feat(forecast): per-map focus factor — honest completion dates

### DIFF
--- a/packages/core/src/__tests__/velocity.test.ts
+++ b/packages/core/src/__tests__/velocity.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampFocusFactor,
+  DEFAULT_FOCUS_FACTOR,
+  FOCUS_FACTOR_MIN,
+  FOCUS_FACTOR_MAX,
+} from '../velocity.js';
+
+describe('clampFocusFactor', () => {
+  it('passes valid values through unchanged', () => {
+    expect(clampFocusFactor(0.5)).toBe(0.5);
+    expect(clampFocusFactor(0.75)).toBe(0.75);
+    expect(clampFocusFactor(FOCUS_FACTOR_MIN)).toBe(FOCUS_FACTOR_MIN);
+    expect(clampFocusFactor(FOCUS_FACTOR_MAX)).toBe(FOCUS_FACTOR_MAX);
+  });
+
+  it('caps above 1 at 1 (can never spend >100% of time on planned work)', () => {
+    expect(clampFocusFactor(1.5)).toBe(1);
+    expect(clampFocusFactor(10)).toBe(1);
+  });
+
+  it('floors at the minimum to avoid a runaway ÷focusFactor', () => {
+    expect(clampFocusFactor(0)).toBe(FOCUS_FACTOR_MIN);
+    expect(clampFocusFactor(-2)).toBe(FOCUS_FACTOR_MIN);
+    expect(clampFocusFactor(0.001)).toBe(FOCUS_FACTOR_MIN);
+  });
+
+  it('falls back to the default (1.0) for missing / non-finite values', () => {
+    expect(clampFocusFactor(null)).toBe(DEFAULT_FOCUS_FACTOR);
+    expect(clampFocusFactor(undefined)).toBe(DEFAULT_FOCUS_FACTOR);
+    expect(clampFocusFactor(NaN)).toBe(DEFAULT_FOCUS_FACTOR);
+    expect(clampFocusFactor(Infinity)).toBe(DEFAULT_FOCUS_FACTOR);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,3 +82,11 @@ export {
   buildInProgressIds,
   buildTodoIds,
 } from './statusWorkflow.js';
+
+// Velocity & capacity helpers
+export {
+  FOCUS_FACTOR_MIN,
+  FOCUS_FACTOR_MAX,
+  DEFAULT_FOCUS_FACTOR,
+  clampFocusFactor,
+} from './velocity.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -372,6 +372,17 @@ export interface MindMap {
    */
   workerCount: number;
 
+  /**
+   * Fraction of calendar time that actually reaches planned-ticket work
+   * (0.05–1.0). Captures the drag of meetings, support, firefighting and
+   * unplanned work — a team spending half its time on planned tickets has a
+   * focus factor of 0.5, so the same estimated effort takes twice as long in
+   * calendar terms. Applied to the *velocity-adjusted* forecast line only
+   * (planned finish stays the idealised scheduler baseline), orthogonal to
+   * the estimation fudge factor. Default 1.0 = no capacity leakage.
+   */
+  focusFactor: number;
+
   // ── Metadata ──────────────────────────────────────────────
   createdAt: string;
   updatedAt: string;

--- a/packages/core/src/velocity.ts
+++ b/packages/core/src/velocity.ts
@@ -1,0 +1,35 @@
+/**
+ * Velocity & capacity helpers.
+ *
+ * The **focus factor** models the fraction of a worker's calendar time that
+ * actually reaches planned-ticket work. Meetings, support, firefighting and
+ * unplanned tickets all eat into a day — a team that spends half its time on
+ * planned work has a focus factor of 0.5, so the same estimated effort takes
+ * twice as long in calendar terms.
+ *
+ * It is orthogonal to the estimation *fudge factor* (actual/estimate): the
+ * fudge factor corrects how a ticket is *sized*, the focus factor corrects how
+ * much sizing gets *delivered* per calendar day. A realistic completion
+ * forecast applies both:
+ *
+ *     calendarDays = schedulerDays × fudgeFactor ÷ focusFactor
+ *
+ * Default 1.0 = no capacity leakage (the historical behaviour — every existing
+ * map forecasts exactly as before until its focus factor is set).
+ */
+
+export const FOCUS_FACTOR_MIN = 0.05;
+export const FOCUS_FACTOR_MAX = 1;
+export const DEFAULT_FOCUS_FACTOR = 1;
+
+/**
+ * Clamp a focus factor to the sane range (0.05, 1]. A factor above 1 would
+ * mean spending more than 100% of calendar time on planned work (that's the
+ * fudge factor's job, not this knob); a factor at/below 0 would blow up the
+ * `÷ focusFactor` division. Non-finite / missing values fall back to the
+ * default (1.0 = no effect).
+ */
+export function clampFocusFactor(value: number | null | undefined): number {
+  if (value == null || !Number.isFinite(value)) return DEFAULT_FOCUS_FACTOR;
+  return Math.min(FOCUS_FACTOR_MAX, Math.max(FOCUS_FACTOR_MIN, value));
+}

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -172,6 +172,8 @@ export interface ScheduleResult {
   projectStartDate: string;
   effortUnit: 'hours' | 'days' | 'points';
   unitsPerDay: number;
+  /** Fraction of calendar time reaching planned work (0.05–1.0); default 1. */
+  focusFactor?: number;
   versionId?: string | null;
   crossVersionDependencies?: Array<{
     fromNodeId: string;
@@ -343,6 +345,7 @@ export function updateMap(
     projectStartDate?: string | null;
     hoursPerDay?: number;
     workerCount?: number;
+    focusFactor?: number;
     autoImportNewIssues?: boolean;
   },
 ): Promise<MapSummary> {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -23,6 +23,7 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { allTools as sharedTools, type ToolSpec } from '@mindblown/tool-kit';
+import { clampFocusFactor } from '@mindblown/core';
 import * as api from './api.js';
 import { scopedLeaves } from './scope.js';
 import { httpBackend } from './backend.js';
@@ -665,6 +666,12 @@ server.tool(
 
       // ── Scheduler-based planned finish ──
       const sched = await api.getSchedule(mapId);
+
+      // ── Focus factor (capacity leakage) — velocity line only ──
+      // Fraction of calendar time reaching planned work; stretches the
+      // velocity-adjusted finish so it reflects real throughput, not just
+      // estimation bias. Default 1.0 = no effect.
+      const focusFactor = clampFocusFactor(sched.focusFactor);
       const scopedIds = new Set(leaves.map((l) => l.id));
       const scopedSched = sched.schedule.filter((s) => scopedIds.has(s.nodeId));
       const maxComputedEnd = scopedSched.reduce((m, s) => Math.max(m, s.computedEnd), 0);
@@ -695,7 +702,7 @@ server.tool(
       const anchor = today > projectStart ? today : projectStart;
       const elapsedFromStart = Math.max(0, daysBetween(anchor, projectStart));
       const remainingSchedulerDays = Math.max(0, plannedFinishCalendarDays - elapsedFromStart);
-      const velocityFinishCalendarDays = remainingSchedulerDays * effectiveFudge;
+      const velocityFinishCalendarDays = (remainingSchedulerDays * effectiveFudge) / focusFactor;
       const velocityFinishDate = addCalendarDays(anchor, velocityFinishCalendarDays);
 
       // ── Target date resolution ──
@@ -733,6 +740,11 @@ server.tool(
       } else {
         lines.push(`Velocity calibration: no data (need leaves with both estimate + actual); using 1.00x`);
       }
+      if (focusFactor < 1) {
+        lines.push(`Focus factor:         ${focusFactor.toFixed(2)} (${Math.round(focusFactor * 100)}% of calendar time reaches planned work — set via update_map)`);
+      } else {
+        lines.push(`Focus factor:         1.00 (full capacity assumed — lower it via update_map to reflect meetings/support/unplanned work)`);
+      }
       lines.push('');
 
       if (maxComputedEnd > 0) {
@@ -741,7 +753,8 @@ server.tool(
         lines.push(`Planned finish:      (no schedulable effort in scope)`);
       }
       if (remainingEffort > 0) {
-        lines.push(`Velocity-adjusted:   ${iso(velocityFinishDate)} (${velocityFinishCalendarDays.toFixed(1)} calendar days from ${iso(anchor)}, fudge ${effectiveFudge.toFixed(2)}x)`);
+        const focusNote = focusFactor < 1 ? `, focus ${focusFactor.toFixed(2)}` : '';
+        lines.push(`Velocity-adjusted:   ${iso(velocityFinishDate)} (${velocityFinishCalendarDays.toFixed(1)} calendar days from ${iso(anchor)}, fudge ${effectiveFudge.toFixed(2)}x${focusNote})`);
       } else {
         lines.push(`Velocity-adjusted:   already complete`);
       }

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -113,6 +113,11 @@ export function ReleasesView() {
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [formState, setFormState] = useState<FormState | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // Focus-factor knob: fraction of calendar time reaching planned work.
+  // Editing it saves via update_map and re-runs the forecast (which stretches
+  // the velocity-adjusted finish dates). Mirrors the server value on load.
+  const [focusInput, setFocusInput] = useState<number>(1);
+  const [savingFocus, setSavingFocus] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -148,6 +153,31 @@ export function ReleasesView() {
   }, [currentMapId, versions, refreshNonce]);
 
   const handleRefresh = () => setRefreshNonce((n) => n + 1);
+
+  // Keep the visible Focus input in sync with whatever the server returns.
+  useEffect(() => {
+    if (forecast?.focusFactor !== undefined) {
+      setFocusInput(forecast.focusFactor);
+    }
+  }, [forecast?.focusFactor]);
+
+  // Commit a new focus factor: clamp to (0.05, 1], persist, then re-forecast.
+  const commitFocus = async (value: number) => {
+    if (!currentMapId) return;
+    const clamped = Math.min(1, Math.max(0.05, value));
+    setFocusInput(clamped);
+    if (forecast && clamped === forecast.focusFactor) return;
+    setSavingFocus(true);
+    try {
+      await api.updateMap(currentMapId, { focusFactor: clamped });
+      setRefreshNonce((n) => n + 1); // re-run forecast with the new factor
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update focus factor');
+      if (forecast) setFocusInput(forecast.focusFactor); // revert visible value
+    } finally {
+      setSavingFocus(false);
+    }
+  };
 
   // Merge store versions (authoritative list, includes empty ones) with
   // the forecast rows (richer stats for versions that have linked leaves).
@@ -243,6 +273,7 @@ export function ReleasesView() {
                 {' · sequential by sortOrder, '}
                 {forecast.dailyCapacity} {unit}/day capacity
                 {fudge != null && ` · ${fudge.toFixed(2)}× velocity`}
+                {forecast.focusFactor < 1 && ` · ${Math.round(forecast.focusFactor * 100)}% focus`}
                 {' · snapshot '}
                 {formatAge(forecast.lastSnapshotAt)}
               </>
@@ -250,7 +281,38 @@ export function ReleasesView() {
             {activeVersionFilter && ' · filtered'}
           </div>
         </div>
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <label
+            title="Focus factor — fraction of calendar time reaching planned work. Below 100% stretches the velocity-adjusted finish to absorb meetings, support and unplanned work."
+            style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11, color: '#64748b', fontWeight: 600 }}
+          >
+            Focus
+            <input
+              type="number"
+              min={5}
+              max={100}
+              step={5}
+              disabled={savingFocus || !forecast}
+              value={Math.round(focusInput * 100)}
+              onChange={(e) => {
+                const pct = Number(e.target.value);
+                if (!Number.isNaN(pct)) setFocusInput(Math.min(100, Math.max(5, pct)) / 100);
+              }}
+              onBlur={() => commitFocus(focusInput)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+              }}
+              style={{
+                width: 52,
+                padding: '3px 6px',
+                fontSize: 12,
+                border: '1px solid #cbd5e1',
+                borderRadius: 4,
+                background: savingFocus ? '#f1f5f9' : '#fff',
+              }}
+            />
+            <span>%</span>
+          </label>
           <button
             onClick={startCreate}
             disabled={formState !== null}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -694,6 +694,8 @@ export interface ScheduleResponse {
   effortUnit: 'hours' | 'days' | 'points';
   unitsPerDay: number;
   workerCount: number;
+  /** Fraction of calendar time reaching planned work (0.05–1.0); default 1. */
+  focusFactor: number;
 }
 
 export function fetchSchedule(mapId: string): Promise<ScheduleResponse> {
@@ -843,6 +845,8 @@ export interface ReleaseForecastResponse {
   effortUnit: string;
   dailyCapacity: number;
   fudgeFactor: number | null;
+  /** Fraction of calendar time reaching planned work (0.05–1.0); default 1. */
+  focusFactor: number;
   calibrationLeafCount: number;
   releases: ReleaseForecastRow[];
   lastSnapshotAt: string | null;

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -85,6 +85,7 @@ export function dbMapToCore(row: Record<string, unknown>): MindMap {
     projectStartDate: (get('projectStartDate', 'project_start_date') as string) ?? null,
     hoursPerDay: (get('hoursPerDay', 'hours_per_day') as number) ?? 8,
     workerCount: (get('workerCount', 'worker_count') as number) ?? 1,
+    focusFactor: (get('focusFactor', 'focus_factor') as number) ?? 1,
     createdAt: (get('createdAt', 'created_at') instanceof Date
       ? (get('createdAt', 'created_at') as Date).toISOString()
       : (get('createdAt', 'created_at') as string)),

--- a/packages/server/src/db/maps.ts
+++ b/packages/server/src/db/maps.ts
@@ -4,6 +4,7 @@ import { maps, mapPermissions, nodes } from './schema.js';
 import { dbMapToCore, dbNodeToCore } from './helpers.js';
 import { notDeleted } from './nodes.js';
 import type { MindMap, Node as CoreNode, StatusDef, CustomFieldDef, LayoutMode, EffortUnit, Baseline } from '@mindblown/core';
+import { clampFocusFactor } from '@mindblown/core';
 
 // ── Create ─────────────────────────────────────────────────────────
 
@@ -116,6 +117,7 @@ export interface UpdateMapInput {
   projectStartDate?: string | null;
   hoursPerDay?: number;
   workerCount?: number;
+  focusFactor?: number;
   githubInstallationId?: string | null;
   githubRepoOwner?: string | null;
   githubRepoName?: string | null;
@@ -139,6 +141,7 @@ export async function updateMap(mapId: string, input: UpdateMapInput): Promise<M
   if (input.projectStartDate !== undefined) updates.projectStartDate = input.projectStartDate;
   if (input.hoursPerDay !== undefined) updates.hoursPerDay = input.hoursPerDay;
   if (input.workerCount !== undefined) updates.workerCount = input.workerCount;
+  if (input.focusFactor !== undefined) updates.focusFactor = clampFocusFactor(input.focusFactor);
   if (input.githubInstallationId !== undefined) updates.githubInstallationId = input.githubInstallationId;
   if (input.githubRepoOwner !== undefined) updates.githubRepoOwner = input.githubRepoOwner;
   if (input.githubRepoName !== undefined) updates.githubRepoName = input.githubRepoName;

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -703,6 +703,14 @@ export async function runMigrations(): Promise<void> {
     ALTER TABLE maps ADD COLUMN IF NOT EXISTS worker_count REAL NOT NULL DEFAULT 1
   `);
 
+  // ── Forecast capacity knob: focusFactor ────────────────────────
+  // Per-map fraction of calendar time reaching planned-ticket work (0.05–1.0).
+  // Discounts the velocity-adjusted completion forecast. Default 1 = no
+  // leakage, so existing maps forecast exactly as before until it is set.
+  await db.execute(sql`
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS focus_factor REAL NOT NULL DEFAULT 1
+  `);
+
   // ── One-shot data migrations ───────────────────────────────────
   // Tracks data flips that should run exactly once per database.
   await db.execute(sql`

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -128,6 +128,12 @@ export const maps = pgTable('maps', {
   // higher = more parallelism. Stored as REAL to allow fractional
   // values later if useful.
   workerCount: real('worker_count').notNull().default(1),
+
+  // ── Forecast capacity knob: focusFactor ────────────────────────
+  // Fraction of calendar time that reaches planned-ticket work (0.05–1.0).
+  // Discounts the velocity-adjusted completion forecast to absorb meetings /
+  // support / firefighting / unplanned work. Default 1 = no leakage.
+  focusFactor: real('focus_factor').notNull().default(1),
 });
 
 // ── Nodes ──────────────────────────────────────────────────────────

--- a/packages/server/src/lib/__tests__/releaseForecast.test.ts
+++ b/packages/server/src/lib/__tests__/releaseForecast.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import type { MindMap, Node as CoreNode, Version } from '@mindblown/core';
+import { computeReleaseForecast } from '../releaseForecast.js';
+
+// ── Minimal fixtures ──
+// A map anchored at a fixed start with one active version holding a single
+// open 10-day leaf and no calibration data (so the estimation fudge is 1.0 and
+// the focus factor is the only thing moving the velocity line).
+const NOW = new Date('2026-01-01T00:00:00Z');
+
+function makeMap(focusFactor: number): MindMap {
+  return {
+    effortUnit: 'days',
+    projectStartDate: '2026-01-01',
+    hoursPerDay: 8,
+    workerCount: 1,
+    focusFactor,
+  } as unknown as MindMap;
+}
+
+const leaf: CoreNode = {
+  id: 'leaf-1',
+  parentId: 'root',
+  childrenIds: [],
+  effortEstimate: 10,
+  actualEffort: null,
+  percentComplete: 0,
+  versionId: 'v1',
+} as unknown as CoreNode;
+
+const root: CoreNode = {
+  id: 'root',
+  parentId: null,
+  childrenIds: ['leaf-1'],
+} as unknown as CoreNode;
+
+const version: Version = {
+  id: 'v1',
+  name: 'V1',
+  status: 'active',
+  sortOrder: 0,
+  targetDate: null,
+} as unknown as Version;
+
+describe('computeReleaseForecast — focusFactor', () => {
+  it('leaves the velocity line equal to planned at focusFactor 1.0', () => {
+    const result = computeReleaseForecast(makeMap(1), [root, leaf], [version], NOW);
+    expect(result.focusFactor).toBe(1);
+    const row = result.releases[0];
+    // 10 remaining days, capacity 1/day → 2026-01-11 for both.
+    expect(row.plannedFinishDate).toBe('2026-01-11');
+    expect(row.velocityAdjustedFinishDate).toBe('2026-01-11');
+  });
+
+  it('doubles the remaining velocity horizon at focusFactor 0.5', () => {
+    const result = computeReleaseForecast(makeMap(0.5), [root, leaf], [version], NOW);
+    expect(result.focusFactor).toBe(0.5);
+    const row = result.releases[0];
+    // Planned stays the idealised baseline...
+    expect(row.plannedFinishDate).toBe('2026-01-11');
+    // ...but only half of each day reaches planned work → 20 cal days.
+    expect(row.velocityAdjustedFinishDate).toBe('2026-01-21');
+  });
+
+  it('clamps an out-of-range focusFactor into the sane band', () => {
+    const result = computeReleaseForecast(makeMap(5), [root, leaf], [version], NOW);
+    // 5 → clamped to 1.0, so velocity == planned.
+    expect(result.focusFactor).toBe(1);
+    expect(result.releases[0].velocityAdjustedFinishDate).toBe('2026-01-11');
+  });
+});

--- a/packages/server/src/lib/releaseForecast.ts
+++ b/packages/server/src/lib/releaseForecast.ts
@@ -1,4 +1,5 @@
 import type { Node as CoreNode, MindMap, Version } from '@mindblown/core';
+import { clampFocusFactor } from '@mindblown/core';
 
 /**
  * Release forecast row for a single version.
@@ -29,6 +30,7 @@ export interface ReleaseForecastResult {
   effortUnit: string;
   dailyCapacity: number;
   fudgeFactor: number | null;
+  focusFactor: number;
   calibrationLeafCount: number;
   releases: ReleaseForecastRow[];
 }
@@ -98,6 +100,12 @@ export function computeReleaseForecast(
   const fudgeFactor = calibEstimate > 0 ? calibActual / calibEstimate : null;
   const effectiveFudge = fudgeFactor ?? 1.0;
 
+  // ── Focus factor (capacity leakage) ──
+  // Discounts effective daily capacity on the velocity-adjusted line only:
+  // if only `focusFactor` of each day reaches planned work, the same remaining
+  // effort spans proportionally more calendar days.
+  const focusFactor = clampFocusFactor(map.focusFactor);
+
   // ── Ancestor-inherited version tags ──
   // A leaf belongs to version V if itself or any ancestor is tagged V.
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
@@ -162,7 +170,7 @@ export function computeReleaseForecast(
       plannedFinishDate = iso(plannedFinish);
       plannedCursor = plannedFinish;
 
-      const velCalDays = (remainingEffort * effectiveFudge) / dailyCapacity;
+      const velCalDays = (remainingEffort * effectiveFudge) / (dailyCapacity * focusFactor);
       const velFinish = addCalendarDays(velocityCursor, velCalDays);
       velocityAdjustedFinishDate = iso(velFinish);
       velocityCursor = velFinish;
@@ -203,6 +211,7 @@ export function computeReleaseForecast(
     effortUnit: map.effortUnit,
     dailyCapacity,
     fudgeFactor,
+    focusFactor,
     calibrationLeafCount: calibrationLeaves.length,
     releases,
   };

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
 import * as mapDb from '../db/maps.js';
@@ -632,6 +632,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       effortUnit: data.map.effortUnit,
       unitsPerDay,
       workerCount: effectiveWorkers,
+      focusFactor: clampFocusFactor(data.map.focusFactor),
       versionId: versionId ?? null,
       crossVersionDependencies: versionId ? crossVersionDependencies : [],
     });
@@ -726,6 +727,9 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     const fudgeFactor = calibEstimate > 0 ? calibActual / calibEstimate : null;
     const effectiveFudge = fudgeFactor ?? 1.0;
 
+    // ── Focus factor (capacity leakage) — velocity line only ──
+    const focusFactor = clampFocusFactor(data.map.focusFactor);
+
     // ── Run scheduler over the full map so cross-scope deps still apply ──
     const projectStart = data.map.projectStartDate
       ? new Date(data.map.projectStartDate)
@@ -780,7 +784,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
             Math.round((anchor.getTime() - projectStart.getTime()) / MS_PER_DAY),
           );
           const remainingSchedulerDays = Math.max(0, plannedCalDays - elapsedFromStart);
-          const velDays = remainingSchedulerDays * effectiveFudge;
+          const velDays = (remainingSchedulerDays * effectiveFudge) / focusFactor;
           velocityAdjustedFinishDate = addCalendarDays(anchor, velDays).toISOString().slice(0, 10);
         }
       }
@@ -824,6 +828,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       remainingEffort,
       effortUnit: data.map.effortUnit,
       fudgeFactor,
+      focusFactor,
       calibrationLeafCount: calibrationLeaves.length,
       projectStartDate: projectStart.toISOString().slice(0, 10),
       plannedFinishDate,

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -185,6 +185,7 @@ export interface ToolBackend {
       projectStartDate?: string | null;
       hoursPerDay?: number;
       workerCount?: number;
+      focusFactor?: number;
       autoImportNewIssues?: boolean;
     },
   ): Promise<MapSummary>;

--- a/packages/tool-kit/src/tools/__tests__/map.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/map.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tool-kit schema/handler regression tests for the map tools.
+ *
+ * Pins the MCP surface of update_map — specifically that `focusFactor`
+ * round-trips through the tool so agents (Jenna et al.) can set a map's
+ * capacity-leakage knob through their normal tools, not a direct REST call.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { updateMapTool } from '../map.js';
+import type { ToolBackend } from '../../backend.js';
+
+function makeRecordingBackend(): {
+  backend: ToolBackend;
+  lastUpdate: { mapId: string; fields: Record<string, unknown> } | null;
+} {
+  const state = { lastUpdate: null as { mapId: string; fields: Record<string, unknown> } | null };
+  const backend = {
+    updateMap: async (mapId: string, fields: Record<string, unknown>) => {
+      state.lastUpdate = { mapId, fields };
+      return { id: mapId, name: 'stub map' };
+    },
+  } as unknown as ToolBackend;
+  return {
+    backend,
+    get lastUpdate() {
+      return state.lastUpdate;
+    },
+  };
+}
+
+describe('update_map tool — focusFactor', () => {
+  it('accepts a focusFactor in range', () => {
+    const schema = z.object(updateMapTool.schema);
+    expect(schema.parse({ mapId: 'm1', focusFactor: 0.5 }).focusFactor).toBe(0.5);
+    expect(schema.parse({ mapId: 'm1', focusFactor: 1 }).focusFactor).toBe(1);
+  });
+
+  it('rejects a focusFactor above 1 or below the 0.05 floor', () => {
+    const schema = z.object(updateMapTool.schema);
+    expect(() => schema.parse({ mapId: 'm1', focusFactor: 1.5 })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', focusFactor: 0 })).toThrow();
+  });
+
+  it('forwards focusFactor to the backend', async () => {
+    const recorder = makeRecordingBackend();
+    const result = await updateMapTool.handler(recorder.backend, {
+      mapId: 'm1',
+      focusFactor: 0.4,
+    } as never);
+    expect(recorder.lastUpdate).not.toBeNull();
+    expect(recorder.lastUpdate?.fields).toMatchObject({ focusFactor: 0.4 });
+    // Undefined fields stripped (handler's clean-fields contract).
+    expect('workerCount' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+    expect(result).toContain('stub map');
+  });
+});

--- a/packages/tool-kit/src/tools/map.ts
+++ b/packages/tool-kit/src/tools/map.ts
@@ -67,7 +67,7 @@ export const createMapTool = defineTool({
 export const updateMapTool = defineTool({
   name: 'update_map',
   description:
-    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, or GitHub auto-import setting. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. Pass nullable fields as null to clear.",
+    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, focus factor, or GitHub auto-import setting. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). focusFactor (0.05–1.0, default 1) is the fraction of calendar time that actually reaches planned-ticket work — set it below 1 to stretch the velocity-adjusted completion forecast for meetings/support/firefighting/unplanned work (e.g. 0.5 = half of each day reaches planned work, so forecasts take twice as long). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. Pass nullable fields as null to clear.",
   schema: {
     mapId: z.string().describe('The map ID'),
     name: z.string().optional().describe('New map name'),
@@ -89,12 +89,18 @@ export const updateMapTool = defineTool({
       .max(100)
       .optional()
       .describe('Number of parallel work tracks the schedule projects onto (view knob, default 1 = strict serial single-worker view; higher = more parallelism).'),
+    focusFactor: z
+      .number()
+      .min(0.05)
+      .max(1)
+      .optional()
+      .describe('Fraction of calendar time reaching planned-ticket work (0.05–1.0, default 1). Below 1 stretches the velocity-adjusted completion forecast to absorb meetings/support/unplanned work (0.5 = half of each day reaches planned work).'),
     autoImportNewIssues: z
       .boolean()
       .optional()
       .describe('When true, new GitHub issues on the bound repo are auto-imported into this map\'s GitHub Inbox.'),
   },
-  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, autoImportNewIssues }) => {
+  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, focusFactor, autoImportNewIssues }) => {
     const fields: {
       name?: string;
       description?: string | null;
@@ -102,6 +108,7 @@ export const updateMapTool = defineTool({
       projectStartDate?: string | null;
       hoursPerDay?: number;
       workerCount?: number;
+      focusFactor?: number;
       autoImportNewIssues?: boolean;
     } = {};
     if (name !== undefined) fields.name = name;
@@ -110,6 +117,7 @@ export const updateMapTool = defineTool({
     if (projectStartDate !== undefined) fields.projectStartDate = projectStartDate;
     if (hoursPerDay !== undefined) fields.hoursPerDay = hoursPerDay;
     if (workerCount !== undefined) fields.workerCount = workerCount;
+    if (focusFactor !== undefined) fields.focusFactor = focusFactor;
     if (autoImportNewIssues !== undefined) fields.autoImportNewIssues = autoImportNewIssues;
     if (Object.keys(fields).length === 0) return 'No fields to update.';
     const updated = await backend.updateMap(mapId, fields);


### PR DESCRIPTION
## Why

Dan's observation: *estimates don't match our dev speed because we do other things besides planned tickets.* Analysis of the Fulcrum CRM Roadmap confirmed the diagnosis is **not** estimation accuracy — the 1.26x fudge factor is ~1.0 once you drop two anecdotal tickets (n=10, and several actuals look copied from estimates). The real gap is **throughput / focus factor**: the forecaster converts remaining effort → dates at full utilization and only corrects for estimation bias, so it's structurally blind to the calendar time that goes to meetings, support, firefighting and unplanned work.

## What

Adds a per-map **`focusFactor`** (0.05–1.0, default **1.0**) — the fraction of calendar time that actually reaches planned-ticket work. It discounts the **velocity-adjusted** forecast line only (planned finish stays the idealised scheduler baseline), orthogonal to the estimation fudge:

```
calendarDays = schedulerDays × fudge ÷ focusFactor
```

`focusFactor = 0.5` → half of each day reaches planned work → the velocity-adjusted horizon doubles. **Default 1.0 = no behaviour change** — every existing map forecasts exactly as before until its focus factor is set.

> **PR 1 of 2** (per "knob then measure"). This is the manual knob. A follow-up PR derives the factor empirically from completion change-events (~13 weeks of history), replacing the hand-set value.

## Layers touched (map-level field, mirrors `workerCount`)

| Layer | Change |
|---|---|
| core | `MindMap.focusFactor` + `clampFocusFactor` helper (new `velocity.ts`) |
| db | `focus_factor` column + idempotent migration + `dbMapToCore` mapping + `UpdateMapInput` (clamped) |
| REST | PUT passthrough + `focusFactor` in schedule/forecast responses |
| MCP | `update_map` zod schema + `completion_forecast` applies & surfaces it |
| UI | editable **Focus %** control in the Releases view header |
| tests | clamp unit, tool-kit round-trip, release-forecast behaviour |

## Verification

- `pnpm turbo typecheck` — clean across all 11 packages
- `pnpm turbo test` — clean (519 server tests + all packages); 3 new release-forecast behaviour tests, tool-kit round-trip, core clamp unit
- Reachable through the MCP surface: `update_map { focusFactor }` sets it, `completion_forecast` shows a `Focus factor:` line and stretches the velocity-adjusted date

🤖 Generated with [Claude Code](https://claude.com/claude-code)