### PR TITLE
feat(velocity): net-of-rework rate + review latency in velocity_report

### DIFF
--- a/packages/core/src/__tests__/velocity.test.ts
+++ b/packages/core/src/__tests__/velocity.test.ts
@@ -2,10 +2,23 @@ import { describe, it, expect } from 'vitest';
 import {
   clampFocusFactor,
   scopedCapacityDays,
+  analyzeRepoThroughput,
+  netDeliveryRate,
   DEFAULT_FOCUS_FACTOR,
   FOCUS_FACTOR_MIN,
   FOCUS_FACTOR_MAX,
 } from '../velocity.js';
+
+function pr(number: number, title: string, openH: number, mergeH: number, body = '') {
+  const base = Date.parse('2026-07-10T00:00:00Z');
+  return {
+    number,
+    title,
+    body,
+    createdAt: new Date(base + openH * 3_600_000).toISOString(),
+    mergedAt: new Date(base + mergeH * 3_600_000).toISOString(),
+  };
+}
 
 describe('clampFocusFactor', () => {
   it('passes valid values through unchanged', () => {
@@ -58,5 +71,58 @@ describe('scopedCapacityDays', () => {
     const r = scopedCapacityDays(10, { workers: 0, unitsPerDay: 0, fudge: 1, focusFactor: 5 });
     expect(Number.isFinite(r.plannedCalendarDays)).toBe(true);
     expect(Number.isFinite(r.velocityCalendarDays)).toBe(true);
+  });
+});
+
+describe('analyzeRepoThroughput', () => {
+  it('classifies correction keywords + references to in-window PRs as rework', () => {
+    const prs = [
+      pr(1, 'feat(a): new thing', 0, 0.5),
+      pr(2, 'feat(b): another', 1, 1.4),
+      pr(3, 'fix(a): correct #1 regression', 2, 2.5), // keyword + ref
+      pr(4, 'follow-up to #2', 3, 3.2),               // keyword + ref
+      pr(5, 'feat(c): builds on #1', 4, 4.3),         // ref only (in-window) → rework
+    ];
+    const rt = analyzeRepoThroughput(prs);
+    expect(rt.merged).toBe(5);
+    expect(rt.reworkCount).toBe(3); // #3, #4, #5
+    expect(rt.reworkFraction).toBeCloseTo(0.6, 6);
+  });
+
+  it('computes review-latency stats and offline (>6h) merges', () => {
+    const prs = [
+      pr(1, 'a', 0, 0.4),   // 0.4h
+      pr(2, 'b', 0, 0.6),   // 0.6h
+      pr(3, 'c', 0, 12),    // 12h → offline
+    ];
+    const rt = analyzeRepoThroughput(prs);
+    expect(rt.medianLatencyHours).toBeCloseTo(0.6, 6);
+    expect(rt.maxLatencyHours).toBeCloseTo(12, 6);
+    expect(rt.offlineMergeCount).toBe(1);
+  });
+
+  it('a reference to a PR NOT in the window is not rework by itself', () => {
+    const prs = [pr(10, 'feat: extends #9999 (not in window)', 0, 0.5)];
+    const rt = analyzeRepoThroughput(prs);
+    expect(rt.reworkCount).toBe(0);
+  });
+
+  it('empty input is safe', () => {
+    const rt = analyzeRepoThroughput([]);
+    expect(rt.merged).toBe(0);
+    expect(rt.reworkFraction).toBe(0);
+    expect(rt.medianLatencyHours).toBe(0);
+  });
+});
+
+describe('netDeliveryRate', () => {
+  it('discounts gross by the rework fraction', () => {
+    expect(netDeliveryRate(3.2, 0.42)).toBeCloseTo(3.2 * 0.58, 6);
+    expect(netDeliveryRate(2, 0)).toBe(2);
+    expect(netDeliveryRate(2, 1)).toBe(0);
+  });
+  it('clamps out-of-range fractions', () => {
+    expect(netDeliveryRate(2, 1.5)).toBe(0);
+    expect(netDeliveryRate(2, -1)).toBe(2);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,5 +91,8 @@ export {
   DEFAULT_FOCUS_FACTOR,
   clampFocusFactor,
   scopedCapacityDays,
+  analyzeRepoThroughput,
+  netDeliveryRate,
+  OFFLINE_MERGE_HOURS,
 } from './velocity.js';
-export type { ScopedCapacityInput } from './velocity.js';
+export type { ScopedCapacityInput, PrRecord, RepoThroughput } from './velocity.js';

--- a/packages/core/src/velocity.ts
+++ b/packages/core/src/velocity.ts
@@ -74,3 +74,109 @@ export function scopedCapacityDays(
     velocityCalendarDays: (rem * opts.fudge) / (capacityPerDay * focus),
   };
 }
+
+// ── Repo throughput: net-of-rework rate + review latency ──────────
+//
+// The MindBlown velocity above measures *gross* completion — effort marked
+// done per calendar day. In an agent-fleet workflow that overstates real
+// progress two ways, both visible in the connected repo's merged-PR stream:
+//
+//  1. **Rework.** A large share of merges are corrections of work that was
+//     already "done" (fix/revert/follow-up PRs). Counting those as progress
+//     inflates the rate. Net-new rate = gross × (1 − reworkFraction).
+//  2. **Review latency.** open→merged time is the human-review-plus-CI wait;
+//     usually short, but spikes when the reviewer is offline. Reported as a
+//     separate signal (it paces delivery but isn't a rework loss).
+//
+// v1 detects rework by signal, not file-overlap: a merged PR is rework if its
+// title/body carries a correction keyword OR references (#NNN) another PR that
+// also merged in the window. That is "same work-item", cheap (no per-PR file
+// fetch), and tighter than a bare keyword match. File-level same-area is a
+// documented follow-up refinement.
+
+/** Correction-intent keywords in a PR title/body → likely rework. */
+const REWORK_KEYWORD = /\b(fix|fixup|hotfix|revert|reverts|redo|rework|re-?work|follow-?ups?|followup|regress\w*|correct\w*|amend|nit|nits)\b/i;
+
+/** PRs merged more than this many hours after opening = reviewer likely offline. */
+export const OFFLINE_MERGE_HOURS = 6;
+
+export interface PrRecord {
+  number: number;
+  title: string;
+  body?: string | null;
+  createdAt: string; // ISO 8601
+  mergedAt: string; // ISO 8601
+}
+
+export interface RepoThroughput {
+  merged: number;
+  /** open→merged latency (review + CI), hours. */
+  medianLatencyHours: number;
+  meanLatencyHours: number;
+  maxLatencyHours: number;
+  /** merges that waited > OFFLINE_MERGE_HOURS (reviewer offline). */
+  offlineMergeCount: number;
+  reworkCount: number;
+  /** 0–1 share of merged PRs that are corrections of prior work. */
+  reworkFraction: number;
+}
+
+function referencedNumbers(pr: PrRecord): number[] {
+  const out: number[] = [];
+  const re = /#(\d+)/g;
+  const text = `${pr.title}\n${pr.body ?? ''}`;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) out.push(Number(m[1]));
+  return out;
+}
+
+/**
+ * Analyse the merged-PR stream for review latency and rework share.
+ *
+ * `prs` should be the PRs that merged inside the measurement window. Rework is
+ * self-referential to that set: a PR referencing another merged PR in the same
+ * window is a follow-up on recent work.
+ */
+export function analyzeRepoThroughput(prs: PrRecord[]): RepoThroughput {
+  const mergedSet = new Set(prs.map((p) => p.number));
+
+  const latencies: number[] = [];
+  let offline = 0;
+  let rework = 0;
+  for (const pr of prs) {
+    const openMs = Date.parse(pr.createdAt);
+    const mergeMs = Date.parse(pr.mergedAt);
+    if (Number.isFinite(openMs) && Number.isFinite(mergeMs) && mergeMs >= openMs) {
+      const hours = (mergeMs - openMs) / 3_600_000;
+      latencies.push(hours);
+      if (hours > OFFLINE_MERGE_HOURS) offline++;
+    }
+    const keyword = REWORK_KEYWORD.test(pr.title) || REWORK_KEYWORD.test(pr.body ?? '');
+    const refsRecent = referencedNumbers(pr).some(
+      (n) => n !== pr.number && mergedSet.has(n),
+    );
+    if (keyword || refsRecent) rework++;
+  }
+
+  latencies.sort((a, b) => a - b);
+  const n = latencies.length;
+  const median = n === 0 ? 0 : n % 2 ? latencies[(n - 1) / 2] : (latencies[n / 2 - 1] + latencies[n / 2]) / 2;
+  const mean = n === 0 ? 0 : latencies.reduce((s, x) => s + x, 0) / n;
+  const max = n === 0 ? 0 : latencies[n - 1];
+
+  return {
+    merged: prs.length,
+    medianLatencyHours: median,
+    meanLatencyHours: mean,
+    maxLatencyHours: max,
+    offlineMergeCount: offline,
+    reworkCount: rework,
+    reworkFraction: prs.length === 0 ? 0 : rework / prs.length,
+  };
+}
+
+/** Net-of-rework delivery rate: gross × (1 − reworkFraction). */
+export function netDeliveryRate(grossRatePerDay: number, reworkFraction: number): number {
+  const f = Math.min(1, Math.max(0, reworkFraction));
+  return Math.max(0, grossRatePerDay) * (1 - f);
+}

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -778,6 +778,20 @@ export interface VelocityResponse {
   sampleSufficient: boolean;
   effortUnit: string;
   truncated: boolean;
+  /** Net-of-rework rate + review latency from the connected repo; null if none. */
+  repoThroughput: {
+    repo: string;
+    merged: number;
+    medianLatencyHours: number;
+    meanLatencyHours: number;
+    maxLatencyHours: number;
+    offlineMergeCount: number;
+    reworkCount: number;
+    reworkFraction: number;
+    grossRatePerDay: number;
+    netRatePerDay: number;
+    truncated: boolean;
+  } | null;
 }
 
 export function getVelocity(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1784,8 +1784,21 @@ server.tool(
         lines.push(`→ To apply: update_map(mapId, focusFactor: ${v.measuredFocusFactor.toFixed(2)}). This stretches the velocity-adjusted completion_forecast to match real throughput.`);
       }
 
+      // ── Net-of-rework rate + review latency (connected repo) ──
+      const rt = v.repoThroughput;
+      if (rt) {
+        lines.push('');
+        lines.push(`── Repo throughput (${rt.repo}, ${v.windowDays}d) — gross vs NET ──`);
+        lines.push(`Merged PRs:           ${rt.merged}${rt.truncated ? ' (page cap hit — floor)' : ''}`);
+        lines.push(`Rework share:         ${Math.round(rt.reworkFraction * 100)}% (${rt.reworkCount}/${rt.merged} merges are corrections of prior work)`);
+        lines.push(`Gross rate:           ${rt.grossRatePerDay.toFixed(2)} ${unit}/day (what you'd forecast off — inflated)`);
+        lines.push(`NET rate:             ${rt.netRatePerDay.toFixed(2)} ${unit}/day  ← forecast off THIS (gross × (1 − rework))`);
+        lines.push(`Review latency:       median ${rt.medianLatencyHours.toFixed(1)}h | mean ${rt.meanLatencyHours.toFixed(1)}h | max ${rt.maxLatencyHours.toFixed(1)}h | ${rt.offlineMergeCount} waited >6h (reviewer offline)`);
+        lines.push(`Rework detection is signal-based (correction keywords + references to other in-window PRs), not file-overlap — an approximation; treat rework% as indicative.`);
+      }
+
       lines.push('');
-      lines.push(`Note: measured in estimate units, so it assumes estimates are roughly unbiased (check get_estimation_accuracy — a large fudge means this factor also absorbs estimation bias). Idle calendar days are included by design, so the rate reflects real capacity, not burst speed.`);
+      lines.push(`Note: gross rate is measured in estimate units, so it assumes estimates are roughly unbiased (check get_estimation_accuracy). Idle calendar days are included by design, so the rate reflects real capacity, not burst speed.`);
       if (v.truncated) {
         lines.push(`⚠ Event window hit the fetch cap — the rate may be based on a partial window.`);
       }

--- a/packages/server/src/lib/repoThroughput.ts
+++ b/packages/server/src/lib/repoThroughput.ts
@@ -1,0 +1,81 @@
+/**
+ * Fetch a repo's recently-merged PRs for the net-of-rework velocity signal.
+ *
+ * MindBlown stores only each node's *current* linked PR, not history, so the
+ * rework + review-latency signals are read live from the connected repo at
+ * report time. This pages closed PRs (newest-updated first) and keeps the ones
+ * merged inside the window; the pure analysis (latency, rework share) lives in
+ * `@mindblown/core` (`analyzeRepoThroughput`).
+ */
+
+import type { PrRecord } from '@mindblown/core';
+import type { GitHubMapContext } from './githubContext.js';
+
+const PER_PAGE = 100;
+
+export interface FetchMergedPrsResult {
+  prs: PrRecord[];
+  truncated: boolean; // hit the page cap — window may be partially covered
+}
+
+/**
+ * Page `GET /repos/:owner/:repo/pulls?state=closed` (sorted by most-recently
+ * updated) and collect PRs whose `merged_at` falls on/after `sinceMs`. Stops
+ * once a full page is older than the window or `maxPages` is reached.
+ */
+export async function fetchMergedPrsSince(
+  ctx: GitHubMapContext,
+  sinceMs: number,
+  maxPages = 8,
+): Promise<FetchMergedPrsResult> {
+  const out: PrRecord[] = [];
+  let page = 1;
+  let truncated = false;
+
+  for (; page <= maxPages; page++) {
+    const url =
+      `https://api.github.com/repos/${ctx.owner}/${ctx.repo}/pulls` +
+      `?state=closed&sort=updated&direction=desc&per_page=${PER_PAGE}&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${ctx.token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!res.ok) {
+      // Auth/rate-limit/other — return what we have rather than failing the report.
+      truncated = true;
+      break;
+    }
+    const rows = (await res.json()) as Array<{
+      number: number;
+      title: string;
+      body: string | null;
+      created_at: string;
+      merged_at: string | null;
+      updated_at: string;
+    }>;
+    if (rows.length === 0) break;
+
+    for (const r of rows) {
+      if (r.merged_at && Date.parse(r.merged_at) >= sinceMs) {
+        out.push({
+          number: r.number,
+          title: r.title,
+          body: r.body,
+          createdAt: r.created_at,
+          mergedAt: r.merged_at,
+        });
+      }
+    }
+
+    // Once the whole page's activity predates the window, older pages can't
+    // contain in-window merges (sorted by updated desc).
+    const pageAllOld = rows.every((r) => Date.parse(r.updated_at) < sinceMs);
+    if (pageAllOld) break;
+    if (page === maxPages && rows.length === PER_PAGE) truncated = true;
+  }
+
+  return { prs: out, truncated };
+}

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, analyzeRepoThroughput, netDeliveryRate } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
@@ -11,6 +11,8 @@ import * as cycleDb from '../db/cycles.js';
 import { computeReleaseForecast } from '../lib/releaseForecast.js';
 import { snapshotReleaseForecastForMap } from '../lib/releaseSnapshots.js';
 import { computeVelocity } from '../lib/velocity.js';
+import { getGitHubContextForMap } from '../lib/githubContext.js';
+import { fetchMergedPrsSince } from '../lib/repoThroughput.js';
 import * as events from '../db/events.js';
 import {
   buildCalendarIcs,
@@ -931,10 +933,34 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       })),
     });
 
+    // ── Repo throughput: net-of-rework rate + review latency ──
+    // The MindBlown velocity above is *gross* completion. Live-read the
+    // connected repo's merged PRs to expose the *net* rate — gross overstates
+    // progress because a large share of merges are corrections of prior work.
+    // Only for GitHub-connected maps; null otherwise (net == gross).
+    let repoThroughput: Record<string, unknown> | null = null;
+    try {
+      const ctx = await getGitHubContextForMap(req.params.id);
+      if (ctx) {
+        const { prs, truncated: prTruncated } = await fetchMergedPrsSince(ctx, since.getTime());
+        const rt = analyzeRepoThroughput(prs);
+        repoThroughput = {
+          ...rt,
+          repo: `${ctx.owner}/${ctx.repo}`,
+          grossRatePerDay: result.deliveryRate,
+          netRatePerDay: netDeliveryRate(result.deliveryRate, rt.reworkFraction),
+          truncated: prTruncated,
+        };
+      }
+    } catch (err) {
+      req.log.warn({ err }, 'repo throughput fetch failed');
+    }
+
     return reply.send({
       ...result,
       effortUnit: data.map.effortUnit,
       truncated: progressEvents.length >= 10_000,
+      repoThroughput,
     });
   });
 


### PR DESCRIPTION
## Why
The MindBlown velocity is **gross** completion. In the agent-fleet workflow that's inflated — ~**42%** of merges on the Fulcrum repo are *corrections* of work already "done." Forecasting off gross overstates progress. This surfaces the **net** rate + the **review-latency** signal.

## What
`velocity_report` / `GET /api/maps/:id/velocity` gains a `repoThroughput` block, live-read from the map's connected repo:
- **Rework share** — a merged PR is a correction if title/body has a correction keyword OR references another in-window PR ("same work-item"; cheap, no per-PR file fetch).
- **NET rate = gross × (1 − rework)** — the honest forecasting number.
- **Review latency** (open→merged): median/mean/max + count that waited >6h (reviewer offline).

`null` for non-GitHub maps (net == gross).

## Design note
Rework detection is **signal-based (keywords + references)**, not file-overlap — cheaper and tighter than a bare keyword proxy, but still an approximation (rework% is indicative). **File-level same-area** is the documented follow-up refinement.

## Verification
- `pnpm turbo typecheck` clean (11 pkgs); `pnpm turbo test` clean — core 124 (6 new: latency stats, keyword+reference rework classification, net-rate clamping), server 570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)