### PR TITLE
feat(requirements): Abnahme — per-user acceptance with history

### DIFF
--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -32,6 +32,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     collapsed: false,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
+    revision: 1,
     requirementId: null,
     requirementPriority: null,
     requirementText: null,

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -130,6 +130,7 @@ export interface NodeWithComputed {
   collapsed: boolean;
   createdAt: string;
   updatedAt: string;
+  revision: number;
   // Requirements register — non-null requirementId marks a requirement.
   requirementId: string | null;
   requirementPriority: 'must' | 'should' | 'could' | null;
@@ -311,6 +312,33 @@ async function requestText(path: string): Promise<string> {
   const res = await fetch(`${ctx.baseUrl}${path}`, { headers });
   if (!res.ok) throw new ApiError(res.status, res.statusText);
   return res.text();
+}
+
+export interface AcceptanceRow {
+  id: string;
+  nodeId: string;
+  userId: string;
+  userName: string;
+  acceptedAt: string;
+  progressAtAcceptance: number;
+  nodeRevisionAtAcceptance: number;
+}
+
+export function getAcceptances(mapId: string): Promise<{ acceptances: AcceptanceRow[] }> {
+  return request<{ acceptances: AcceptanceRow[] }>(`/api/maps/${mapId}/acceptances`);
+}
+
+export function acceptRequirement(mapId: string, nodeId: string): Promise<AcceptanceRow> {
+  return request<AcceptanceRow>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+export function revokeAcceptance(mapId: string, nodeId: string): Promise<{ success: boolean }> {
+  return request<{ success: boolean }>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
+    method: 'DELETE',
+  });
 }
 
 export function exportRequirements(mapId: string): Promise<string> {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -445,6 +445,60 @@ server.tool(
 );
 
 server.tool(
+  'accept_requirement',
+  "Record the calling user's acceptance (Abnahme) of a requirement — a human sign-off, orthogonal to the derived status. Snapshots current progress + node revision so later changes flag the acceptance as stale. Identify the requirement by requirementId (e.g. MAN-01) or nodeId.",
+  {
+    mapId: z.string().describe('The map ID'),
+    requirementId: z.string().optional().describe('Requirement ID, e.g. "MAN-01"'),
+    nodeId: z.string().optional().describe('Node ID (alternative to requirementId)'),
+  },
+  async ({ mapId, requirementId, nodeId }) => {
+    try {
+      let id = nodeId;
+      if (!id) {
+        if (!requirementId) return toolError('Provide requirementId or nodeId.');
+        const data = await api.getMap(mapId);
+        const hit = data.nodes.find((n) => n.requirementId === requirementId);
+        if (!hit) return toolError(`No node with requirementId ${requirementId} in map ${mapId}.`);
+        id = hit.id;
+      }
+      const a = await api.acceptRequirement(mapId, id);
+      return toolResult(
+        `Accepted ${requirementId ?? id} as ${a.userName} at ${a.acceptedAt} (progress ${Math.round(a.progressAtAcceptance)}%, revision ${a.nodeRevisionAtAcceptance}).`,
+      );
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
+  'revoke_acceptance',
+  "Revoke the calling user's active acceptance on a requirement. History is preserved (append-only); a later re-acceptance is a new sign-off.",
+  {
+    mapId: z.string().describe('The map ID'),
+    requirementId: z.string().optional().describe('Requirement ID, e.g. "MAN-01"'),
+    nodeId: z.string().optional().describe('Node ID (alternative to requirementId)'),
+  },
+  async ({ mapId, requirementId, nodeId }) => {
+    try {
+      let id = nodeId;
+      if (!id) {
+        if (!requirementId) return toolError('Provide requirementId or nodeId.');
+        const data = await api.getMap(mapId);
+        const hit = data.nodes.find((n) => n.requirementId === requirementId);
+        if (!hit) return toolError(`No node with requirementId ${requirementId} in map ${mapId}.`);
+        id = hit.id;
+      }
+      await api.revokeAcceptance(mapId, id);
+      return toolResult(`Revoked acceptance on ${requirementId ?? id}.`);
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
   'requirements_export',
   'Export the requirements register as a Markdown Anforderungsdokument: chapter per Bereich, one table row per requirement (ID, business text, Muss/Soll/Kann, derived status, Aufwand/Rest in S/M/L/XL buckets). Returns the full Markdown document — save it to a file or convert with pandoc for docx/pdf.',
   {
@@ -476,6 +530,11 @@ server.tool(
   async ({ mapId, status, requirementPriority }) => {
     try {
       const data = await api.getMap(mapId);
+      const { acceptances } = await api.getAcceptances(mapId).catch(() => ({ acceptances: [] }));
+      const accByNode = new Map<string, typeof acceptances>();
+      for (const a of acceptances) {
+        (accByNode.get(a.nodeId) ?? accByNode.set(a.nodeId, []).get(a.nodeId)!).push(a);
+      }
       const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
       const rootId = data.map.rootNodeId;
       const unit = data.map.effortUnit ?? 'units';
@@ -606,6 +665,16 @@ server.tool(
           }
           if (r.ghLinks.length > 0) {
             parts.push(`· gh: ${r.ghLinks.join(', ')}`);
+          }
+          const accs = accByNode.get(r.node.id) ?? [];
+          if (accs.length > 0) {
+            const fmt = accs.map((a) => {
+              const stale =
+                Math.abs(r.progress - a.progressAtAcceptance) > 1 ||
+                r.node.revision !== a.nodeRevisionAtAcceptance;
+              return `${a.userName}${stale ? ' ⚠stale' : ''}`;
+            });
+            parts.push(`· Abnahme: ${fmt.join(', ')}`);
           }
           lines.push(`  ${parts.join(' ')}`);
         }

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Node } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import * as api from './api.js';
@@ -71,7 +71,33 @@ export function RequirementsView() {
   const setActiveView = useMindmapStore((s) => s.setActiveView);
   const effortUnit = useMindmapStore((s) => s.currentMap?.effortUnit ?? 'days');
 
+  const user = useMindmapStore((s) => s.user);
+  const [acceptances, setAcceptances] = useState<api.AcceptanceRow[]>([]);
+  const [acceptanceFilter, setAcceptanceFilter] = useState<'' | 'none' | 'mine-open'>('');
   const [exporting, setExporting] = useState(false);
+
+  useEffect(() => {
+    if (!currentMapId) return;
+    let cancelled = false;
+    api
+      .fetchAcceptances(currentMapId)
+      .then((r) => !cancelled && setAcceptances(r.acceptances))
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [currentMapId]);
+
+  const accByNode = useMemo(() => {
+    const m = new Map<string, api.AcceptanceRow[]>();
+    for (const a of acceptances) {
+      const list = m.get(a.nodeId) ?? [];
+      list.push(a);
+      m.set(a.nodeId, list);
+    }
+    return m;
+  }, [acceptances]);
+
   const [statusFilter, setStatusFilter] = useState<'' | ReqStatus>('');
   const [priorityFilter, setPriorityFilter] = useState<'' | 'must' | 'should' | 'could'>('');
   const [editingCell, setEditingCell] = useState<{ nodeId: string; field: string } | null>(null);
@@ -136,12 +162,19 @@ export function RequirementsView() {
 
   const filteredRows = useMemo(
     () =>
-      allRows.filter(
-        (r) =>
-          (!statusFilter || r.status === statusFilter) &&
-          (!priorityFilter || r.node.requirementPriority === priorityFilter),
-      ),
-    [allRows, statusFilter, priorityFilter],
+      allRows.filter((r) => {
+        if (statusFilter && r.status !== statusFilter) return false;
+        if (priorityFilter && r.node.requirementPriority !== priorityFilter) return false;
+        if (acceptanceFilter) {
+          const accs = accByNode.get(r.node.id) ?? [];
+          if (acceptanceFilter === 'none' && accs.length > 0) return false;
+          if (acceptanceFilter === 'mine-open' && accs.some((a) => a.userId === user?.id)) {
+            return false;
+          }
+        }
+        return true;
+      }),
+    [allRows, statusFilter, priorityFilter, acceptanceFilter, accByNode, user],
   );
 
   // Depth-first tree order — used to sort chapter groups so the register
@@ -188,6 +221,29 @@ export function RequirementsView() {
       ? (nodes[rootNodeId]?.childrenIds ?? []).map((id) => nodes[id]).filter(Boolean)
       : [];
   }, [allRows, nodes, rootNodeId, dfsOrder]);
+
+  const toggleAcceptance = async (row: ReqRow) => {
+    if (!currentMapId || !user) return;
+    const mine = (accByNode.get(row.node.id) ?? []).find((a) => a.userId === user.id);
+    try {
+      if (mine) {
+        await api.revokeAcceptance(currentMapId, row.node.id);
+        setAcceptances((prev) => prev.filter((a) => a.id !== mine.id));
+      } else {
+        if (
+          row.status !== 'done' &&
+          !window.confirm(`Status ist ${STATUS_LABEL[row.status]} — trotzdem abnehmen?`)
+        ) {
+          return;
+        }
+        const created = await api.acceptRequirement(currentMapId, row.node.id);
+        setAcceptances((prev) => [...prev, created]);
+      }
+    } catch {
+      // Refresh on conflict (e.g. accepted elsewhere) — server state wins.
+      api.fetchAcceptances(currentMapId).then((r) => setAcceptances(r.acceptances)).catch(() => {});
+    }
+  };
 
   const jumpToNode = (node: Node) => {
     setActiveView('mindmap');
@@ -254,6 +310,15 @@ export function RequirementsView() {
             <option value="must">Must</option>
             <option value="should">Should</option>
             <option value="could">Could</option>
+          </select>
+          <select
+            value={acceptanceFilter}
+            onChange={(e) => setAcceptanceFilter(e.target.value as '' | 'none' | 'mine-open')}
+            style={filterSelectStyle}
+          >
+            <option value="">Abnahme: alle</option>
+            <option value="none">Nicht abgenommen</option>
+            <option value="mine-open">Meine Abnahme offen</option>
           </select>
           <button
             onClick={() => setShowCreate((v) => !v)}
@@ -367,6 +432,7 @@ export function RequirementsView() {
                 <th style={{ ...thStyle, width: 130 }}>Progress</th>
                 <th style={{ ...thStyle, width: 130, textAlign: 'right' }}>Remaining</th>
                 <th style={{ ...thStyle, width: 140 }}>GitHub</th>
+                <th style={{ ...thStyle, width: 170 }}>Abnahme</th>
               </tr>
             </thead>
             <tbody>
@@ -380,6 +446,9 @@ export function RequirementsView() {
                   setEditingCell={setEditingCell}
                   updateNode={updateNode}
                   jumpToNode={jumpToNode}
+                  accByNode={accByNode}
+                  currentUserId={user?.id ?? null}
+                  toggleAcceptance={toggleAcceptance}
                 />
               ))}
             </tbody>
@@ -400,6 +469,9 @@ function ChapterGroup({
   setEditingCell,
   updateNode,
   jumpToNode,
+  accByNode,
+  currentUserId,
+  toggleAcceptance,
 }: {
   chapterText: string;
   rows: ReqRow[];
@@ -408,12 +480,15 @@ function ChapterGroup({
   setEditingCell: (cell: { nodeId: string; field: string } | null) => void;
   updateNode: (id: string, updates: Partial<Node>) => void;
   jumpToNode: (node: Node) => void;
+  accByNode: Map<string, api.AcceptanceRow[]>;
+  currentUserId: string | null;
+  toggleAcceptance: (row: ReqRow) => void;
 }) {
   const done = rows.filter((r) => r.status === 'done').length;
   return (
     <>
       <tr>
-        <td colSpan={7} style={groupHeaderStyle}>
+        <td colSpan={8} style={groupHeaderStyle}>
           {chapterText}
           <span style={{ fontWeight: 400, color: '#64748b', marginLeft: 8 }}>
             {rows.length} req · {done} done
@@ -638,6 +713,60 @@ function ChapterGroup({
                 </a>
               ))
             )}
+          </td>
+
+          {/* Abnahme — per-user sign-off chips; own chip toggles */}
+          <td style={{ ...tdStyle, whiteSpace: 'nowrap' }} onClick={(e) => e.stopPropagation()}>
+            {(accByNode.get(r.node.id) ?? []).map((a) => {
+              const stale =
+                Math.abs(r.progress - a.progressAtAcceptance) > 1 ||
+                r.node.revision !== a.nodeRevisionAtAcceptance;
+              const own = a.userId === currentUserId;
+              const label = `${a.userName.split(' ')[0]} ✓ ${a.acceptedAt.slice(5, 10).split('-').reverse().join('.')}.`;
+              return (
+                <span
+                  key={a.id}
+                  onClick={own ? () => toggleAcceptance(r) : undefined}
+                  title={
+                    (stale ? 'Seit Abnahme geändert! ' : '') +
+                    `${a.userName}, abgenommen ${a.acceptedAt.slice(0, 10)} bei ${Math.round(a.progressAtAcceptance)}%` +
+                    (own ? ' — klicken zum Zurückziehen' : '')
+                  }
+                  style={{
+                    display: 'inline-block',
+                    padding: '2px 8px',
+                    marginRight: 4,
+                    borderRadius: 10,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    cursor: own ? 'pointer' : 'default',
+                    background: stale ? '#fef3c7' : '#d1fae5',
+                    color: stale ? '#92400e' : '#065f46',
+                  }}
+                >
+                  {stale ? '⚠ ' : ''}
+                  {label}
+                </span>
+              );
+            })}
+            {currentUserId &&
+              !(accByNode.get(r.node.id) ?? []).some((a) => a.userId === currentUserId) && (
+                <button
+                  onClick={() => toggleAcceptance(r)}
+                  title="Requirement abnehmen (persönliche Abnahme, Status bleibt abgeleitet)"
+                  style={{
+                    padding: '2px 8px',
+                    borderRadius: 10,
+                    fontSize: 11,
+                    border: '1px dashed #cbd5e1',
+                    background: 'transparent',
+                    color: '#64748b',
+                    cursor: 'pointer',
+                  }}
+                >
+                  ✓ Abnehmen
+                </button>
+              )}
           </td>
         </tr>
       ))}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -576,6 +576,31 @@ export async function exportRequirements(mapId: string): Promise<string> {
   return res.text();
 }
 
+export interface AcceptanceRow {
+  id: string;
+  nodeId: string;
+  userId: string;
+  userName: string;
+  acceptedAt: string;
+  progressAtAcceptance: number;
+  nodeRevisionAtAcceptance: number;
+}
+
+export function fetchAcceptances(mapId: string): Promise<{ acceptances: AcceptanceRow[] }> {
+  return request<{ acceptances: AcceptanceRow[] }>(`/api/maps/${mapId}/acceptances`);
+}
+
+export function acceptRequirement(mapId: string, nodeId: string): Promise<AcceptanceRow> {
+  return request<AcceptanceRow>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+export function revokeAcceptance(mapId: string, nodeId: string): Promise<void> {
+  return request<void>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, { method: 'DELETE' });
+}
+
 // ── Nodes ────────────────────────────────────────────────────────
 
 export function createNode(

--- a/packages/server/src/db/acceptances.ts
+++ b/packages/server/src/db/acceptances.ts
@@ -1,0 +1,105 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { db } from './connection.js';
+import { requirementAcceptances, users } from './schema.js';
+
+/**
+ * Requirement acceptances (Abnahme) — human sign-off per requirement
+ * node per user, orthogonal to the derived plan status.
+ *
+ * History model: append-only. `accept` inserts a new row; `revoke`
+ * stamps `revoked_at` on the active row. A re-acceptance after a revoke
+ * is a fresh row, so the full audit trail (who accepted/revoked what,
+ * when, at which progress) is preserved forever.
+ */
+
+export interface Acceptance {
+  id: string;
+  mapId: string;
+  nodeId: string;
+  userId: string;
+  userName: string;
+  acceptedAt: string;
+  progressAtAcceptance: number;
+  nodeRevisionAtAcceptance: number;
+}
+
+function toIso(v: unknown): string {
+  return v instanceof Date ? v.toISOString() : String(v);
+}
+
+/** All ACTIVE acceptances of a map, with the acceptor's display name. */
+export async function listActiveAcceptances(mapId: string): Promise<Acceptance[]> {
+  const rows = await db
+    .select({
+      id: requirementAcceptances.id,
+      mapId: requirementAcceptances.mapId,
+      nodeId: requirementAcceptances.nodeId,
+      userId: requirementAcceptances.userId,
+      userName: users.name,
+      acceptedAt: requirementAcceptances.acceptedAt,
+      progressAtAcceptance: requirementAcceptances.progressAtAcceptance,
+      nodeRevisionAtAcceptance: requirementAcceptances.nodeRevisionAtAcceptance,
+    })
+    .from(requirementAcceptances)
+    .innerJoin(users, eq(users.id, requirementAcceptances.userId))
+    .where(and(eq(requirementAcceptances.mapId, mapId), isNull(requirementAcceptances.revokedAt)));
+  return rows.map((r) => ({ ...r, acceptedAt: toIso(r.acceptedAt) }));
+}
+
+/**
+ * Accept a requirement node. Snapshots the derived progress and node
+ * revision the acceptor saw. Returns the new acceptance, or null when
+ * an active acceptance by this user already exists (idempotent accept —
+ * the 23505 on the partial unique index is mapped to null so a double
+ * click never errors).
+ */
+export async function accept(
+  mapId: string,
+  nodeId: string,
+  userId: string,
+  progressAtAcceptance: number,
+  nodeRevisionAtAcceptance: number,
+): Promise<Acceptance | null> {
+  try {
+    const [row] = await db
+      .insert(requirementAcceptances)
+      .values({ mapId, nodeId, userId, progressAtAcceptance, nodeRevisionAtAcceptance })
+      .returning();
+    const [u] = await db.select({ name: users.name }).from(users).where(eq(users.id, userId));
+    return {
+      id: row.id,
+      mapId: row.mapId,
+      nodeId: row.nodeId,
+      userId: row.userId,
+      userName: u?.name ?? userId,
+      acceptedAt: toIso(row.acceptedAt),
+      progressAtAcceptance: row.progressAtAcceptance,
+      nodeRevisionAtAcceptance: row.nodeRevisionAtAcceptance,
+    };
+  } catch (err) {
+    const e = err as { code?: string; constraint?: string };
+    if (e?.code === '23505' && e?.constraint === 'requirement_acceptances_active_unique') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Revoke the caller's active acceptance on a node. Returns true when a
+ * row was revoked, false when there was none (idempotent).
+ */
+export async function revoke(nodeId: string, userId: string): Promise<boolean> {
+  const rows = await db
+    .update(requirementAcceptances)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(requirementAcceptances.nodeId, nodeId),
+        eq(requirementAcceptances.userId, userId),
+        isNull(requirementAcceptances.revokedAt),
+      ),
+    )
+    .returning({ id: requirementAcceptances.id });
+  return rows.length > 0;
+}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -787,5 +787,32 @@ export async function runMigrations(): Promise<void> {
       WHERE requirement_id IS NOT NULL AND deleted_at IS NULL
   `);
 
+  // ── Requirement acceptances (Abnahme) ──────────────────────────
+  // Append-only sign-off history per requirement node per user.
+  // Active acceptance = revoked_at IS NULL; the partial unique index
+  // guarantees at most one active acceptance per (node, user) even
+  // under concurrent accepts.
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS requirement_acceptances (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      map_id UUID NOT NULL REFERENCES maps(id) ON DELETE CASCADE,
+      node_id UUID NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+      user_id UUID NOT NULL REFERENCES users(id),
+      accepted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      progress_at_acceptance REAL NOT NULL,
+      node_revision_at_acceptance INTEGER NOT NULL,
+      revoked_at TIMESTAMPTZ
+    )
+  `);
+  await db.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS requirement_acceptances_active_unique
+      ON requirement_acceptances (node_id, user_id)
+      WHERE revoked_at IS NULL
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS requirement_acceptances_map_idx
+      ON requirement_acceptances (map_id)
+  `);
+
   console.log('[db] Migrations complete.');
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -447,3 +447,23 @@ export const cycles = pgTable('cycles', {
   status: text('status').notNull().default('planned'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });
+
+// ── Requirement acceptances (Abnahme) ──────────────────────────────
+//
+// Human sign-off per requirement node per user — orthogonal to the
+// derived status. Append-only history: revoking sets revoked_at, a
+// re-acceptance is a NEW row. Active acceptance = revoked_at IS NULL
+// (enforced unique per node+user via partial index in migrate.ts).
+// progress/revision snapshots power the "changed since acceptance"
+// staleness flag on the read side.
+
+export const requirementAcceptances = pgTable('requirement_acceptances', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  mapId: uuid('map_id').notNull().references(() => maps.id, { onDelete: 'cascade' }),
+  nodeId: uuid('node_id').notNull().references(() => nodes.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').notNull().references(() => users.id),
+  acceptedAt: timestamp('accepted_at', { withTimezone: true }).notNull().defaultNow(),
+  progressAtAcceptance: real('progress_at_acceptance').notNull(),
+  nodeRevisionAtAcceptance: integer('node_revision_at_acceptance').notNull(),
+  revokedAt: timestamp('revoked_at', { withTimezone: true }),
+});

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -14,6 +14,29 @@ import {
 
 // ── Register data (shared by both renderers) ─────────────────────
 
+export interface AcceptanceInfo {
+  userId: string;
+  userName: string;
+  acceptedAt: string; // ISO
+  progressAtAcceptance: number;
+  nodeRevisionAtAcceptance: number;
+}
+
+/**
+ * An acceptance is stale when the requirement changed materially after
+ * sign-off: derived progress moved by more than one point, or the node
+ * itself was edited (revision bump). Pure — shared by export, MCP
+ * overview and (conceptually) the register UI.
+ */
+export function acceptanceIsStale(
+  acc: AcceptanceInfo,
+  currentProgress: number,
+  currentRevision: number,
+): boolean {
+  if (Math.abs(currentProgress - acc.progressAtAcceptance) > 1) return true;
+  return currentRevision !== acc.nodeRevisionAtAcceptance;
+}
+
 export interface RegisterRow {
   id: string;
   text: string;
@@ -21,6 +44,8 @@ export interface RegisterRow {
   status: string;
   aufwand: string;
   rest: string;
+  /** e.g. "D. Haas ✓ 15.07." — one entry per active acceptance, ⚠-suffixed when stale. */
+  abnahme: string[];
 }
 
 export interface RegisterData {
@@ -42,7 +67,12 @@ export function buildRegisterData(
   map: MindMap,
   nodes: CoreNode[],
   computed: Map<NodeId, ComputedNodeValues>,
+  acceptances: Array<AcceptanceInfo & { nodeId: string }> = [],
 ): RegisterData {
+  const accByNode = new Map<string, Array<AcceptanceInfo & { nodeId: string }>>();
+  for (const a of acceptances) {
+    (accByNode.get(a.nodeId) ?? accByNode.set(a.nodeId, []).get(a.nodeId)!).push(a);
+  }
   const byId = new Map(nodes.map((n) => [n.id, n]));
   const requirements = nodes.filter((n) => n.requirementId != null);
 
@@ -87,6 +117,11 @@ export function buildRegisterData(
           const p = progressOf(n);
           const status = statusOf(p);
           const effort = computed.get(n.id)?.computedEffort ?? n.effortEstimate ?? 0;
+          const abnahme = (accByNode.get(n.id) ?? []).map((a) => {
+            const d = a.acceptedAt.slice(5, 10).split('-').reverse().join('.');
+            const stale = acceptanceIsStale(a, p, n.revision) ? ' ⚠' : '';
+            return `${a.userName} ✓ ${d}.${stale}`;
+          });
           return {
             id: n.requirementId ?? '',
             text: (n.requirementText ?? n.text).replace(/\n/g, ' '),
@@ -94,6 +129,7 @@ export function buildRegisterData(
             status,
             aufwand: sizeOf(effort),
             rest: status === 'Umgesetzt' ? '—' : sizeOf(effort * (1 - p / 100)),
+            abnahme,
           };
         }),
     }));
@@ -136,11 +172,11 @@ export function renderMarkdown(data: RegisterData): string {
     L.push('');
     L.push(`## ${i + 1}. ${ch.name}`);
     L.push('');
-    L.push('| ID | Anforderung | Priorität | Status | Aufwand | Rest |');
-    L.push('|---|---|---|---|---|---|');
+    L.push('| ID | Anforderung | Priorität | Status | Aufwand | Rest | Abnahme |');
+    L.push('|---|---|---|---|---|---|---|');
     for (const r of ch.rows) {
       L.push(
-        `| ${r.id} | ${r.text.replace(/\|/g, '\\|')} | ${r.prio} | ${r.status} | ${r.aufwand} | ${r.rest} |`,
+        `| ${r.id} | ${r.text.replace(/\|/g, '\\|')} | ${r.prio} | ${r.status} | ${r.aufwand} | ${r.rest} | ${r.abnahme.join(' · ') || '—'} |`,
       );
     }
   });
@@ -218,11 +254,12 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
       tableHeader: true,
       children: [
         cell('ID', { bold: true, fill: 'e2e8f0', width: 9 }),
-        cell('Anforderung', { bold: true, fill: 'e2e8f0', width: 55 }),
+        cell('Anforderung', { bold: true, fill: 'e2e8f0', width: 43 }),
         cell('Priorität', { bold: true, fill: 'e2e8f0', width: 9 }),
         cell('Status', { bold: true, fill: 'e2e8f0', width: 11 }),
-        cell('Aufwand', { bold: true, fill: 'e2e8f0', width: 8 }),
-        cell('Rest', { bold: true, fill: 'e2e8f0', width: 8 }),
+        cell('Aufwand', { bold: true, fill: 'e2e8f0', width: 7 }),
+        cell('Rest', { bold: true, fill: 'e2e8f0', width: 7 }),
+        cell('Abnahme', { bold: true, fill: 'e2e8f0', width: 14 }),
       ],
     });
     const rows = ch.rows.map(
@@ -235,6 +272,7 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
             cell(r.status, { fill: STATUS_FILL[r.status] }),
             cell(r.aufwand),
             cell(r.rest),
+            cell(r.abnahme.join('\n') || '—'),
           ],
         }),
     );

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,6 +20,7 @@ import { nodeRoutes } from './routes/nodes.js';
 import { cycleRoutes } from './routes/cycles.js';
 import { versionRoutes } from './routes/versions.js';
 import { commentRoutes } from './routes/comments.js';
+import { acceptanceRoutes } from './routes/acceptances.js';
 import { permissionRoutes } from './routes/permissions.js';
 import { integrationRoutes } from './routes/integrations.js';
 import { triageRoutes } from './routes/triage.js';
@@ -83,6 +84,7 @@ async function main(): Promise<void> {
   await app.register(cycleRoutes);
   await app.register(versionRoutes);
   await app.register(commentRoutes);
+  await app.register(acceptanceRoutes);
   await app.register(permissionRoutes);
   await app.register(integrationRoutes);
   await app.register(triageRoutes);

--- a/packages/server/src/routes/acceptances.ts
+++ b/packages/server/src/routes/acceptances.ts
@@ -1,0 +1,117 @@
+import type { FastifyInstance } from 'fastify';
+import { computeTree } from '@mindblown/core';
+import * as acceptanceDb from '../db/acceptances.js';
+import * as mapDb from '../db/maps.js';
+import * as nodeDb from '../db/nodes.js';
+import * as permDb from '../db/permissions.js';
+import { broadcast } from '../ws.js';
+
+/**
+ * Requirement acceptance (Abnahme) routes. Acceptance is the one write
+ * a view-permission user may perform: it never touches the node itself,
+ * only the append-only requirement_acceptances history.
+ */
+export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
+  // ── GET /api/maps/:id/acceptances — active acceptances ─────────
+  app.get<{ Params: { id: string } }>('/api/maps/:id/acceptances', async (req, reply) => {
+    const userId = req.userId;
+    if (userId) {
+      const perm = await permDb.getPermission(req.params.id, userId);
+      if (!permDb.hasPermission(perm, 'view')) {
+        return reply.status(403).send({
+          error: { code: 'FORBIDDEN', message: 'You do not have access to this map' },
+        });
+      }
+    }
+    return reply.send({ acceptances: await acceptanceDb.listActiveAcceptances(req.params.id) });
+  });
+
+  // ── POST /api/maps/:id/nodes/:nodeId/acceptance — accept ───────
+  app.post<{ Params: { id: string; nodeId: string } }>(
+    '/api/maps/:id/nodes/:nodeId/acceptance',
+    async (req, reply) => {
+      const userId = req.userId;
+      if (!userId) {
+        return reply.status(401).send({
+          error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+        });
+      }
+      const perm = await permDb.getPermission(req.params.id, userId);
+      if (!permDb.hasPermission(perm, 'view')) {
+        return reply.status(403).send({
+          error: { code: 'FORBIDDEN', message: 'You do not have access to this map' },
+        });
+      }
+
+      const node = await nodeDb.getNode(req.params.nodeId);
+      if (!node || node.mapId !== req.params.id) {
+        return reply.status(404).send({
+          error: { code: 'NODE_NOT_FOUND', message: `Node ${req.params.nodeId} not found` },
+        });
+      }
+      if (node.requirementId == null) {
+        return reply.status(400).send({
+          error: {
+            code: 'NOT_A_REQUIREMENT',
+            message: 'Only requirement nodes (with a requirementId) can be accepted',
+          },
+        });
+      }
+
+      // Snapshot the derived progress the acceptor is signing off on —
+      // rollup for parents, own percentComplete for leaves.
+      const data = await mapDb.getMap(req.params.id);
+      let progress = node.percentComplete ?? 0;
+      if (data && node.childrenIds.length > 0) {
+        const computed = computeTree(data.nodes, data.map.healthThreshold);
+        progress = computed.get(node.id)?.computedProgress ?? progress;
+      }
+
+      const acceptance = await acceptanceDb.accept(
+        req.params.id,
+        node.id,
+        userId,
+        progress,
+        node.revision,
+      );
+      if (!acceptance) {
+        return reply.status(409).send({
+          error: {
+            code: 'ALREADY_ACCEPTED',
+            message: 'You already have an active acceptance on this requirement',
+          },
+        });
+      }
+
+      broadcast(req.params.id, { type: 'acceptance:changed', nodeId: node.id });
+      return reply.status(201).send(acceptance);
+    },
+  );
+
+  // ── DELETE /api/maps/:id/nodes/:nodeId/acceptance — revoke own ─
+  app.delete<{ Params: { id: string; nodeId: string } }>(
+    '/api/maps/:id/nodes/:nodeId/acceptance',
+    async (req, reply) => {
+      const userId = req.userId;
+      if (!userId) {
+        return reply.status(401).send({
+          error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+        });
+      }
+      const perm = await permDb.getPermission(req.params.id, userId);
+      if (!permDb.hasPermission(perm, 'view')) {
+        return reply.status(403).send({
+          error: { code: 'FORBIDDEN', message: 'You do not have access to this map' },
+        });
+      }
+      const revoked = await acceptanceDb.revoke(req.params.nodeId, userId);
+      if (!revoked) {
+        return reply.status(404).send({
+          error: { code: 'NO_ACTIVE_ACCEPTANCE', message: 'No active acceptance to revoke' },
+        });
+      }
+      broadcast(req.params.id, { type: 'acceptance:changed', nodeId: req.params.nodeId });
+      return reply.send({ success: true });
+    },
+  );
+}

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
 import { computeTree, schedule, criticalPath } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
+import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
 import * as mapDb from '../db/maps.js';
 import * as permDb from '../db/permissions.js';
@@ -261,7 +262,8 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const computed = computeTree(data.nodes, data.map.healthThreshold);
-      const register = buildRegisterData(data.map, data.nodes, computed);
+      const acceptances = await listActiveAcceptances(req.params.id);
+      const register = buildRegisterData(data.map, data.nodes, computed, acceptances);
       const format = (req.query as { format?: string }).format ?? 'md';
 
       if (format === 'docx') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.29.0(zod@3.25.76)
+      docx:
+        specifier: ^9.7.1
+        version: 9.7.1
       drizzle-orm:
         specifier: ^0.39.3
         version: 0.39.3(@types/pg@8.20.0)(pg@8.20.0)
@@ -1498,6 +1501,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -1535,6 +1541,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  docx@9.7.1:
+    resolution: {integrity: sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==}
+    engines: {node: '>=10'}
 
   drizzle-kit@0.30.6:
     resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
@@ -1829,6 +1839,9 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -1853,6 +1866,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1890,6 +1906,9 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1934,11 +1953,17 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
@@ -2128,6 +2153,9 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   mnemonist@0.40.0:
     resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
 
@@ -2137,6 +2165,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   negotiator@1.0.0:
@@ -2183,6 +2216,9 @@ packages:
         optional: true
       zod:
         optional: true
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -2280,6 +2316,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
@@ -2326,6 +2365,9 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -2374,6 +2416,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -2387,6 +2432,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2413,6 +2462,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -2481,6 +2533,9 @@ packages:
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -2707,6 +2762,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3485,7 +3547,6 @@ snapshots:
   '@types/node@25.5.2':
     dependencies:
       undici-types: 7.18.2
-    optional: true
 
   '@types/nodemailer@6.4.23':
     dependencies:
@@ -3680,6 +3741,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -3710,6 +3773,15 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  docx@9.7.1:
+    dependencies:
+      '@types/node': 25.5.2
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.16
+      xml: 1.0.1
+      xml-js: 1.6.11
 
   drizzle-kit@0.30.6:
     dependencies:
@@ -4083,6 +4155,11 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -4127,6 +4204,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  immediate@3.0.6: {}
+
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
@@ -4151,6 +4230,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -4192,6 +4273,13 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.4
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -4202,6 +4290,10 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   light-my-request@6.6.0:
     dependencies:
@@ -4593,6 +4685,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  minimalistic-assert@1.0.1: {}
+
   mnemonist@0.40.0:
     dependencies:
       obliterator: 2.0.5
@@ -4600,6 +4694,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.16: {}
 
   negotiator@1.0.0: {}
 
@@ -4627,6 +4723,8 @@ snapshots:
     optionalDependencies:
       ws: 8.20.0
       zod: 3.25.76
+
+  pako@1.0.11: {}
 
   parse-entities@4.0.2:
     dependencies:
@@ -4725,6 +4823,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
@@ -4777,6 +4877,16 @@ snapshots:
   react-refresh@0.17.0: {}
 
   react@19.2.4: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -4871,6 +4981,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.0:
@@ -4880,6 +4992,8 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  sax@1.6.0: {}
 
   scheduler@0.27.0: {}
 
@@ -4915,6 +5029,8 @@ snapshots:
       - supports-color
 
   set-cookie-parser@2.7.2: {}
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -4980,6 +5096,10 @@ snapshots:
   std-env@3.10.0: {}
 
   stream-shift@1.0.3: {}
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -5057,8 +5177,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.18.2:
-    optional: true
+  undici-types@7.18.2: {}
 
   unified@11.0.5:
     dependencies:
@@ -5283,6 +5402,12 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
+  xml@1.0.1: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Acceptance is a human judgment orthogonal to the derived status: each
user signs off requirements individually; the register can then show
"Umgesetzt but not yet accepted by Thomas" or "accepted but changed
since ⚠".

- requirement_acceptances table: append-only history (revoke stamps
  revoked_at, re-acceptance is a new row), snapshots derived progress +
  node revision at sign-off. Partial unique index = max one ACTIVE
  acceptance per (node, user), 23505 mapped to a friendly 409.
- REST: GET /acceptances, POST/DELETE .../nodes/:id/acceptance —
  acceptance is the one write a view-permission user may perform (it
  never touches the node). Guards: 401/403/404, 400 NOT_A_REQUIREMENT.
- Staleness (shared pure helper acceptanceIsStale): progress moved >1pt
  or node revision changed since sign-off → ⚠ in register, export and
  requirements_overview.
- MCP: accept_requirement / revoke_acceptance (by requirementId or
  nodeId) + Abnahme info in requirements_overview.
- Register UI: Abnahme column (chips per acceptor, own chip toggles,
  confirm dialog when accepting a non-done requirement), filter
  "Nicht abgenommen" / "Meine Abnahme offen".
- Export (md + docx): Abnahme column with ⚠ staleness suffix.
- Also fixes pnpm-lock.yaml drift from #211 (docx dep was committed to
  package.json only).

Verified end-to-end on a scratch DB: REST guards + double-accept 409,
revoke idempotence, history preservation across revoke/re-accept,
staleness flag after progress drop, MCP tools over stdio, UI chip
toggle + confirm dialog + reload persistence. 516/516 tests.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn
