### PR TITLE
feat(orchestration): conflict_scan duplicate-link detection + map-wide sweep

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -1025,10 +1025,16 @@ export interface ConflictEntryApi {
   overlappingScopes: string[];
 }
 
+export interface DuplicateLinkGroupApi {
+  externalId: string;
+  nodes: Array<{ id: string; text: string; percentComplete: number | null; hasChildren: boolean }>;
+}
+
 export interface ConflictScanResultApi {
-  candidateId: string;
+  candidateId: string | null;
   candidateScopes: string[];
   conflicts: ConflictEntryApi[];
+  duplicateLinks: DuplicateLinkGroupApi[];
 }
 
 export function readyNodes(
@@ -1068,9 +1074,11 @@ export function releaseNode(
 
 export function conflictScan(
   mapId: string,
-  candidateNodeId: string,
+  candidateNodeId?: string,
 ): Promise<ConflictScanResultApi> {
   return request<ConflictScanResultApi>(
-    `/api/maps/${mapId}/nodes/${candidateNodeId}/conflict-scan`,
+    candidateNodeId === undefined
+      ? `/api/maps/${mapId}/conflict-scan`
+      : `/api/maps/${mapId}/nodes/${candidateNodeId}/conflict-scan`,
   );
 }

--- a/packages/mcp/src/backend.ts
+++ b/packages/mcp/src/backend.ts
@@ -30,5 +30,5 @@ export const httpBackend: ToolBackend = {
   readyNodes: (mapId, opts) => api.readyNodes(mapId, opts),
   claimNode: (mapId, nodeId, sessionId) => api.claimNode(mapId, nodeId, sessionId),
   releaseNode: (mapId, nodeId, sessionId) => api.releaseNode(mapId, nodeId, sessionId),
-  conflictScan: (mapId, candidateNodeId) => api.conflictScan(mapId, candidateNodeId),
+  conflictScan: (mapId, candidateNodeId?) => api.conflictScan(mapId, candidateNodeId),
 };

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -252,6 +252,6 @@ export function createChatBackend(userId: string): ToolBackend {
     readyNodes: (mapId, opts) => orchestrationService.readyNodes(mapId, opts),
     claimNode: (mapId, nodeId, sessionId) => orchestrationService.claimNode(mapId, nodeId, sessionId),
     releaseNode: (mapId, nodeId, sessionId) => orchestrationService.releaseNode(mapId, nodeId, sessionId),
-    conflictScan: (mapId, candidateNodeId) => orchestrationService.conflictScan(mapId, candidateNodeId),
+    conflictScan: (mapId, candidateNodeId?) => orchestrationService.conflictScan(mapId, candidateNodeId),
   };
 }

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -107,6 +107,20 @@ export async function orchestrationRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
+  // ── GET /api/maps/:id/conflict-scan — map-wide duplicate sweep ──
+  // conflict_scan without a candidate: reports every GitHub link that
+  // is attached to more than one node (the duplicate-node pattern).
+  app.get<{ Params: { id: string } }>(
+    '/api/maps/:id/conflict-scan',
+    async (req, reply) => {
+      try {
+        return reply.send(await conflictScan(req.params.id));
+      } catch (err) {
+        return handleOrchestrationError(err, reply);
+      }
+    },
+  );
+
   // ── GET /api/maps/:id/nodes/:nodeId/conflict-scan — conflict_scan ──
   app.get<{ Params: { id: string; nodeId: string } }>(
     '/api/maps/:id/nodes/:nodeId/conflict-scan',

--- a/packages/server/src/services/orchestration.ts
+++ b/packages/server/src/services/orchestration.ts
@@ -250,20 +250,57 @@ export async function releaseNode(
 
 export async function conflictScan(
   mapId: string,
-  candidateNodeId: string,
+  candidateNodeId?: string,
 ): Promise<ConflictScanResult> {
-  const [candidateRow] = await db
+  const allRows = await db
     .select()
     .from(nodes)
-    .where(and(eq(nodes.id, candidateNodeId), notDeleted));
-  if (!candidateRow) {
+    .where(and(eq(nodes.mapId, mapId), notDeleted));
+  const all = allRows.map((r) => dbNodeToCore(r as unknown as Record<string, unknown>));
+
+  // ── Duplicate GitHub links ──────────────────────────────────────
+  // The same issue linked on several nodes falsifies progress rollups
+  // and makes status answers contradictory (2026-07-15 cleanup removed
+  // 164 such pairs map-wide). Per-candidate scans check the candidate's
+  // links; map-wide scans (no candidate) report every duplicated link.
+  const byLink = new Map<string, CoreNode[]>();
+  for (const n of all) {
+    for (const l of n.externalLinks) {
+      if (l.provider !== 'github') continue;
+      (byLink.get(l.externalId) ?? byLink.set(l.externalId, []).get(l.externalId)!).push(n);
+    }
+  }
+  const toGroup = (externalId: string, group: CoreNode[]) => ({
+    externalId,
+    nodes: group.map((n) => ({
+      id: n.id,
+      text: n.text,
+      percentComplete: n.percentComplete,
+      hasChildren: n.childrenIds.length > 0,
+    })),
+  });
+
+  if (candidateNodeId === undefined) {
+    const duplicateLinks = [...byLink.entries()]
+      .filter(([, group]) => group.length > 1)
+      .sort((a, b) => a[0].localeCompare(b[0], undefined, { numeric: true }))
+      .map(([ext, group]) => toGroup(ext, group));
+    return { candidateId: null, candidateScopes: [], conflicts: [], duplicateLinks };
+  }
+
+  const candidate = all.find((n) => n.id === candidateNodeId);
+  if (!candidate) {
     throw new OrchestrationNotFoundError(`Node ${candidateNodeId} not found`);
   }
 
-  const candidate = dbNodeToCore(candidateRow as unknown as Record<string, unknown>);
+  const duplicateLinks = candidate.externalLinks
+    .filter((l) => l.provider === 'github')
+    .map((l) => [l.externalId, byLink.get(l.externalId) ?? []] as const)
+    .filter(([, group]) => group.length > 1)
+    .map(([ext, group]) => toGroup(ext, group));
 
   if (candidate.scopes.length === 0) {
-    return { candidateId: candidateNodeId, candidateScopes: [], conflicts: [] };
+    return { candidateId: candidateNodeId, candidateScopes: [], conflicts: [], duplicateLinks };
   }
 
   const [mapRow] = await db
@@ -273,15 +310,9 @@ export async function conflictScan(
   const workflow = ((mapRow?.statusWorkflow as StatusDef[]) ?? []);
   const inProgressIds = buildInProgressIds(workflow);
 
-  const allRows = await db
-    .select()
-    .from(nodes)
-    .where(and(eq(nodes.mapId, mapId), notDeleted));
-
   const conflicts: ConflictScanResult['conflicts'] = [];
-  for (const row of allRows) {
-    if ((row.id as string) === candidateNodeId) continue;
-    const n = dbNodeToCore(row as unknown as Record<string, unknown>);
+  for (const n of all) {
+    if (n.id === candidateNodeId) continue;
     const isInProgress = n.status !== null && inProgressIds.has(n.status);
     const isClaimed = n.claimedBySession !== null;
     if (!isInProgress && !isClaimed) continue;
@@ -302,5 +333,6 @@ export async function conflictScan(
     candidateId: candidateNodeId,
     candidateScopes: candidate.scopes,
     conflicts,
+    duplicateLinks,
   };
 }

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -166,10 +166,28 @@ export interface ConflictEntry {
   overlappingScopes: string[];
 }
 
+/** Nodes sharing one GitHub issue link — the duplicate-node pattern. */
+export interface DuplicateLinkGroup {
+  externalId: string;
+  nodes: Array<{
+    id: string;
+    text: string;
+    percentComplete: number | null;
+    hasChildren: boolean;
+  }>;
+}
+
 export interface ConflictScanResult {
-  candidateId: string;
+  /** null in map-wide mode (no candidate given). */
+  candidateId: string | null;
   candidateScopes: string[];
   conflicts: ConflictEntry[];
+  /**
+   * GitHub links attached to more than one node. Per-candidate scans
+   * restrict this to the candidate's own links; map-wide scans (no
+   * candidateNodeId) report every duplicated link in the map.
+   */
+  duplicateLinks: DuplicateLinkGroup[];
 }
 
 export interface ToolBackend {
@@ -257,5 +275,5 @@ export interface ToolBackend {
   ): Promise<ReadyNodesResult>;
   claimNode(mapId: string, nodeId: string, sessionId: string): Promise<ClaimNodeResult>;
   releaseNode(mapId: string, nodeId: string, sessionId: string): Promise<ReleaseNodeResult>;
-  conflictScan(mapId: string, candidateNodeId: string): Promise<ConflictScanResult>;
+  conflictScan(mapId: string, candidateNodeId?: string): Promise<ConflictScanResult>;
 }

--- a/packages/tool-kit/src/tools/__tests__/conflict-scan-duplicates.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/conflict-scan-duplicates.test.ts
@@ -1,0 +1,77 @@
+/**
+ * conflict_scan duplicate-link detection — the tool's formatting contract
+ * for the map-wide sweep and the per-candidate duplicate section.
+ * (Duplicate GH links falsify rollups; 164 were removed in the 2026-07-15
+ * cleanup — this is the hygiene check that keeps them from regrowing.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { conflictScanTool } from '../orchestration.js';
+import type { ToolBackend, ConflictScanResult } from '../../backend.js';
+
+function backendReturning(result: ConflictScanResult): ToolBackend {
+  return { conflictScan: async () => result } as unknown as ToolBackend;
+}
+
+const DUPE = {
+  externalId: 'FulcrumCRM/crm#2649',
+  nodes: [
+    { id: 'n-done', text: '#2649 Epic: Jahressitzung', percentComplete: 100, hasChildren: true },
+    { id: 'n-zero', text: '#2649 Jahressitzung (Inbox)', percentComplete: 0, hasChildren: false },
+  ],
+};
+
+describe('conflict_scan — map-wide duplicate sweep (no candidate)', () => {
+  it('reports duplicate groups with per-node progress', async () => {
+    const out = await conflictScanTool.handler(
+      backendReturning({ candidateId: null, candidateScopes: [], conflicts: [], duplicateLinks: [DUPE] }),
+      { mapId: 'm1' } as never,
+    );
+    expect(out).toContain('Map-wide duplicate sweep: 1 GitHub link(s)');
+    expect(out).toContain('FulcrumCRM/crm#2649 on 2 nodes');
+    expect(out).toContain('n-done');
+    expect(out).toContain('n-zero');
+    // The resolution warning must mention stripping links before delete —
+    // deleting a linked node closes the GitHub issue as not_planned.
+    expect(out).toMatch(/strip.*externalLinks.*BEFORE deleting/i);
+  });
+
+  it('reports a clean map tersely', async () => {
+    const out = await conflictScanTool.handler(
+      backendReturning({ candidateId: null, candidateScopes: [], conflicts: [], duplicateLinks: [] }),
+      { mapId: 'm1' } as never,
+    );
+    expect(out).toContain('Clean');
+  });
+});
+
+describe('conflict_scan — per-candidate duplicate section', () => {
+  it('appends duplicates to a no-scope candidate result', async () => {
+    const out = await conflictScanTool.handler(
+      backendReturning({
+        candidateId: 'n-zero',
+        candidateScopes: [],
+        conflicts: [],
+        duplicateLinks: [DUPE],
+      }),
+      { mapId: 'm1', candidateNodeId: 'n-zero' } as never,
+    );
+    expect(out).toContain('scope-conflict detection skipped');
+    expect(out).toContain('duplicate GitHub link(s) involving this node');
+    expect(out).toContain('FulcrumCRM/crm#2649');
+  });
+
+  it('stays silent about duplicates when there are none', async () => {
+    const out = await conflictScanTool.handler(
+      backendReturning({
+        candidateId: 'n1',
+        candidateScopes: ['apps/x'],
+        conflicts: [],
+        duplicateLinks: [],
+      }),
+      { mapId: 'm1', candidateNodeId: 'n1' } as never,
+    );
+    expect(out).toContain('No scope conflicts');
+    expect(out).not.toContain('duplicate');
+  });
+});

--- a/packages/tool-kit/src/tools/orchestration.ts
+++ b/packages/tool-kit/src/tools/orchestration.ts
@@ -140,36 +140,79 @@ export const conflictScanTool = defineTool({
     '  2. conflict_scan(candidate) → if non-empty, decide: skip, wait, or dispatch anyway',
     '  3. claim_node → dispatch agent',
     '',
-    'If the candidate has no scopes declared, returns empty (no conflict detection).',
-    'Set scopes via update_node({ scopes: ["apps/workflows", "migration:workflows"] }).',
+    'If the candidate has no scopes declared, scope conflicts are skipped (set scopes',
+    'via update_node), but duplicate detection still runs.',
+    '',
+    'DUPLICATE DETECTION: the scan also reports GitHub issue links attached to more',
+    'than one node — the duplicate-node pattern that falsifies progress rollups.',
+    'Per-candidate scans check the candidate\'s links; calling WITHOUT candidateNodeId',
+    'runs a map-wide duplicate sweep (hygiene check for housekeeping agents).',
   ].join('\n'),
   schema: {
     mapId: z.string().describe('The map ID'),
-    candidateNodeId: z.string().describe('The node ID to check for conflicts'),
+    candidateNodeId: z
+      .string()
+      .optional()
+      .describe('The node ID to check. Omit for a map-wide duplicate-link sweep.'),
   },
   handler: async (backend, { mapId, candidateNodeId }) => {
     const result = await backend.conflictScan(mapId, candidateNodeId);
+    const lines: string[] = [];
+
+    const formatDupes = () => {
+      for (const g of result.duplicateLinks) {
+        lines.push(`  - ${g.externalId} on ${g.nodes.length} nodes:`);
+        for (const n of g.nodes) {
+          const pct = n.percentComplete != null ? ` ${n.percentComplete}%` : '';
+          lines.push(`      ${n.id} "${n.text.slice(0, 70)}"${pct}${n.hasChildren ? ' (has children)' : ''}`);
+        }
+      }
+    };
+
+    if (candidateNodeId === undefined) {
+      if (result.duplicateLinks.length === 0) {
+        return 'Map-wide duplicate sweep: no GitHub link is attached to more than one node. Clean.';
+      }
+      lines.push(
+        `Map-wide duplicate sweep: ${result.duplicateLinks.length} GitHub link(s) attached to multiple nodes:`,
+        '',
+      );
+      formatDupes();
+      lines.push('');
+      lines.push(
+        'Resolution pattern: keep the node with real progress/children, strip the externalLinks from the duplicate (update_node) BEFORE deleting it — deleting a linked node closes the GitHub issue as not_planned.',
+      );
+      return lines.join('\n');
+    }
 
     if (result.candidateScopes.length === 0) {
-      return `Node ${candidateNodeId} has no scopes declared — no conflict detection possible. Set scopes via update_node to enable conflict scanning.`;
+      lines.push(
+        `Node ${candidateNodeId} has no scopes declared — scope-conflict detection skipped. Set scopes via update_node to enable it.`,
+      );
+    } else if (result.conflicts.length === 0) {
+      lines.push(
+        `No scope conflicts for node ${candidateNodeId} (scopes: [${result.candidateScopes.join(', ')}]).`,
+      );
+    } else {
+      lines.push(
+        `${result.conflicts.length} conflict(s) found for node ${candidateNodeId} (scopes: [${result.candidateScopes.join(', ')}]):`,
+        '',
+      );
+      for (const c of result.conflicts) {
+        const status = c.status ? ` status=${c.status}` : '';
+        const claimed = c.claimedBySession ? ` claimed_by=${c.claimedBySession}` : '';
+        lines.push(`  - ${c.id} "${c.text}"${status}${claimed}`);
+        lines.push(`    overlapping scopes: [${c.overlappingScopes.join(', ')}]`);
+      }
+      lines.push('');
+      lines.push('Consider waiting for these to complete or dispatching with isolation: "worktree".');
     }
 
-    if (result.conflicts.length === 0) {
-      return `No conflicts found for node ${candidateNodeId} (scopes: [${result.candidateScopes.join(', ')}]).`;
+    if (result.duplicateLinks.length > 0) {
+      lines.push('');
+      lines.push(`⚠ ${result.duplicateLinks.length} duplicate GitHub link(s) involving this node:`);
+      formatDupes();
     }
-
-    const lines: string[] = [
-      `${result.conflicts.length} conflict(s) found for node ${candidateNodeId} (scopes: [${result.candidateScopes.join(', ')}]):`,
-      '',
-    ];
-    for (const c of result.conflicts) {
-      const status = c.status ? ` status=${c.status}` : '';
-      const claimed = c.claimedBySession ? ` claimed_by=${c.claimedBySession}` : '';
-      lines.push(`  - ${c.id} "${c.text}"${status}${claimed}`);
-      lines.push(`    overlapping scopes: [${c.overlappingScopes.join(', ')}]`);
-    }
-    lines.push('');
-    lines.push('Consider waiting for these to complete or dispatching with isolation: "worktree".');
     return lines.join('\n');
   },
 });


### PR DESCRIPTION
The duplicate-node pattern (same GitHub issue linked on several nodes)
falsifies progress rollups — the 2026-07-15 cleanup removed 164 such
pairs map-wide. conflict_scan now keeps them from regrowing:

- Per-candidate scans additionally report every GitHub link of the
  candidate that is attached to other nodes (duplicateLinks with
  per-node progress + hasChildren, so the keeper is obvious).
  Duplicate detection runs even when the candidate has no scopes
  (scope conflicts are still skipped then).
- New map-wide mode: conflict_scan WITHOUT candidateNodeId sweeps the
  whole map for duplicated links — the hygiene check for housekeeping
  agents (Jenna). New route GET /api/maps/:id/conflict-scan.
- Tool output includes the safe resolution pattern (strip externalLinks
  BEFORE deleting the duplicate — deletion closes linked issues as
  not_planned).
- ToolBackend.conflictScan candidateNodeId now optional (both impls),
  ConflictScanResult gains duplicateLinks / nullable candidateId.

Verified on a scratch DB (REST both modes) + 4 new tool-kit tests for
the formatting contract. 516 server / 71 tool-kit tests green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn
