### PR TITLE
feat(mcp): unlink_github_issue — safe duplicate resolution primitive

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2403,6 +2403,46 @@ server.tool(
 );
 
 server.tool(
+  'unlink_github_issue',
+  "Remove a GitHub issue link from a node WITHOUT touching the issue on GitHub. This is the safe first step when resolving duplicate-node findings from conflict_scan: strip the duplicate's link first, THEN delete_node — deleting a still-linked node closes its GitHub issue as not_planned.",
+  {
+    mapId: z.string().describe('The map ID'),
+    nodeId: z.string().describe('The node ID to unlink'),
+    externalId: z
+      .string()
+      .optional()
+      .describe('Specific link to remove, e.g. "FulcrumCRM/crm#2649". Omit to remove ALL GitHub links of the node.'),
+  },
+  async ({ mapId, nodeId, externalId }) => {
+    try {
+      const mapData = await api.getMap(mapId);
+      const node = mapData.nodes.find((n) => n.id === nodeId);
+      if (!node) {
+        return toolError(`Node ${nodeId} not found in map ${mapId}.`);
+      }
+      const links = node.externalLinks ?? [];
+      const removed = links.filter(
+        (l) => l.provider === 'github' && (externalId === undefined || l.externalId === externalId),
+      );
+      if (removed.length === 0) {
+        return toolError(
+          externalId
+            ? `Node ${nodeId} has no GitHub link ${externalId}.`
+            : `Node ${nodeId} has no GitHub links.`,
+        );
+      }
+      const remaining = links.filter((l) => !removed.includes(l));
+      await api.updateNode(mapId, nodeId, { externalLinks: remaining });
+      return toolResult(
+        `Unlinked ${removed.map((l) => l.externalId).join(', ')} from node ${nodeId}. The GitHub issue(s) were NOT touched; the node no longer syncs with them.`,
+      );
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
   'github_sync_overview',
   'Three-way diff between a MindBlown map and its connected GitHub repo: which nodes are linked to issues (synced), which leaf nodes have no GitHub link yet (onlyInMindBlown), and which repo issues are not yet linked to any node in the map (onlyInGitHub). Use this to audit the sync state before bulk operations or to find gaps worth promoting/linking. Requires the map to have a GitHub repo connected.',
   {

--- a/packages/tool-kit/src/tools/__tests__/conflict-scan-duplicates.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/conflict-scan-duplicates.test.ts
@@ -33,7 +33,7 @@ describe('conflict_scan — map-wide duplicate sweep (no candidate)', () => {
     expect(out).toContain('n-zero');
     // The resolution warning must mention stripping links before delete —
     // deleting a linked node closes the GitHub issue as not_planned.
-    expect(out).toMatch(/strip.*externalLinks.*BEFORE deleting/i);
+    expect(out).toMatch(/unlink_github_issue BEFORE deleting/i);
   });
 
   it('reports a clean map tersely', async () => {

--- a/packages/tool-kit/src/tools/orchestration.ts
+++ b/packages/tool-kit/src/tools/orchestration.ts
@@ -180,7 +180,7 @@ export const conflictScanTool = defineTool({
       formatDupes();
       lines.push('');
       lines.push(
-        'Resolution pattern: keep the node with real progress/children, strip the externalLinks from the duplicate (update_node) BEFORE deleting it — deleting a linked node closes the GitHub issue as not_planned.',
+        'Resolution pattern: keep the node with real progress/children, strip the duplicate\'s links via unlink_github_issue BEFORE deleting it — deleting a still-linked node closes the GitHub issue as not_planned.',
       );
       return lines.join('\n');
     }


### PR DESCRIPTION
conflict_scan's duplicate findings need a safe resolution primitive:
stripping a node's GitHub links WITHOUT touching the issue, before
delete_node (deleting a still-linked node closes the issue as
not_planned). update_node deliberately doesn't expose externalLinks to
agents, so housekeeping agents had no way to execute the pattern.

unlink_github_issue {mapId, nodeId, externalId?} removes one specific
github link or all of them; the issue itself is never written to.
conflict_scan's resolution hint now names the tool.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn
