### PR TITLE
feat(lint): requirements pack (3 rules) + sprint scoping

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -288,7 +288,7 @@ Once connected, the AI can fully manage your projects through natural conversati
 | `status_digest` | Markdown status digest: done / in progress / behind / changes | `mapId`, `sinceDays?` |
 | `alert_digest` | Threshold-triggered alerts (slipped milestones, overdue, unassigned P0/P1) | `mapId` |
 | `risk_scan` | Stalled WIP, no-estimate leaves, overruns, fragile critical path | `mapId`, `nodeId?`, `versionId?`, `milestoneId?`, `stalledDays?` |
-| `plan_lint` | Plan-quality coach: 8 hygiene checks (unestimated/oversized leaves, stale progress, overdue-unreplanned, calibration drift, missing done-criteria, stale plan, missing dependencies), each with a teaching why + fix | `mapId`, `nodeId?`, `versionId?`, `stalledDays?`, `rule?`, `limit?` |
+| `plan_lint` | Plan-quality coach: 11 hygiene checks (unestimated/oversized leaves, stale progress, overdue-unreplanned, calibration drift, missing done-criteria, stale plan, missing dependencies, uncovered/unscheduled must-requirements, stale acceptances), each with a teaching why + fix | `mapId`, `nodeId?`, `versionId?`, `cycleId?`, `stalledDays?`, `rule?`, `limit?` |
 | `scope_simulate` | In-memory what-if: before/after totals for a list of add/remove/update patches | `mapId`, `patches` |
 
 ### GitHub Integration Tools

--- a/docs/plan-linter.md
+++ b/docs/plan-linter.md
@@ -1,6 +1,6 @@
 # Plan Linter — v1 Specification
 
-*Status: surfaces 1 (`plan_lint` MCP tool) and 2 (plan-health panel + dismissals) implemented; the engine lives server-side (`packages/server/src/lint/engine.ts`) and both surfaces consume `GET /api/maps/:id/lint`. Moment-of-action nudges (surface 3) open. Companion to the "Guided Project Management" section of [product-vision.md](product-vision.md).*
+*Status: surfaces 1 (`plan_lint` MCP tool) and 2 (plan-health panel + dismissals) implemented, plus the requirements pack (rules 9–11) and sprint (`cycleId`) scoping; the engine lives server-side (`packages/server/src/lint/engine.ts`) and both surfaces consume `GET /api/maps/:id/lint`. Moment-of-action nudges (surface 3) open. Companion to the "Guided Project Management" section of [product-vision.md](product-vision.md).*
 
 ---
 
@@ -39,6 +39,16 @@ Ordered basics-first: "when is it done / how much is left" hygiene before advanc
 | 6 | `no-done-criteria` | Leaf with estimate ≥ 2 days and empty description | info | "A task without a definition of done tends to be 90% finished forever — one sentence of 'done means…' prevents it." | Prompt description (links to requirements register where present) |
 | 7 | `stale-plan` | Map < 100% complete and no change_events at all in **14 days** | info | "A plan that isn't touched weekly is a document, not a plan — a 2-minute review keeps the forecast honest." | Suggest review (offer `status_digest`) |
 | 8 | `dates-without-dependencies` | Map has ≥ 10 dated leaves and zero dependencies | info | "Without dependencies the schedule assumes everything can happen in parallel — the critical path is what makes a finish date real." | Point at dependency creation |
+
+### Requirements pack (added 2026-07-16, evaluated map-wide)
+
+| # | Rule id | Fires when | Severity | Why-line (teaching sentence) | Fix action |
+|---|---|---|---|---|---|
+| 9 | `uncovered-requirement` | Incomplete `must`-requirement with zero estimated effort in its subtree | warn | "A requirement without estimated implementation work exists only on paper — the forecast has no idea it is missing." | Break into estimated children (ai_breakdown) |
+| 10 | `stale-acceptance` | Active acceptance whose node changed since sign-off (>1% progress drift or revision bump — same definition as the register) | warn | "A sign-off is a snapshot — when the work changes afterwards, the acceptance silently stops meaning anything." | Re-review with the acceptor: re-accept or revoke |
+| 11 | `unscheduled-must` | Incomplete `must`-requirement with no version tag (own or inherited) | info | "A must-requirement with no release assignment is committed scope floating outside every plan." | Assign a target version |
+
+Scoping also accepts `cycleId` (sprint) with the same ancestor-inheritance semantics — lint a sprint's contents before committing to it.
 
 Thresholds above are **opinionated defaults, not configuration**. v1 exposes only `stalledDays`-style overrides where `risk_scan` already does; no settings sprawl.
 

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -723,11 +723,18 @@ export interface LintReport {
 
 export function getLint(
   mapId: string,
-  opts: { nodeId?: string; versionId?: string; stalledDays?: number; rule?: string } = {},
+  opts: {
+    nodeId?: string;
+    versionId?: string;
+    cycleId?: string;
+    stalledDays?: number;
+    rule?: string;
+  } = {},
 ): Promise<LintReport> {
   const params = new URLSearchParams();
   if (opts.nodeId) params.set('nodeId', opts.nodeId);
   if (opts.versionId) params.set('versionId', opts.versionId);
+  if (opts.cycleId) params.set('cycleId', opts.cycleId);
   if (opts.stalledDays != null) params.set('stalledDays', String(opts.stalledDays));
   if (opts.rule) params.set('rule', opts.rule);
   const qs = params.toString();

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1084,26 +1084,30 @@ const LINT_RULES = [
   'no-done-criteria',
   'stale-plan',
   'dates-without-dependencies',
+  'uncovered-requirement',
+  'stale-acceptance',
+  'unscheduled-must',
 ] as const;
 
 server.tool(
   'plan_lint',
-  'Check plan QUALITY (hygiene), not execution risk — the coaching counterpart to risk_scan. Runs 8 deterministic checks ordered basics-first: unestimated leaves, oversized leaves, stale progress, overdue-but-never-replanned, calibration drift, missing done-criteria, stale plan, dates without dependencies. Every finding explains why it matters (one teaching sentence) and names the fix. Scope with nodeId (subtree) or versionId; the map-level checks (calibration-drift, stale-plan, dates-without-dependencies) always evaluate the whole map. See docs/plan-linter.md for the rule rationale.',
+  'Check plan QUALITY (hygiene), not execution risk — the coaching counterpart to risk_scan. Runs 11 deterministic checks ordered basics-first: unestimated leaves, oversized leaves, stale progress, overdue-but-never-replanned, calibration drift, missing done-criteria, stale plan, dates without dependencies, plus a requirements pack (must-requirements with no estimated work, acceptances gone stale since sign-off, must-requirements with no target version). Every finding explains why it matters (one teaching sentence) and names the fix. Scope with nodeId (subtree), versionId, or cycleId (sprint); map-level checks (calibration-drift, stale-plan, dates-without-dependencies, the requirements pack) always evaluate the whole map. See docs/plan-linter.md for the rule rationale.',
   {
     mapId: z.string().describe('The map ID'),
     nodeId: z.string().optional().describe('Scope to this node and its descendants'),
     versionId: z.string().optional().describe('Scope to leaves tagged with this version (directly or via an ancestor)'),
+    cycleId: z.string().optional().describe('Scope to leaves assigned to this sprint/cycle (directly or via an ancestor) — lint a sprint before committing to it'),
     stalledDays: z.number().int().min(1).default(7).describe('Days without a progress update before in-progress work counts as stale (default 7)'),
-    rule: z.enum(LINT_RULES).optional().describe('Run only this one rule instead of all eight'),
+    rule: z.enum(LINT_RULES).optional().describe('Run only this one rule instead of all eleven'),
     limit: z.number().int().min(1).max(1000).default(20).describe('Max findings listed per rule (default 20)'),
   },
-  async ({ mapId, nodeId, versionId, stalledDays, rule, limit }) => {
+  async ({ mapId, nodeId, versionId, cycleId, stalledDays, rule, limit }) => {
     try {
       // The rules run server-side (packages/server/src/lint/engine.ts) so
       // the MCP tool and the plan-health panel share one engine; this
       // handler only formats. Dismissed findings (panel) are excluded
       // from counts and listings but summarized per rule.
-      const report = await api.getLint(mapId, { nodeId, versionId, stalledDays, rule });
+      const report = await api.getLint(mapId, { nodeId, versionId, cycleId, stalledDays, rule });
 
       const lines: string[] = [];
       lines.push(`Plan lint — ${report.scopeLabel}`);

--- a/packages/server/src/lint/__tests__/engine.test.ts
+++ b/packages/server/src/lint/__tests__/engine.test.ts
@@ -39,6 +39,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementText: null,
     claimedBySession: null,
     claimedAt: null,
+    revision: 0,
     ...overrides,
   } as Node;
 }
@@ -218,6 +219,80 @@ describe('computePlanLint — rules', () => {
   });
 });
 
+describe('computePlanLint — requirements pack', () => {
+  it('uncovered-requirement fires on incomplete must-requirements with zero subtree estimate', () => {
+    const report = lint(
+      [
+        makeNode({ id: 'root', childrenIds: ['bare', 'covered', 'should', 'done'] }),
+        // must-requirement, no estimate anywhere → fires
+        makeNode({ id: 'bare', parentId: 'root', requirementId: 'REQ-1', requirementPriority: 'must', childrenIds: ['bare-child'] }),
+        makeNode({ id: 'bare-child', parentId: 'bare' }),
+        // must-requirement with an estimated child → clean
+        makeNode({ id: 'covered', parentId: 'root', requirementId: 'REQ-2', requirementPriority: 'must', childrenIds: ['covered-child'] }),
+        makeNode({ id: 'covered-child', parentId: 'covered', effortEstimate: 3 }),
+        // should-requirement → out of scope for this rule
+        makeNode({ id: 'should', parentId: 'root', requirementId: 'REQ-3', requirementPriority: 'should' }),
+        // completed must-requirement → exempt
+        makeNode({ id: 'done', parentId: 'root', requirementId: 'REQ-4', requirementPriority: 'must', percentComplete: 100 }),
+      ],
+      { computedProgress: new Map([['done', 100]]) },
+    );
+    const r = rule(report, 'uncovered-requirement');
+    expect(r.findings.map((f) => f.nodeId)).toEqual(['bare']);
+    expect(r.findings[0].detail).toContain('REQ-1');
+  });
+
+  it('stale-acceptance mirrors the register: >1% progress drift or revision change', () => {
+    const nodes = [
+      makeNode({ id: 'root', childrenIds: ['fresh', 'moved', 'edited'] }),
+      makeNode({ id: 'fresh', parentId: 'root', requirementId: 'R1', percentComplete: 50 }),
+      makeNode({ id: 'moved', parentId: 'root', requirementId: 'R2', percentComplete: 80 }),
+      makeNode({ id: 'edited', parentId: 'root', requirementId: 'R3', percentComplete: 50 }),
+    ] as ReturnType<typeof makeNode>[];
+    (nodes[3] as { revision: number }).revision = 7;
+    const acceptances = [
+      { nodeId: 'fresh', userName: 'Thomas', acceptedAt: '2026-07-01T00:00:00Z', progressAtAcceptance: 50, nodeRevisionAtAcceptance: 0 },
+      { nodeId: 'moved', userName: 'Thomas', acceptedAt: '2026-07-01T00:00:00Z', progressAtAcceptance: 50, nodeRevisionAtAcceptance: 0 },
+      { nodeId: 'edited', userName: 'Rita', acceptedAt: '2026-07-01T00:00:00Z', progressAtAcceptance: 50, nodeRevisionAtAcceptance: 0 },
+      { nodeId: 'gone', userName: 'Rita', acceptedAt: '2026-07-01T00:00:00Z', progressAtAcceptance: 50, nodeRevisionAtAcceptance: 0 },
+    ];
+    const report = lint(nodes, { acceptances });
+    const r = rule(report, 'stale-acceptance');
+    // fresh: unchanged → clean. moved: 50→80. edited: revision 0→7. gone: node deleted → skipped.
+    expect(r.findings.map((f) => f.nodeId).sort()).toEqual(['edited', 'moved']);
+    expect(r.findings.find((f) => f.nodeId === 'moved')!.detail).toContain('Thomas');
+  });
+
+  it('stale-acceptance is skipped (not empty-passed) without acceptance data', () => {
+    const report = lint([makeNode({ id: 'root' })]);
+    expect(rule(report, 'stale-acceptance').skipped).toBeTruthy();
+  });
+
+  it('unscheduled-must fires only without an own or inherited version tag', () => {
+    const report = lint([
+      makeNode({ id: 'root', childrenIds: ['epic', 'floating'] }),
+      makeNode({ id: 'epic', parentId: 'root', versionId: 'v1', childrenIds: ['tagged'] }),
+      // inherits v1 from epic → clean
+      makeNode({ id: 'tagged', parentId: 'epic', requirementId: 'R1', requirementPriority: 'must' }),
+      // no version anywhere up the chain → fires
+      makeNode({ id: 'floating', parentId: 'root', requirementId: 'R2', requirementPriority: 'must' }),
+    ]);
+    expect(rule(report, 'unscheduled-must').findings.map((f) => f.nodeId)).toEqual(['floating']);
+  });
+
+  it('requirement rules evaluate map-wide even under subtree scoping', () => {
+    const report = lint(
+      [
+        makeNode({ id: 'root', childrenIds: ['a', 'req'] }),
+        makeNode({ id: 'a', parentId: 'root' }),
+        makeNode({ id: 'req', parentId: 'root', requirementId: 'R9', requirementPriority: 'must' }),
+      ],
+      { nodeId: 'a' },
+    );
+    expect(rule(report, 'uncovered-requirement').findings.map((f) => f.nodeId)).toEqual(['req']);
+  });
+});
+
 describe('computePlanLint — scoping and dismissals', () => {
   const tree = () => [
     makeNode({ id: 'root', childrenIds: ['epicA', 'epicB'] }),
@@ -237,6 +312,21 @@ describe('computePlanLint — scoping and dismissals', () => {
   it('versionId scopes with ancestor inheritance', () => {
     const report = lint(tree(), { versionId: 'v1' });
     expect(rule(report, 'unestimated-leaf').findings.map((f) => f.nodeId).sort()).toEqual(['a1', 'a2']);
+  });
+
+  it('cycleId scopes with ancestor inheritance', () => {
+    const nodes = [
+      makeNode({ id: 'root', childrenIds: ['epic', 'other'] }),
+      makeNode({ id: 'epic', parentId: 'root', cycleId: 's1', childrenIds: ['in1', 'in2'] }),
+      makeNode({ id: 'in1', parentId: 'epic' }),
+      makeNode({ id: 'in2', parentId: 'epic', cycleId: 's2' }),
+      makeNode({ id: 'other', parentId: 'root' }),
+    ];
+    const s1 = lint(nodes, { cycleId: 's1' });
+    expect(rule(s1, 'unestimated-leaf').findings.map((f) => f.nodeId).sort()).toEqual(['in1', 'in2']);
+    expect(s1.scopeLabel).toContain('sprint s1');
+    const s2 = lint(nodes, { cycleId: 's2' });
+    expect(rule(s2, 'unestimated-leaf').findings.map((f) => f.nodeId)).toEqual(['in2']);
   });
 
   it('unknown nodeId returns an error, not a report', () => {

--- a/packages/server/src/lint/engine.ts
+++ b/packages/server/src/lint/engine.ts
@@ -17,6 +17,10 @@ export const LINT_RULE_IDS = [
   'no-done-criteria',
   'stale-plan',
   'dates-without-dependencies',
+  // Requirements pack — evaluated map-wide (the register is map-global).
+  'uncovered-requirement',
+  'stale-acceptance',
+  'unscheduled-must',
 ] as const;
 export type LintRuleId = (typeof LINT_RULE_IDS)[number];
 export type LintSeverity = 'warn' | 'info';
@@ -65,6 +69,15 @@ export interface LintDismissal {
   ruleId: string;
 }
 
+/** Active requirement sign-off (see db/acceptances.ts) for stale-acceptance. */
+export interface AcceptanceInfo {
+  nodeId: string;
+  userName: string;
+  acceptedAt: string;
+  progressAtAcceptance: number;
+  nodeRevisionAtAcceptance: number;
+}
+
 export interface LintOptions {
   map: {
     statusWorkflow?: Array<{ id: string; category: string }> | null;
@@ -74,8 +87,13 @@ export interface LintOptions {
   unitsPerDay: number;
   history: LintHistory;
   dismissals: LintDismissal[];
+  /** Active acceptances; omit to skip the stale-acceptance rule. */
+  acceptances?: AcceptanceInfo[];
+  /** Rolled-up progress per node (core computeTree); enables requirement rules on parent nodes. */
+  computedProgress?: Map<string, number>;
   nodeId?: string;
   versionId?: string;
+  cycleId?: string;
   stalledDays?: number;
   now?: Date;
 }
@@ -95,10 +113,10 @@ export const DEFAULT_STALLED_DAYS = 7;
 
 const isLeaf = (n: Node) => (n.childrenIds?.length ?? 0) === 0;
 
-/** Subtree + inherited-version scoping (same semantics as the MI suite). */
+/** Subtree + inherited version/cycle scoping (same semantics as the MI suite). */
 function scopeLeaves(
   nodes: Node[],
-  opts: { nodeId?: string; versionId?: string },
+  opts: { nodeId?: string; versionId?: string; cycleId?: string },
 ): { leaves: Node[]; scopeLabel: string } | { error: string } {
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
   let leaves: Node[];
@@ -122,17 +140,23 @@ function scopeLeaves(
     leaves = nodes.filter(isLeaf);
   }
 
+  // A leaf is in scope when it OR any ancestor carries the tag.
+  const inheritsTag = (leaf: Node, field: 'versionId' | 'cycleId', value: string): boolean => {
+    let cur: Node | undefined = leaf;
+    while (cur) {
+      if (cur[field] === value) return true;
+      cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
+    }
+    return false;
+  };
+
   if (opts.versionId) {
     scopeLabel = `version ${opts.versionId}` + (opts.nodeId ? ` within ${scopeLabel}` : '');
-    const inherits = (leaf: Node): boolean => {
-      let cur: Node | undefined = leaf;
-      while (cur) {
-        if (cur.versionId === opts.versionId) return true;
-        cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
-      }
-      return false;
-    };
-    leaves = leaves.filter(inherits);
+    leaves = leaves.filter((l) => inheritsTag(l, 'versionId', opts.versionId!));
+  }
+  if (opts.cycleId) {
+    scopeLabel = `sprint ${opts.cycleId} within ${scopeLabel}`;
+    leaves = leaves.filter((l) => inheritsTag(l, 'cycleId', opts.cycleId!));
   }
 
   return { leaves, scopeLabel };
@@ -143,9 +167,16 @@ export function computePlanLint(opts: LintOptions): LintReport | { error: string
   const stalledDays = opts.stalledDays ?? DEFAULT_STALLED_DAYS;
   const now = opts.now ?? new Date();
 
-  const scoped = scopeLeaves(nodes, { nodeId: opts.nodeId, versionId: opts.versionId });
+  const scoped = scopeLeaves(nodes, {
+    nodeId: opts.nodeId,
+    versionId: opts.versionId,
+    cycleId: opts.cycleId,
+  });
   if ('error' in scoped) return { error: scoped.error };
   const { leaves, scopeLabel } = scoped;
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  const progressOf = (n: Node): number =>
+    opts.computedProgress?.get(n.id) ?? n.percentComplete ?? 0;
 
   const unit = map.effortUnit ?? 'units';
   const incomplete = leaves.filter((l) => (l.percentComplete ?? 0) < 100);
@@ -325,6 +356,82 @@ export function computePlanLint(opts: LintOptions): LintReport | { error: string
       datedLeaves.length >= MIN_DATED_LEAVES_FOR_DEPS && totalDeps === 0
         ? [mapFinding(`${datedLeaves.length} dated leaves, 0 dependencies`)]
         : [],
+  });
+
+  // ── Requirements pack (map-wide — the register is map-global) ──
+  const mustRequirements = nodes.filter(
+    (n) => n.requirementId != null && n.requirementPriority === 'must',
+  );
+  const subtreeEstimate = (root: Node): number => {
+    let sum = 0;
+    const stack = [root];
+    while (stack.length) {
+      const n = stack.pop()!;
+      if (isLeaf(n)) sum += n.effortEstimate ?? 0;
+      else for (const cid of n.childrenIds) {
+        const c = nodeById.get(cid);
+        if (c) stack.push(c);
+      }
+    }
+    return sum;
+  };
+  const hasVersionTag = (node: Node): boolean => {
+    let cur: Node | undefined = node;
+    while (cur) {
+      if (cur.versionId != null) return true;
+      cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
+    }
+    return false;
+  };
+
+  // 9. uncovered-requirement
+  rules.push({
+    ruleId: 'uncovered-requirement',
+    severity: 'warn',
+    title: 'Must-requirements with no estimated work (map-level)',
+    why: 'A requirement without estimated implementation work exists only on paper — the forecast has no idea it is missing.',
+    fix: 'Break the requirement into estimated child tasks, or estimate the node itself.',
+    findings: mustRequirements
+      .filter((r) => progressOf(r) < 99.5 && subtreeEstimate(r) === 0)
+      .map((r) => finding(r, `${r.requirementId}: no estimated work in its subtree`)),
+  });
+
+  // 10. stale-acceptance — staleness mirrors the requirements register:
+  // progress moved by more than a point, or the node was edited (revision).
+  const acceptances = opts.acceptances ?? [];
+  rules.push({
+    ruleId: 'stale-acceptance',
+    severity: 'warn',
+    title: 'Accepted requirements changed since sign-off (map-level)',
+    why: 'A sign-off is a snapshot — when the work changes afterwards, the acceptance silently stops meaning anything.',
+    fix: 'Re-review with the acceptor: re-accept, or revoke until the change is verified.',
+    findings: acceptances
+      .map((a) => ({ a, node: nodeById.get(a.nodeId) }))
+      .filter((x): x is { a: AcceptanceInfo; node: Node } => x.node != null)
+      .filter(
+        ({ a, node }) =>
+          Math.abs(progressOf(node) - a.progressAtAcceptance) > 1 ||
+          node.revision !== a.nodeRevisionAtAcceptance,
+      )
+      .map(({ a, node }) =>
+        finding(
+          node,
+          `accepted by ${a.userName} on ${a.acceptedAt.slice(0, 10)} at ${a.progressAtAcceptance.toFixed(0)}% (rev ${a.nodeRevisionAtAcceptance}) — now ${progressOf(node).toFixed(0)}% (rev ${node.revision})`,
+        ),
+      ),
+    skipped: opts.acceptances == null ? 'acceptance data unavailable' : undefined,
+  });
+
+  // 11. unscheduled-must
+  rules.push({
+    ruleId: 'unscheduled-must',
+    severity: 'info',
+    title: 'Must-requirements with no target version (map-level)',
+    why: 'A must-requirement with no release assignment is committed scope floating outside every plan.',
+    fix: 'Tag it with a version so the release forecast owns it.',
+    findings: mustRequirements
+      .filter((r) => progressOf(r) < 99.5 && !hasVersionTag(r))
+      .map((r) => finding(r, `${r.requirementId}: no target version`)),
   });
 
   // ── Apply dismissals ──

--- a/packages/server/src/routes/__tests__/lint-routes.test.ts
+++ b/packages/server/src/routes/__tests__/lint-routes.test.ts
@@ -62,6 +62,10 @@ vi.mock('../../db/events.js', () => ({
   listEvents: vi.fn(async () => []),
 }));
 
+vi.mock('../../db/acceptances.js', () => ({
+  listActiveAcceptances: vi.fn(async () => []),
+}));
+
 interface DismissalRow {
   id: string;
   mapId: string;

--- a/packages/server/src/routes/lint.ts
+++ b/packages/server/src/routes/lint.ts
@@ -10,9 +10,11 @@
  * nodes from the map, change-event digests, dismissals, unitsPerDay.
  */
 import type { FastifyInstance } from 'fastify';
+import { computeTree } from '@mindblown/core';
 import * as mapDb from '../db/maps.js';
 import * as permDb from '../db/permissions.js';
 import * as lintDb from '../db/lint.js';
+import { listActiveAcceptances } from '../db/acceptances.js';
 import { listEvents } from '../db/events.js';
 import {
   computePlanLint,
@@ -58,7 +60,13 @@ export async function lintRoutes(app: FastifyInstance) {
   // ── GET /api/maps/:id/lint ─────────────────────────────────────
   app.get<{
     Params: { id: string };
-    Querystring: { nodeId?: string; versionId?: string; stalledDays?: string; rule?: string };
+    Querystring: {
+      nodeId?: string;
+      versionId?: string;
+      cycleId?: string;
+      stalledDays?: string;
+      rule?: string;
+    };
   }>('/api/maps/:id/lint', async (req, reply) => {
     const userId = req.userId;
     if (userId) {
@@ -94,10 +102,18 @@ export async function lintRoutes(app: FastifyInstance) {
     const unitsPerDay = data.map.effortUnit === 'hours' ? (data.map.hoursPerDay ?? 8) : 1;
 
     const now = new Date();
-    const [history, dismissalRows] = await Promise.all([
+    const [history, dismissalRows, acceptances] = await Promise.all([
       loadHistory(req.params.id, now),
       lintDb.listDismissals(req.params.id),
+      // Best-effort: a failed acceptance load skips stale-acceptance
+      // (reported as such) instead of failing the whole lint run.
+      listActiveAcceptances(req.params.id).catch(() => undefined),
     ]);
+
+    // Rolled-up progress so requirement rules work on parent nodes too.
+    const computed = computeTree(data.nodes, data.map.healthThreshold);
+    const computedProgress = new Map<string, number>();
+    for (const [id, cv] of computed) computedProgress.set(id, cv.computedProgress);
 
     const report = computePlanLint({
       map: data.map,
@@ -105,8 +121,11 @@ export async function lintRoutes(app: FastifyInstance) {
       unitsPerDay,
       history,
       dismissals: dismissalRows.map((d) => ({ nodeId: d.nodeId, ruleId: d.ruleId })),
+      acceptances,
+      computedProgress,
       nodeId: req.query.nodeId,
       versionId: req.query.versionId,
+      cycleId: req.query.cycleId,
       stalledDays,
       now,
     });


### PR DESCRIPTION
Extends the plan linter (#209/#215) with the requirements pack and sprint scoping — the checks that make the linter useful for sprint planning and requirements management, not just generic hygiene.

## New rules (map-wide, like the other register-global checks)

| Rule | Severity | Fires when |
|---|---|---|
| `uncovered-requirement` | warn | incomplete `must`-requirement with **zero estimated effort in its subtree** — exists on paper, invisible to the forecast |
| `stale-acceptance` | warn | active Abnahme whose node changed since sign-off — staleness mirrors the register's own definition exactly (>1% progress drift or revision bump, from the #218 snapshots) |
| `unscheduled-must` | info | incomplete `must`-requirement with no version tag (own or inherited) — committed scope outside every release |

## Sprint scoping

`GET /api/maps/:id/lint` and the `plan_lint` MCP tool accept `cycleId` with the same ancestor-inheritance semantics as `versionId` — "lint Sprint 3 before we commit to it" now works.

## Mechanics

- The route feeds the engine `computeTree` rolled-up progress so requirement rules evaluate correctly on parent nodes, and loads active acceptances best-effort (a failed load reports `stale-acceptance` as skipped rather than failing the run).
- Panel and dismissals pick the new rules up generically — no UI changes needed.
- 6 new engine tests (all three rules incl. the acceptance-mirroring semantics, cycle scoping, map-wide evaluation under subtree scope); suite fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9eAuogxQ9r6TrjMGyjpTz