### PR TITLE
feat(velocity): velocity_report — measure the focus factor from history

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -661,6 +661,38 @@ export function getChangeHistory(
   return request<{ events: ChangeEvent[] }>(`/api/maps/${mapId}/changes${qs ? `?${qs}` : ''}`);
 }
 
+// ── Velocity (empirical focus factor) ─────────────────────────
+
+export interface VelocityResponse {
+  windowDays: number;
+  unitsPerDay: number;
+  workerCount: number;
+  nominalCapacity: number;
+  currentFocusFactor: number;
+  completionEvents: number;
+  estCompleted: number;
+  deliveryRate: number;
+  measuredFocusFactor: number;
+  activeDays: number;
+  estCompletedRaw: number;
+  deliveryRateRaw: number;
+  measuredFocusFactorRaw: number;
+  bulkGroupsExcluded: number;
+  bulkEventsExcluded: number;
+  estCompletedExcludedAsBulk: number;
+  sampleSufficient: boolean;
+  effortUnit: string;
+  truncated: boolean;
+}
+
+export function getVelocity(
+  mapId: string,
+  opts: { windowDays?: number } = {},
+): Promise<VelocityResponse> {
+  const qs = opts.windowDays != null ? `?windowDays=${opts.windowDays}` : '';
+  return request<VelocityResponse>(`/api/maps/${mapId}/velocity${qs}`);
+}
+
 // ── Versions ──────────────────────────────────────────────────
 
 export function listVersions(mapId: string): Promise<VersionInfo[]> {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -743,7 +743,7 @@ server.tool(
       if (focusFactor < 1) {
         lines.push(`Focus factor:         ${focusFactor.toFixed(2)} (${Math.round(focusFactor * 100)}% of calendar time reaches planned work — set via update_map)`);
       } else {
-        lines.push(`Focus factor:         1.00 (full capacity assumed — lower it via update_map to reflect meetings/support/unplanned work)`);
+        lines.push(`Focus factor:         1.00 (full capacity assumed — run velocity_report to measure it from history, then set via update_map)`);
       }
       lines.push('');
 
@@ -1877,6 +1877,60 @@ server.tool(
             );
           }
         }
+      }
+
+      return toolResult(lines.join('\n'));
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
+  'velocity_report',
+  'Measure the empirical focus factor — the fraction of nominal capacity that actually reaches planned-ticket work — from completion history, and recommend a value for the map\'s focusFactor knob (settable via update_map). Reads estimate-weighted percentComplete deltas from change_events over a window (default 8 weeks), so it captures the drag of meetings/support/firefighting/unplanned work without inferring per-ticket duration. Batch writes (hygiene passes, sprint-close) are detected by shared timestamps and excluded from the clean rate. Read-only; it does not change the forecast — set the recommended value with update_map to apply it.',
+  {
+    mapId: z.string().describe('The map ID'),
+    windowDays: z
+      .number()
+      .int()
+      .min(7)
+      .max(365)
+      .default(56)
+      .describe('Look-back window in calendar days (default 56 = 8 weeks). Idle days count against the rate — that is the point.'),
+  },
+  async ({ mapId, windowDays }) => {
+    try {
+      const v = await api.getVelocity(mapId, { windowDays });
+      const unit = v.effortUnit ?? 'units';
+      const lines: string[] = [];
+
+      lines.push(`Velocity / focus factor — ${v.windowDays}-day window`);
+      lines.push('');
+      lines.push(`Completed (organic):  ${v.estCompleted.toFixed(2)} ${unit} across ${v.completionEvents} completion event(s), ${v.activeDays} active day(s)`);
+      lines.push(`Delivery rate:        ${v.deliveryRate.toFixed(3)} ${unit}/calendar-day`);
+      lines.push(`Nominal capacity:     ${v.nominalCapacity.toFixed(2)} ${unit}/day (workerCount ${v.workerCount} × ${v.unitsPerDay} ${unit}/day)`);
+      lines.push('');
+      lines.push(`Measured focus factor: ${v.measuredFocusFactor.toFixed(2)} (${Math.round(v.measuredFocusFactor * 100)}% of nominal capacity reaches planned work)`);
+      lines.push(`Current map setting:   ${v.currentFocusFactor.toFixed(2)}`);
+      lines.push('');
+
+      if (v.bulkEventsExcluded > 0) {
+        lines.push(`Excluded as bulk:     ${v.estCompletedExcludedAsBulk.toFixed(2)} ${unit} from ${v.bulkGroupsExcluded} batch write(s) (${v.bulkEventsExcluded} events sharing a timestamp — hygiene/sprint-close, not daily throughput)`);
+        lines.push(`Raw incl. bulk:       ${v.deliveryRateRaw.toFixed(3)} ${unit}/day → focus ${v.measuredFocusFactorRaw.toFixed(2)}`);
+        lines.push('');
+      }
+
+      if (!v.sampleSufficient) {
+        lines.push(`⚠ Not enough organic completions to trust this yet (need ≥3, have ${v.completionEvents}). Treat the number as indicative, not a setting — let more work complete, then re-run.`);
+      } else {
+        lines.push(`→ To apply: update_map(mapId, focusFactor: ${v.measuredFocusFactor.toFixed(2)}). This stretches the velocity-adjusted completion_forecast to match real throughput.`);
+      }
+
+      lines.push('');
+      lines.push(`Note: measured in estimate units, so it assumes estimates are roughly unbiased (check get_estimation_accuracy — a large fudge means this factor also absorbs estimation bias). Idle calendar days are included by design, so the rate reflects real capacity, not burst speed.`);
+      if (v.truncated) {
+        lines.push(`⚠ Event window hit the fetch cap — the rate may be based on a partial window.`);
       }
 
       return toolResult(lines.join('\n'));

--- a/packages/server/src/lib/__tests__/velocity.test.ts
+++ b/packages/server/src/lib/__tests__/velocity.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { computeVelocity, BULK_TIMESTAMP_THRESHOLD } from '../velocity.js';
+
+// Three leaves, each estimated 2 days.
+const estimates = new Map<string, number>([
+  ['a', 2],
+  ['b', 2],
+  ['c', 2],
+]);
+
+function progress(nodeId: string, from: number, to: number, createdAt: string) {
+  return { nodeId, oldValue: from, newValue: to, createdAt };
+}
+
+describe('computeVelocity', () => {
+  it('rate = estimate-weighted completion ÷ calendar window, focus = rate ÷ capacity', () => {
+    // Three leaves fully completed on distinct days → 6 estimate-days.
+    const result = computeVelocity({
+      windowDays: 12,
+      unitsPerDay: 1,
+      workerCount: 1,
+      currentFocusFactor: 1,
+      estimateByNodeId: estimates,
+      progressEvents: [
+        progress('a', 0, 100, '2026-07-01T09:00:00.000Z'),
+        progress('b', 0, 100, '2026-07-03T09:00:00.000Z'),
+        progress('c', 0, 100, '2026-07-05T09:00:00.000Z'),
+      ],
+    });
+    expect(result.estCompleted).toBe(6);
+    expect(result.completionEvents).toBe(3);
+    expect(result.activeDays).toBe(3);
+    expect(result.deliveryRate).toBeCloseTo(0.5, 6); // 6 / 12
+    expect(result.measuredFocusFactor).toBeCloseTo(0.5, 6); // 0.5 / (1×1)
+    expect(result.sampleSufficient).toBe(true);
+  });
+
+  it('counts only forward progress and weights partial deltas', () => {
+    const result = computeVelocity({
+      windowDays: 10,
+      unitsPerDay: 1,
+      workerCount: 1,
+      currentFocusFactor: 1,
+      estimateByNodeId: estimates,
+      progressEvents: [
+        progress('a', 0, 50, '2026-07-01T09:00:00.000Z'), // +50% of 2 = 1
+        progress('a', 50, 20, '2026-07-02T09:00:00.000Z'), // backward → ignored
+        progress('b', 0, 100, '2026-07-03T09:00:00.000Z'), // +2
+      ],
+    });
+    expect(result.estCompleted).toBe(3);
+    expect(result.completionEvents).toBe(2);
+  });
+
+  it('excludes bulk writes that share an exact timestamp', () => {
+    const ts = '2026-07-10T06:14:52.000Z';
+    const bulk = Array.from({ length: BULK_TIMESTAMP_THRESHOLD + 1 }, (_, i) =>
+      progress(`bulk-${i}`, 0, 100, ts),
+    );
+    // Give the bulk nodes estimates too so raw ≠ 0.
+    const est = new Map(estimates);
+    bulk.forEach((e) => est.set(e.nodeId!, 2));
+
+    const result = computeVelocity({
+      windowDays: 10,
+      unitsPerDay: 1,
+      workerCount: 1,
+      currentFocusFactor: 1,
+      estimateByNodeId: est,
+      progressEvents: [
+        progress('a', 0, 100, '2026-07-01T09:00:00.000Z'), // organic +2
+        ...bulk, // one batch write → excluded
+      ],
+    });
+    expect(result.bulkGroupsExcluded).toBe(1);
+    expect(result.bulkEventsExcluded).toBe(BULK_TIMESTAMP_THRESHOLD + 1);
+    expect(result.estCompleted).toBe(2); // only the organic one
+    expect(result.completionEvents).toBe(1);
+    expect(result.estCompletedRaw).toBeGreaterThan(result.estCompleted);
+    expect(result.estCompletedExcludedAsBulk).toBe((BULK_TIMESTAMP_THRESHOLD + 1) * 2);
+  });
+
+  it('flags an insufficient sample and never divides by zero capacity', () => {
+    const result = computeVelocity({
+      windowDays: 56,
+      unitsPerDay: 1,
+      workerCount: 1,
+      currentFocusFactor: 1,
+      estimateByNodeId: estimates,
+      progressEvents: [progress('a', 0, 100, '2026-07-01T09:00:00.000Z')],
+    });
+    expect(result.completionEvents).toBe(1);
+    expect(result.sampleSufficient).toBe(false);
+    expect(Number.isFinite(result.measuredFocusFactor)).toBe(true);
+  });
+
+  it('scales focus by nominal capacity (workerCount × unitsPerDay)', () => {
+    // Same 6 days completed, but 2 workers → half the focus.
+    const result = computeVelocity({
+      windowDays: 12,
+      unitsPerDay: 1,
+      workerCount: 2,
+      currentFocusFactor: 1,
+      estimateByNodeId: estimates,
+      progressEvents: [
+        progress('a', 0, 100, '2026-07-01T09:00:00.000Z'),
+        progress('b', 0, 100, '2026-07-03T09:00:00.000Z'),
+        progress('c', 0, 100, '2026-07-05T09:00:00.000Z'),
+      ],
+    });
+    expect(result.nominalCapacity).toBe(2);
+    expect(result.measuredFocusFactor).toBeCloseTo(0.25, 6); // 0.5 / 2
+  });
+});

--- a/packages/server/src/lib/velocity.ts
+++ b/packages/server/src/lib/velocity.ts
@@ -1,0 +1,173 @@
+import { clampFocusFactor } from '@mindblown/core';
+
+/**
+ * Empirical velocity / focus-factor measurement.
+ *
+ * Measures how much *planned scope* a map actually completes per calendar day
+ * and expresses it as a **focus factor** — the fraction of nominal capacity
+ * that reaches planned-ticket work (see `@mindblown/core` velocity helpers and
+ * the completion forecast). This is the empirical counterpart to the manual
+ * `focusFactor` knob: instead of the user guessing "half our time goes to
+ * planned work", we read it off the history.
+ *
+ * ## Why this dodges the elapsed-vs-effort hazard
+ *
+ * We do NOT infer per-ticket duration from timestamps. Completion is measured
+ * exactly like `burnup`: estimate-weighted `percentComplete` deltas — a leaf
+ * estimated at 2 days going 0→100% contributes 2 *estimate-days* of completed
+ * scope, regardless of how long it sat open. Timestamps are used ONLY to (a)
+ * place a completion inside the window and (b) detect bulk writes. So the
+ * numerator is in the same estimate-unit space as the forecast's remaining
+ * scope, and calendar-elapsed never enters.
+ *
+ * ## Bulk-op noise
+ *
+ * A hygiene pass or sprint-close can flip dozens of leaves at once — those are
+ * batch writes, not organic daily throughput, and would spike the rate. We
+ * detect them structurally: progress events that share an exact `createdAt`
+ * timestamp in groups larger than {@link BULK_TIMESTAMP_THRESHOLD} are treated
+ * as one bulk action and excluded from the clean rate. Both raw and
+ * bulk-excluded numbers are returned so the caller can be transparent.
+ *
+ * ## Consistency with the forecast
+ *
+ * `nominalCapacity = workerCount × unitsPerDay` — the planned-scope-per-day the
+ * forecast assumes at focus 1.0. `measuredFocusFactor = deliveryRate ÷
+ * nominalCapacity`. Because both the measurement and the forecast use the same
+ * `workerCount`, the factor is self-consistent for the common single-track
+ * (workerCount = 1) case. It reads scope in *estimates*, so it assumes the
+ * estimation fudge is ≈1 (verified on the target map); a large fudge would mean
+ * the factor also absorbs estimation bias, which the caller should note.
+ */
+
+/** Progress events sharing one exact timestamp beyond this count = one bulk write. */
+export const BULK_TIMESTAMP_THRESHOLD = 5;
+
+/** Minimum organic completion events before the measurement is trustworthy. */
+export const MIN_SAMPLE_EVENTS = 3;
+
+export interface VelocityProgressEvent {
+  nodeId: string | null;
+  oldValue: unknown;
+  newValue: unknown;
+  createdAt: string; // ISO 8601
+}
+
+export interface VelocityInput {
+  windowDays: number;
+  unitsPerDay: number;
+  workerCount: number;
+  currentFocusFactor: number;
+  /** Current estimate per leaf id — used to weight progress deltas (burnup's proxy). */
+  estimateByNodeId: Map<string, number>;
+  progressEvents: VelocityProgressEvent[];
+}
+
+export interface VelocityResult {
+  windowDays: number;
+  unitsPerDay: number;
+  workerCount: number;
+  nominalCapacity: number;
+  currentFocusFactor: number;
+
+  /** Organic (bulk-excluded) figures. */
+  completionEvents: number;
+  estCompleted: number;
+  deliveryRate: number;
+  measuredFocusFactor: number;
+  activeDays: number;
+
+  /** Bulk-inclusive figures, for transparency. */
+  estCompletedRaw: number;
+  deliveryRateRaw: number;
+  measuredFocusFactorRaw: number;
+
+  /** How much was set aside as batch writes. */
+  bulkGroupsExcluded: number;
+  bulkEventsExcluded: number;
+  estCompletedExcludedAsBulk: number;
+
+  /** False when there are too few organic completions to trust the number. */
+  sampleSufficient: boolean;
+}
+
+export function computeVelocity(input: VelocityInput): VelocityResult {
+  const {
+    windowDays,
+    unitsPerDay,
+    workerCount,
+    currentFocusFactor,
+    estimateByNodeId,
+    progressEvents,
+  } = input;
+
+  // Group by exact timestamp to spot bulk writes.
+  const byTimestamp = new Map<string, VelocityProgressEvent[]>();
+  for (const e of progressEvents) {
+    const g = byTimestamp.get(e.createdAt);
+    if (g) g.push(e);
+    else byTimestamp.set(e.createdAt, [e]);
+  }
+
+  // Estimate-weighted completed scope from a single positive-progress event.
+  const completedFor = (e: VelocityProgressEvent): number => {
+    const oldProg = Number(e.oldValue ?? 0);
+    const newProg = Number(e.newValue ?? 0);
+    const delta = newProg - oldProg;
+    if (!(delta > 0)) return 0; // only forward progress counts as completion
+    const est = e.nodeId ? (estimateByNodeId.get(e.nodeId) ?? 0) : 0;
+    return est * (delta / 100);
+  };
+
+  let estCompleted = 0;
+  let estCompletedRaw = 0;
+  let completionEvents = 0;
+  let bulkGroupsExcluded = 0;
+  let bulkEventsExcluded = 0;
+  let estCompletedExcludedAsBulk = 0;
+  const activeDaySet = new Set<string>();
+
+  for (const [, group] of byTimestamp) {
+    const isBulk = group.length > BULK_TIMESTAMP_THRESHOLD;
+    for (const e of group) {
+      const done = completedFor(e);
+      estCompletedRaw += done;
+      if (isBulk) {
+        estCompletedExcludedAsBulk += done;
+      } else if (done > 0) {
+        estCompleted += done;
+        completionEvents++;
+        activeDaySet.add(e.createdAt.slice(0, 10));
+      }
+    }
+    if (isBulk) {
+      bulkGroupsExcluded++;
+      bulkEventsExcluded += group.length;
+    }
+  }
+
+  const safeWindow = Math.max(1, windowDays);
+  const nominalCapacity = Math.max(1e-9, workerCount * unitsPerDay);
+  const deliveryRate = estCompleted / safeWindow;
+  const deliveryRateRaw = estCompletedRaw / safeWindow;
+
+  return {
+    windowDays,
+    unitsPerDay,
+    workerCount,
+    nominalCapacity,
+    currentFocusFactor: clampFocusFactor(currentFocusFactor),
+    completionEvents,
+    estCompleted,
+    deliveryRate,
+    measuredFocusFactor: clampFocusFactor(deliveryRate / nominalCapacity),
+    activeDays: activeDaySet.size,
+    estCompletedRaw,
+    deliveryRateRaw,
+    measuredFocusFactorRaw: clampFocusFactor(deliveryRateRaw / nominalCapacity),
+    bulkGroupsExcluded,
+    bulkEventsExcluded,
+    estCompletedExcludedAsBulk,
+    sampleSufficient: completionEvents >= MIN_SAMPLE_EVENTS && estCompleted > 0,
+  };
+}

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -9,6 +9,8 @@ import * as versionDb from '../db/versions.js';
 import * as cycleDb from '../db/cycles.js';
 import { computeReleaseForecast } from '../lib/releaseForecast.js';
 import { snapshotReleaseForecastForMap } from '../lib/releaseSnapshots.js';
+import { computeVelocity } from '../lib/velocity.js';
+import * as events from '../db/events.js';
 import {
   buildCalendarIcs,
   calendarTokenFor,
@@ -837,6 +839,71 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       targetSource,
       slipPlannedDays,
       slipVelocityDays,
+    });
+  });
+
+  // ── GET /api/maps/:id/velocity — Empirical focus-factor measurement
+  //
+  // Reads estimate-weighted completion (percentComplete deltas) from
+  // change_events over a window and expresses it as a focus factor —
+  // deliveryRate ÷ nominal capacity. Bulk writes (batch hygiene/sprint-close,
+  // detected by shared exact timestamps) are excluded from the clean rate. The
+  // math lives in lib/velocity.ts; this route just gathers inputs.
+  app.get<{
+    Params: { id: string };
+    Querystring: { windowDays?: string };
+  }>('/api/maps/:id/velocity', async (req, reply) => {
+    const data = await mapDb.getMap(req.params.id);
+    if (!data) {
+      return reply.status(404).send({
+        error: { code: 'MAP_NOT_FOUND', message: `Map ${req.params.id} not found` },
+      });
+    }
+
+    const windowDays = req.query.windowDays
+      ? Math.max(7, Math.min(365, Math.floor(Number(req.query.windowDays))))
+      : 56; // default 8 weeks
+    const since = new Date(Date.now() - windowDays * 86_400_000);
+
+    // Current estimate per leaf — the weight for progress deltas (same proxy
+    // burnup uses; cross-time estimate drift is rare enough to ignore for v1).
+    const estimateByNodeId = new Map<string, number>();
+    for (const n of data.nodes) {
+      if ((n.childrenIds?.length ?? 0) === 0 && n.effortEstimate != null) {
+        estimateByNodeId.set(n.id, n.effortEstimate);
+      }
+    }
+
+    // High limit so a busy window isn't silently truncated; percentComplete
+    // events are far fewer than estimate edits, so this comfortably covers it.
+    const progressEvents = await events.listEvents({
+      mapId: req.params.id,
+      fieldName: 'percentComplete',
+      since,
+      limit: 10_000,
+    });
+
+    const unitsPerDay = data.map.effortUnit === 'hours' ? (data.map.hoursPerDay ?? 8) : 1;
+    const workerCount = Math.max(1, Math.min(100, Math.floor(data.map.workerCount ?? 1)));
+
+    const result = computeVelocity({
+      windowDays,
+      unitsPerDay,
+      workerCount,
+      currentFocusFactor: data.map.focusFactor ?? 1,
+      estimateByNodeId,
+      progressEvents: progressEvents.map((e) => ({
+        nodeId: e.nodeId,
+        oldValue: e.oldValue,
+        newValue: e.newValue,
+        createdAt: e.createdAt,
+      })),
+    });
+
+    return reply.send({
+      ...result,
+      effortUnit: data.map.effortUnit,
+      truncated: progressEvents.length >= 10_000,
     });
   });
 


### PR DESCRIPTION
**Stacked on #216** (base = `feat/focus-factor`). PR 2 of 2. Review/merge #216 first.

## Why

PR #216 added the manual `focusFactor` knob. This PR **measures** it from history so you set it from data instead of by feel — the answer to Dan's "how accurate are our estimates / why don't dates match our speed."

## What

- **`GET /api/maps/:id/velocity`** + pure **`computeVelocity`** lib (`packages/server/src/lib/velocity.ts`)
- **`velocity_report` MCP tool** — reports delivery rate, measured focus factor, and a recommended `update_map focusFactor=X`. **Read-only** — it does not touch the forecast or the map; you apply the value yourself.
- `completion_forecast` now nudges you to run `velocity_report` when focus is at its 1.0 default.

## How it measures (and why it's honest)

| Concern | Approach |
|---|---|
| **Elapsed-vs-effort hazard** (flagged in analysis) | Sidestepped entirely. Completion is measured in **estimate units** — a 2-day leaf going 0→100% = 2 estimate-days — exactly like `burnup`. Timestamps only place a completion in the window and flag batches; calendar-elapsed never enters, so no per-ticket duration inference. |
| **Bulk-op noise** (the sibling's ~1,400 batch writes) | Excluded structurally: >5 progress events sharing one exact timestamp = one batch write, dropped from the clean rate. Raw + excluded both reported — no silent caps. |
| **Idle time** | Idle calendar days count against the rate *by design* — that's the capacity signal, not a bug. |
| **Thin sample** | `<3` organic completions → flagged as insufficient, no confident-looking number emitted. |
| **Estimation bias** | Measured in estimates, so it assumes fudge≈1 (verified on the target map); output notes that a large fudge means the factor also absorbs estimation bias. |

`measuredFocusFactor = deliveryRate ÷ (workerCount × unitsPerDay)` — self-consistent with the forecast for the common single-track (workerCount=1) case.

## Verification

- `pnpm turbo typecheck` clean (11 packages)
- `pnpm turbo test` clean — 524 server tests incl. 5 new `computeVelocity` cases (rate, forward-only/partial deltas, bulk exclusion, insufficient-sample guard, capacity scaling)

## Follow-up (not in this PR)

Auto-apply (`velocity_report … apply:true` → `update_map`) and folding the recommendation into the forecast automatically were deliberately left out — kept read-only so a human vets the number against a real prod map first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)