### PR TITLE
feat: Phase as lightweight editable column (PhaseDef list + node.phaseId)

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -42,6 +42,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementId: null,
     requirementPriority: null,
     requirementText: null,
+    phaseId: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -40,6 +40,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementId: null,
     requirementPriority: null,
     requirementText: null,
+    phaseId: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -43,6 +43,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementId: null,
     requirementPriority: null,
     requirementText: null,
+    phaseId: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export type {
   BlockedBy,
   CustomFieldDef,
   StatusDef,
+  PhaseDef,
   Baseline,
   MindMap,
   User,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -232,6 +232,16 @@ export interface Node {
    */
   requirementText: string | null;
 
+  // ── Phase ─────────────────────────────────────────────────
+  /**
+   * Reference to a `PhaseDef.id` from the map's `phases` list (same
+   * idiom as `status` → `Map.statusWorkflow`, and same shape as
+   * versionId/cycleId). Lightweight by design — a phase is a label
+   * with an order, NOT a heavy entity (the April-removed Milestones):
+   * no rollup, no health, no scheduling. null = no phase assigned.
+   */
+  phaseId: string | null;
+
   // ── Auto-progress (parent-epic rollup) ────────────────────
   /**
    * When set to `'children'`, the server auto-computes percentComplete on this
@@ -294,6 +304,20 @@ export interface CustomFieldDef {
   required: boolean;
 }
 
+/**
+ * A project phase (e.g. "M1 – Grundgerüst"). Lives on the map (same
+ * pattern as StatusDef in `statusWorkflow`); nodes reference it via
+ * `Node.phaseId`. Stable `id` so phases can be renamed without touching
+ * nodes; `position` is the canonical phase order.
+ */
+export interface PhaseDef {
+  id: string; // stable — rename without touching nodes
+  name: string; // e.g. 'M1 – Grundgerüst'
+  position: number; // canonical sort order
+  color?: string; // optional hex, unused in v1 UI
+  targetDate?: string | null; // optional ISO date; deliberately in the model, unused in v1
+}
+
 /** A status in the workflow. */
 export interface StatusDef {
   id: string;
@@ -339,6 +363,15 @@ export interface MindMap {
   customFieldDefs: CustomFieldDef[];
   defaultLayout: LayoutMode;
   healthThreshold: number; // 0–1, default 0.2 (at_risk if 20% behind pace)
+
+  // ── Phases ────────────────────────────────────────────────
+  /**
+   * Project phases of this map (statusWorkflow idiom): definitions live
+   * here, nodes reference them via `phaseId`. `position` is the
+   * canonical order. Rename/reorder by replacing the array via map
+   * update — node phaseIds stay valid because ids are stable.
+   */
+  phases: PhaseDef[];
 
   // ── Baselines ─────────────────────────────────────────────
   baselines: Baseline[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -370,6 +370,11 @@ export interface MindMap {
    * here, nodes reference them via `phaseId`. `position` is the
    * canonical order. Rename/reorder by replacing the array via map
    * update — node phaseIds stay valid because ids are stable.
+   *
+   * Updates are replace-mode, last-writer-wins: there is no
+   * optimistic-concurrency guard on map-level fields, so two concurrent
+   * full-array writes silently drop each other's additions (same
+   * trade-off as statusWorkflow/customFieldDefs).
    */
   phases: PhaseDef[];
 

--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -36,6 +36,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     requirementId: null,
     requirementPriority: null,
     requirementText: null,
+    phaseId: null,
     claimedBySession: null,
     claimedAt: null,
     computedEffort: 0,

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -135,6 +135,9 @@ export interface NodeWithComputed {
   requirementId: string | null;
   requirementPriority: 'must' | 'should' | 'could' | null;
   requirementText: string | null;
+  // References a PhaseDef.id from the map's `phases` list (statusWorkflow
+  // idiom). null = no phase assigned.
+  phaseId: string | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;
@@ -149,11 +152,22 @@ export interface NodeWithComputed {
   };
 }
 
+/** Project phase definition (mirrors core PhaseDef; statusWorkflow idiom). */
+export interface PhaseDef {
+  id: string;
+  name: string;
+  position: number;
+  color?: string;
+  targetDate?: string | null;
+}
+
 export interface MapDetail {
   map: MapSummary & {
     statusWorkflow: Array<{ id: string; name: string; category: string; color: string; position: number }>;
     baselines: unknown[];
     wipLimit: number | null;
+    /** Project phase definitions; `position` = canonical phase order. */
+    phases?: PhaseDef[];
   };
   nodes: NodeWithComputed[];
 }
@@ -377,6 +391,7 @@ export function updateMap(
     workerCount?: number;
     focusFactor?: number;
     autoImportNewIssues?: boolean;
+    phases?: PhaseDef[];
   },
 ): Promise<MapSummary> {
   return request<MapSummary>(`/api/maps/${mapId}`, {

--- a/packages/mcp/src/formatters.ts
+++ b/packages/mcp/src/formatters.ts
@@ -38,6 +38,7 @@ function renderTreeNode(
   nodeId: string,
   lookup: Map<string, NodeWithComputed>,
   indent: number,
+  phaseNameById?: Map<string, string>,
 ): string[] {
   const node = lookup.get(nodeId);
   if (!node) return [];
@@ -62,6 +63,9 @@ function renderTreeNode(
   if (node.priority) {
     parts.push(node.priority);
   }
+  if (node.phaseId) {
+    parts.push(`phase: ${phaseNameById?.get(node.phaseId) ?? node.phaseId}`);
+  }
   if (node.dueDate) {
     parts.push(`due: ${node.dueDate}`);
   }
@@ -85,7 +89,7 @@ function renderTreeNode(
 
   // Recurse into children
   for (const childId of node.childrenIds) {
-    lines.push(...renderTreeNode(childId, lookup, indent + 1));
+    lines.push(...renderTreeNode(childId, lookup, indent + 1, phaseNameById));
   }
 
   return lines;
@@ -152,10 +156,17 @@ export function formatMapTree(data: MapDetail): string {
     lines.push(`${data.map.description}`);
   }
   lines.push(`Effort unit: ${data.map.effortUnit ?? 'hours'}`);
+  const orderedPhases = [...(data.map.phases ?? [])].sort((a, b) => a.position - b.position);
+  if (orderedPhases.length > 0) {
+    lines.push(
+      `Phases (ordered): ${orderedPhases.map((p) => `${p.name} (id: ${p.id})`).join(' → ')}`,
+    );
+  }
   lines.push('');
 
+  const phaseNameById = new Map(orderedPhases.map((p) => [p.id, p.name] as const));
   if (rootNode) {
-    lines.push(...renderTreeNode(data.map.rootNodeId, lookup, 0));
+    lines.push(...renderTreeNode(data.map.rootNodeId, lookup, 0, phaseNameById));
   } else {
     lines.push('(empty map)');
   }
@@ -321,6 +332,13 @@ export function formatNodeDetail(node: NodeWithComputed, mapData: MapDetail): st
   lines.push('## Task Properties');
   lines.push(`- **Status:** ${node.status ?? 'unset'}`);
   lines.push(`- **Priority:** ${node.priority ?? 'unset'}`);
+  lines.push(
+    `- **Phase:** ${
+      node.phaseId
+        ? (mapData.map.phases?.find((p) => p.id === node.phaseId)?.name ?? node.phaseId)
+        : 'unset'
+    }`,
+  );
   lines.push(`- **Effort estimate:** ${node.effortEstimate ?? 'unestimated'}`);
   lines.push(`- **Actual effort:** ${node.actualEffort ?? 'unrecorded'}`);
   lines.push(`- **Percent complete:** ${node.percentComplete ?? 'unset'}`);

--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -859,7 +859,7 @@ const VIEW_TABS: { id: ActiveView; label: string; enabled: boolean }[] = [
   { id: 'gantt', label: 'Gantt', enabled: true },
   { id: 'releases', label: 'Releases', enabled: true },
   { id: 'requirements', label: 'Requirements', enabled: true },
-  { id: 'list', label: 'List', enabled: false },
+  { id: 'list', label: 'List', enabled: true },
   { id: 'calendar', label: 'Calendar', enabled: true },
   { id: 'hill', label: 'Hill Chart', enabled: true },
   { id: 'workload', label: 'Workload', enabled: true },

--- a/packages/mindmap/src/ListView.tsx
+++ b/packages/mindmap/src/ListView.tsx
@@ -45,18 +45,24 @@ const ROW_HEIGHT = 36;
 const INDENT_PX = 20;
 const DEBOUNCE_MS = 400;
 
+// Sentinel option value for the "+ New phase…" entry in the phase
+// dropdown — switches the cell into an inline text editor that creates
+// the phase (appended to the map's phases list) and assigns it.
+const NEW_PHASE_VALUE = '__new_phase__';
+
 type SortKey =
   | 'tree'
   | 'title'
   | 'status'
   | 'priority'
+  | 'phase'
   | 'effort'
   | 'progress'
   | 'health'
   | 'startDate'
   | 'dueDate';
 type SortDir = 'asc' | 'desc';
-type GroupBy = 'none' | 'status' | 'priority' | 'parent';
+type GroupBy = 'none' | 'status' | 'priority' | 'phase' | 'parent';
 
 // ── Flat row type ──────────────────────────────────────────────
 
@@ -124,11 +130,13 @@ const disabledCell: React.CSSProperties = {
 
 export function ListView() {
   const nodes = useMindmapStore((s) => s.nodes);
+  const currentMap = useMindmapStore((s) => s.currentMap);
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
   const computed = useMindmapStore((s) => s.computed);
   const selectedNodeId = useMindmapStore((s) => s.selectedNodeId);
   const selectNode = useMindmapStore((s) => s.selectNode);
   const updateNode = useMindmapStore((s) => s.updateNode);
+  const createPhase = useMindmapStore((s) => s.createPhase);
   const deleteNode = useMindmapStore((s) => s.deleteNode);
   const toggleCollapse = useMindmapStore((s) => s.toggleCollapse);
   const getVisibleNodes = useMindmapStore((s) => s.getVisibleNodes);
@@ -152,6 +160,17 @@ export function ListView() {
 
   const debounce = useDebouncedCallback(DEBOUNCE_MS);
   const tableRef = useRef<HTMLDivElement>(null);
+
+  // Phase definitions of the current map, sorted by position (canonical
+  // phase order) — dropdown options and phase grouping render in this order.
+  const mapPhases = useMemo(
+    () => [...(currentMap?.phases ?? [])].sort((a, b) => a.position - b.position),
+    [currentMap],
+  );
+  const phaseNameById = useMemo(
+    () => new Map(mapPhases.map((p) => [p.id, p.name] as const)),
+    [mapPhases],
+  );
 
   // Sync single selection with store
   useEffect(() => {
@@ -288,6 +307,16 @@ export function ListView() {
         case 'priority':
           cmp = (a.node.priority ?? 'P9').localeCompare(b.node.priority ?? 'P9');
           break;
+        case 'phase': {
+          // Sort by the map's canonical phase order (position); rows
+          // without a phase (or with a dangling id) sort last.
+          const ai = a.node.phaseId ? mapPhases.findIndex((p) => p.id === a.node.phaseId) : -1;
+          const bi = b.node.phaseId ? mapPhases.findIndex((p) => p.id === b.node.phaseId) : -1;
+          cmp =
+            (ai === -1 ? Number.MAX_SAFE_INTEGER : ai) -
+            (bi === -1 ? Number.MAX_SAFE_INTEGER : bi);
+          break;
+        }
         case 'effort':
           cmp = (a.cv?.computedEffort ?? 0) - (b.cv?.computedEffort ?? 0);
           break;
@@ -310,7 +339,7 @@ export function ListView() {
     });
 
     return sorted;
-  }, [filteredRows, sortKey, sortDir]);
+  }, [filteredRows, sortKey, sortDir, mapPhases]);
 
   // ── Group ─────────────────────────────────────────────────────
 
@@ -329,6 +358,11 @@ export function ListView() {
           break;
         case 'priority':
           key = row.node.priority ?? '(no priority)';
+          break;
+        case 'phase':
+          key = row.node.phaseId
+            ? (phaseNameById.get(row.node.phaseId) ?? '(unknown phase)')
+            : '(no phase)';
           break;
         case 'parent':
           key = row.node.parentId ? (nodes[row.node.parentId]?.text ?? '(unknown)') : '(root)';
@@ -349,8 +383,19 @@ export function ListView() {
       result.push({ label, rows, stats: { effort: totalEffort, progress: avgProgress, count: rows.length } });
     }
 
+    // Phase groups render in canonical phase order (position), with the
+    // "(no phase)" / "(unknown phase)" buckets at the end.
+    if (groupBy === 'phase') {
+      const orderByLabel = new Map(mapPhases.map((p, i) => [p.name, i] as const));
+      result.sort(
+        (x, y) =>
+          (orderByLabel.get(x.label) ?? Number.MAX_SAFE_INTEGER) -
+          (orderByLabel.get(y.label) ?? Number.MAX_SAFE_INTEGER),
+      );
+    }
+
     return result;
-  }, [sortedRows, groupBy, nodes]);
+  }, [sortedRows, groupBy, nodes, mapPhases, phaseNameById]);
 
   // ── Column header click → sort ────────────────────────────────
 
@@ -696,6 +741,67 @@ export function ListView() {
               </span>
             ) : (
               <span style={{ fontSize: 11, color: '#cbd5e1' }}>-</span>
+            )
+          )}
+        </div>
+
+        {/* Phase */}
+        <div
+          style={{ width: 110, minWidth: 110, height: '100%', display: 'flex', alignItems: 'center', borderRight: '1px solid #f1f5f9', padding: '0 4px', boxSizing: 'border-box' }}
+          onClick={(e) => {
+            // Don't restart the select while the "+ New phase…" text
+            // editor is open — a click inside the input bubbles here.
+            if (isEditingField('phaseNew')) {
+              e.stopPropagation();
+              return;
+            }
+            handleCellClick(node.id, 'phase', e);
+          }}
+        >
+          {isEditingField('phaseNew') ? (
+            <PhaseEditor
+              onSave={async (name) => {
+                // Create the PhaseDef on the map (appended at the end of
+                // the canonical order), then assign it to the node.
+                const phaseId = await createPhase(name);
+                if (phaseId) updateNode(node.id, { phaseId });
+                setEditingCell(null);
+              }}
+              onCancel={() => setEditingCell(null)}
+            />
+          ) : isEditingField('phase') ? (
+            <select
+              autoFocus
+              value={node.phaseId ?? ''}
+              onChange={(e) => {
+                if (e.target.value === NEW_PHASE_VALUE) {
+                  setEditingCell({ nodeId: node.id, field: 'phaseNew' });
+                  return;
+                }
+                updateNode(node.id, { phaseId: e.target.value || null });
+                setEditingCell(null);
+              }}
+              onBlur={() =>
+                // Keep the phaseNew editor alive when the blur was caused
+                // by switching to it via the "+ New phase…" option.
+                setEditingCell((cur) => (cur?.field === 'phaseNew' ? cur : null))
+              }
+              onKeyDown={(e) => { e.stopPropagation(); if (e.key === 'Escape') setEditingCell(null); }}
+              style={cellSelect}
+            >
+              <option value="">—</option>
+              {mapPhases.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+              <option value={NEW_PHASE_VALUE}>+ New phase…</option>
+            </select>
+          ) : (
+            node.phaseId ? (
+              <span style={{ fontSize: 11, fontWeight: 500, padding: '2px 6px', borderRadius: 4, background: '#f5f3ff', color: '#6d28d9', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {phaseNameById.get(node.phaseId) ?? node.phaseId}
+              </span>
+            ) : (
+              <span style={{ fontSize: 11, color: '#cbd5e1' }}>—</span>
             )
           )}
         </div>
@@ -1062,6 +1168,7 @@ export function ListView() {
             <option value="none">None</option>
             <option value="status">Status</option>
             <option value="priority">Priority</option>
+            <option value="phase">Phase</option>
             <option value="parent">Parent</option>
           </select>
         </div>
@@ -1098,6 +1205,9 @@ export function ListView() {
           </div>
           <div style={thStyle(70)} onClick={() => handleSort('priority')}>
             Priority{sortArrow('priority')}
+          </div>
+          <div style={thStyle(110)} onClick={() => handleSort('phase')}>
+            Phase{sortArrow('phase')}
           </div>
           <div style={thStyle(100)}>
             Assignee
@@ -1304,6 +1414,51 @@ function TitleEditor({
         fontWeight: 500,
         paddingLeft: 4,
       }}
+    />
+  );
+}
+
+// ── Inline "new phase" editor ───────────────────────────────────
+//
+// Rendered when "+ New phase…" is picked in the phase dropdown. Typing a
+// label and committing assigns it to the node; the server appends unknown
+// labels to the map's ordered phases list automatically (the store
+// mirrors that append locally so the dropdown updates immediately).
+
+function PhaseEditor({
+  onSave,
+  onCancel,
+}: {
+  onSave: (v: string) => void;
+  onCancel: () => void;
+}) {
+  const [text, setText] = useState('');
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  const commit = () => {
+    const trimmed = text.trim();
+    if (trimmed) onSave(trimmed);
+    else onCancel();
+  };
+
+  return (
+    <input
+      ref={ref}
+      value={text}
+      placeholder="New phase…"
+      onChange={(e) => setText(e.target.value)}
+      onClick={(e) => e.stopPropagation()}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === 'Enter') commit();
+        else if (e.key === 'Escape') onCancel();
+      }}
+      style={{ ...cellInput, fontSize: 11 }}
     />
   );
 }

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -631,6 +631,9 @@ function PropertyPanelInner({
         {/* Sprint / Cycle */}
         <CycleField nodeId={nodeId} currentCycleId={node.cycleId} />
 
+        {/* Phase */}
+        <PhaseField nodeId={nodeId} currentPhaseId={node.phaseId} />
+
         {/* Divider */}
         <div style={{ height: 1, background: '#f1f5f9', margin: '4px 0' }} />
 
@@ -644,6 +647,43 @@ function PropertyPanelInner({
         <CommentsPanel mapId={node.mapId} nodeId={nodeId} />
       </div>
     </div>
+  );
+}
+
+// ── Phase Field ──────────────────────────────────────────────────
+//
+// Select over the map's PhaseDefs (statusWorkflow idiom), ordered by
+// position. Sits next to Version/Sprint — a phase is a lightweight
+// label reference (node.phaseId), not a heavy entity.
+
+function PhaseField({
+  nodeId,
+  currentPhaseId,
+}: {
+  nodeId: string;
+  currentPhaseId: string | null;
+}) {
+  const currentMap = useMindmapStore((s) => s.currentMap);
+  const updateNode = useMindmapStore((s) => s.updateNode);
+
+  const phases = [...(currentMap?.phases ?? [])].sort((a, b) => a.position - b.position);
+
+  return (
+    <Field label="Phase">
+      <select
+        value={currentPhaseId ?? ''}
+        onChange={(e) => updateNode(nodeId, { phaseId: e.target.value || null })}
+        onKeyDown={(e) => e.stopPropagation()}
+        style={selectStyle}
+      >
+        <option value="">None</option>
+        {phases.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+    </Field>
   );
 }
 

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -97,6 +97,15 @@ export interface MindmapState {
   createMap: (name: string) => Promise<void>;
   closeMap: () => void;
   updateMapName: (name: string) => void;
+  /**
+   * Append a new phase (PhaseDef) to the current map's phases list and
+   * persist via PUT /api/maps/:id. Returns the new phase's id (so callers
+   * can immediately assign it to a node via updateNode phaseId), or null
+   * when there is no current map / the name is blank. When a phase with
+   * the same name already exists, returns that phase's id instead of
+   * creating a duplicate.
+   */
+  createPhase: (name: string) => Promise<string | null>;
 
   // Actions — view
   setActiveView: (view: ActiveView) => void;
@@ -365,6 +374,40 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       // Revert on error
       set({ currentMap: state.currentMap });
     });
+  },
+
+  createPhase: async (name: string) => {
+    const state = get();
+    const mapId = state.currentMapId;
+    const map = state.currentMap;
+    if (!mapId || !map) return null;
+
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+
+    const current = map.phases ?? [];
+    // Reuse an existing phase with the same name instead of duplicating.
+    const existing = current.find((p) => p.name === trimmed);
+    if (existing) return existing.id;
+
+    const newPhase = {
+      id: crypto.randomUUID(),
+      name: trimmed,
+      position: current.length > 0 ? Math.max(...current.map((p) => p.position)) + 1 : 0,
+    };
+    const phases = [...current, newPhase];
+
+    // Optimistic update so the dropdown shows the phase immediately.
+    set({ currentMap: { ...map, phases } });
+
+    try {
+      await api.updateMap(mapId, { phases });
+      return newPhase.id;
+    } catch (e: any) {
+      // Revert on error
+      set({ currentMap: { ...get().currentMap!, phases: current }, error: e.message ?? 'Failed to create phase' });
+      return null;
+    }
   },
 
   // ── Cycle / sprint actions ────────────────────────────────────
@@ -842,6 +885,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       requirementId: null,
       requirementPriority: null,
       requirementText: null,
+      phaseId: null,
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -76,6 +76,7 @@ function toNodeWithComputed(
     requirementId: node.requirementId,
     requirementPriority: node.requirementPriority,
     requirementText: node.requirementText,
+    phaseId: node.phaseId,
     claimedBySession: node.claimedBySession,
     claimedAt: node.claimedAt,
     computedEffort: computed?.computedEffort ?? 0,
@@ -124,6 +125,7 @@ export function createChatBackend(userId: string): ToolBackend {
           statusWorkflow: data.map.statusWorkflow,
           baselines: data.map.baselines,
           wipLimit: data.map.wipLimit,
+          phases: data.map.phases,
         },
         nodes: nodesWithComputed,
       };

--- a/packages/server/src/db/__tests__/phaseValidation.test.ts
+++ b/packages/server/src/db/__tests__/phaseValidation.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit coverage for assertPhaseIdKnown — the app-level referential guard
+ * between nodes.phase_id and the map's PhaseDef list (maps.phases is
+ * jsonb, so there is no FK to lean on). Exercised with a stub DbHandle
+ * (mergeTags pattern: no Postgres needed) that mimics the drizzle
+ * select().from().where() chain.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assertPhaseIdKnown, PhaseIdValidationError } from '../nodes.js';
+import type { DbHandle } from '../nodes.js';
+
+/** Stub handle returning a fixed maps row (or none) and counting queries. */
+function stubHandle(mapRow?: { phases: unknown }): { handle: DbHandle; queries: () => number } {
+  let count = 0;
+  const handle = {
+    select: () => {
+      count++;
+      return {
+        from: () => ({
+          where: async () => (mapRow ? [mapRow] : []),
+        }),
+      };
+    },
+  } as unknown as DbHandle;
+  return { handle, queries: () => count };
+}
+
+const PHASES = [
+  { id: 'ph-1', name: 'M1', position: 0 },
+  { id: 'ph-2', name: 'M2', position: 1 },
+];
+
+describe('assertPhaseIdKnown', () => {
+  it('passes for a phaseId present in the map phases', async () => {
+    const { handle } = stubHandle({ phases: PHASES });
+    await expect(assertPhaseIdKnown(handle, 'map-1', 'ph-2')).resolves.toBeUndefined();
+  });
+
+  it('throws PhaseIdValidationError for an unknown phaseId', async () => {
+    const { handle } = stubHandle({ phases: PHASES });
+    await expect(assertPhaseIdKnown(handle, 'map-1', 'ph-nope')).rejects.toThrow(
+      PhaseIdValidationError,
+    );
+  });
+
+  it('throws when the map has no phases at all', async () => {
+    const { handle } = stubHandle({ phases: [] });
+    await expect(assertPhaseIdKnown(handle, 'map-1', 'ph-1')).rejects.toThrow(
+      PhaseIdValidationError,
+    );
+  });
+
+  it('treats a null phases column defensively as empty', async () => {
+    const { handle } = stubHandle({ phases: null });
+    await expect(assertPhaseIdKnown(handle, 'map-1', 'ph-1')).rejects.toThrow(
+      PhaseIdValidationError,
+    );
+  });
+
+  it('throws when the map row does not exist', async () => {
+    const { handle } = stubHandle(undefined);
+    await expect(assertPhaseIdKnown(handle, 'map-1', 'ph-1')).rejects.toThrow(
+      PhaseIdValidationError,
+    );
+  });
+
+  it('null / undefined phaseId short-circuits without touching the DB', async () => {
+    const { handle, queries } = stubHandle({ phases: PHASES });
+    await expect(assertPhaseIdKnown(handle, 'map-1', null)).resolves.toBeUndefined();
+    await expect(assertPhaseIdKnown(handle, 'map-1', undefined)).resolves.toBeUndefined();
+    expect(queries()).toBe(0);
+  });
+});

--- a/packages/server/src/db/events.ts
+++ b/packages/server/src/db/events.ts
@@ -38,6 +38,7 @@ export const TRACKED_FIELDS = new Set<keyof CoreNode>([
   'versionId',
   'cycleId',
   'assigneeIds',
+  'phaseId',
 ]);
 
 function valuesDiffer(a: unknown, b: unknown): boolean {

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -42,6 +42,7 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     requirementPriority:
       (get('requirementPriority', 'requirement_priority') as CoreNode['requirementPriority']) ?? null,
     requirementText: (get('requirementText', 'requirement_text') as string) ?? null,
+    phaseId: (get('phaseId', 'phase_id') as string) ?? null,
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date
@@ -80,6 +81,7 @@ export function dbMapToCore(row: Record<string, unknown>): MindMap {
     customFieldDefs: (get('customFieldDefs', 'custom_field_defs') as MindMap['customFieldDefs']) ?? [],
     defaultLayout: (get('defaultLayout', 'default_layout') as MindMap['defaultLayout']) ?? 'tree_lr',
     healthThreshold: (get('healthThreshold', 'health_threshold') as number) ?? 0.2,
+    phases: (get('phases', 'phases') as MindMap['phases']) ?? [],
     baselines: (get('baselines', 'baselines') as MindMap['baselines']) ?? [],
     wipLimit: (get('wipLimit', 'wip_limit') as number) ?? null,
     projectStartDate: (get('projectStartDate', 'project_start_date') as string) ?? null,

--- a/packages/server/src/db/maps.ts
+++ b/packages/server/src/db/maps.ts
@@ -3,7 +3,7 @@ import { db } from './connection.js';
 import { maps, mapPermissions, nodes } from './schema.js';
 import { dbMapToCore, dbNodeToCore } from './helpers.js';
 import { notDeleted } from './nodes.js';
-import type { MindMap, Node as CoreNode, StatusDef, CustomFieldDef, LayoutMode, EffortUnit, Baseline } from '@mindblown/core';
+import type { MindMap, Node as CoreNode, StatusDef, PhaseDef, CustomFieldDef, LayoutMode, EffortUnit, Baseline } from '@mindblown/core';
 import { clampFocusFactor } from '@mindblown/core';
 
 // ── Create ─────────────────────────────────────────────────────────
@@ -112,6 +112,12 @@ export interface UpdateMapInput {
   customFieldDefs?: CustomFieldDef[];
   defaultLayout?: LayoutMode;
   healthThreshold?: number;
+  /**
+   * Project phase definitions — full replacement array (statusWorkflow
+   * idiom). Reorder = new `position` values; rename = same `id`, new
+   * `name` (node phaseIds stay valid because ids are stable).
+   */
+  phases?: PhaseDef[];
   baselines?: Baseline[];
   wipLimit?: number | null;
   projectStartDate?: string | null;
@@ -136,6 +142,7 @@ export async function updateMap(mapId: string, input: UpdateMapInput): Promise<M
   if (input.customFieldDefs !== undefined) updates.customFieldDefs = input.customFieldDefs;
   if (input.defaultLayout !== undefined) updates.defaultLayout = input.defaultLayout;
   if (input.healthThreshold !== undefined) updates.healthThreshold = input.healthThreshold;
+  if (input.phases !== undefined) updates.phases = input.phases;
   if (input.baselines !== undefined) updates.baselines = input.baselines;
   if (input.wipLimit !== undefined) updates.wipLimit = input.wipLimit;
   if (input.projectStartDate !== undefined) updates.projectStartDate = input.projectStartDate;

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -822,6 +822,19 @@ export async function runMigrations(): Promise<void> {
       ON requirement_acceptances (map_id)
   `);
 
+  // ── Phase column (nodes.phase_id + maps.phases) ────────────────
+  // maps.phases: PhaseDef[] jsonb — {id, name, position, color?,
+  // targetDate?} (statusWorkflow idiom). nodes.phase_id: nullable TEXT
+  // referencing a PhaseDef.id; stable ids make phase renames free.
+  // Deliberately lightweight — a phase is a label with an order, not an
+  // entity (unlike the April-removed Milestones).
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS phase_id TEXT
+  `);
+  await db.execute(sql`
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS phases JSONB NOT NULL DEFAULT '[]'
+  `);
+
   // ── Lint dismissals (plan-health panel) ────────────────────────
   // node_id NULL = rule muted map-wide. Non-FK node_id by convention
   // (see triage_decisions.placed_node_id) so node deletion leaves the

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -131,6 +131,44 @@ export function mergeTags(
   return [...kept, ...append.filter((t) => !kept.includes(t))];
 }
 
+// ── Phase reference validation ────────────────────────────────────
+//
+// `nodes.phase_id` references a PhaseDef.id in `maps.phases` (jsonb,
+// statusWorkflow idiom — no FK possible). Writes with an unknown id are
+// rejected with PhaseIdValidationError → 400, so a typo'd/stale id
+// can't silently orphan a node. null always passes (clears the phase).
+
+export class PhaseIdValidationError extends Error {
+  constructor(phaseId: string) {
+    super(
+      `Unknown phaseId "${phaseId}" — it does not reference a phase of this map. ` +
+        `Add the phase to the map first (update_map phases / PUT /api/maps/:id).`,
+    );
+    this.name = 'PhaseIdValidationError';
+  }
+}
+
+/**
+ * Assert `phaseId` (when non-null) references a PhaseDef of the map.
+ * Exported for unit tests (mergeTags pattern — testable with a stub
+ * handle, no Postgres needed).
+ */
+export async function assertPhaseIdKnown(
+  handle: DbHandle,
+  mapId: string,
+  phaseId: string | null | undefined,
+): Promise<void> {
+  if (phaseId == null) return;
+  const [map] = await handle
+    .select({ phases: maps.phases })
+    .from(maps)
+    .where(eq(maps.id, mapId));
+  const defs = ((map?.phases as Array<{ id: string }>) ?? []);
+  if (!defs.some((p) => p.id === phaseId)) {
+    throw new PhaseIdValidationError(phaseId);
+  }
+}
+
 // ── Auto-status from progress ─────────────────────────────────────
 //
 // When percentComplete moves but status is left untouched, we promote
@@ -204,6 +242,7 @@ export interface CreateNodeInput {
   requirementId?: string | null;
   requirementPriority?: 'must' | 'should' | 'could' | null;
   requirementText?: string | null;
+  phaseId?: string | null;
 }
 
 export async function createNode(
@@ -221,6 +260,11 @@ export async function createNode(
 
   if (input.requirementId != null) {
     await assertRequirementIdAvailable(handle, input.mapId, input.requirementId);
+  }
+
+  // phaseId must reference a PhaseDef of this map (null = no phase).
+  if (input.phaseId != null) {
+    await assertPhaseIdKnown(handle, input.mapId, input.phaseId);
   }
 
   // Create the node
@@ -246,6 +290,7 @@ export async function createNode(
       requirementId: input.requirementId ?? null,
       requirementPriority: input.requirementPriority ?? null,
       requirementText: input.requirementText ?? null,
+      phaseId: input.phaseId ?? null,
       assigneeIds: [],
       tags: [],
       customFields: {},
@@ -338,6 +383,7 @@ export interface UpdateNodeInput {
   requirementId?: string | null;
   requirementPriority?: 'must' | 'should' | 'could' | null;
   requirementText?: string | null;
+  phaseId?: string | null;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -397,6 +443,17 @@ export async function updateNode(
     }
   }
 
+  // phaseId must reference a PhaseDef of this map (null clears it).
+  if (input.phaseId != null) {
+    const [row] = await handle
+      .select({ mapId: nodes.mapId })
+      .from(nodes)
+      .where(and(eq(nodes.id, nodeId), notDeleted));
+    if (row) {
+      await assertPhaseIdKnown(handle, row.mapId as string, input.phaseId);
+    }
+  }
+
   // Auto-derive status from percentComplete when status is not explicitly set
   // in this update. See deriveAutoStatus for the exact rules.
   if (input.percentComplete !== undefined && input.status === undefined) {
@@ -445,6 +502,7 @@ export async function updateNode(
   if (input.requirementId !== undefined) updates.requirementId = input.requirementId;
   if (input.requirementPriority !== undefined) updates.requirementPriority = input.requirementPriority;
   if (input.requirementText !== undefined) updates.requirementText = input.requirementText;
+  if (input.phaseId !== undefined) updates.phaseId = input.phaseId;
   // Orchestration substrate (#111)
   if (input.claimedBySession !== undefined) updates.claimedBySession = input.claimedBySession;
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -79,6 +79,10 @@ export const maps = pgTable('maps', {
   defaultLayout: text('default_layout').notNull().default('tree_lr'),
   healthThreshold: real('health_threshold').notNull().default(0.2),
   baselines: jsonb('baselines').notNull().default([]),
+  // Project phases (statusWorkflow idiom): PhaseDef[] — {id, name, position,
+  // color?, targetDate?}. Nodes reference entries via nodes.phase_id; stable
+  // ids make renames free. position = canonical phase order.
+  phases: jsonb('phases').notNull().default([]), // PhaseDef[]
   wipLimit: real('wip_limit'),
   projectStartDate: date('project_start_date'),
   hoursPerDay: real('hours_per_day').notNull().default(8),
@@ -202,6 +206,13 @@ export const nodes = pgTable('nodes', {
   requirementPriority: text('requirement_priority'),
   // Business phrasing for register/doc export; NOT GitHub-synced.
   requirementText: text('requirement_text'),
+
+  // ── Phase ─────────────────────────────────────────────────────
+  // References a PhaseDef.id from maps.phases (statusWorkflow idiom,
+  // same shape as version_id/cycle_id). TEXT, no FK — phase defs live
+  // in the maps.phases jsonb, not a table. Validated app-level in
+  // db/nodes.ts (unknown id → PhaseIdValidationError → 400).
+  phaseId: text('phase_id'),
 
   // ── Orchestration substrate (#111) ───────────────────────────
   // claimed_by_session: session ID that owns this node for active work.

--- a/packages/server/src/lint/__tests__/engine.test.ts
+++ b/packages/server/src/lint/__tests__/engine.test.ts
@@ -37,6 +37,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementId: null,
     requirementPriority: null,
     requirementText: null,
+    phaseId: null,
     claimedBySession: null,
     claimedAt: null,
     revision: 0,

--- a/packages/server/src/routes/__tests__/phase-map-routes.test.ts
+++ b/packages/server/src/routes/__tests__/phase-map-routes.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Round-trip tests for the map-level phases list (PhaseDef[]) exposed via
+ * PUT /api/maps/:id — the write surface behind "add / rename / reorder
+ * phases". REPLACE mode: the full array is forwarded verbatim to
+ * mapDb.updateMap (statusWorkflow idiom; ids stay stable so node.phaseId
+ * references survive renames).
+ *
+ * Mock pattern mirrors maps-triage-flags.test.ts — stub the DB +
+ * permissions module so we exercise route wiring without Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const updateMapMock = vi.fn();
+const getMapMock = vi.fn();
+const listMapsForUserMock = vi.fn<(...args: unknown[]) => Promise<unknown[]>>(async () => []);
+const createBaselineMock = vi.fn();
+const deleteMapMock = vi.fn();
+const createMapMock = vi.fn();
+
+vi.mock('../../db/maps.js', () => ({
+  updateMap: (...args: unknown[]) => updateMapMock(...args),
+  getMap: (...args: unknown[]) => getMapMock(...args),
+  listMapsForUser: (...args: unknown[]) => listMapsForUserMock(...args),
+  createBaseline: (...args: unknown[]) => createBaselineMock(...args),
+  deleteMap: (...args: unknown[]) => deleteMapMock(...args),
+  createMap: (...args: unknown[]) => createMapMock(...args),
+}));
+
+const getPermissionMock = vi.fn<(...args: unknown[]) => Promise<'view' | 'edit' | 'admin' | null>>(async () => 'edit');
+vi.mock('../../db/permissions.js', () => ({
+  getPermission: (...args: unknown[]) => getPermissionMock(...args),
+  hasPermission: (actual: string | null, required: string) => {
+    if (actual == null) return false;
+    const rank: Record<string, number> = { view: 1, edit: 2, admin: 3 };
+    return (rank[actual] ?? 0) >= (rank[required] ?? 0);
+  },
+}));
+
+vi.mock('../../db/versions.js', () => ({}));
+vi.mock('../../db/cycles.js', () => ({}));
+vi.mock('../../db/connection.js', () => ({ db: {} }));
+vi.mock('../../db/schema.js', () => ({
+  workspaces: {},
+  users: {},
+  releaseSnapshots: {},
+}));
+vi.mock('../../lib/releaseForecast.js', () => ({
+  computeReleaseForecast: vi.fn(),
+}));
+vi.mock('../../lib/releaseSnapshots.js', () => ({
+  snapshotReleaseForecastForMap: vi.fn(),
+}));
+vi.mock('../../lib/calendarIcs.js', () => ({
+  buildCalendarIcs: vi.fn(),
+  calendarTokenFor: vi.fn(),
+  verifyCalendarToken: vi.fn(),
+  CALENDAR_VIEWS: [],
+}));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  lte: vi.fn(),
+  desc: vi.fn(),
+}));
+
+import { mapRoutes } from '../maps.js';
+
+// ── Test harness ──────────────────────────────────────────────────
+
+const USER_ID = 'uuuu-uuuu-uuuu-uuuu';
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    req.userId = USER_ID;
+    req.authSource = 'jwt';
+  });
+  await app.register(mapRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  updateMapMock.mockReset();
+  getMapMock.mockReset();
+  getPermissionMock.mockClear();
+});
+
+// ── Cases ─────────────────────────────────────────────────────────
+
+describe('PUT /api/maps/:id — phases (PhaseDef[]) round-trip', () => {
+  it('forwards a new phases array to updateMap and returns the updated row', async () => {
+    const phases = [
+      { id: 'ph-1', name: 'M1 – Grundgerüst', position: 0 },
+      { id: 'ph-2', name: 'M2 – Auth', position: 1 },
+    ];
+    updateMapMock.mockResolvedValueOnce({ id: MAP_ID, name: 'My Map', phases });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { phases },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMapMock).toHaveBeenCalledOnce();
+    expect(updateMapMock.mock.calls[0][0]).toBe(MAP_ID);
+    expect(updateMapMock.mock.calls[0][1]).toEqual({ phases });
+    expect(res.json().phases).toEqual(phases);
+  });
+
+  it('round-trips a reorder — same ids, swapped positions', async () => {
+    const reordered = [
+      { id: 'ph-2', name: 'M2 – Auth', position: 0 },
+      { id: 'ph-1', name: 'M1 – Grundgerüst', position: 1 },
+    ];
+    updateMapMock.mockResolvedValueOnce({ id: MAP_ID, name: 'My Map', phases: reordered });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { phases: reordered },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    // Ids must be forwarded untouched — node.phaseId references depend on it.
+    expect(updateMapMock.mock.calls[0][1]).toEqual({ phases: reordered });
+    expect(res.json().phases.map((p: { id: string }) => p.id)).toEqual(['ph-2', 'ph-1']);
+  });
+
+  it('round-trips a rename — same id, new name', async () => {
+    const renamed = [{ id: 'ph-1', name: 'M1 – Fundament', position: 0 }];
+    updateMapMock.mockResolvedValueOnce({ id: MAP_ID, name: 'My Map', phases: renamed });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { phases: renamed },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMapMock.mock.calls[0][1]).toEqual({ phases: renamed });
+  });
+
+  it('403s when the caller lacks edit permission (regression guard)', async () => {
+    getPermissionMock.mockResolvedValueOnce('view' as const);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}`,
+      payload: { phases: [] },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(403);
+    expect(updateMapMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/routes/__tests__/phase-node-routes.test.ts
+++ b/packages/server/src/routes/__tests__/phase-node-routes.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Route tests for the phase column on the node write surface.
+ *
+ * nodes.phaseId references a PhaseDef.id from maps.phases (statusWorkflow
+ * idiom). These tests lock down the REST wiring:
+ *   - PUT  /api/maps/:id/nodes/:nodeId forwards phaseId (set AND null/clear)
+ *     verbatim to db updateNode,
+ *   - POST /api/maps/:id/nodes forwards phaseId on create,
+ *   - PhaseIdValidationError from the DB layer maps to 400 UNKNOWN_PHASE_ID
+ *     on both routes.
+ *
+ * Mock pattern mirrors maps-triage-flags.test.ts — stub the DB layer +
+ * side-effect modules, exercise route wiring without Postgres. The DB
+ * module is spread from the real one so error classes keep identity for
+ * the route's `instanceof` checks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const createNodeMock = vi.fn();
+const updateNodeMock = vi.fn();
+const getNodeMock = vi.fn(async () => null);
+
+vi.mock('../../db/nodes.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/nodes.js')>();
+  return {
+    ...actual,
+    createNode: (...args: unknown[]) => createNodeMock(...args),
+    updateNode: (...args: unknown[]) => updateNodeMock(...args),
+    getNode: (...args: unknown[]) => getNodeMock(),
+  };
+});
+
+vi.mock('../../db/maps.js', () => ({ updateMap: vi.fn() }));
+vi.mock('../../db/events.js', () => ({
+  recordEvent: vi.fn(async () => {}),
+  recordFieldChanges: vi.fn(async () => {}),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../../ai/embeddings.js', () => ({ scheduleEmbedNode: vi.fn() }));
+vi.mock('@mindblown/integrations', () => ({
+  updateGitHubIssue: vi.fn(),
+  getGitHubIssue: vi.fn(),
+}));
+vi.mock('../integrations.js', () => ({
+  getGitHubContextForMap: vi.fn(async () => null),
+}));
+
+import { nodeRoutes } from '../nodes.js';
+import { PhaseIdValidationError } from '../../db/nodes.js';
+
+// ── Test harness ──────────────────────────────────────────────────
+
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+const NODE_ID = 'nnnn-nnnn-nnnn-nnnn';
+
+/** Minimal CoreNode-shaped stub the routes can broadcast/sync safely. */
+function stubNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: NODE_ID,
+    mapId: MAP_ID,
+    parentId: 'pppp-pppp',
+    childrenIds: [],
+    text: 'stub node',
+    externalLinks: [],
+    phaseId: null,
+    ...overrides,
+  };
+}
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    req.userId = 'uuuu-uuuu-uuuu-uuuu';
+  });
+  await app.register(nodeRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  createNodeMock.mockReset();
+  updateNodeMock.mockReset();
+  getNodeMock.mockReset();
+  getNodeMock.mockResolvedValue(null as never);
+});
+
+// ── Cases ─────────────────────────────────────────────────────────
+
+describe('PUT /api/maps/:id/nodes/:nodeId — phaseId round-trip', () => {
+  it('forwards phaseId (set) to updateNode and returns the updated node', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ phaseId: 'ph-1' }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { phaseId: 'ph-1' },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock).toHaveBeenCalledOnce();
+    expect(updateNodeMock.mock.calls[0][0]).toBe(NODE_ID);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ phaseId: 'ph-1' });
+    expect(res.json().phaseId).toBe('ph-1');
+  });
+
+  it('forwards phaseId: null (clear) — null survives as a value, not an omission', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ phaseId: null }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { phaseId: null },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ phaseId: null });
+    expect(res.json().phaseId).toBeNull();
+  });
+
+  it('maps PhaseIdValidationError to 400 UNKNOWN_PHASE_ID', async () => {
+    updateNodeMock.mockRejectedValueOnce(new PhaseIdValidationError('ph-nope'));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { phaseId: 'ph-nope' },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe('UNKNOWN_PHASE_ID');
+    expect(res.json().error.message).toContain('ph-nope');
+  });
+});
+
+describe('POST /api/maps/:id/nodes — phaseId on create', () => {
+  it('forwards phaseId to createNode', async () => {
+    createNodeMock.mockResolvedValueOnce(stubNode({ phaseId: 'ph-2', text: 'phased task' }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/maps/${MAP_ID}/nodes`,
+      payload: { parentId: 'pppp-pppp', text: 'phased task', phaseId: 'ph-2' },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(201);
+    expect(createNodeMock).toHaveBeenCalledOnce();
+    expect(createNodeMock.mock.calls[0][0]).toMatchObject({
+      mapId: MAP_ID,
+      parentId: 'pppp-pppp',
+      text: 'phased task',
+      phaseId: 'ph-2',
+    });
+    expect(res.json().phaseId).toBe('ph-2');
+  });
+
+  it('maps PhaseIdValidationError to 400 UNKNOWN_PHASE_ID on create', async () => {
+    createNodeMock.mockRejectedValueOnce(new PhaseIdValidationError('ph-nope'));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/maps/${MAP_ID}/nodes`,
+      payload: { parentId: 'pppp-pppp', text: 'phased task', phaseId: 'ph-nope' },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe('UNKNOWN_PHASE_ID');
+  });
+});

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -467,6 +467,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           requirementId: null,
           requirementPriority: null,
           requirementText: null,
+          phaseId: null,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import * as nodeDb from '../db/nodes.js';
-import { DependencyValidationError, RequirementIdConflictError, RevisionConflictError, TagsModeConflictError } from '../db/nodes.js';
+import { DependencyValidationError, PhaseIdValidationError, RequirementIdConflictError, RevisionConflictError, TagsModeConflictError } from '../db/nodes.js';
 import * as mapDb from '../db/maps.js';
 import * as events from '../db/events.js';
 import { broadcast } from '../ws.js';
@@ -171,6 +171,7 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       requirementId?: string | null;
       requirementPriority?: 'must' | 'should' | 'could' | null;
       requirementText?: string | null;
+      phaseId?: string | null;
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`
        * auto-link backstop (#58). Useful when the leading `#NNNN` is
@@ -201,6 +202,11 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       if (err instanceof RequirementIdConflictError) {
         return reply.status(400).send({
           error: { code: 'REQUIREMENT_ID_CONFLICT', message: err.message },
+        });
+      }
+      if (err instanceof PhaseIdValidationError) {
+        return reply.status(400).send({
+          error: { code: 'UNKNOWN_PHASE_ID', message: err.message },
         });
       }
       throw err;
@@ -321,6 +327,11 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
         if (err instanceof RequirementIdConflictError) {
           return reply.status(400).send({
             error: { code: 'REQUIREMENT_ID_CONFLICT', message: err.message },
+          });
+        }
+        if (err instanceof PhaseIdValidationError) {
+          return reply.status(400).send({
+            error: { code: 'UNKNOWN_PHASE_ID', message: err.message },
           });
         }
         if (err instanceof RevisionConflictError) {

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -8,7 +8,7 @@
  * Adding a new backend method requires adding it to both implementations.
  */
 
-import type { MapDetail, MapSummary, NodeWithComputed } from './types.js';
+import type { MapDetail, MapSummary, NodeWithComputed, PhaseDef } from './types.js';
 
 // ── Triage shapes (#96 Phase 3) ────────────────────────────────────
 // Mirrors the persisted `triage_decisions` row, plus the per-request
@@ -205,6 +205,7 @@ export interface ToolBackend {
       workerCount?: number;
       focusFactor?: number;
       autoImportNewIssues?: boolean;
+      phases?: PhaseDef[];
     },
   ): Promise<MapSummary>;
   deleteMap(mapId: string): Promise<void>;

--- a/packages/tool-kit/src/formatters.ts
+++ b/packages/tool-kit/src/formatters.ts
@@ -42,6 +42,7 @@ function renderTreeNode(
   nodeId: string,
   lookup: Map<string, NodeWithComputed>,
   indent: number,
+  phaseNameById?: Map<string, string>,
 ): string[] {
   const node = lookup.get(nodeId);
   if (!node) return [];
@@ -63,6 +64,7 @@ function renderTreeNode(
   }
   if (node.status) parts.push(`status: ${node.status}`);
   if (node.priority) parts.push(node.priority);
+  if (node.phaseId) parts.push(`phase: ${phaseNameById?.get(node.phaseId) ?? node.phaseId}`);
   if (node.dueDate) parts.push(`due: ${node.dueDate}`);
   if (node.externalLinks?.length > 0) {
     parts.push(node.externalLinks.map((l) => `[${l.externalId}]`).join(' '));
@@ -81,7 +83,7 @@ function renderTreeNode(
 
   const lines = [line];
   for (const childId of node.childrenIds) {
-    lines.push(...renderTreeNode(childId, lookup, indent + 1));
+    lines.push(...renderTreeNode(childId, lookup, indent + 1, phaseNameById));
   }
   return lines;
 }
@@ -133,10 +135,17 @@ export function formatMapTree(data: MapDetail): string {
   lines.push(`# ${data.map.name}`);
   if (data.map.description) lines.push(`${data.map.description}`);
   lines.push(`Effort unit: ${data.map.effortUnit ?? 'hours'}`);
+  const orderedPhases = [...(data.map.phases ?? [])].sort((a, b) => a.position - b.position);
+  if (orderedPhases.length > 0) {
+    lines.push(
+      `Phases (ordered): ${orderedPhases.map((p) => `${p.name} (id: ${p.id})`).join(' → ')}`,
+    );
+  }
   lines.push('');
 
+  const phaseNameById = new Map(orderedPhases.map((p) => [p.id, p.name] as const));
   if (rootNode) {
-    lines.push(...renderTreeNode(data.map.rootNodeId, lookup, 0));
+    lines.push(...renderTreeNode(data.map.rootNodeId, lookup, 0, phaseNameById));
   } else {
     lines.push('(empty map)');
   }

--- a/packages/tool-kit/src/tools/__tests__/map.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/map.test.ts
@@ -56,3 +56,74 @@ describe('update_map tool — focusFactor', () => {
     expect(result).toContain('stub map');
   });
 });
+
+// Phase column — update_map is the write surface for the map's PhaseDef
+// list (add / rename / reorder in REPLACE mode). The handler normalizes:
+// missing ids are generated, missing positions default to the array index.
+describe('update_map tool — phases', () => {
+  it('accepts a full PhaseDef array', () => {
+    const schema = z.object(updateMapTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      phases: [
+        { id: 'ph-1', name: 'M1', position: 0 },
+        { id: 'ph-2', name: 'M2', position: 1, color: '#ff0000', targetDate: null },
+      ],
+    });
+    expect(parsed.phases).toHaveLength(2);
+  });
+
+  it('rejects entries without a name', () => {
+    const schema = z.object(updateMapTool.schema);
+    expect(() => schema.parse({ mapId: 'm1', phases: [{ id: 'ph-1' }] })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', phases: [{ name: '' }] })).toThrow();
+  });
+
+  it('forwards a reorder (position swap) to the backend with ids intact', async () => {
+    const recorder = makeRecordingBackend();
+    await updateMapTool.handler(recorder.backend, {
+      mapId: 'm1',
+      phases: [
+        { id: 'ph-2', name: 'M2', position: 0 },
+        { id: 'ph-1', name: 'M1', position: 1 },
+      ],
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({
+      phases: [
+        { id: 'ph-2', name: 'M2', position: 0 },
+        { id: 'ph-1', name: 'M1', position: 1 },
+      ],
+    });
+  });
+
+  it('generates an id for new entries and defaults position to the array index', async () => {
+    const recorder = makeRecordingBackend();
+    await updateMapTool.handler(recorder.backend, {
+      mapId: 'm1',
+      phases: [
+        { id: 'ph-1', name: 'M1', position: 0 },
+        { name: 'M9' }, // new phase: no id, no position
+      ],
+    } as never);
+    const sent = (recorder.lastUpdate?.fields.phases ?? []) as Array<{
+      id: string;
+      name: string;
+      position: number;
+    }>;
+    expect(sent).toHaveLength(2);
+    expect(sent[0]).toMatchObject({ id: 'ph-1', name: 'M1', position: 0 });
+    expect(sent[1].name).toBe('M9');
+    expect(sent[1].position).toBe(1);
+    expect(typeof sent[1].id).toBe('string');
+    expect(sent[1].id.length).toBeGreaterThan(0);
+  });
+
+  it('does not send phases when omitted', async () => {
+    const recorder = makeRecordingBackend();
+    await updateMapTool.handler(recorder.backend, {
+      mapId: 'm1',
+      name: 'renamed',
+    } as never);
+    expect('phases' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+  });
+});

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -673,3 +673,116 @@ describe('search_nodes tool — notStatus filter', () => {
     expect(out).toContain('notStatus=done');
   });
 });
+
+// Phase column — node.phaseId references a PhaseDef.id from the map's
+// `phases` list (statusWorkflow idiom). Must round-trip through
+// create_node AND update_node (the CLAUDE.md layer-6 failure mode), and
+// null must clear it.
+describe('phase fields', () => {
+  it('accepts phaseId on update_node', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({ mapId: 'm1', nodeId: 'n1', phaseId: 'ph-1' });
+    expect(parsed.phaseId).toBe('ph-1');
+  });
+
+  it('accepts null to clear the phase', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({ mapId: 'm1', nodeId: 'n1', phaseId: null });
+    expect(parsed.phaseId).toBeNull();
+  });
+
+  it('forwards phaseId to the backend on update (set)', async () => {
+    const recorder = makeRecordingBackend();
+    const out = await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      phaseId: 'ph-1',
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({ phaseId: 'ph-1' });
+    expect(out).toContain('phaseId');
+  });
+
+  it('forwards phaseId: null to the backend on update (clear)', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      phaseId: null,
+    } as never);
+    // null is a real value (clear), not an omitted field — it must survive
+    // the handler's undefined-stripping.
+    expect(recorder.lastUpdate?.fields).toMatchObject({ phaseId: null });
+    expect('phaseId' in (recorder.lastUpdate?.fields ?? {})).toBe(true);
+  });
+
+  it('forwards phaseId to the backend on create', async () => {
+    const recorder = makeRecordingBackend();
+    await createNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'phased task',
+      phaseId: 'ph-2',
+    } as never);
+    expect(recorder.lastCreate?.fields).toMatchObject({ phaseId: 'ph-2' });
+  });
+
+  it('omits phaseId from the backend call when not provided', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      text: 'rename me',
+    } as never);
+    expect('phaseId' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+  });
+});
+
+describe('search_nodes tool — phase name in output', () => {
+  it('renders the phase NAME (resolved via map.phases), not the raw id', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => ({
+      map: {
+        id: 'm1',
+        rootNodeId: 'root',
+        phases: [{ id: 'ph-1', name: 'M1 – Grundgerüst', position: 0 }],
+      } as unknown as MapDetail['map'],
+      nodes: [
+        {
+          id: 'n1',
+          mapId: 'm1',
+          parentId: null,
+          childrenIds: [],
+          text: 'phased node',
+          description: null,
+          effortEstimate: null,
+          actualEffort: null,
+          percentComplete: null,
+          status: null,
+          assigneeIds: [],
+          priority: null,
+          dueDate: null,
+          startDate: null,
+          tags: [],
+          dependencies: [],
+          versionId: null,
+          cycleId: null,
+          phaseId: 'ph-1',
+          externalLinks: [],
+          collapsed: false,
+          createdAt: '2026-07-16T00:00:00Z',
+          updatedAt: '2026-07-16T00:00:00Z',
+          claimedBySession: null,
+          claimedAt: null,
+          computedEffort: 0,
+          computedProgress: 0,
+          healthSignal: 'on_track',
+        } as unknown as NodeWithComputed,
+      ],
+    });
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: 'phased',
+    } as never);
+    expect(out).toContain('phase: M1 – Grundgerüst');
+  });
+});

--- a/packages/tool-kit/src/tools/bulk.ts
+++ b/packages/tool-kit/src/tools/bulk.ts
@@ -16,6 +16,7 @@ const VALID_NODE_FIELDS = new Set([
   'tagsRemove',
   'assigneeIds',
   'priorityRank',
+  'phaseId',
 ]);
 
 /**
@@ -47,7 +48,7 @@ function normalizeBulkUpdateItem(
 export const bulkUpdateNodesTool = defineTool({
   name: 'bulk_update_nodes',
   description:
-    'Update multiple nodes at once. Each update is {nodeId, ...fields} OR {nodeId, fields: {...}} — both shapes are accepted. Valid fields: text, description, effortEstimate, percentComplete, status, blockedReason, priority, dueDate, startDate, tags, tagsAppend, tagsRemove, assigneeIds, priorityRank. Use `tagsAppend`/`tagsRemove` for tag-set merges that preserve other tags; use `tags` only when you intend to fully replace the set.',
+    'Update multiple nodes at once. Each update is {nodeId, ...fields} OR {nodeId, fields: {...}} — both shapes are accepted. Valid fields: text, description, effortEstimate, percentComplete, status, blockedReason, priority, dueDate, startDate, tags, tagsAppend, tagsRemove, assigneeIds, priorityRank, phaseId. Use `tagsAppend`/`tagsRemove` for tag-set merges that preserve other tags; use `tags` only when you intend to fully replace the set.',
   schema: {
     mapId: z.string().describe('The map ID'),
     updates: z
@@ -108,6 +109,10 @@ export const bulkCreateNodesTool = defineTool({
           status: z.string().optional().describe("Status (must match map's status workflow)"),
           dueDate: z.string().optional().describe('Due date (ISO 8601)'),
           startDate: z.string().optional().describe('Start date (ISO 8601)'),
+          phaseId: z
+            .string()
+            .optional()
+            .describe('Phase reference — id of a PhaseDef from the map\'s phases list (add phases via update_map first)'),
         }),
       )
       .describe('Array of node definitions to create, processed in order'),

--- a/packages/tool-kit/src/tools/map.ts
+++ b/packages/tool-kit/src/tools/map.ts
@@ -147,14 +147,20 @@ export const updateMapTool = defineTool({
     if (phases !== undefined) {
       // Normalize: generate ids for new entries, default position to the
       // array index — callers reordering can just send the array in the
-      // desired order without renumbering by hand.
-      fields.phases = phases.map((p, i) => ({
-        id: p.id ?? crypto.randomUUID(),
-        name: p.name,
-        position: p.position ?? i,
-        ...(p.color !== undefined ? { color: p.color } : {}),
-        ...(p.targetDate !== undefined ? { targetDate: p.targetDate } : {}),
-      }));
+      // desired order without renumbering by hand. Entries carrying an
+      // explicit position win the ordering (stable sort), then positions
+      // are renumbered sequentially so mixed explicit/omitted input can't
+      // produce duplicate positions with arbitrary tie-breaks downstream.
+      fields.phases = phases
+        .map((p, i) => ({
+          id: p.id ?? crypto.randomUUID(),
+          name: p.name,
+          position: p.position ?? i,
+          ...(p.color !== undefined ? { color: p.color } : {}),
+          ...(p.targetDate !== undefined ? { targetDate: p.targetDate } : {}),
+        }))
+        .sort((a, b) => a.position - b.position)
+        .map((p, i) => ({ ...p, position: i }));
     }
     if (Object.keys(fields).length === 0) return 'No fields to update.';
     const updated = await backend.updateMap(mapId, fields);

--- a/packages/tool-kit/src/tools/map.ts
+++ b/packages/tool-kit/src/tools/map.ts
@@ -67,7 +67,7 @@ export const createMapTool = defineTool({
 export const updateMapTool = defineTool({
   name: 'update_map',
   description:
-    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, focus factor, or GitHub auto-import setting. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). focusFactor (0.05–1.0, default 1) is the fraction of calendar time that actually reaches planned-ticket work — set it below 1 to stretch the velocity-adjusted completion forecast for meetings/support/firefighting/unplanned work (e.g. 0.5 = half of each day reaches planned work, so forecasts take twice as long). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. Pass nullable fields as null to clear.",
+    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, focus factor, phases, or GitHub auto-import setting. phases is the map's project-phase definition list ({id, name, position} — statusWorkflow idiom); pass the COMPLETE new array to add, rename, or reorder phases. Keep existing ids stable when renaming/reordering — nodes reference phases by id (node.phaseId), so a changed id orphans them. Omit id on a NEW entry and one is generated. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). focusFactor (0.05–1.0, default 1) is the fraction of calendar time that actually reaches planned-ticket work — set it below 1 to stretch the velocity-adjusted completion forecast for meetings/support/firefighting/unplanned work (e.g. 0.5 = half of each day reaches planned work, so forecasts take twice as long). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. Pass nullable fields as null to clear.",
   schema: {
     mapId: z.string().describe('The map ID'),
     name: z.string().optional().describe('New map name'),
@@ -99,8 +99,32 @@ export const updateMapTool = defineTool({
       .boolean()
       .optional()
       .describe('When true, new GitHub issues on the bound repo are auto-imported into this map\'s GitHub Inbox.'),
+    phases: z
+      .array(
+        z.object({
+          id: z
+            .string()
+            .optional()
+            .describe('Stable phase id. REQUIRED for existing phases (keep it unchanged); omit for a new phase and one is generated.'),
+          name: z.string().min(1).describe('Display name, e.g. "M1 – Grundgerüst"'),
+          position: z
+            .number()
+            .optional()
+            .describe('Canonical sort position. Omitted = the entry\'s index in this array.'),
+          color: z.string().optional().describe('Optional hex color'),
+          targetDate: z
+            .string()
+            .nullable()
+            .optional()
+            .describe('Optional ISO target date (modeled, unused in v1)'),
+        }),
+      )
+      .optional()
+      .describe(
+        'Project phase definitions (REPLACE mode — the full new array). Send the complete list to add, rename, or reorder; keep ids of existing phases stable so node.phaseId references stay valid.',
+      ),
   },
-  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, focusFactor, autoImportNewIssues }) => {
+  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, focusFactor, autoImportNewIssues, phases }) => {
     const fields: {
       name?: string;
       description?: string | null;
@@ -110,6 +134,7 @@ export const updateMapTool = defineTool({
       workerCount?: number;
       focusFactor?: number;
       autoImportNewIssues?: boolean;
+      phases?: Array<{ id: string; name: string; position: number; color?: string; targetDate?: string | null }>;
     } = {};
     if (name !== undefined) fields.name = name;
     if (description !== undefined) fields.description = description;
@@ -119,6 +144,18 @@ export const updateMapTool = defineTool({
     if (workerCount !== undefined) fields.workerCount = workerCount;
     if (focusFactor !== undefined) fields.focusFactor = focusFactor;
     if (autoImportNewIssues !== undefined) fields.autoImportNewIssues = autoImportNewIssues;
+    if (phases !== undefined) {
+      // Normalize: generate ids for new entries, default position to the
+      // array index — callers reordering can just send the array in the
+      // desired order without renumbering by hand.
+      fields.phases = phases.map((p, i) => ({
+        id: p.id ?? crypto.randomUUID(),
+        name: p.name,
+        position: p.position ?? i,
+        ...(p.color !== undefined ? { color: p.color } : {}),
+        ...(p.targetDate !== undefined ? { targetDate: p.targetDate } : {}),
+      }));
+    }
     if (Object.keys(fields).length === 0) return 'No fields to update.';
     const updated = await backend.updateMap(mapId, fields);
     return `Updated map "${updated.name}" (id: ${updated.id})`;

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -45,6 +45,13 @@ export const createNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('Business phrasing of the requirement for the register/doc export. Falls back to the node text when null. Not synced to GitHub.'),
+    phaseId: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Phase reference — the id of a PhaseDef from the map\'s `phases` list (shown by get_map). Must reference an existing phase; add new phases via update_map first. Same idiom as versionId.',
+      ),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -131,6 +138,13 @@ export const updateNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('Business phrasing for the register/doc export (falls back to node text). Safe to edit freely — never pushed to GitHub. null clears it.'),
+    phaseId: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Phase reference — the id of a PhaseDef from the map\'s `phases` list (shown by get_map). Must reference an existing phase; add new phases via update_map first. null clears the phase. Same idiom as versionId.',
+      ),
     // Orchestration substrate (#111)
     scopes: z
       .array(z.string())
@@ -351,6 +365,9 @@ export const searchNodesTool = defineTool({
       return `No ${subject}${filterStr} found in map ${mapId}.`;
     }
 
+    const phaseNameById = new Map(
+      (data.map.phases ?? []).map((p) => [p.id, p.name] as const),
+    );
     const lines = matches.map((n) => {
       const health =
         n.healthSignal === 'on_track' ? '[OK]' : n.healthSignal === 'at_risk' ? '[AT RISK]' : '[BEHIND]';
@@ -361,7 +378,10 @@ export const searchNodesTool = defineTool({
       const claim = ' ' + formatClaim(n.claimedBySession, n.claimedAt);
       const kids = n.childrenIds?.length ?? 0;
       const kidsStr = kids > 0 ? ` (${kids} child${kids === 1 ? '' : 'ren'})` : '';
-      return `- "${n.text}" (id: ${n.id}) — ${progress}% ${health}${n.status ? ` [${n.status}]` : ''}${n.priority ? ` ${n.priority}` : ''}${kidsStr}${links}${claim}`;
+      const phase = n.phaseId
+        ? ` (phase: ${phaseNameById.get(n.phaseId) ?? n.phaseId})`
+        : '';
+      return `- "${n.text}" (id: ${n.id}) — ${progress}% ${health}${n.status ? ` [${n.status}]` : ''}${n.priority ? ` ${n.priority}` : ''}${phase}${kidsStr}${links}${claim}`;
     });
 
     return `Found ${matches.length} node(s) matching "${query}":\n${lines.join('\n')}`;

--- a/packages/tool-kit/src/types.ts
+++ b/packages/tool-kit/src/types.ts
@@ -50,6 +50,9 @@ export interface NodeWithComputed {
   requirementId: string | null;
   requirementPriority: 'must' | 'should' | 'could' | null;
   requirementText: string | null;
+  // References a PhaseDef.id from the map's `phases` list (statusWorkflow
+  // idiom). null = no phase assigned.
+  phaseId: string | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;
@@ -58,11 +61,22 @@ export interface NodeWithComputed {
   healthSignal: string;
 }
 
+/** Project phase definition (mirrors core PhaseDef; statusWorkflow idiom). */
+export interface PhaseDef {
+  id: string;
+  name: string;
+  position: number;
+  color?: string;
+  targetDate?: string | null;
+}
+
 export interface MapDetail {
   map: MapSummary & {
     statusWorkflow: Array<{ id: string; name: string; category: string; color: string; position: number }>;
     baselines: unknown[];
     wipLimit: number | null;
+    /** Project phase definitions; `position` = canonical phase order. */
+    phases?: PhaseDef[];
   };
   nodes: NodeWithComputed[];
 }


### PR DESCRIPTION
Phases as an ordered PhaseDef list on the map (statusWorkflow idiom: stable id, name, position, optional color/targetDate) + node.phaseId. ListView gets an editable Phase column with inline «+ New phase…», group-by-phase, PropertyPanel select; MCP create/update_node + bulk accept phaseId, update_map manages the phases array; unknown phaseId → 400 UNKNOWN_PHASE_ID on every write path.

Reviewed by Ray (APPROVE, no must-fix; both should-fixes applied: position renumbering after normalize, replace-mode doc note). 789 tests green across core/tool-kit/mcp/server; acceptance test run in a real browser (create phase → reload persists → second node picks it from dropdown) plus live MCP round-trip.

Design paper: ~/temp/mindblown-phase-column-design.md (filter/canvas badges/forecast deliberately out of scope for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6RVBDQptbVQe1cDrHM3AH