### PR TITLE
fix(forecast): scoped completion_forecast projects the scope, not its backlog position

### DIFF
--- a/packages/core/src/__tests__/velocity.test.ts
+++ b/packages/core/src/__tests__/velocity.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   clampFocusFactor,
+  scopedCapacityDays,
   DEFAULT_FOCUS_FACTOR,
   FOCUS_FACTOR_MIN,
   FOCUS_FACTOR_MAX,
@@ -30,5 +31,32 @@ describe('clampFocusFactor', () => {
     expect(clampFocusFactor(undefined)).toBe(DEFAULT_FOCUS_FACTOR);
     expect(clampFocusFactor(NaN)).toBe(DEFAULT_FOCUS_FACTOR);
     expect(clampFocusFactor(Infinity)).toBe(DEFAULT_FOCUS_FACTOR);
+  });
+});
+
+describe('scopedCapacityDays', () => {
+  it('planned = remaining ÷ (workers × unitsPerDay); velocity applies fudge & focus', () => {
+    // 50 remaining, 5 workers, 1 unit/day → 10 calendar days planned.
+    const r = scopedCapacityDays(50, { workers: 5, unitsPerDay: 1, fudge: 1, focusFactor: 1 });
+    expect(r.plannedCalendarDays).toBeCloseTo(10, 6);
+    expect(r.velocityCalendarDays).toBeCloseTo(10, 6);
+  });
+
+  it('velocity stretches by fudge and by 1/focus, planned does not', () => {
+    const r = scopedCapacityDays(50, { workers: 5, unitsPerDay: 1, fudge: 1.26, focusFactor: 0.5 });
+    expect(r.plannedCalendarDays).toBeCloseTo(10, 6); // idealised baseline
+    expect(r.velocityCalendarDays).toBeCloseTo((50 * 1.26) / (5 * 0.5), 6); // 25.2
+  });
+
+  it('does not bury a small scope behind a big backlog — depends only on scope size', () => {
+    // Whatever the rest of the map holds, a 20-day scope at 5 workers is ~4 days.
+    const r = scopedCapacityDays(20, { workers: 5, unitsPerDay: 1, fudge: 1, focusFactor: 1 });
+    expect(r.plannedCalendarDays).toBeCloseTo(4, 6);
+  });
+
+  it('clamps focus and never divides by zero capacity', () => {
+    const r = scopedCapacityDays(10, { workers: 0, unitsPerDay: 0, fudge: 1, focusFactor: 5 });
+    expect(Number.isFinite(r.plannedCalendarDays)).toBe(true);
+    expect(Number.isFinite(r.velocityCalendarDays)).toBe(true);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,4 +89,6 @@ export {
   FOCUS_FACTOR_MAX,
   DEFAULT_FOCUS_FACTOR,
   clampFocusFactor,
+  scopedCapacityDays,
 } from './velocity.js';
+export type { ScopedCapacityInput } from './velocity.js';

--- a/packages/core/src/velocity.ts
+++ b/packages/core/src/velocity.ts
@@ -33,3 +33,44 @@ export function clampFocusFactor(value: number | null | undefined): number {
   if (value == null || !Number.isFinite(value)) return DEFAULT_FOCUS_FACTOR;
   return Math.min(FOCUS_FACTOR_MAX, Math.max(FOCUS_FACTOR_MIN, value));
 }
+
+/**
+ * Capacity-based calendar projection for a **scoped** forecast (a version /
+ * milestone or a subtree), from now.
+ *
+ * The whole-map completion forecast runs the critical-path scheduler over the
+ * entire map and reads a scope's finish off where its leaves land in that
+ * global ordering. For a *scoped* forecast that is wrong: the milestone's
+ * leaves get buried behind the entire backlog, so the date reflects the
+ * backlog's size, not the milestone's. When you commit to a milestone you work
+ * *it*, so the honest projection is its own remaining effort against the team's
+ * capacity:
+ *
+ *     plannedCalendarDays  = remaining ÷ (workers × unitsPerDay)
+ *     velocityCalendarDays = remaining × fudge ÷ (workers × unitsPerDay × focus)
+ *
+ * Both are measured from today (the work is ahead of you). This intentionally
+ * ignores within-scope dependency chains — a milestone with a long serial
+ * critical path can run longer than pure capacity implies; that refinement can
+ * schedule the isolated subtree later. It is still far closer than the
+ * backlog-buried scheduler position it replaces.
+ */
+export interface ScopedCapacityInput {
+  workers: number;
+  unitsPerDay: number;
+  fudge: number;
+  focusFactor: number;
+}
+
+export function scopedCapacityDays(
+  remainingEffort: number,
+  opts: ScopedCapacityInput,
+): { plannedCalendarDays: number; velocityCalendarDays: number } {
+  const capacityPerDay = Math.max(1e-9, opts.workers * opts.unitsPerDay);
+  const focus = clampFocusFactor(opts.focusFactor);
+  const rem = Math.max(0, remainingEffort);
+  return {
+    plannedCalendarDays: rem / capacityPerDay,
+    velocityCalendarDays: (rem * opts.fudge) / (capacityPerDay * focus),
+  };
+}

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -173,6 +173,8 @@ export interface ScheduleResult {
   projectStartDate: string;
   effortUnit: 'hours' | 'days' | 'points';
   unitsPerDay: number;
+  /** Parallel work tracks the schedule projects onto; default 1. */
+  workerCount?: number;
   /** Fraction of calendar time reaching planned work (0.05–1.0); default 1. */
   focusFactor?: number;
   versionId?: string | null;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -23,7 +23,7 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { allTools as sharedTools, type ToolSpec } from '@mindblown/tool-kit';
-import { clampFocusFactor } from '@mindblown/core';
+import { clampFocusFactor, scopedCapacityDays } from '@mindblown/core';
 import * as api from './api.js';
 import { scopedLeaves } from './scope.js';
 import { httpBackend } from './backend.js';
@@ -733,7 +733,7 @@ server.tool(
       const fudgeFactor = calibEstimate > 0 ? calibActual / calibEstimate : null;
       const effectiveFudge = fudgeFactor ?? 1.0;
 
-      // ── Scheduler-based planned finish ──
+      // ── Scheduler meta (project start, units, capacity, focus) ──
       const sched = await api.getSchedule(mapId);
 
       // ── Focus factor (capacity leakage) — velocity line only ──
@@ -741,16 +741,12 @@ server.tool(
       // velocity-adjusted finish so it reflects real throughput, not just
       // estimation bias. Default 1.0 = no effect.
       const focusFactor = clampFocusFactor(sched.focusFactor);
-      const scopedIds = new Set(leaves.map((l) => l.id));
-      const scopedSched = sched.schedule.filter((s) => scopedIds.has(s.nodeId));
-      const maxComputedEnd = scopedSched.reduce((m, s) => Math.max(m, s.computedEnd), 0);
 
       const MS_PER_DAY = 86_400_000;
       const projectStart = new Date(sched.projectStartDate);
       const today = new Date();
       today.setUTCHours(0, 0, 0, 0);
-
-      const effortUnitsToCalendarDays = (units: number): number => units / sched.unitsPerDay;
+      const anchor = today > projectStart ? today : projectStart;
       const addCalendarDays = (base: Date, days: number): Date => {
         const d = new Date(base.getTime());
         d.setUTCDate(d.getUTCDate() + Math.ceil(days));
@@ -760,19 +756,44 @@ server.tool(
       const daysBetween = (a: Date, b: Date) =>
         Math.round((a.getTime() - b.getTime()) / MS_PER_DAY);
 
-      const plannedFinishCalendarDays = effortUnitsToCalendarDays(maxComputedEnd);
-      const plannedFinishDate = addCalendarDays(projectStart, plannedFinishCalendarDays);
+      // A scoped forecast (a version/milestone or subtree) must NOT read its
+      // finish off the whole-map scheduler — its leaves land behind the entire
+      // backlog there, so the date reflects the backlog, not the milestone.
+      // Project the scope's own remaining effort against team capacity instead.
+      const scoped = Boolean(versionId || nodeId);
+      const workers = Math.max(1, Math.floor(sched.workerCount ?? 1));
+      let plannedFinishCalendarDays: number;
+      let velocityFinishCalendarDays: number;
+      let plannedFinishDate: Date;
+      let velocityFinishDate: Date;
+      let hasSchedulableEffort: boolean;
 
-      // Velocity-adjusted finish: take the scheduler's remaining calendar days
-      // (which already accounts for parallelism and dependencies) and scale by
-      // the fudge factor. If the scheduler says 5 days and fudge is 1.5x, we
-      // expect 7.5 days. Anchor at max(today, projectStart) so a future-start
-      // project doesn't report a past finish.
-      const anchor = today > projectStart ? today : projectStart;
-      const elapsedFromStart = Math.max(0, daysBetween(anchor, projectStart));
-      const remainingSchedulerDays = Math.max(0, plannedFinishCalendarDays - elapsedFromStart);
-      const velocityFinishCalendarDays = (remainingSchedulerDays * effectiveFudge) / focusFactor;
-      const velocityFinishDate = addCalendarDays(anchor, velocityFinishCalendarDays);
+      if (scoped) {
+        const cap = scopedCapacityDays(remainingEffort, {
+          workers,
+          unitsPerDay: sched.unitsPerDay,
+          fudge: effectiveFudge,
+          focusFactor,
+        });
+        plannedFinishCalendarDays = cap.plannedCalendarDays;
+        velocityFinishCalendarDays = cap.velocityCalendarDays;
+        plannedFinishDate = addCalendarDays(anchor, plannedFinishCalendarDays);
+        velocityFinishDate = addCalendarDays(anchor, velocityFinishCalendarDays);
+        hasSchedulableEffort = remainingEffort > 0;
+      } else {
+        // Whole map: the critical-path scheduler IS the right answer.
+        const scopedIds = new Set(leaves.map((l) => l.id));
+        const maxComputedEnd = sched.schedule
+          .filter((s) => scopedIds.has(s.nodeId))
+          .reduce((m, s) => Math.max(m, s.computedEnd), 0);
+        plannedFinishCalendarDays = maxComputedEnd / sched.unitsPerDay;
+        plannedFinishDate = addCalendarDays(projectStart, plannedFinishCalendarDays);
+        const elapsedFromStart = Math.max(0, daysBetween(anchor, projectStart));
+        const remainingSchedulerDays = Math.max(0, plannedFinishCalendarDays - elapsedFromStart);
+        velocityFinishCalendarDays = (remainingSchedulerDays * effectiveFudge) / focusFactor;
+        velocityFinishDate = addCalendarDays(anchor, velocityFinishCalendarDays);
+        hasSchedulableEffort = maxComputedEnd > 0;
+      }
 
       // ── Target date resolution ──
       let targetDate: string | null = null;
@@ -816,10 +837,13 @@ server.tool(
       }
       lines.push('');
 
-      if (maxComputedEnd > 0) {
-        lines.push(`Planned finish:      ${iso(plannedFinishDate)} (scheduler, project start ${sched.projectStartDate})`);
+      if (hasSchedulableEffort) {
+        const basis = scoped
+          ? `capacity: ${remainingEffort.toFixed(1)} ${unit} ÷ ${workers} worker(s) from ${iso(anchor)}`
+          : `scheduler, project start ${sched.projectStartDate}`;
+        lines.push(`Planned finish:      ${iso(plannedFinishDate)} (${basis})`);
       } else {
-        lines.push(`Planned finish:      (no schedulable effort in scope)`);
+        lines.push(`Planned finish:      (no remaining effort in scope)`);
       }
       if (remainingEffort > 0) {
         const focusNote = focusFactor < 1 ? `, focus ${focusFactor.toFixed(2)}` : '';
@@ -832,7 +856,7 @@ server.tool(
         lines.push('');
         lines.push(`Target:              ${targetDate} (${targetSource})`);
         const targetDateObj = new Date(targetDate);
-        if (maxComputedEnd > 0) {
+        if (hasSchedulableEffort) {
           const slipPlanned = daysBetween(plannedFinishDate, targetDateObj);
           lines.push(`Slip (planned):      ${slipPlanned >= 0 ? '+' : ''}${slipPlanned} days`);
         }

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath, clampFocusFactor } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
@@ -761,35 +761,63 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     let plannedFinishDate: string | null = null;
     let velocityAdjustedFinishDate: string | null = null;
     let maxScopedEnd = 0;
+    const scoped = Boolean(versionId || nodeId);
+    const workers = Math.max(1, Math.min(100, Math.floor(data.map.workerCount ?? 1)));
     try {
-      const workers = Math.max(1, Math.min(100, Math.floor(data.map.workerCount ?? 1)));
-      const scheduled = schedule(data.nodes, 0, constraints, undefined, workers);
-      const scopedIds = new Set(leaves.map((l) => l.id));
-      maxScopedEnd = scheduled
-        .filter((s) => scopedIds.has(s.nodeId))
-        .reduce((m, s) => Math.max(m, s.computedEnd), 0);
-
       const addCalendarDays = (base: Date, days: number): Date => {
         const d = new Date(base.getTime());
         d.setUTCDate(d.getUTCDate() + Math.ceil(days));
         return d;
       };
+      const today = new Date();
+      today.setUTCHours(0, 0, 0, 0);
+      const anchor = today > projectStart ? today : projectStart;
 
-      if (maxScopedEnd > 0) {
-        const plannedCalDays = maxScopedEnd / unitsPerDay;
-        plannedFinishDate = addCalendarDays(projectStart, plannedCalDays).toISOString().slice(0, 10);
-
+      if (scoped) {
+        // A scoped forecast (version/milestone or subtree) must project the
+        // scope's OWN remaining effort against capacity. Reading a finish off
+        // the whole-map scheduler buries the milestone behind the entire
+        // backlog, so the date reflects the backlog's size, not the milestone.
         if (remainingEffort > 0) {
-          const today = new Date();
-          today.setUTCHours(0, 0, 0, 0);
-          const anchor = today > projectStart ? today : projectStart;
-          const elapsedFromStart = Math.max(
-            0,
-            Math.round((anchor.getTime() - projectStart.getTime()) / MS_PER_DAY),
-          );
-          const remainingSchedulerDays = Math.max(0, plannedCalDays - elapsedFromStart);
-          const velDays = (remainingSchedulerDays * effectiveFudge) / focusFactor;
-          velocityAdjustedFinishDate = addCalendarDays(anchor, velDays).toISOString().slice(0, 10);
+          const cap = scopedCapacityDays(remainingEffort, {
+            workers,
+            unitsPerDay,
+            fudge: effectiveFudge,
+            focusFactor,
+          });
+          plannedFinishDate = addCalendarDays(anchor, cap.plannedCalendarDays)
+            .toISOString()
+            .slice(0, 10);
+          velocityAdjustedFinishDate = addCalendarDays(anchor, cap.velocityCalendarDays)
+            .toISOString()
+            .slice(0, 10);
+          maxScopedEnd = remainingEffort; // non-zero → "has schedulable effort"
+        }
+      } else {
+        // Whole map: the critical-path scheduler IS the right answer.
+        const scheduled = schedule(data.nodes, 0, constraints, undefined, workers);
+        const scopedIds = new Set(leaves.map((l) => l.id));
+        maxScopedEnd = scheduled
+          .filter((s) => scopedIds.has(s.nodeId))
+          .reduce((m, s) => Math.max(m, s.computedEnd), 0);
+
+        if (maxScopedEnd > 0) {
+          const plannedCalDays = maxScopedEnd / unitsPerDay;
+          plannedFinishDate = addCalendarDays(projectStart, plannedCalDays)
+            .toISOString()
+            .slice(0, 10);
+
+          if (remainingEffort > 0) {
+            const elapsedFromStart = Math.max(
+              0,
+              Math.round((anchor.getTime() - projectStart.getTime()) / MS_PER_DAY),
+            );
+            const remainingSchedulerDays = Math.max(0, plannedCalDays - elapsedFromStart);
+            const velDays = (remainingSchedulerDays * effectiveFudge) / focusFactor;
+            velocityAdjustedFinishDate = addCalendarDays(anchor, velDays)
+              .toISOString()
+              .slice(0, 10);
+          }
         }
       }
     } catch {


### PR DESCRIPTION
## The bug

A **scoped** `completion_forecast` (by `versionId` or `nodeId`) read its finish off the **whole-map** critical-path scheduler, then filtered to the scoped leaves. When the map has a big backlog, a milestone's leaves land *behind everything else* in that global ordering — so the date reflected the backlog's size, not the milestone's.

Concretely, on the Fulcrum CRM Roadmap this made a **21-day MVP milestone forecast to 2030**. It's why milestone dates had to be hand-computed with capacity math instead of trusting the tool.

## The fix

For a scoped forecast, project the scope's **own** remaining effort against team capacity, from today:

```
plannedCalendarDays  = remaining ÷ (workers × unitsPerDay)
velocityCalendarDays = remaining × fudge ÷ (workers × unitsPerDay × focus)
```

The whole-map (unscoped) forecast is **unchanged** — there the scheduler's critical path is the right answer. A shared `scopedCapacityDays` helper in `@mindblown/core` keeps the server `/forecast` route and the MCP `completion_forecast` tool consistent.

**Known limitation (documented):** this ignores within-scope dependency chains — a milestone with a long *serial* critical path can run longer than pure capacity implies. A later refinement can schedule the isolated subtree; this is still far closer than the backlog-buried position it replaces.

## Changes
- **core**: `scopedCapacityDays` helper + 4 unit tests
- **mcp**: `completion_forecast` branches on scope; output shows the capacity basis (`remaining ÷ N worker(s)`); `ScheduleResult` now carries `workerCount`
- **server**: `/forecast` route branches on scope

## Verification
- `pnpm turbo typecheck` clean (11 packages)
- `pnpm turbo test` clean — 549 server tests + 8 core velocity tests (incl. "does not bury a small scope behind a big backlog")

🤖 Generated with [Claude Code](https://claude.com/claude-code)