### PR TITLE
fix(orchestration): conflict_scan '' candidate = map-wide sweep

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -1154,9 +1154,11 @@ export function conflictScan(
   mapId: string,
   candidateNodeId?: string,
 ): Promise<ConflictScanResultApi> {
+  // Empty/whitespace candidate = map-wide sweep (agents pass '' for "none").
+  const candidate = candidateNodeId?.trim();
   return request<ConflictScanResultApi>(
-    candidateNodeId === undefined
+    !candidate
       ? `/api/maps/${mapId}/conflict-scan`
-      : `/api/maps/${mapId}/nodes/${candidateNodeId}/conflict-scan`,
+      : `/api/maps/${mapId}/nodes/${candidate}/conflict-scan`,
   );
 }

--- a/packages/tool-kit/src/tools/__tests__/conflict-scan-duplicates.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/conflict-scan-duplicates.test.ts
@@ -45,6 +45,26 @@ describe('conflict_scan — map-wide duplicate sweep (no candidate)', () => {
   });
 });
 
+describe('conflict_scan — empty candidateNodeId means map-wide', () => {
+  // Jenna passed candidateNodeId: '' on 2026-07-16 and got a 404 node
+  // lookup — agents use '' for "none", the tool must treat it as omitted.
+  it("treats '' as a map-wide sweep", async () => {
+    let received: unknown = 'sentinel';
+    const backend = {
+      conflictScan: async (_m: string, c?: string) => {
+        received = c;
+        return { candidateId: null, candidateScopes: [], conflicts: [], duplicateLinks: [] };
+      },
+    } as unknown as ToolBackend;
+    const out = await conflictScanTool.handler(backend, {
+      mapId: 'm1',
+      candidateNodeId: '',
+    } as never);
+    expect(received).toBeUndefined();
+    expect(out).toContain('Map-wide duplicate sweep');
+  });
+});
+
 describe('conflict_scan — per-candidate duplicate section', () => {
   it('appends duplicates to a no-scope candidate result', async () => {
     const out = await conflictScanTool.handler(

--- a/packages/tool-kit/src/tools/orchestration.ts
+++ b/packages/tool-kit/src/tools/orchestration.ts
@@ -156,7 +156,10 @@ export const conflictScanTool = defineTool({
       .describe('The node ID to check. Omit for a map-wide duplicate-link sweep.'),
   },
   handler: async (backend, { mapId, candidateNodeId }) => {
-    const result = await backend.conflictScan(mapId, candidateNodeId);
+    // Agents pass '' or whitespace to mean "no candidate" — treat like omitted
+    // (an empty id would otherwise 404 as a node lookup on the server).
+    const candidate = candidateNodeId?.trim() || undefined;
+    const result = await backend.conflictScan(mapId, candidate);
     const lines: string[] = [];
 
     const formatDupes = () => {
@@ -169,7 +172,7 @@ export const conflictScanTool = defineTool({
       }
     };
 
-    if (candidateNodeId === undefined) {
+    if (candidate === undefined) {
       if (result.duplicateLinks.length === 0) {
         return 'Map-wide duplicate sweep: no GitHub link is attached to more than one node. Clean.';
       }
@@ -187,15 +190,15 @@ export const conflictScanTool = defineTool({
 
     if (result.candidateScopes.length === 0) {
       lines.push(
-        `Node ${candidateNodeId} has no scopes declared — scope-conflict detection skipped. Set scopes via update_node to enable it.`,
+        `Node ${candidate} has no scopes declared — scope-conflict detection skipped. Set scopes via update_node to enable it.`,
       );
     } else if (result.conflicts.length === 0) {
       lines.push(
-        `No scope conflicts for node ${candidateNodeId} (scopes: [${result.candidateScopes.join(', ')}]).`,
+        `No scope conflicts for node ${candidate} (scopes: [${result.candidateScopes.join(', ')}]).`,
       );
     } else {
       lines.push(
-        `${result.conflicts.length} conflict(s) found for node ${candidateNodeId} (scopes: [${result.candidateScopes.join(', ')}]):`,
+        `${result.conflicts.length} conflict(s) found for node ${candidate} (scopes: [${result.candidateScopes.join(', ')}]):`,
         '',
       );
       for (const c of result.conflicts) {


### PR DESCRIPTION
Jenna's first §8.12 run passed candidateNodeId: '' (agent idiom for
"none") — the empty id flowed into the per-node route and 404ed as a
node lookup ("Node  not found"). Empty/whitespace now means omitted, in
both the tool handler and the MCP api client. Regression test included.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ajg3jijJZDSmL6ZxJH5sn
