### PR TITLE
fix(mindmap): HillChart and WorkloadView respect version/cycle filters

### DIFF
--- a/packages/mindmap/package.json
+++ b/packages/mindmap/package.json
@@ -15,6 +15,8 @@
     "dev": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "sync-help": "cp ../../docs/user-guide.md public/user-guide.md && pandoc ../../docs/user-guide.md -o public/user-guide.pdf --pdf-engine=weasyprint --metadata title='MindBlown User Guide'"
   },
   "dependencies": {
@@ -30,6 +32,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/mindmap/src/HillChart.tsx
+++ b/packages/mindmap/src/HillChart.tsx
@@ -66,8 +66,6 @@ export function HillChart() {
   const selectNode = useMindmapStore((s) => s.selectNode);
   const selectedNodeId = useMindmapStore((s) => s.selectedNodeId);
   const getVisibleNodes = useMindmapStore((s) => s.getVisibleNodes);
-  const focusNodeId = useMindmapStore((s) => s.focusNodeId);
-  const maxDepth = useMindmapStore((s) => s.maxDepth);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
 
@@ -75,12 +73,18 @@ export function HillChart() {
   const [dragging, setDragging] = useState<string | null>(null);
   const [hovered, setHovered] = useState<string | null>(null);
 
-  // Top-level branches (direct children of the effective root), taken from
-  // the store's visible-node set so the active version/sprint filters and
-  // drill-down scope apply — same data basis as ListView/CalendarView.
+  // Top-level branches (direct children of the map root), taken from the
+  // store's scope walk so the active version/sprint filters apply (incl.
+  // tag inheritance + ancestor connect). Drill-down focus, depth limit,
+  // and collapse state deliberately do NOT apply — the hill always shows
+  // the root branches, exactly as before the filter fix.
   const branches: HillBranch[] = useMemo(
-    () => selectHillBranches(getVisibleNodes(), computed),
-    [nodes, rootNodeId, computed, getVisibleNodes, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter],
+    () =>
+      selectHillBranches(
+        getVisibleNodes({ respectFocus: false, respectDepth: false, respectCollapsed: false }),
+        computed,
+      ),
+    [nodes, rootNodeId, computed, getVisibleNodes, activeVersionFilter, activeCycleFilter],
   );
 
   const maxEffort = branches.length > 0 ? Math.max(...branches.map((b) => b.computed.computedEffort)) : 0;

--- a/packages/mindmap/src/HillChart.tsx
+++ b/packages/mindmap/src/HillChart.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useMindmapStore } from './store.js';
-import type { Node, ComputedNodeValues } from '@mindblown/core';
+import { selectHillBranches } from './viewScope.js';
+import type { HillBranch } from './viewScope.js';
 
 // ── Hill curve math ─────────────────────────────────────────────
 
@@ -57,12 +58,6 @@ function dotRadius(effort: number, maxEffort: number): number {
 
 // ── Component ────────────────────────────────────────────────────
 
-interface BranchDot {
-  node: Node;
-  computed: ComputedNodeValues;
-  hillPosition: number; // 0-100
-}
-
 export function HillChart() {
   const nodes = useMindmapStore((s) => s.nodes);
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
@@ -70,33 +65,23 @@ export function HillChart() {
   const updateNode = useMindmapStore((s) => s.updateNode);
   const selectNode = useMindmapStore((s) => s.selectNode);
   const selectedNodeId = useMindmapStore((s) => s.selectedNodeId);
+  const getVisibleNodes = useMindmapStore((s) => s.getVisibleNodes);
+  const focusNodeId = useMindmapStore((s) => s.focusNodeId);
+  const maxDepth = useMindmapStore((s) => s.maxDepth);
+  const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
+  const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
 
   const svgRef = useRef<SVGSVGElement>(null);
   const [dragging, setDragging] = useState<string | null>(null);
   const [hovered, setHovered] = useState<string | null>(null);
 
-  // Get top-level branches (direct children of root)
-  const branches: BranchDot[] = [];
-  if (rootNodeId && nodes[rootNodeId]) {
-    const root = nodes[rootNodeId];
-    let maxEffort = 0;
-
-    // First pass: collect and find max effort
-    const rawBranches: { node: Node; computed: ComputedNodeValues; hillPosition: number }[] = [];
-    for (const childId of root.childrenIds) {
-      const child = nodes[childId];
-      const comp = computed.get(childId);
-      if (!child || !comp) continue;
-
-      const hp = (child.customFields?.hillPosition as number) ?? 0;
-      rawBranches.push({ node: child, computed: comp, hillPosition: hp });
-      if (comp.computedEffort > maxEffort) maxEffort = comp.computedEffort;
-    }
-
-    for (const b of rawBranches) {
-      branches.push(b);
-    }
-  }
+  // Top-level branches (direct children of the effective root), taken from
+  // the store's visible-node set so the active version/sprint filters and
+  // drill-down scope apply — same data basis as ListView/CalendarView.
+  const branches: HillBranch[] = useMemo(
+    () => selectHillBranches(getVisibleNodes(), computed),
+    [nodes, rootNodeId, computed, getVisibleNodes, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter],
+  );
 
   const maxEffort = branches.length > 0 ? Math.max(...branches.map((b) => b.computed.computedEffort)) : 0;
 
@@ -360,7 +345,9 @@ export function HillChart() {
               fill="#94a3b8"
               fontSize="14"
             >
-              No top-level branches to display. Add children to the root node.
+              {activeVersionFilter || activeCycleFilter
+                ? 'No branches match the active filter.'
+                : 'No top-level branches to display. Add children to the root node.'}
             </text>
           )}
         </svg>

--- a/packages/mindmap/src/WorkloadView.tsx
+++ b/packages/mindmap/src/WorkloadView.tsx
@@ -1,34 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useMindmapStore } from './store.js';
-import type { Node } from '@mindblown/core';
-
-// ── Types ────────────────────────────────────────────────────────
-
-interface AssigneeWorkload {
-  assigneeId: string;
-  todo: number;
-  inProgress: number;
-  done: number;
-  total: number;
-  tasksByStatus: {
-    status: 'todo' | 'in_progress' | 'done';
-    nodes: Node[];
-  }[];
-}
-
-// ── Status category mapping ──────────────────────────────────────
-
-function statusCategory(node: Node, statusWorkflow: { id: string; name: string; category: string }[]): 'todo' | 'in_progress' | 'done' {
-  if (!node.status) return 'todo';
-  const def = statusWorkflow.find((s) => s.id === node.status || s.name === node.status);
-  if (def) return def.category as 'todo' | 'in_progress' | 'done';
-
-  // Fallback heuristics
-  const lower = node.status.toLowerCase();
-  if (lower === 'done' || lower === 'completed' || lower === 'closed') return 'done';
-  if (lower === 'in_progress' || lower === 'in progress' || lower === 'active' || lower === 'doing') return 'in_progress';
-  return 'todo';
-}
+import { computeWorkloads } from './viewScope.js';
 
 // ── Colors ───────────────────────────────────────────────────────
 
@@ -51,6 +23,12 @@ export function WorkloadView() {
   const currentMap = useMindmapStore((s) => s.currentMap);
   const selectNode = useMindmapStore((s) => s.selectNode);
   const setActiveView = useMindmapStore((s) => s.setActiveView);
+  const getVisibleNodes = useMindmapStore((s) => s.getVisibleNodes);
+  const rootNodeId = useMindmapStore((s) => s.rootNodeId);
+  const focusNodeId = useMindmapStore((s) => s.focusNodeId);
+  const maxDepth = useMindmapStore((s) => s.maxDepth);
+  const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
+  const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
 
   const [capacity, setCapacity] = useState(40);
   const [editingCapacity, setEditingCapacity] = useState(false);
@@ -59,60 +37,13 @@ export function WorkloadView() {
 
   const statusWorkflow = currentMap?.statusWorkflow ?? [];
 
-  // Compute workloads from leaf nodes
-  const workloads = useMemo(() => {
-    const map = new Map<string, { todo: number; inProgress: number; done: number; todoNodes: Node[]; ipNodes: Node[]; doneNodes: Node[] }>();
-
-    const allNodes = Object.values(nodes);
-    // Leaf nodes with assignees and effort
-    const leaves = allNodes.filter((n) => n.childrenIds.length === 0);
-
-    for (const leaf of leaves) {
-      if (leaf.assigneeIds.length === 0) continue;
-      const effort = leaf.effortEstimate ?? 0;
-      if (effort === 0) continue;
-
-      const cat = statusCategory(leaf, statusWorkflow);
-
-      for (const assignee of leaf.assigneeIds) {
-        let entry = map.get(assignee);
-        if (!entry) {
-          entry = { todo: 0, inProgress: 0, done: 0, todoNodes: [], ipNodes: [], doneNodes: [] };
-          map.set(assignee, entry);
-        }
-        if (cat === 'todo') {
-          entry.todo += effort;
-          entry.todoNodes.push(leaf);
-        } else if (cat === 'in_progress') {
-          entry.inProgress += effort;
-          entry.ipNodes.push(leaf);
-        } else {
-          entry.done += effort;
-          entry.doneNodes.push(leaf);
-        }
-      }
-    }
-
-    const result: AssigneeWorkload[] = [];
-    for (const [assigneeId, data] of map.entries()) {
-      result.push({
-        assigneeId,
-        todo: data.todo,
-        inProgress: data.inProgress,
-        done: data.done,
-        total: data.todo + data.inProgress + data.done,
-        tasksByStatus: [
-          { status: 'todo', nodes: data.todoNodes },
-          { status: 'in_progress', nodes: data.ipNodes },
-          { status: 'done', nodes: data.doneNodes },
-        ],
-      });
-    }
-
-    // Sort by total effort descending
-    result.sort((a, b) => b.total - a.total);
-    return result;
-  }, [nodes, statusWorkflow]);
+  // Per-assignee effort from the leaf nodes of the store's visible set, so
+  // the active version/sprint filters and drill-down scope apply — same
+  // data basis as ListView/CalendarView.
+  const workloads = useMemo(
+    () => computeWorkloads(getVisibleNodes(), statusWorkflow),
+    [nodes, rootNodeId, getVisibleNodes, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter, statusWorkflow],
+  );
 
   const maxEffort = Math.max(capacity, ...workloads.map((w) => w.total));
 
@@ -238,7 +169,9 @@ export function WorkloadView() {
               fontSize: 13,
             }}
           >
-            No assigned tasks with effort estimates found. Assign tasks and add effort estimates to leaf nodes.
+            {activeVersionFilter || activeCycleFilter
+              ? 'No assigned tasks with effort estimates match the active filter.'
+              : 'No assigned tasks with effort estimates found. Assign tasks and add effort estimates to leaf nodes.'}
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>

--- a/packages/mindmap/src/WorkloadView.tsx
+++ b/packages/mindmap/src/WorkloadView.tsx
@@ -25,8 +25,6 @@ export function WorkloadView() {
   const setActiveView = useMindmapStore((s) => s.setActiveView);
   const getVisibleNodes = useMindmapStore((s) => s.getVisibleNodes);
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
-  const focusNodeId = useMindmapStore((s) => s.focusNodeId);
-  const maxDepth = useMindmapStore((s) => s.maxDepth);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
 
@@ -37,12 +35,18 @@ export function WorkloadView() {
 
   const statusWorkflow = currentMap?.statusWorkflow ?? [];
 
-  // Per-assignee effort from the leaf nodes of the store's visible set, so
-  // the active version/sprint filters and drill-down scope apply — same
-  // data basis as ListView/CalendarView.
+  // Per-assignee effort from the leaf nodes of the store's scope walk, so
+  // the active version/sprint filters apply (incl. tag inheritance +
+  // ancestor connect). Drill-down focus, depth limit, and collapse state
+  // deliberately do NOT apply — the workload always aggregates ALL leaves,
+  // exactly as before the filter fix.
   const workloads = useMemo(
-    () => computeWorkloads(getVisibleNodes(), statusWorkflow),
-    [nodes, rootNodeId, getVisibleNodes, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter, statusWorkflow],
+    () =>
+      computeWorkloads(
+        getVisibleNodes({ respectFocus: false, respectDepth: false, respectCollapsed: false }),
+        statusWorkflow,
+      ),
+    [nodes, rootNodeId, getVisibleNodes, activeVersionFilter, activeCycleFilter, statusWorkflow],
   );
 
   const maxEffort = Math.max(capacity, ...workloads.map((w) => w.total));

--- a/packages/mindmap/src/__tests__/viewScope.test.ts
+++ b/packages/mindmap/src/__tests__/viewScope.test.ts
@@ -247,6 +247,33 @@ describe('scope-only getVisibleNodes as the data basis for HillChart/WorkloadVie
     });
   });
 
+  describe('combined and non-matching filters', () => {
+    it('version + cycle filter combine with AND semantics (both view data bases)', () => {
+      useMindmapStore.setState({ activeVersionFilter: 'v1', activeCycleFilter: 'c1' });
+      // Only b1 matches both: versionId v1 AND cycleId c1.
+      // a1 inherits v1 from epicA but has no cycle → no c1 match → out.
+      // epicB survives only as b1's connecting ancestor.
+      expect(scopeIds().sort()).toEqual(['b1', 'epicB', 'root']);
+
+      expect(hillBranchIds()).toEqual(['epicB']);
+
+      const w = workloadsNow();
+      expect(w.map((x) => x.assigneeId)).toEqual(['alice']);
+      expect(w[0]).toMatchObject({ todo: 0, inProgress: 0, done: 2, total: 2 });
+      // The connecting ancestor epicB must not contribute (it is no leaf).
+      expect(
+        w.flatMap((x) => x.tasksByStatus.flatMap((g) => g.nodes.map((n) => n.id))),
+      ).toEqual(['b1']);
+    });
+
+    it('a filter matching nothing empties both view data bases', () => {
+      useMindmapStore.setState({ activeVersionFilter: 'v999' });
+      expect(scopeIds()).toEqual([]);
+      expect(hillBranchIds()).toEqual([]);
+      expect(workloadsNow()).toEqual([]);
+    });
+  });
+
   describe('default getVisibleNodes() semantics stay intact for existing callers', () => {
     it('respects maxDepth by default', () => {
       useMindmapStore.setState({ maxDepth: 1 });

--- a/packages/mindmap/src/__tests__/viewScope.test.ts
+++ b/packages/mindmap/src/__tests__/viewScope.test.ts
@@ -21,6 +21,13 @@ if (typeof globalThis.localStorage === 'undefined') {
 
 const { useMindmapStore } = await import('../store.js');
 
+/**
+ * How HillChart/WorkloadView call the store's scope walk: only the
+ * version/sprint filter applies; drill-down focus, depth limit, and
+ * collapse state must NOT cut the aggregate views' data basis.
+ */
+const SCOPE_ONLY = { respectFocus: false, respectDepth: false, respectCollapsed: false } as const;
+
 // ── Fixtures ─────────────────────────────────────────────────────
 
 function makeNode(id: string, parentId: string | null, overrides: Partial<Node> = {}): Node {
@@ -115,39 +122,60 @@ function setStoreState(overrides: Record<string, unknown> = {}) {
     computed: computeTree(Object.values(nodes)),
     focusNodeId: null,
     focusHistory: [],
-    maxDepth: 0, // unlimited — the aggregate views care about deep leaves
+    maxDepth: 0,
     activeVersionFilter: null,
     activeCycleFilter: null,
-    ...overrides,
   });
+  if (Object.keys(overrides).length > 0) {
+    useMindmapStore.setState(overrides);
+  }
 }
 
-const visibleIds = () =>
+/** Patch one fixture node in place (e.g. flip `collapsed`). */
+function patchNode(id: string, patch: Partial<Node>) {
+  const nodes = useMindmapStore.getState().nodes;
+  useMindmapStore.setState({ nodes: { ...nodes, [id]: { ...nodes[id], ...patch } } });
+}
+
+const scopeIds = () =>
   useMindmapStore
     .getState()
-    .getVisibleNodes()
-    .filter((v) => !v.isDimmed)
+    .getVisibleNodes(SCOPE_ONLY)
     .map((v) => v.node.id);
 
-describe('getVisibleNodes as the data basis for HillChart/WorkloadView', () => {
+const hillBranchIds = () =>
+  selectHillBranches(
+    useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY),
+    useMindmapStore.getState().computed,
+  ).map((b) => b.node.id);
+
+const workflow = [
+  { id: 'todo', name: 'To Do', category: 'todo' },
+  { id: 'in_progress', name: 'In Progress', category: 'in_progress' },
+  { id: 'done', name: 'Done', category: 'done' },
+];
+
+const workloadsNow = () =>
+  computeWorkloads(useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY), workflow);
+
+describe('scope-only getVisibleNodes as the data basis for HillChart/WorkloadView', () => {
   beforeEach(() => setStoreState());
 
   it('without filters, every node is in scope', () => {
-    expect(visibleIds().sort()).toEqual(['a1', 'a2', 'b1', 'b2', 'epicA', 'epicB', 'root']);
+    expect(scopeIds().sort()).toEqual(['a1', 'a2', 'b1', 'b2', 'epicA', 'epicB', 'root']);
   });
 
   it('active version filter keeps only nodes of that version, incl. scope inheritance and connecting ancestors', () => {
     useMindmapStore.setState({ activeVersionFilter: 'v1' });
-    const ids = visibleIds().sort();
     // a1 inherits v1 from epicA; a2 overrides with v2 → out.
     // b1 is tagged v1 directly; epicB survives only as its connecting ancestor; b2 → out.
-    expect(ids).toEqual(['a1', 'b1', 'epicA', 'epicB', 'root']);
+    expect(scopeIds().sort()).toEqual(['a1', 'b1', 'epicA', 'epicB', 'root']);
   });
 
   describe('HillChart branch selection', () => {
     it('shows all top-level branches without filters', () => {
       const branches = selectHillBranches(
-        useMindmapStore.getState().getVisibleNodes(),
+        useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY),
         useMindmapStore.getState().computed,
       );
       expect(branches.map((b) => b.node.id)).toEqual(['epicA', 'epicB']);
@@ -159,46 +187,25 @@ describe('getVisibleNodes as the data basis for HillChart/WorkloadView', () => {
 
     it('drops branches outside the active version filter', () => {
       useMindmapStore.setState({ activeVersionFilter: 'v2' });
-      const branches = selectHillBranches(
-        useMindmapStore.getState().getVisibleNodes(),
-        useMindmapStore.getState().computed,
-      );
       // Only epicA contains a v2 node (a2); epicB has none.
-      expect(branches.map((b) => b.node.id)).toEqual(['epicA']);
+      expect(hillBranchIds()).toEqual(['epicA']);
     });
 
     it('drops branches outside the active cycle filter', () => {
       useMindmapStore.setState({ activeCycleFilter: 'c1' });
-      const branches = selectHillBranches(
-        useMindmapStore.getState().getVisibleNodes(),
-        useMindmapStore.getState().computed,
-      );
       // Only b1 is in sprint c1 → epicB survives as its ancestor branch.
-      expect(branches.map((b) => b.node.id)).toEqual(['epicB']);
+      expect(hillBranchIds()).toEqual(['epicB']);
     });
 
-    it('excludes dimmed drill-down context siblings', () => {
-      useMindmapStore.setState({ focusNodeId: 'epicA' });
-      const branches = selectHillBranches(
-        useMindmapStore.getState().getVisibleNodes(),
-        useMindmapStore.getState().computed,
-      );
-      // Focused on epicA: its children are the depth-1 branches; the dimmed
-      // sibling epicB must not leak in.
-      expect(branches.map((b) => b.node.id)).toEqual(['a1', 'a2']);
+    it('keeps showing the root branches under drill-down focus, depth limit, and collapse', () => {
+      useMindmapStore.setState({ focusNodeId: 'epicA', maxDepth: 1 });
+      patchNode('epicA', { collapsed: true });
+      // Unchanged: the hill is root-branch level regardless of drill-down state.
+      expect(hillBranchIds()).toEqual(['epicA', 'epicB']);
     });
   });
 
   describe('Workload aggregation', () => {
-    const workflow = [
-      { id: 'todo', name: 'To Do', category: 'todo' },
-      { id: 'in_progress', name: 'In Progress', category: 'in_progress' },
-      { id: 'done', name: 'Done', category: 'done' },
-    ];
-
-    const workloadsNow = () =>
-      computeWorkloads(useMindmapStore.getState().getVisibleNodes(), workflow);
-
     it('aggregates all assigned leaves without filters', () => {
       const w = workloadsNow();
       expect(w.map((x) => x.assigneeId)).toEqual(['bob', 'alice']); // sorted by total desc
@@ -213,9 +220,8 @@ describe('getVisibleNodes as the data basis for HillChart/WorkloadView', () => {
       const w = workloadsNow();
       // bob's leaves (a2: v2, b2: untagged) are out of scope entirely.
       expect(w.map((x) => x.assigneeId)).toEqual(['alice']);
-      const alice = w[0];
       // a1 (5h, inherits v1 from epicA) + b1 (2h, tagged v1 directly)
-      expect(alice).toMatchObject({ todo: 5, inProgress: 0, done: 2, total: 7 });
+      expect(w[0]).toMatchObject({ todo: 5, inProgress: 0, done: 2, total: 7 });
       // The surviving ancestor epicB must not contribute (it is no leaf).
       expect(
         w.flatMap((x) => x.tasksByStatus.flatMap((g) => g.nodes.map((n) => n.id))).sort(),
@@ -227,6 +233,51 @@ describe('getVisibleNodes as the data basis for HillChart/WorkloadView', () => {
       const w = workloadsNow();
       expect(w.map((x) => x.assigneeId)).toEqual(['alice']);
       expect(w[0]).toMatchObject({ todo: 0, inProgress: 0, done: 2, total: 2 });
+    });
+
+    it('keeps aggregating ALL leaves under drill-down focus, depth limit, and collapse', () => {
+      useMindmapStore.setState({ focusNodeId: 'epicA', maxDepth: 1 });
+      patchNode('epicB', { collapsed: true });
+      const w = workloadsNow();
+      // Unchanged from the unfiltered case: deep, collapsed, or out-of-focus
+      // leaves must not vanish from the workload bars.
+      expect(w.map((x) => x.assigneeId)).toEqual(['bob', 'alice']);
+      expect(w.find((x) => x.assigneeId === 'bob')!.total).toBe(11);
+      expect(w.find((x) => x.assigneeId === 'alice')!.total).toBe(7);
+    });
+  });
+
+  describe('default getVisibleNodes() semantics stay intact for existing callers', () => {
+    it('respects maxDepth by default', () => {
+      useMindmapStore.setState({ maxDepth: 1 });
+      const ids = useMindmapStore
+        .getState()
+        .getVisibleNodes()
+        .map((v) => v.node.id)
+        .sort();
+      expect(ids).toEqual(['epicA', 'epicB', 'root']); // leaves cut at depth 1
+    });
+
+    it('respects collapse by default', () => {
+      patchNode('epicA', { collapsed: true });
+      const ids = useMindmapStore
+        .getState()
+        .getVisibleNodes()
+        .map((v) => v.node.id)
+        .sort();
+      expect(ids).toEqual(['b1', 'b2', 'epicA', 'epicB', 'root']); // a1/a2 hidden
+    });
+
+    it('respects drill-down focus by default (incl. dimmed context siblings)', () => {
+      useMindmapStore.setState({ focusNodeId: 'epicA' });
+      const vns = useMindmapStore.getState().getVisibleNodes();
+      expect(
+        vns
+          .filter((v) => !v.isDimmed)
+          .map((v) => v.node.id)
+          .sort(),
+      ).toEqual(['a1', 'a2', 'epicA']);
+      expect(vns.filter((v) => v.isDimmed).map((v) => v.node.id)).toEqual(['epicB']);
     });
   });
 });

--- a/packages/mindmap/src/__tests__/viewScope.test.ts
+++ b/packages/mindmap/src/__tests__/viewScope.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { computeTree } from '@mindblown/core';
+import type { Node } from '@mindblown/core';
+import { selectHillBranches, computeWorkloads } from '../viewScope.js';
+
+// The store module reads localStorage at import time (auth-token bootstrap);
+// shim it for the node test environment BEFORE the dynamic import below.
+if (typeof globalThis.localStorage === 'undefined') {
+  const mem = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => void mem.set(k, String(v)),
+    removeItem: (k: string) => void mem.delete(k),
+    clear: () => mem.clear(),
+    key: () => null,
+    get length() {
+      return mem.size;
+    },
+  } as Storage;
+}
+
+const { useMindmapStore } = await import('../store.js');
+
+// ── Fixtures ─────────────────────────────────────────────────────
+
+function makeNode(id: string, parentId: string | null, overrides: Partial<Node> = {}): Node {
+  return {
+    id,
+    mapId: 'm1',
+    parentId,
+    childrenIds: [],
+    text: id,
+    description: null,
+    x: null,
+    y: null,
+    collapsed: false,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    blockedReason: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    customFields: {},
+    dependencies: [],
+    versionId: null,
+    cycleId: null,
+    externalLinks: [],
+    priorityRank: null,
+    completedAt: null,
+    claimedBySession: null,
+    claimedAt: null,
+    scopes: [],
+    linkedPr: null,
+    requirementId: null,
+    requirementPriority: null,
+    requirementText: null,
+    autoProgress: 'off',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    createdBy: 'u1',
+    revision: 1,
+    deletedAt: null,
+    ...overrides,
+  } as Node;
+}
+
+/**
+ * Tree:
+ *   root
+ *   ├─ epicA (versionId v1)
+ *   │   ├─ a1  leaf — no own tag → inherits v1; alice, 5h, todo
+ *   │   └─ a2  leaf — versionId v2 (overrides); bob, 3h, in_progress
+ *   └─ epicB (untagged)
+ *       ├─ b1  leaf — versionId v1, cycleId c1; alice, 2h, done
+ *       └─ b2  leaf — untagged; bob, 8h, todo
+ */
+function buildFixture(): Record<string, Node> {
+  const nodes: Record<string, Node> = {
+    root: makeNode('root', null, { childrenIds: ['epicA', 'epicB'] }),
+    epicA: makeNode('epicA', 'root', {
+      childrenIds: ['a1', 'a2'],
+      versionId: 'v1',
+      customFields: { hillPosition: 30 },
+    }),
+    epicB: makeNode('epicB', 'root', { childrenIds: ['b1', 'b2'] }),
+    a1: makeNode('a1', 'epicA', { assigneeIds: ['alice'], effortEstimate: 5 }),
+    a2: makeNode('a2', 'epicA', {
+      versionId: 'v2',
+      assigneeIds: ['bob'],
+      effortEstimate: 3,
+      status: 'in_progress',
+    }),
+    b1: makeNode('b1', 'epicB', {
+      versionId: 'v1',
+      cycleId: 'c1',
+      assigneeIds: ['alice'],
+      effortEstimate: 2,
+      status: 'done',
+      percentComplete: 100,
+    }),
+    b2: makeNode('b2', 'epicB', { assigneeIds: ['bob'], effortEstimate: 8 }),
+  };
+  return nodes;
+}
+
+function setStoreState(overrides: Record<string, unknown> = {}) {
+  const nodes = buildFixture();
+  useMindmapStore.setState({
+    nodes,
+    rootNodeId: 'root',
+    computed: computeTree(Object.values(nodes)),
+    focusNodeId: null,
+    focusHistory: [],
+    maxDepth: 0, // unlimited — the aggregate views care about deep leaves
+    activeVersionFilter: null,
+    activeCycleFilter: null,
+    ...overrides,
+  });
+}
+
+const visibleIds = () =>
+  useMindmapStore
+    .getState()
+    .getVisibleNodes()
+    .filter((v) => !v.isDimmed)
+    .map((v) => v.node.id);
+
+describe('getVisibleNodes as the data basis for HillChart/WorkloadView', () => {
+  beforeEach(() => setStoreState());
+
+  it('without filters, every node is in scope', () => {
+    expect(visibleIds().sort()).toEqual(['a1', 'a2', 'b1', 'b2', 'epicA', 'epicB', 'root']);
+  });
+
+  it('active version filter keeps only nodes of that version, incl. scope inheritance and connecting ancestors', () => {
+    useMindmapStore.setState({ activeVersionFilter: 'v1' });
+    const ids = visibleIds().sort();
+    // a1 inherits v1 from epicA; a2 overrides with v2 → out.
+    // b1 is tagged v1 directly; epicB survives only as its connecting ancestor; b2 → out.
+    expect(ids).toEqual(['a1', 'b1', 'epicA', 'epicB', 'root']);
+  });
+
+  describe('HillChart branch selection', () => {
+    it('shows all top-level branches without filters', () => {
+      const branches = selectHillBranches(
+        useMindmapStore.getState().getVisibleNodes(),
+        useMindmapStore.getState().computed,
+      );
+      expect(branches.map((b) => b.node.id)).toEqual(['epicA', 'epicB']);
+      expect(branches[0].hillPosition).toBe(30); // customFields passthrough
+      expect(branches[1].hillPosition).toBe(0); // default
+      // Aggregates come from computeTree, over the branch subtree
+      expect(branches[0].computed.computedEffort).toBe(8); // a1 5h + a2 3h
+    });
+
+    it('drops branches outside the active version filter', () => {
+      useMindmapStore.setState({ activeVersionFilter: 'v2' });
+      const branches = selectHillBranches(
+        useMindmapStore.getState().getVisibleNodes(),
+        useMindmapStore.getState().computed,
+      );
+      // Only epicA contains a v2 node (a2); epicB has none.
+      expect(branches.map((b) => b.node.id)).toEqual(['epicA']);
+    });
+
+    it('drops branches outside the active cycle filter', () => {
+      useMindmapStore.setState({ activeCycleFilter: 'c1' });
+      const branches = selectHillBranches(
+        useMindmapStore.getState().getVisibleNodes(),
+        useMindmapStore.getState().computed,
+      );
+      // Only b1 is in sprint c1 → epicB survives as its ancestor branch.
+      expect(branches.map((b) => b.node.id)).toEqual(['epicB']);
+    });
+
+    it('excludes dimmed drill-down context siblings', () => {
+      useMindmapStore.setState({ focusNodeId: 'epicA' });
+      const branches = selectHillBranches(
+        useMindmapStore.getState().getVisibleNodes(),
+        useMindmapStore.getState().computed,
+      );
+      // Focused on epicA: its children are the depth-1 branches; the dimmed
+      // sibling epicB must not leak in.
+      expect(branches.map((b) => b.node.id)).toEqual(['a1', 'a2']);
+    });
+  });
+
+  describe('Workload aggregation', () => {
+    const workflow = [
+      { id: 'todo', name: 'To Do', category: 'todo' },
+      { id: 'in_progress', name: 'In Progress', category: 'in_progress' },
+      { id: 'done', name: 'Done', category: 'done' },
+    ];
+
+    const workloadsNow = () =>
+      computeWorkloads(useMindmapStore.getState().getVisibleNodes(), workflow);
+
+    it('aggregates all assigned leaves without filters', () => {
+      const w = workloadsNow();
+      expect(w.map((x) => x.assigneeId)).toEqual(['bob', 'alice']); // sorted by total desc
+      const bob = w.find((x) => x.assigneeId === 'bob')!;
+      expect(bob.total).toBe(11); // a2 3h + b2 8h
+      const alice = w.find((x) => x.assigneeId === 'alice')!;
+      expect(alice).toMatchObject({ todo: 5, inProgress: 0, done: 2, total: 7 });
+    });
+
+    it('with an active version filter, only leaves of that version contribute (incl. inheritance)', () => {
+      useMindmapStore.setState({ activeVersionFilter: 'v1' });
+      const w = workloadsNow();
+      // bob's leaves (a2: v2, b2: untagged) are out of scope entirely.
+      expect(w.map((x) => x.assigneeId)).toEqual(['alice']);
+      const alice = w[0];
+      // a1 (5h, inherits v1 from epicA) + b1 (2h, tagged v1 directly)
+      expect(alice).toMatchObject({ todo: 5, inProgress: 0, done: 2, total: 7 });
+      // The surviving ancestor epicB must not contribute (it is no leaf).
+      expect(
+        w.flatMap((x) => x.tasksByStatus.flatMap((g) => g.nodes.map((n) => n.id))).sort(),
+      ).toEqual(['a1', 'b1']);
+    });
+
+    it('with an active cycle filter, only leaves of that sprint contribute', () => {
+      useMindmapStore.setState({ activeCycleFilter: 'c1' });
+      const w = workloadsNow();
+      expect(w.map((x) => x.assigneeId)).toEqual(['alice']);
+      expect(w[0]).toMatchObject({ todo: 0, inProgress: 0, done: 2, total: 2 });
+    });
+  });
+});

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -27,6 +27,23 @@ export interface VisibleNode {
 }
 
 /**
+ * Options for getVisibleNodes(). All default to true (full drill-down
+ * semantics — what the tree-shaped views want). Aggregate views (Hill
+ * Chart, Workload) pass all three as false so ONLY the version/sprint
+ * scope walk (incl. tag inheritance + ancestor connect) applies, and
+ * drill-down focus, depth limit, and collapse state don't cut their
+ * data basis.
+ */
+export interface VisibleNodesOptions {
+  /** Walk from the drill-down focus node and append dimmed context siblings. */
+  respectFocus?: boolean;
+  /** Truncate the walk at the maxDepth level (0 = unlimited). */
+  respectDepth?: boolean;
+  /** Don't descend into collapsed nodes. */
+  respectCollapsed?: boolean;
+}
+
+/**
  * Live presence info for another user on this map.
  * Broadcast over WebSocket; viewport is encoded as a logical SVG center
  * (cx, cy) + zoom so it survives different window sizes.
@@ -147,7 +164,7 @@ export interface MindmapState {
 
   // Presence / follow mode actions
   setFollowingUser: (userId: string | null) => void;
-  getVisibleNodes: () => VisibleNode[];
+  getVisibleNodes: (options?: VisibleNodesOptions) => VisibleNode[];
   getFocusBreadcrumb: () => Array<{ id: string; text: string }>;
 
   // Helpers
@@ -576,11 +593,12 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
 
   setFollowingUser: (userId) => set({ followingUserId: userId }),
 
-  getVisibleNodes: () => {
+  getVisibleNodes: (options) => {
+    const { respectFocus = true, respectDepth = true, respectCollapsed = true } = options ?? {};
     const { nodes, rootNodeId, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter } = get();
     if (!rootNodeId) return [];
 
-    const effectiveRootId = focusNodeId ?? rootNodeId;
+    const effectiveRootId = (respectFocus ? focusNodeId : null) ?? rootNodeId;
     const effectiveRoot = nodes[effectiveRootId];
     if (!effectiveRoot) return [];
 
@@ -658,7 +676,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       const visibleChildren = filterMatchIds
         ? node.childrenIds.filter((id) => filterMatchIds!.has(id))
         : node.childrenIds;
-      const atMaxDepth = maxDepth > 0 && depth >= maxDepth;
+      const atMaxDepth = respectDepth && maxDepth > 0 && depth >= maxDepth;
       const hasChildren = visibleChildren.length > 0;
       const hasHiddenChildren = atMaxDepth && hasChildren;
       const hiddenDescendantCount = hasHiddenChildren ? countDescendants(nodeId) : 0;
@@ -672,7 +690,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       });
 
       // Don't recurse past maxDepth (0 = unlimited)
-      if (!atMaxDepth && !node.collapsed) {
+      if (!atMaxDepth && (!respectCollapsed || !node.collapsed)) {
         for (const childId of visibleChildren) {
           walk(childId, depth + 1);
         }
@@ -682,7 +700,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
     walk(effectiveRootId, 0);
 
     // If we have a focus node (not the actual root), add dimmed siblings for context
-    if (focusNodeId && focusNodeId !== rootNodeId) {
+    if (respectFocus && focusNodeId && focusNodeId !== rootNodeId) {
       const focusNode = nodes[focusNodeId];
       if (focusNode?.parentId) {
         const parent = nodes[focusNode.parentId];

--- a/packages/mindmap/src/viewScope.ts
+++ b/packages/mindmap/src/viewScope.ts
@@ -1,0 +1,162 @@
+import type { Node, ComputedNodeValues } from '@mindblown/core';
+
+/**
+ * Pure selection helpers for the secondary views (Hill Chart, Workload).
+ *
+ * Both views used to read the raw `s.nodes` record and therefore ignored
+ * the active version / sprint filters entirely (filter chip visible, view
+ * still showing everything). They now consume the store's
+ * `getVisibleNodes()` output — the same filtered set ListView and
+ * CalendarView are built on — and these helpers derive each view's data
+ * basis from it. Kept as pure functions (no store import) so they are
+ * unit-testable without a DOM or the zustand store machinery.
+ */
+
+/**
+ * Structural subset of the store's `VisibleNode` that these helpers need.
+ * The store's type satisfies it; tests can build it from `getVisibleNodes()`
+ * or by hand.
+ */
+export interface ScopedVisibleNode {
+  node: Node;
+  depth: number; // relative to the effective root (drill-down focus or map root)
+  isDimmed: boolean; // sibling branches shown only for drill-down context
+}
+
+// ── Hill Chart ───────────────────────────────────────────────────
+
+export interface HillBranch {
+  node: Node;
+  computed: ComputedNodeValues;
+  hillPosition: number; // 0-100
+}
+
+/**
+ * Select the Hill Chart dots from the visible-node set.
+ *
+ * Depth 1 = direct children of the effective root (the drill-down focus,
+ * or the map root when not drilled down). Dimmed context siblings and
+ * nodes outside the active version/sprint filter are already excluded
+ * from `visibleNodes`, so the hill only shows in-scope branches.
+ * Preserves the sibling order `getVisibleNodes()` emits (= childrenIds
+ * order).
+ */
+export function selectHillBranches(
+  visibleNodes: ScopedVisibleNode[],
+  computed: Map<string, ComputedNodeValues>,
+): HillBranch[] {
+  const branches: HillBranch[] = [];
+  for (const vn of visibleNodes) {
+    if (vn.isDimmed || vn.depth !== 1) continue;
+    const comp = computed.get(vn.node.id);
+    if (!comp) continue;
+    const hp = (vn.node.customFields?.hillPosition as number) ?? 0;
+    branches.push({ node: vn.node, computed: comp, hillPosition: hp });
+  }
+  return branches;
+}
+
+// ── Workload ─────────────────────────────────────────────────────
+
+export type StatusCategoryId = 'todo' | 'in_progress' | 'done';
+
+export interface StatusWorkflowStep {
+  id: string;
+  name: string;
+  category: string;
+}
+
+export interface AssigneeWorkload {
+  assigneeId: string;
+  todo: number;
+  inProgress: number;
+  done: number;
+  total: number;
+  tasksByStatus: {
+    status: StatusCategoryId;
+    nodes: Node[];
+  }[];
+}
+
+export function statusCategory(
+  node: Node,
+  statusWorkflow: StatusWorkflowStep[],
+): StatusCategoryId {
+  if (!node.status) return 'todo';
+  const def = statusWorkflow.find((s) => s.id === node.status || s.name === node.status);
+  if (def) return def.category as StatusCategoryId;
+
+  // Fallback heuristics
+  const lower = node.status.toLowerCase();
+  if (lower === 'done' || lower === 'completed' || lower === 'closed') return 'done';
+  if (lower === 'in_progress' || lower === 'in progress' || lower === 'active' || lower === 'doing') return 'in_progress';
+  return 'todo';
+}
+
+/**
+ * Aggregate per-assignee effort from the leaf nodes of the visible set.
+ *
+ * A leaf is a node without children (raw `childrenIds`, same notion
+ * CalendarView uses); dimmed drill-down context siblings are skipped.
+ * Only leaves that survived the active version/sprint filter contribute,
+ * so the Workload bars reflect the same scope the filter chip announces.
+ * Result is sorted by total effort descending.
+ */
+export function computeWorkloads(
+  visibleNodes: ScopedVisibleNode[],
+  statusWorkflow: StatusWorkflowStep[],
+): AssigneeWorkload[] {
+  const map = new Map<
+    string,
+    { todo: number; inProgress: number; done: number; todoNodes: Node[]; ipNodes: Node[]; doneNodes: Node[] }
+  >();
+
+  for (const vn of visibleNodes) {
+    if (vn.isDimmed) continue;
+    const leaf = vn.node;
+    if (leaf.childrenIds.length !== 0) continue;
+    if (leaf.assigneeIds.length === 0) continue;
+    const effort = leaf.effortEstimate ?? 0;
+    if (effort === 0) continue;
+
+    const cat = statusCategory(leaf, statusWorkflow);
+
+    for (const assignee of leaf.assigneeIds) {
+      let entry = map.get(assignee);
+      if (!entry) {
+        entry = { todo: 0, inProgress: 0, done: 0, todoNodes: [], ipNodes: [], doneNodes: [] };
+        map.set(assignee, entry);
+      }
+      if (cat === 'todo') {
+        entry.todo += effort;
+        entry.todoNodes.push(leaf);
+      } else if (cat === 'in_progress') {
+        entry.inProgress += effort;
+        entry.ipNodes.push(leaf);
+      } else {
+        entry.done += effort;
+        entry.doneNodes.push(leaf);
+      }
+    }
+  }
+
+  const result: AssigneeWorkload[] = [];
+  for (const [assigneeId, data] of map.entries()) {
+    result.push({
+      assigneeId,
+      todo: data.todo,
+      inProgress: data.inProgress,
+      done: data.done,
+      total: data.todo + data.inProgress + data.done,
+      tasksByStatus: [
+        { status: 'todo', nodes: data.todoNodes },
+        { status: 'in_progress', nodes: data.ipNodes },
+        { status: 'done', nodes: data.doneNodes },
+      ],
+    });
+  }
+
+  // Sort by total effort descending
+  result.sort((a, b) => b.total - a.total);
+  return result;
+}

--- a/packages/mindmap/src/viewScope.ts
+++ b/packages/mindmap/src/viewScope.ts
@@ -5,11 +5,14 @@ import type { Node, ComputedNodeValues } from '@mindblown/core';
  *
  * Both views used to read the raw `s.nodes` record and therefore ignored
  * the active version / sprint filters entirely (filter chip visible, view
- * still showing everything). They now consume the store's
- * `getVisibleNodes()` output — the same filtered set ListView and
- * CalendarView are built on — and these helpers derive each view's data
- * basis from it. Kept as pure functions (no store import) so they are
- * unit-testable without a DOM or the zustand store machinery.
+ * still showing everything). They now consume the output of
+ * `getVisibleNodes({ respectFocus: false, respectDepth: false,
+ * respectCollapsed: false })` — the store's ONE scope walk with only the
+ * version/sprint filter applied (incl. tag inheritance + ancestor
+ * connect), while drill-down focus, depth limit, and collapse state keep
+ * NOT affecting these aggregate views, exactly as before the filter fix.
+ * Kept as pure functions (no store import) so they are unit-testable
+ * without a DOM or the zustand store machinery.
  */
 
 /**
@@ -34,12 +37,13 @@ export interface HillBranch {
 /**
  * Select the Hill Chart dots from the visible-node set.
  *
- * Depth 1 = direct children of the effective root (the drill-down focus,
- * or the map root when not drilled down). Dimmed context siblings and
- * nodes outside the active version/sprint filter are already excluded
- * from `visibleNodes`, so the hill only shows in-scope branches.
- * Preserves the sibling order `getVisibleNodes()` emits (= childrenIds
- * order).
+ * Depth 1 = direct children of the walk root (the map root, since the
+ * view calls the scope walk with `respectFocus: false`). Nodes outside
+ * the active version/sprint filter are already excluded from
+ * `visibleNodes`, so the hill only shows in-scope branches; dimmed
+ * context siblings are skipped defensively should a caller ever pass a
+ * focus-aware set. Preserves the sibling order `getVisibleNodes()`
+ * emits (= childrenIds order).
  */
 export function selectHillBranches(
   visibleNodes: ScopedVisibleNode[],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.5.2)(tsx@4.21.0)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.2)(tsx@4.21.0)
 
   packages/server:
     dependencies:


### PR DESCRIPTION
HillChart and WorkloadView read raw store nodes and ignored the active version/cycle filters (filter chip visible, view showed everything). The single canonical scope walk in store.getVisibleNodes is now parameterized (respectFocus/respectDepth/respectCollapsed, default true — existing callers unchanged); both views call the scope-only variant, so only the version/cycle filter (incl. inheritance + ancestor-connect) applies and their existing depth/drill-down/collapse behavior is preserved. Pure helpers extracted to viewScope.ts; first vitest setup for the mindmap package; 15 store-driven tests pin default and scope-only semantics incl. combined version+cycle AND-filter and no-match case.

Reviewed by Ray (APPROVE; should-fix test gap closed). Known limitation (pre-existing): HillChart dot radius aggregates the full subtree effort, not the filtered subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6RVBDQptbVQe1cDrHM3AH