### PR TITLE
feat(mindmap): phase filter in FiltersPopover; unify the three scope-walk copies

### DIFF
--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMindmapStore } from './store.js';
 import type { ActiveView } from './store.js';
+import { resolveFilterChip } from './scopeFilter.js';
 import { MindmapEditor } from './MindmapEditor.js';
 import { PropertyPanel } from './PropertyPanel.js';
 import { KanbanView } from './KanbanView.js';
@@ -956,9 +957,11 @@ function FiltersPopover({
   const filterCycle = activeCycleFilter
     ? cycles.find((c) => c.id === activeCycleFilter)
     : null;
-  const filterPhase = activePhaseFilter
-    ? phases.find((p) => p.id === activePhaseFilter)
-    : null;
+  // Keyed on the active id, NOT on whether it still resolves: a phase can
+  // vanish from currentMap.phases under an active filter (WS sync / map
+  // reload) and the chip + "Clear all" must survive as the only UI path
+  // to clearing it — see resolveFilterChip.
+  const filterPhase = resolveFilterChip(activePhaseFilter, phases, '(unknown phase)');
   const activeSprint = cycles.find((c) => c.status === 'active');
   const hasAnyFilter = !!(filterVersion || filterCycle || filterPhase);
 

--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMindmapStore } from './store.js';
 import type { ActiveView } from './store.js';
 import { MindmapEditor } from './MindmapEditor.js';
@@ -906,7 +906,7 @@ function ViewSwitcher({ active, onChange }: { active: ActiveView; onChange: (v: 
   );
 }
 
-// ── Filters Popover (Version + Sprint) ───────────────────────
+// ── Filters Popover (Version + Sprint + Phase) ───────────────
 
 function FiltersPopover({
   versions,
@@ -915,6 +915,9 @@ function FiltersPopover({
   cycles,
   activeCycleFilter,
   onCycleFilterChange,
+  phases,
+  activePhaseFilter,
+  onPhaseFilterChange,
 }: {
   versions: { id: string; name: string; status: string }[];
   activeVersionFilter: string | null;
@@ -922,6 +925,10 @@ function FiltersPopover({
   cycles: { id: string; name: string; status: string; startDate: string; endDate: string }[];
   activeCycleFilter: string | null;
   onCycleFilterChange: (id: string | null) => void;
+  /** PhaseDefs from the current map, already sorted by position. */
+  phases: { id: string; name: string; position: number }[];
+  activePhaseFilter: string | null;
+  onPhaseFilterChange: (id: string | null) => void;
 }) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -949,8 +956,11 @@ function FiltersPopover({
   const filterCycle = activeCycleFilter
     ? cycles.find((c) => c.id === activeCycleFilter)
     : null;
+  const filterPhase = activePhaseFilter
+    ? phases.find((p) => p.id === activePhaseFilter)
+    : null;
   const activeSprint = cycles.find((c) => c.status === 'active');
-  const hasAnyFilter = !!(filterVersion || filterCycle);
+  const hasAnyFilter = !!(filterVersion || filterCycle || filterPhase);
 
   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
   function fmtShort(iso: string): string {
@@ -984,7 +994,7 @@ function FiltersPopover({
     <div ref={wrapRef} style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 6 }}>
       <button
         onClick={() => setOpen((o) => !o)}
-        title="Filter the mindmap by version or sprint"
+        title="Filter the mindmap by version, sprint, or phase"
         style={{
           padding: '3px 10px',
           borderRadius: 4,
@@ -1039,6 +1049,23 @@ function FiltersPopover({
         >
           {filterCycle.name}
           {chipCloseBtn(() => onCycleFilterChange(null), 'Clear sprint filter')}
+        </span>
+      )}
+      {filterPhase && (
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            fontSize: 10,
+            fontWeight: 600,
+            padding: '2px 4px 2px 8px',
+            borderRadius: 4,
+            background: '#fffbeb',
+            color: '#d97706',
+          }}
+        >
+          {filterPhase.name}
+          {chipCloseBtn(() => onPhaseFilterChange(null), 'Clear phase filter')}
         </span>
       )}
 
@@ -1145,11 +1172,42 @@ function FiltersPopover({
             </label>
           )}
 
+          {phases.length > 0 && (
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ color: '#64748b', fontWeight: 600, fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.4 }}>
+                Phase
+              </span>
+              <select
+                value={activePhaseFilter ?? ''}
+                onChange={(e) => onPhaseFilterChange(e.target.value || null)}
+                onKeyDown={(e) => e.stopPropagation()}
+                style={{
+                  fontSize: 12,
+                  fontFamily: 'inherit',
+                  border: '1px solid #e2e8f0',
+                  borderRadius: 4,
+                  padding: '5px 8px',
+                  color: '#0f172a',
+                  background: '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                <option value="">All phases</option>
+                {phases.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
           {hasAnyFilter && (
             <button
               onClick={() => {
                 onVersionFilterChange(null);
                 onCycleFilterChange(null);
+                onPhaseFilterChange(null);
               }}
               style={{
                 marginTop: 2,
@@ -1390,6 +1448,14 @@ export function App() {
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const setActiveVersionFilter = useMindmapStore((s) => s.setActiveVersionFilter);
   const loadVersions = useMindmapStore((s) => s.loadVersions);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
+  const setActivePhaseFilter = useMindmapStore((s) => s.setActivePhaseFilter);
+  // PhaseDefs live on the map itself (statusWorkflow idiom) — sorted by
+  // position, the canonical phase order, for the filter dropdown.
+  const sortedPhases = useMemo(
+    () => [...(currentMap?.phases ?? [])].sort((a, b) => a.position - b.position),
+    [currentMap],
+  );
 
   const loadMaps = useMindmapStore((s) => s.loadMaps);
   const loadMap = useMindmapStore((s) => s.loadMap);
@@ -1854,7 +1920,7 @@ export function App() {
 
           <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
 
-          {/* Combined Version + Sprint filters */}
+          {/* Combined Version + Sprint + Phase filters */}
           <FiltersPopover
             versions={versions}
             activeVersionFilter={activeVersionFilter}
@@ -1862,6 +1928,9 @@ export function App() {
             cycles={cycles}
             activeCycleFilter={activeCycleFilter}
             onCycleFilterChange={setActiveCycleFilter}
+            phases={sortedPhases}
+            activePhaseFilter={activePhaseFilter}
+            onPhaseFilterChange={setActivePhaseFilter}
           />
 
           {/* Sprints panel toggle (opens the right-dock panel — distinct from the sprint filter) */}

--- a/packages/mindmap/src/CalendarView.tsx
+++ b/packages/mindmap/src/CalendarView.tsx
@@ -409,6 +409,7 @@ export function CalendarView() {
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
   const versions = useMindmapStore((s) => s.versions);
   const cycles = useMindmapStore((s) => s.cycles);
 
@@ -577,7 +578,7 @@ export function CalendarView() {
       });
     }
     return result;
-  }, [nodes, computed, today, currentMap, getNodeBreadcrumb, getVisibleNodes, scheduleDates, focusNodeId, maxDepth, rootNodeId, activeVersionFilter, activeCycleFilter]);
+  }, [nodes, computed, today, currentMap, getNodeBreadcrumb, getVisibleNodes, scheduleDates, focusNodeId, maxDepth, rootNodeId, activeVersionFilter, activeCycleFilter, activePhaseFilter]);
 
   // ── Group tasks by date key ─────────────────────────────────
 

--- a/packages/mindmap/src/GanttView.tsx
+++ b/packages/mindmap/src/GanttView.tsx
@@ -7,6 +7,7 @@ import {
   businessDaysBetween,
 } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
+import { collectScopeMatches, hasActiveScopeFilter } from './scopeFilter.js';
 import { fetchSchedule, updateMap as updateMapApi } from './api.js';
 
 // ── Schedule response shape (from GET /api/maps/:id/schedule) ────
@@ -268,6 +269,7 @@ export function GanttView() {
   const selectedNodeId = useMindmapStore((s) => s.selectedNodeId);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
 
   // Local UI state
   const [scale, setScale] = useState<TimeScale>('week');
@@ -413,26 +415,22 @@ export function GanttView() {
   // mindmap silently hide their children from the Gantt (the same bug
   // KanbanView had before v0.7.1).
   //
-  // Version/cycle filters still apply, with ancestor inheritance: if a
-  // parent is tagged V1, its untagged children inherit V1. A subtree is
-  // shown only if the current node matches the active filter.
+  // Version/cycle/phase filters still apply, with ancestor inheritance:
+  // if a parent is tagged V1, its untagged children inherit V1. A subtree
+  // is shown only if the current node matches the active filter (shared
+  // walk in scopeFilter.ts, same semantics as getVisibleNodes).
   const rows = useMemo(() => {
     if (!rootNodeId || !nodes[rootNodeId]) return [];
 
-    const inScope = new Set<string>();
-    if (activeVersionFilter || activeCycleFilter) {
-      const walkScope = (nodeId: string, inheritedVersion: string | null, inheritedCycle: string | null) => {
-        const node = nodes[nodeId];
-        if (!node) return;
-        const effVersion = node.versionId ?? inheritedVersion;
-        const effCycle = node.cycleId ?? inheritedCycle;
-        const matchesVersion = !activeVersionFilter || effVersion === activeVersionFilter;
-        const matchesCycle = !activeCycleFilter || effCycle === activeCycleFilter;
-        if (matchesVersion && matchesCycle) inScope.add(nodeId);
-        for (const cid of node.childrenIds) walkScope(cid, effVersion, effCycle);
-      };
-      walkScope(rootNodeId, null, null);
-    }
+    const scopeFilters = {
+      versionId: activeVersionFilter,
+      cycleId: activeCycleFilter,
+      phaseId: activePhaseFilter,
+    };
+    const scopeFilterActive = hasActiveScopeFilter(scopeFilters);
+    const inScope = scopeFilterActive
+      ? collectScopeMatches(nodes, rootNodeId, scopeFilters)
+      : new Set<string>();
 
     // "Behind only" filter keeps any leaf flagged behind (via computed
     // health) plus every ancestor up to the root, so the tree shape
@@ -459,7 +457,7 @@ export function GanttView() {
     const walk = (nodeId: string, depth: number) => {
       const node = nodes[nodeId];
       if (!node) return;
-      if ((activeVersionFilter || activeCycleFilter) && !inScope.has(nodeId)) {
+      if (scopeFilterActive && !inScope.has(nodeId)) {
         // Skip this node but still descend — a tagged leaf can live under
         // an untagged parent.
         for (const cid of node.childrenIds) walk(cid, depth);
@@ -494,6 +492,7 @@ export function GanttView() {
     collapsedSet,
     activeVersionFilter,
     activeCycleFilter,
+    activePhaseFilter,
     showBehindOnly,
     hideDone,
     computed,

--- a/packages/mindmap/src/HillChart.tsx
+++ b/packages/mindmap/src/HillChart.tsx
@@ -68,6 +68,7 @@ export function HillChart() {
   const getVisibleNodes = useMindmapStore((s) => s.getVisibleNodes);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
 
   const svgRef = useRef<SVGSVGElement>(null);
   const [dragging, setDragging] = useState<string | null>(null);
@@ -84,7 +85,7 @@ export function HillChart() {
         getVisibleNodes({ respectFocus: false, respectDepth: false, respectCollapsed: false }),
         computed,
       ),
-    [nodes, rootNodeId, computed, getVisibleNodes, activeVersionFilter, activeCycleFilter],
+    [nodes, rootNodeId, computed, getVisibleNodes, activeVersionFilter, activeCycleFilter, activePhaseFilter],
   );
 
   const maxEffort = branches.length > 0 ? Math.max(...branches.map((b) => b.computed.computedEffort)) : 0;
@@ -349,7 +350,7 @@ export function HillChart() {
               fill="#94a3b8"
               fontSize="14"
             >
-              {activeVersionFilter || activeCycleFilter
+              {activeVersionFilter || activeCycleFilter || activePhaseFilter
                 ? 'No branches match the active filter.'
                 : 'No top-level branches to display. Add children to the root node.'}
             </text>

--- a/packages/mindmap/src/KanbanView.tsx
+++ b/packages/mindmap/src/KanbanView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useMindmapStore } from './store.js';
+import { collectScopeMatches, hasActiveScopeFilter } from './scopeFilter.js';
 import type { Node, NodeId, StatusDef, HealthSignal, Priority } from '@mindblown/core';
 import { OctocatIcon } from './icons/Octocat.js';
 
@@ -450,6 +451,7 @@ export function KanbanView() {
   const getNodeBreadcrumb = useMindmapStore((s) => s.getNodeBreadcrumb);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
 
   const [swimlanes, setSwimlanes] = useState(false);
@@ -473,26 +475,17 @@ export function KanbanView() {
   const columns: KanbanColumn[] = useMemo(() => {
     // Kanban shows ALL leaves regardless of the mindmap's collapse state or
     // depth limit — those are mindmap-only concerns. We still respect the
-    // explicit version/sprint filters via ancestor inheritance.
+    // explicit version/sprint/phase filters via ancestor inheritance
+    // (shared walk in scopeFilter.ts, same semantics as getVisibleNodes).
     let leafNodes = getLeafNodes();
 
-    if ((activeVersionFilter || activeCycleFilter) && rootNodeId) {
-      const inScope = new Set<string>();
-      const walk = (
-        nodeId: string,
-        inheritedVersion: string | null,
-        inheritedCycle: string | null,
-      ) => {
-        const node = nodes[nodeId];
-        if (!node) return;
-        const effVersion = node.versionId ?? inheritedVersion;
-        const effCycle = node.cycleId ?? inheritedCycle;
-        const matchesVersion = !activeVersionFilter || effVersion === activeVersionFilter;
-        const matchesCycle = !activeCycleFilter || effCycle === activeCycleFilter;
-        if (matchesVersion && matchesCycle) inScope.add(nodeId);
-        for (const cid of node.childrenIds) walk(cid, effVersion, effCycle);
-      };
-      walk(rootNodeId, null, null);
+    const scopeFilters = {
+      versionId: activeVersionFilter,
+      cycleId: activeCycleFilter,
+      phaseId: activePhaseFilter,
+    };
+    if (hasActiveScopeFilter(scopeFilters) && rootNodeId) {
+      const inScope = collectScopeMatches(nodes, rootNodeId, scopeFilters);
       leafNodes = leafNodes.filter((n) => inScope.has(n.id));
     }
 
@@ -551,7 +544,7 @@ export function KanbanView() {
     }
 
     return result;
-  }, [statusColumns, getLeafNodes, getNodeBreadcrumb, computed, activeCycleFilter, activeVersionFilter, nodes, rootNodeId]);
+  }, [statusColumns, getLeafNodes, getNodeBreadcrumb, computed, activeCycleFilter, activeVersionFilter, activePhaseFilter, nodes, rootNodeId]);
 
   // Drag and drop handlers
   const handleDragStart = useCallback((e: React.DragEvent, nodeId: string) => {

--- a/packages/mindmap/src/ListView.tsx
+++ b/packages/mindmap/src/ListView.tsx
@@ -144,6 +144,7 @@ export function ListView() {
   const maxDepth = useMindmapStore((s) => s.maxDepth);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
 
   // ── Local UI state ────────────────────────────────────────────
 
@@ -202,7 +203,7 @@ export function ListView() {
     }
 
     return rows;
-  }, [nodes, rootNodeId, computed, getVisibleNodes, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter]);
+  }, [nodes, rootNodeId, computed, getVisibleNodes, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter, activePhaseFilter]);
 
   // ── Filter ────────────────────────────────────────────────────
 

--- a/packages/mindmap/src/MindmapEditor.tsx
+++ b/packages/mindmap/src/MindmapEditor.tsx
@@ -374,6 +374,7 @@ export function MindmapEditor() {
   const user = useMindmapStore((s) => s.user);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
   const currentMapId = useMindmapStore((s) => s.currentMapId);
   const currentMap = useMindmapStore((s) => s.currentMap);
   const presence = useMindmapStore((s) => s.presence);
@@ -504,7 +505,7 @@ export function MindmapEditor() {
 
   // ── Visible nodes computation ───────────────────────────────
 
-  const visibleNodes = useMemo(() => getVisibleNodes(), [nodes, focusNodeId, maxDepth, rootNodeId, activeVersionFilter, activeCycleFilter, getVisibleNodes]);
+  const visibleNodes = useMemo(() => getVisibleNodes(), [nodes, focusNodeId, maxDepth, rootNodeId, activeVersionFilter, activeCycleFilter, activePhaseFilter, getVisibleNodes]);
 
   // Build a filtered nodes record containing only visible (non-dimmed) nodes
   // with adjusted parentId for the layout algorithm

--- a/packages/mindmap/src/WorkloadView.tsx
+++ b/packages/mindmap/src/WorkloadView.tsx
@@ -27,6 +27,7 @@ export function WorkloadView() {
   const rootNodeId = useMindmapStore((s) => s.rootNodeId);
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
+  const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
 
   const [capacity, setCapacity] = useState(40);
   const [editingCapacity, setEditingCapacity] = useState(false);
@@ -46,7 +47,7 @@ export function WorkloadView() {
         getVisibleNodes({ respectFocus: false, respectDepth: false, respectCollapsed: false }),
         statusWorkflow,
       ),
-    [nodes, rootNodeId, getVisibleNodes, activeVersionFilter, activeCycleFilter, statusWorkflow],
+    [nodes, rootNodeId, getVisibleNodes, activeVersionFilter, activeCycleFilter, activePhaseFilter, statusWorkflow],
   );
 
   const maxEffort = Math.max(capacity, ...workloads.map((w) => w.total));
@@ -173,7 +174,7 @@ export function WorkloadView() {
               fontSize: 13,
             }}
           >
-            {activeVersionFilter || activeCycleFilter
+            {activeVersionFilter || activeCycleFilter || activePhaseFilter
               ? 'No assigned tasks with effort estimates match the active filter.'
               : 'No assigned tasks with effort estimates found. Assign tasks and add effort estimates to leaf nodes.'}
           </div>

--- a/packages/mindmap/src/__tests__/scopeFilter.test.ts
+++ b/packages/mindmap/src/__tests__/scopeFilter.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@mindblown/core';
+import { collectScopeMatches, hasActiveScopeFilter } from '../scopeFilter.js';
+import type { ScopeFilters } from '../scopeFilter.js';
+
+/**
+ * Unit tests for the shared version/sprint/phase scope walk. This is the
+ * exact code path KanbanView and GanttView use to pre-filter their rows
+ * (they consume the DIRECT match set without ancestor expansion), and
+ * the store's getVisibleNodes builds on it too — so the inheritance
+ * semantics pinned here hold for every view.
+ */
+
+function makeNode(id: string, parentId: string | null, overrides: Partial<Node> = {}): Node {
+  return {
+    id,
+    mapId: 'm1',
+    parentId,
+    childrenIds: [],
+    text: id,
+    versionId: null,
+    cycleId: null,
+    phaseId: null,
+    ...overrides,
+  } as Node;
+}
+
+/**
+ * Tree (same shape as the viewScope fixture):
+ *   root
+ *   ├─ epicA (versionId v1, phaseId p1)
+ *   │   ├─ a1  untagged → inherits v1 + p1
+ *   │   └─ a2  versionId v2 (overrides), inherits p1
+ *   └─ epicB (untagged)
+ *       ├─ b1  versionId v1, cycleId c1, phaseId p2
+ *       └─ b2  untagged
+ */
+function buildNodes(): Record<string, Node> {
+  return {
+    root: makeNode('root', null, { childrenIds: ['epicA', 'epicB'] }),
+    epicA: makeNode('epicA', 'root', { childrenIds: ['a1', 'a2'], versionId: 'v1', phaseId: 'p1' }),
+    epicB: makeNode('epicB', 'root', { childrenIds: ['b1', 'b2'] }),
+    a1: makeNode('a1', 'epicA'),
+    a2: makeNode('a2', 'epicA', { versionId: 'v2' }),
+    b1: makeNode('b1', 'epicB', { versionId: 'v1', cycleId: 'c1', phaseId: 'p2' }),
+    b2: makeNode('b2', 'epicB'),
+  };
+}
+
+const NO_FILTERS: ScopeFilters = { versionId: null, cycleId: null, phaseId: null };
+
+function matchIds(filters: Partial<ScopeFilters>): string[] {
+  return [...collectScopeMatches(buildNodes(), 'root', { ...NO_FILTERS, ...filters })].sort();
+}
+
+describe('hasActiveScopeFilter', () => {
+  it('is false when all filters are null', () => {
+    expect(hasActiveScopeFilter(NO_FILTERS)).toBe(false);
+  });
+
+  it('is true when any single filter is set', () => {
+    expect(hasActiveScopeFilter({ ...NO_FILTERS, versionId: 'v1' })).toBe(true);
+    expect(hasActiveScopeFilter({ ...NO_FILTERS, cycleId: 'c1' })).toBe(true);
+    expect(hasActiveScopeFilter({ ...NO_FILTERS, phaseId: 'p1' })).toBe(true);
+  });
+});
+
+describe('collectScopeMatches', () => {
+  it('returns an empty set when no filter is active (callers must guard)', () => {
+    expect(matchIds({})).toEqual([]);
+  });
+
+  it('version filter matches tagged nodes and untagged descendants (inheritance), child override wins', () => {
+    // a1 inherits v1 from epicA; a2's own v2 overrides → out; b1 tagged v1 directly.
+    expect(matchIds({ versionId: 'v1' })).toEqual(['a1', 'b1', 'epicA']);
+    expect(matchIds({ versionId: 'v2' })).toEqual(['a2']);
+  });
+
+  it('phase filter uses the identical inheritance semantics', () => {
+    // a1 AND a2 inherit p1 from epicA — a2's version override is irrelevant here.
+    expect(matchIds({ phaseId: 'p1' })).toEqual(['a1', 'a2', 'epicA']);
+    expect(matchIds({ phaseId: 'p2' })).toEqual(['b1']);
+  });
+
+  it('cycle filter matches only the tagged subtree', () => {
+    expect(matchIds({ cycleId: 'c1' })).toEqual(['b1']);
+  });
+
+  it('multiple filters combine with AND', () => {
+    // version v1 AND phase p1: epicA + a1 (a2 fails version, b1 fails phase).
+    expect(matchIds({ versionId: 'v1', phaseId: 'p1' })).toEqual(['a1', 'epicA']);
+    // version v2 AND phase p1: only a2 (own v2, inherited p1).
+    expect(matchIds({ versionId: 'v2', phaseId: 'p1' })).toEqual(['a2']);
+    // phase p2 AND cycle c1: only b1 carries both.
+    expect(matchIds({ phaseId: 'p2', cycleId: 'c1' })).toEqual(['b1']);
+    // all three: b1 matches; adding a phase that nothing shares with c1 empties it.
+    expect(matchIds({ versionId: 'v1', cycleId: 'c1', phaseId: 'p2' })).toEqual(['b1']);
+    expect(matchIds({ versionId: 'v1', cycleId: 'c1', phaseId: 'p1' })).toEqual([]);
+  });
+
+  it('a filter value matching nothing yields the empty set', () => {
+    expect(matchIds({ phaseId: 'p999' })).toEqual([]);
+    expect(matchIds({ versionId: 'v999' })).toEqual([]);
+  });
+
+  it('tolerates a missing root id', () => {
+    expect([...collectScopeMatches(buildNodes(), 'nope', { ...NO_FILTERS, phaseId: 'p1' })]).toEqual([]);
+  });
+});

--- a/packages/mindmap/src/__tests__/scopeFilter.test.ts
+++ b/packages/mindmap/src/__tests__/scopeFilter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Node } from '@mindblown/core';
-import { collectScopeMatches, hasActiveScopeFilter } from '../scopeFilter.js';
+import { collectScopeMatches, hasActiveScopeFilter, resolveFilterChip } from '../scopeFilter.js';
 import type { ScopeFilters } from '../scopeFilter.js';
 
 /**
@@ -105,5 +105,40 @@ describe('collectScopeMatches', () => {
 
   it('tolerates a missing root id', () => {
     expect([...collectScopeMatches(buildNodes(), 'nope', { ...NO_FILTERS, phaseId: 'p1' })]).toEqual([]);
+  });
+});
+
+describe('resolveFilterChip (FiltersPopover chip data basis)', () => {
+  const phases = [
+    { id: 'p1', name: 'M1 – Grundgerüst' },
+    { id: 'p2', name: 'M2 – Ausbau' },
+  ];
+
+  it('returns null only when no filter is active', () => {
+    expect(resolveFilterChip(null, phases, '(unknown phase)')).toBeNull();
+  });
+
+  it('resolves an existing id to its definition name', () => {
+    expect(resolveFilterChip('p2', phases, '(unknown phase)')).toEqual({
+      id: 'p2',
+      name: 'M2 – Ausbau',
+    });
+  });
+
+  it('keeps the chip alive when the active id no longer resolves (dangling filter stays clearable)', () => {
+    // A phase removed from currentMap.phases under an active filter (WS
+    // sync / map reload) must NOT hide the chip or the "Clear all filters"
+    // button — the store filter still restricts every view, and the chip's
+    // × is the only UI path to clearing it (there is no deletePhase hook
+    // that clears the filter, unlike deleteVersion).
+    const chip = resolveFilterChip('p-vanished', phases, '(unknown phase)');
+    expect(chip).toEqual({ id: 'p-vanished', name: '(unknown phase)' });
+    // hasAnyFilter in the popover keys on this truthiness:
+    expect(!!chip).toBe(true);
+    // ...even against an empty definition list (map lost all phases).
+    expect(resolveFilterChip('p-vanished', [], '(unknown phase)')).toEqual({
+      id: 'p-vanished',
+      name: '(unknown phase)',
+    });
   });
 });

--- a/packages/mindmap/src/__tests__/viewScope.test.ts
+++ b/packages/mindmap/src/__tests__/viewScope.test.ts
@@ -55,6 +55,7 @@ function makeNode(id: string, parentId: string | null, overrides: Partial<Node> 
     dependencies: [],
     versionId: null,
     cycleId: null,
+    phaseId: null,
     externalLinks: [],
     priorityRank: null,
     completedAt: null,
@@ -78,11 +79,11 @@ function makeNode(id: string, parentId: string | null, overrides: Partial<Node> 
 /**
  * Tree:
  *   root
- *   ├─ epicA (versionId v1)
- *   │   ├─ a1  leaf — no own tag → inherits v1; alice, 5h, todo
- *   │   └─ a2  leaf — versionId v2 (overrides); bob, 3h, in_progress
+ *   ├─ epicA (versionId v1, phaseId p1)
+ *   │   ├─ a1  leaf — no own tag → inherits v1 + p1; alice, 5h, todo
+ *   │   └─ a2  leaf — versionId v2 (overrides), inherits p1; bob, 3h, in_progress
  *   └─ epicB (untagged)
- *       ├─ b1  leaf — versionId v1, cycleId c1; alice, 2h, done
+ *       ├─ b1  leaf — versionId v1, cycleId c1, phaseId p2; alice, 2h, done
  *       └─ b2  leaf — untagged; bob, 8h, todo
  */
 function buildFixture(): Record<string, Node> {
@@ -91,6 +92,7 @@ function buildFixture(): Record<string, Node> {
     epicA: makeNode('epicA', 'root', {
       childrenIds: ['a1', 'a2'],
       versionId: 'v1',
+      phaseId: 'p1',
       customFields: { hillPosition: 30 },
     }),
     epicB: makeNode('epicB', 'root', { childrenIds: ['b1', 'b2'] }),
@@ -104,6 +106,7 @@ function buildFixture(): Record<string, Node> {
     b1: makeNode('b1', 'epicB', {
       versionId: 'v1',
       cycleId: 'c1',
+      phaseId: 'p2',
       assigneeIds: ['alice'],
       effortEstimate: 2,
       status: 'done',
@@ -125,6 +128,7 @@ function setStoreState(overrides: Record<string, unknown> = {}) {
     maxDepth: 0,
     activeVersionFilter: null,
     activeCycleFilter: null,
+    activePhaseFilter: null,
   });
   if (Object.keys(overrides).length > 0) {
     useMindmapStore.setState(overrides);
@@ -271,6 +275,52 @@ describe('scope-only getVisibleNodes as the data basis for HillChart/WorkloadVie
       expect(scopeIds()).toEqual([]);
       expect(hillBranchIds()).toEqual([]);
       expect(workloadsNow()).toEqual([]);
+    });
+  });
+
+  describe('phase filter (same inheritance semantics as version/cycle)', () => {
+    it('active phase filter keeps only nodes of that phase, incl. scope inheritance and connecting ancestors', () => {
+      useMindmapStore.setState({ activePhaseFilter: 'p1' });
+      // epicA is tagged p1; a1 AND a2 inherit p1 (a2's versionId override
+      // does not affect phase inheritance). b1 is p2, b2 untagged → out.
+      expect(scopeIds().sort()).toEqual(['a1', 'a2', 'epicA', 'root']);
+    });
+
+    it('phase + version filters combine with AND semantics', () => {
+      useMindmapStore.setState({ activeVersionFilter: 'v1', activePhaseFilter: 'p1' });
+      // epicA matches both directly; a1 inherits both; a2 fails on version
+      // (own v2 overrides). b1 is v1 but phase p2 → out.
+      expect(scopeIds().sort()).toEqual(['a1', 'epicA', 'root']);
+    });
+
+    it('phase + version AND can isolate a single leaf under a partially-matching epic', () => {
+      useMindmapStore.setState({ activeVersionFilter: 'v2', activePhaseFilter: 'p1' });
+      // Only a2: own versionId v2 + inherited phase p1. epicA itself is v1
+      // → survives only as a2's connecting ancestor.
+      expect(scopeIds().sort()).toEqual(['a2', 'epicA', 'root']);
+    });
+
+    it('phase + cycle filters combine with AND semantics', () => {
+      useMindmapStore.setState({ activeCycleFilter: 'c1', activePhaseFilter: 'p2' });
+      // Only b1 carries both c1 and p2; epicB survives as connecting ancestor.
+      expect(scopeIds().sort()).toEqual(['b1', 'epicB', 'root']);
+    });
+
+    it('a phase filter matching nothing empties the scope and both view data bases', () => {
+      useMindmapStore.setState({ activePhaseFilter: 'p999' });
+      expect(scopeIds()).toEqual([]);
+      expect(hillBranchIds()).toEqual([]);
+      expect(workloadsNow()).toEqual([]);
+    });
+
+    it('feeds the HillChart/Workload data bases like the other filters', () => {
+      useMindmapStore.setState({ activePhaseFilter: 'p1' });
+      expect(hillBranchIds()).toEqual(['epicA']);
+      const w = workloadsNow();
+      // a1 (alice, 5h todo) + a2 (bob, 3h in_progress) are in phase scope.
+      expect(w.map((x) => x.assigneeId)).toEqual(['alice', 'bob']);
+      expect(w.find((x) => x.assigneeId === 'alice')!).toMatchObject({ todo: 5, total: 5 });
+      expect(w.find((x) => x.assigneeId === 'bob')!).toMatchObject({ inProgress: 3, total: 3 });
     });
   });
 

--- a/packages/mindmap/src/scopeFilter.ts
+++ b/packages/mindmap/src/scopeFilter.ts
@@ -33,6 +33,30 @@ export function hasActiveScopeFilter(filters: ScopeFilters): boolean {
 }
 
 /**
+ * Resolve an active filter id to the chip that announces it in the UI.
+ *
+ * Keyed on the ACTIVE ID, not on whether the id still resolves against
+ * the definition list: if the referenced definition vanishes from under
+ * the filter (WS map sync / map reload — phases have no
+ * delete-clears-filter hook the way deleteVersion has), the filter still
+ * restricts every view, so the chip and the "Clear all filters" button
+ * must stay visible and clickable. We fall back to `unknownLabel` for
+ * the chip text instead of silently dropping the user's only UI path to
+ * clearing the filter.
+ *
+ * Returns null only when no filter is active.
+ */
+export function resolveFilterChip(
+  activeId: string | null,
+  defs: { id: string; name: string }[],
+  unknownLabel: string,
+): { id: string; name: string } | null {
+  if (!activeId) return null;
+  const def = defs.find((d) => d.id === activeId);
+  return def ? { id: def.id, name: def.name } : { id: activeId, name: unknownLabel };
+}
+
+/**
  * DFS from `rootId`, propagating inherited version/cycle/phase tags
  * downward, and collect the ids of every node whose effective tags
  * match ALL active filters (AND semantics). Inactive filters (null)

--- a/packages/mindmap/src/scopeFilter.ts
+++ b/packages/mindmap/src/scopeFilter.ts
@@ -1,0 +1,77 @@
+import type { Node } from '@mindblown/core';
+
+/**
+ * Shared scope-filter walk for the version / sprint / phase filters.
+ *
+ * This used to live as three near-identical copies: the store's
+ * `getVisibleNodes` (`inheritDfs`), KanbanView's leaf pre-filter, and
+ * GanttView's row pre-filter. All three now call `collectScopeMatches`
+ * so the inheritance semantics can never drift apart again (the phase
+ * filter is the third tag that would otherwise have to be added in
+ * three places).
+ *
+ * Semantic: a node is a DIRECT match if its effective version, cycle,
+ * and phase each match every active filter (AND), where "effective"
+ * means the node's own tag OR the nearest tagged ancestor. This lets
+ * users tag an epic/branch and see the entire subtree under it, while
+ * still supporting leaf-level tags (a leaf's own tag overrides the
+ * inherited one).
+ *
+ * Callers that need a connected tree (the store) expand the result with
+ * ancestors themselves; flat views (Kanban, Gantt) use the direct
+ * matches as-is.
+ */
+export interface ScopeFilters {
+  versionId: string | null;
+  cycleId: string | null;
+  phaseId: string | null;
+}
+
+/** True when at least one scope filter is active. */
+export function hasActiveScopeFilter(filters: ScopeFilters): boolean {
+  return !!(filters.versionId || filters.cycleId || filters.phaseId);
+}
+
+/**
+ * DFS from `rootId`, propagating inherited version/cycle/phase tags
+ * downward, and collect the ids of every node whose effective tags
+ * match ALL active filters (AND semantics). Inactive filters (null)
+ * match everything. Returns an empty set when no filter is active —
+ * callers guard with `hasActiveScopeFilter` before treating the set
+ * as a restriction.
+ */
+export function collectScopeMatches(
+  nodes: Record<string, Node>,
+  rootId: string,
+  filters: ScopeFilters,
+): Set<string> {
+  const matches = new Set<string>();
+  if (!hasActiveScopeFilter(filters)) return matches;
+
+  const { versionId, cycleId, phaseId } = filters;
+
+  function walk(
+    nodeId: string,
+    inheritedVersion: string | null,
+    inheritedCycle: string | null,
+    inheritedPhase: string | null,
+  ) {
+    const node = nodes[nodeId];
+    if (!node) return;
+    const effVersion = node.versionId ?? inheritedVersion;
+    const effCycle = node.cycleId ?? inheritedCycle;
+    const effPhase = node.phaseId ?? inheritedPhase;
+    const matchesVersion = !versionId || effVersion === versionId;
+    const matchesCycle = !cycleId || effCycle === cycleId;
+    const matchesPhase = !phaseId || effPhase === phaseId;
+    if (matchesVersion && matchesCycle && matchesPhase) {
+      matches.add(nodeId);
+    }
+    for (const childId of node.childrenIds) {
+      walk(childId, effVersion, effCycle, effPhase);
+    }
+  }
+  walk(rootId, null, null, null);
+
+  return matches;
+}

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -5,6 +5,7 @@ import * as api from './api.js';
 import type { MapSummary, AuthUser } from './api.js';
 import { connectWs } from './ws.js';
 import type { WsClient } from './ws.js';
+import { collectScopeMatches, hasActiveScopeFilter } from './scopeFilter.js';
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -92,6 +93,9 @@ export interface MindmapState {
   versions: Version[];
   activeVersionFilter: string | null;
 
+  // Phase state (PhaseDefs live on currentMap.phases; only the filter is store state)
+  activePhaseFilter: string | null;
+
   // UI state
   activeView: ActiveView;
   loading: boolean;
@@ -142,6 +146,9 @@ export interface MindmapState {
   updateVersion: (id: string, fields: Partial<api.CreateVersionFields>) => Promise<void>;
   deleteVersion: (id: string) => Promise<void>;
   setActiveVersionFilter: (versionId: string | null) => void;
+
+  // Actions — phase
+  setActivePhaseFilter: (phaseId: string | null) => void;
 
   // Actions — layout
   setLayoutType: (layout: 'tree-lr' | 'tree-tb' | 'radial' | 'org-chart') => void;
@@ -211,6 +218,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
   activeCycleFilter: null,
   versions: [],
   activeVersionFilter: null,
+  activePhaseFilter: null,
   activeView: 'mindmap',
   loading: false,
   error: null,
@@ -374,6 +382,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       maxDepth: 1,
       versions: [],
       activeVersionFilter: null,
+      activePhaseFilter: null,
       wsConnected: false,
       presence: {},
       followingUserId: null,
@@ -601,6 +610,10 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
 
   setActiveVersionFilter: (versionId) => set({ activeVersionFilter: versionId }),
 
+  // ── Phase actions ────────────────────────────────────────────
+
+  setActivePhaseFilter: (phaseId) => set({ activePhaseFilter: phaseId }),
+
   // ── View actions ─────────────────────────────────────────────
 
   setActiveView: (view) => set({ activeView: view }),
@@ -638,49 +651,29 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
 
   getVisibleNodes: (options) => {
     const { respectFocus = true, respectDepth = true, respectCollapsed = true } = options ?? {};
-    const { nodes, rootNodeId, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter } = get();
+    const { nodes, rootNodeId, focusNodeId, maxDepth, activeVersionFilter, activeCycleFilter, activePhaseFilter } = get();
     if (!rootNodeId) return [];
 
     const effectiveRootId = (respectFocus ? focusNodeId : null) ?? rootNodeId;
     const effectiveRoot = nodes[effectiveRootId];
     if (!effectiveRoot) return [];
 
-    // Build the visible set for the active version + sprint filters.
+    // Build the visible set for the active version + sprint + phase
+    // filters — see `collectScopeMatches` in scopeFilter.ts for the tag
+    // inheritance / AND semantics (shared with KanbanView and GanttView).
     //
-    // Semantic: a node is "in scope" if its effective version/cycle matches
-    // every active filter, where "effective" means the node's own tag OR
-    // the nearest tagged ancestor. This lets users tag an epic/branch with
-    // a sprint and see the entire subtree under it, while still supporting
-    // leaf-level tags for fine-grained work items.
-    //
-    // We also include ancestors of in-scope nodes so the mindmap stays a
-    // connected tree even when scope nodes are deep.
+    // We walk from rootNodeId (not effectiveRootId) so inheritance picks
+    // up tags on nodes above the current drill-down focus, and we expand
+    // with ancestors of in-scope nodes so the mindmap stays a connected
+    // tree even when scope nodes are deep.
+    const scopeFilters = {
+      versionId: activeVersionFilter,
+      cycleId: activeCycleFilter,
+      phaseId: activePhaseFilter,
+    };
     let filterMatchIds: Set<string> | null = null;
-    if (activeVersionFilter || activeCycleFilter) {
-      const directMatches = new Set<string>();
-
-      // DFS from the real root, propagating inherited tags downward.
-      // We walk from rootNodeId (not effectiveRootId) so inheritance picks
-      // up tags on nodes above the current drill-down focus.
-      function inheritDfs(
-        nodeId: string,
-        inheritedVersion: string | null,
-        inheritedCycle: string | null,
-      ) {
-        const node = nodes[nodeId];
-        if (!node) return;
-        const effVersion = node.versionId ?? inheritedVersion;
-        const effCycle = node.cycleId ?? inheritedCycle;
-        const matchesVersion = !activeVersionFilter || effVersion === activeVersionFilter;
-        const matchesCycle = !activeCycleFilter || effCycle === activeCycleFilter;
-        if (matchesVersion && matchesCycle) {
-          directMatches.add(nodeId);
-        }
-        for (const childId of node.childrenIds) {
-          inheritDfs(childId, effVersion, effCycle);
-        }
-      }
-      inheritDfs(rootNodeId, null, null);
+    if (hasActiveScopeFilter(scopeFilters)) {
+      const directMatches = collectScopeMatches(nodes, rootNodeId, scopeFilters);
 
       // Expand with ancestors of every in-scope node so the tree stays
       // connected back to the root.


### PR DESCRIPTION
Third scope filter «Phase» (activePhaseFilter, same semantics as version: nearest-tagged-ancestor inheritance, child override, AND with version/cycle). The three previously identical scope-walk copies (store inheritDfs, KanbanView, GanttView) are collapsed into one tested helper (scopeFilter.ts) — per the views-filter audit recommendation. FiltersPopover gets a Phase dropdown (only when the map has phases) + amber chip; five getVisibleNodes consumers gained the filter memo-deps; stale-filter chip stays clearable even when the phase no longer resolves.

Reviewed by Ray (APPROVE; should-fix closed: chip/clear-all now key off the raw filter id). mindmap suite 30+ tests green, turbo typecheck+test 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6RVBDQptbVQe1cDrHM3AH