### PR TITLE
feat(requirements): verification how-to fields + reject-with-comment verdicts

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -43,6 +43,8 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementPriority: null,
     requirementText: null,
     phaseId: null,
+    verificationText: null,
+    verificationUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -41,6 +41,8 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementPriority: null,
     requirementText: null,
     phaseId: null,
+    verificationText: null,
+    verificationUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -44,6 +44,8 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementPriority: null,
     requirementText: null,
     phaseId: null,
+    verificationText: null,
+    verificationUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -241,6 +241,19 @@ export interface Node {
    * no rollup, no health, no scheduling. null = no phase assigned.
    */
   phaseId: string | null;
+  /**
+   * How to verify this requirement (Prüfanleitung): markdown with numbered
+   * steps, expected result and test data, written for a non-technical
+   * reviewer. Rendered on the review surface next to the accept/reject
+   * actions. Like `requirementText`, NOT in the GitHub SYNC_FIELDS.
+   */
+  verificationText: string | null;
+
+  /**
+   * Deep link to where this requirement is verified (e.g. a staging URL).
+   * Rendered as an "open" button on the review surface.
+   */
+  verificationUrl: string | null;
 
   // ── Auto-progress (parent-epic rollup) ────────────────────
   /**

--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -37,6 +37,8 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     requirementPriority: null,
     requirementText: null,
     phaseId: null,
+    verificationText: null,
+    verificationUrl: null,
     claimedBySession: null,
     claimedAt: null,
     computedEffort: 0,

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -138,6 +138,8 @@ export interface NodeWithComputed {
   // References a PhaseDef.id from the map's `phases` list (statusWorkflow
   // idiom). null = no phase assigned.
   phaseId: string | null;
+  verificationText: string | null;
+  verificationUrl: string | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;
@@ -340,16 +342,22 @@ export interface AcceptanceRow {
   acceptedAt: string;
   progressAtAcceptance: number;
   nodeRevisionAtAcceptance: number;
+  decision: 'accepted' | 'rejected';
+  comment: string | null;
 }
 
 export function getAcceptances(mapId: string): Promise<{ acceptances: AcceptanceRow[] }> {
   return request<{ acceptances: AcceptanceRow[] }>(`/api/maps/${mapId}/acceptances`);
 }
 
-export function acceptRequirement(mapId: string, nodeId: string): Promise<AcceptanceRow> {
+export function acceptRequirement(
+  mapId: string,
+  nodeId: string,
+  verdict?: { decision: 'accepted' | 'rejected'; comment?: string },
+): Promise<AcceptanceRow> {
   return request<AcceptanceRow>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
     method: 'POST',
-    body: JSON.stringify({}),
+    body: JSON.stringify(verdict ?? {}),
   });
 }
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -474,8 +474,40 @@ server.tool(
 );
 
 server.tool(
+  'reject_requirement',
+  "Record the calling user's REJECTION of a requirement with a mandatory comment explaining why — the counterpart to accept_requirement. Shows as ✗ in the register, overview and exports so the objection is visible data. One active verdict per user per requirement: revoke_acceptance first to change an existing verdict. Identify the requirement by requirementId (e.g. MAN-01) or nodeId.",
+  {
+    mapId: z.string().describe('The map ID'),
+    requirementId: z.string().optional().describe('Requirement ID, e.g. "MAN-01"'),
+    nodeId: z.string().optional().describe('Node ID (alternative to requirementId)'),
+    comment: z
+      .string()
+      .min(1)
+      .describe('Why the requirement is rejected — what is wrong or missing (mandatory)'),
+  },
+  async ({ mapId, requirementId, nodeId, comment }) => {
+    try {
+      let id = nodeId;
+      if (!id) {
+        if (!requirementId) return toolError('Provide requirementId or nodeId.');
+        const data = await api.getMap(mapId);
+        const hit = data.nodes.find((n) => n.requirementId === requirementId);
+        if (!hit) return toolError(`No node with requirementId ${requirementId} in map ${mapId}.`);
+        id = hit.id;
+      }
+      const a = await api.acceptRequirement(mapId, id, { decision: 'rejected', comment });
+      return toolResult(
+        `Rejected ${requirementId ?? id} as ${a.userName} at ${a.acceptedAt} (progress ${Math.round(a.progressAtAcceptance)}%, revision ${a.nodeRevisionAtAcceptance}): «${comment}»`,
+      );
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
   'revoke_acceptance',
-  "Revoke the calling user's active acceptance on a requirement. History is preserved (append-only); a later re-acceptance is a new sign-off.",
+  "Revoke the calling user's active verdict (acceptance OR rejection) on a requirement. History is preserved (append-only); a later re-acceptance/re-rejection is a new sign-off row.",
   {
     mapId: z.string().describe('The map ID'),
     requirementId: z.string().optional().describe('Requirement ID, e.g. "MAN-01"'),
@@ -492,7 +524,7 @@ server.tool(
         id = hit.id;
       }
       await api.revokeAcceptance(mapId, id);
-      return toolResult(`Revoked acceptance on ${requirementId ?? id}.`);
+      return toolResult(`Revoked verdict on ${requirementId ?? id}.`);
     } catch (err) {
       return toolError(err);
     }
@@ -673,7 +705,9 @@ server.tool(
               const stale =
                 Math.abs(r.progress - a.progressAtAcceptance) > 1 ||
                 r.node.revision !== a.nodeRevisionAtAcceptance;
-              return `${a.userName}${stale ? ' ⚠stale' : ''}`;
+              const mark = a.decision === 'rejected' ? ' ✗' : '';
+              const why = a.decision === 'rejected' && a.comment ? ` («${a.comment}»)` : '';
+              return `${a.userName}${mark}${why}${stale ? ' ⚠stale' : ''}`;
             });
             parts.push(`· Abnahme: ${fmt.join(', ')}`);
           }

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -203,6 +203,8 @@ function PropertyPanelInner({
   const [startDate, setStartDate] = useState(node.startDate ?? '');
   const [blockedReason, setBlockedReason] = useState(node.blockedReason ?? '');
   const [requirementId, setRequirementId] = useState(node.requirementId ?? '');
+  const [verificationText, setVerificationText] = useState(node.verificationText ?? '');
+  const [verificationUrl, setVerificationUrl] = useState(node.verificationUrl ?? '');
 
   // Sync local state when node changes externally
   useEffect(() => { setTitle(node.text); }, [node.text]);
@@ -214,6 +216,8 @@ function PropertyPanelInner({
   useEffect(() => { setStartDate(node.startDate ?? ''); }, [node.startDate]);
   useEffect(() => { setBlockedReason(node.blockedReason ?? ''); }, [node.blockedReason]);
   useEffect(() => { setRequirementId(node.requirementId ?? ''); }, [node.requirementId]);
+  useEffect(() => { setVerificationText(node.verificationText ?? ''); }, [node.verificationText]);
+  useEffect(() => { setVerificationUrl(node.verificationUrl ?? ''); }, [node.verificationUrl]);
 
   const allNodes = useMindmapStore((s) => s.nodes);
   const predecessorTitles = (computedValues?.blockedBy?.predecessorIds ?? [])
@@ -452,6 +456,49 @@ function PropertyPanelInner({
               <option value="could">Could (Kann)</option>
             </select>
           </Field>
+        )}
+
+        {/* Verification how-to + deep link — the review surface reads these */}
+        {(node.requirementId != null || requirementId.trim() !== '') && (
+          <>
+            <Field label="Prüfanleitung">
+              <textarea
+                value={verificationText}
+                onChange={(e) => setVerificationText(e.target.value)}
+                onBlur={() => {
+                  const trimmed = verificationText.trim();
+                  const persisted = node.verificationText ?? '';
+                  if (trimmed !== persisted) {
+                    directUpdate(nodeId, { verificationText: trimmed || null });
+                  }
+                }}
+                onKeyDown={(e) => e.stopPropagation()}
+                style={{
+                  ...inputStyle,
+                  minHeight: 80,
+                  resize: 'vertical',
+                  fontFamily: 'inherit',
+                }}
+                placeholder={'Wie prüfen? Markdown, z.B.\n1. Einloggen als …\n2. …\n\n**Erwartet:** …\n**Testen mit:** …'}
+              />
+            </Field>
+            <Field label="Prüf-Link">
+              <input
+                value={verificationUrl}
+                onChange={(e) => setVerificationUrl(e.target.value)}
+                onBlur={() => {
+                  const trimmed = verificationUrl.trim();
+                  const persisted = node.verificationUrl ?? '';
+                  if (trimmed !== persisted) {
+                    directUpdate(nodeId, { verificationUrl: trimmed || null });
+                  }
+                }}
+                onKeyDown={(e) => e.stopPropagation()}
+                style={inputStyle}
+                placeholder="https://staging… (wo wird geprüft?)"
+              />
+            </Field>
+          </>
         )}
 
         {/* Effort estimate */}

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -73,7 +73,7 @@ export function RequirementsView() {
 
   const user = useMindmapStore((s) => s.user);
   const [acceptances, setAcceptances] = useState<api.AcceptanceRow[]>([]);
-  const [acceptanceFilter, setAcceptanceFilter] = useState<'' | 'none' | 'mine-open'>('');
+  const [acceptanceFilter, setAcceptanceFilter] = useState<'' | 'none' | 'mine-open' | 'rejected'>('');
   const [exporting, setExporting] = useState(false);
 
   useEffect(() => {
@@ -171,6 +171,9 @@ export function RequirementsView() {
           if (acceptanceFilter === 'mine-open' && accs.some((a) => a.userId === user?.id)) {
             return false;
           }
+          if (acceptanceFilter === 'rejected' && !accs.some((a) => a.decision === 'rejected')) {
+            return false;
+          }
         }
         return true;
       }),
@@ -245,6 +248,24 @@ export function RequirementsView() {
     }
   };
 
+  const rejectRequirement = async (row: ReqRow) => {
+    if (!currentMapId || !user) return;
+    const comment = window.prompt(
+      `${row.node.requirementId} ablehnen — warum? (Begründung ist Pflicht)`,
+    );
+    if (comment == null) return; // cancelled
+    if (comment.trim() === '') return;
+    try {
+      const created = await api.acceptRequirement(currentMapId, row.node.id, {
+        decision: 'rejected',
+        comment: comment.trim(),
+      });
+      setAcceptances((prev) => [...prev, created]);
+    } catch {
+      api.fetchAcceptances(currentMapId).then((r) => setAcceptances(r.acceptances)).catch(() => {});
+    }
+  };
+
   const jumpToNode = (node: Node) => {
     setActiveView('mindmap');
     selectNode(node.id);
@@ -313,12 +334,15 @@ export function RequirementsView() {
           </select>
           <select
             value={acceptanceFilter}
-            onChange={(e) => setAcceptanceFilter(e.target.value as '' | 'none' | 'mine-open')}
+            onChange={(e) =>
+              setAcceptanceFilter(e.target.value as '' | 'none' | 'mine-open' | 'rejected')
+            }
             style={filterSelectStyle}
           >
             <option value="">Abnahme: alle</option>
             <option value="none">Nicht abgenommen</option>
             <option value="mine-open">Meine Abnahme offen</option>
+            <option value="rejected">Abgelehnt</option>
           </select>
           <button
             onClick={() => setShowCreate((v) => !v)}
@@ -449,6 +473,7 @@ export function RequirementsView() {
                   accByNode={accByNode}
                   currentUserId={user?.id ?? null}
                   toggleAcceptance={toggleAcceptance}
+                  rejectRequirement={rejectRequirement}
                 />
               ))}
             </tbody>
@@ -472,6 +497,7 @@ function ChapterGroup({
   accByNode,
   currentUserId,
   toggleAcceptance,
+  rejectRequirement,
 }: {
   chapterText: string;
   rows: ReqRow[];
@@ -483,6 +509,7 @@ function ChapterGroup({
   accByNode: Map<string, api.AcceptanceRow[]>;
   currentUserId: string | null;
   toggleAcceptance: (row: ReqRow) => void;
+  rejectRequirement: (row: ReqRow) => void;
 }) {
   const done = rows.filter((r) => r.status === 'done').length;
   return (
@@ -722,14 +749,17 @@ function ChapterGroup({
                 Math.abs(r.progress - a.progressAtAcceptance) > 1 ||
                 r.node.revision !== a.nodeRevisionAtAcceptance;
               const own = a.userId === currentUserId;
-              const label = `${a.userName.split(' ')[0]} ✓ ${a.acceptedAt.slice(5, 10).split('-').reverse().join('.')}.`;
+              const rejected = a.decision === 'rejected';
+              const mark = rejected ? '✗' : '✓';
+              const label = `${a.userName.split(' ')[0]} ${mark} ${a.acceptedAt.slice(5, 10).split('-').reverse().join('.')}.`;
               return (
                 <span
                   key={a.id}
                   onClick={own ? () => toggleAcceptance(r) : undefined}
                   title={
-                    (stale ? 'Seit Abnahme geändert! ' : '') +
-                    `${a.userName}, abgenommen ${a.acceptedAt.slice(0, 10)} bei ${Math.round(a.progressAtAcceptance)}%` +
+                    (stale ? 'Seit dem Urteil geändert! ' : '') +
+                    `${a.userName}, ${rejected ? 'abgelehnt' : 'abgenommen'} ${a.acceptedAt.slice(0, 10)} bei ${Math.round(a.progressAtAcceptance)}%` +
+                    (rejected && a.comment ? ` — «${a.comment}»` : '') +
                     (own ? ' — klicken zum Zurückziehen' : '')
                   }
                   style={{
@@ -740,8 +770,8 @@ function ChapterGroup({
                     fontSize: 11,
                     fontWeight: 600,
                     cursor: own ? 'pointer' : 'default',
-                    background: stale ? '#fef3c7' : '#d1fae5',
-                    color: stale ? '#92400e' : '#065f46',
+                    background: rejected ? '#fee2e2' : stale ? '#fef3c7' : '#d1fae5',
+                    color: rejected ? '#991b1b' : stale ? '#92400e' : '#065f46',
                   }}
                 >
                   {stale ? '⚠ ' : ''}
@@ -751,21 +781,39 @@ function ChapterGroup({
             })}
             {currentUserId &&
               !(accByNode.get(r.node.id) ?? []).some((a) => a.userId === currentUserId) && (
-                <button
-                  onClick={() => toggleAcceptance(r)}
-                  title="Requirement abnehmen (persönliche Abnahme, Status bleibt abgeleitet)"
-                  style={{
-                    padding: '2px 8px',
-                    borderRadius: 10,
-                    fontSize: 11,
-                    border: '1px dashed #cbd5e1',
-                    background: 'transparent',
-                    color: '#64748b',
-                    cursor: 'pointer',
-                  }}
-                >
-                  ✓ Abnehmen
-                </button>
+                <>
+                  <button
+                    onClick={() => toggleAcceptance(r)}
+                    title="Requirement abnehmen (persönliche Abnahme, Status bleibt abgeleitet)"
+                    style={{
+                      padding: '2px 8px',
+                      borderRadius: 10,
+                      fontSize: 11,
+                      border: '1px dashed #cbd5e1',
+                      background: 'transparent',
+                      color: '#64748b',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    ✓ Abnehmen
+                  </button>
+                  <button
+                    onClick={() => rejectRequirement(r)}
+                    title="Requirement ablehnen — Begründung ist Pflicht"
+                    style={{
+                      padding: '2px 8px',
+                      marginLeft: 4,
+                      borderRadius: 10,
+                      fontSize: 11,
+                      border: '1px dashed #fca5a5',
+                      background: 'transparent',
+                      color: '#b91c1c',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    ✗
+                  </button>
+                </>
               )}
           </td>
         </tr>

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -584,16 +584,22 @@ export interface AcceptanceRow {
   acceptedAt: string;
   progressAtAcceptance: number;
   nodeRevisionAtAcceptance: number;
+  decision: 'accepted' | 'rejected';
+  comment: string | null;
 }
 
 export function fetchAcceptances(mapId: string): Promise<{ acceptances: AcceptanceRow[] }> {
   return request<{ acceptances: AcceptanceRow[] }>(`/api/maps/${mapId}/acceptances`);
 }
 
-export function acceptRequirement(mapId: string, nodeId: string): Promise<AcceptanceRow> {
+export function acceptRequirement(
+  mapId: string,
+  nodeId: string,
+  verdict?: { decision: 'accepted' | 'rejected'; comment?: string },
+): Promise<AcceptanceRow> {
   return request<AcceptanceRow>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
     method: 'POST',
-    body: JSON.stringify({}),
+    body: JSON.stringify(verdict ?? {}),
   });
 }
 

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -897,6 +897,8 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       requirementPriority: null,
       requirementText: null,
       phaseId: null,
+      verificationText: null,
+      verificationUrl: null,
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/server/src/db/acceptances.ts
+++ b/packages/server/src/db/acceptances.ts
@@ -12,6 +12,8 @@ import { requirementAcceptances, users } from './schema.js';
  * when, at which progress) is preserved forever.
  */
 
+export type AcceptanceDecision = 'accepted' | 'rejected';
+
 export interface Acceptance {
   id: string;
   mapId: string;
@@ -21,6 +23,10 @@ export interface Acceptance {
   acceptedAt: string;
   progressAtAcceptance: number;
   nodeRevisionAtAcceptance: number;
+  /** Verdict of this sign-off row. Pre-decision rows default to 'accepted'. */
+  decision: AcceptanceDecision;
+  /** Reviewer comment — always present on rejections (route-enforced). */
+  comment: string | null;
 }
 
 function toIso(v: unknown): string {
@@ -39,19 +45,26 @@ export async function listActiveAcceptances(mapId: string): Promise<Acceptance[]
       acceptedAt: requirementAcceptances.acceptedAt,
       progressAtAcceptance: requirementAcceptances.progressAtAcceptance,
       nodeRevisionAtAcceptance: requirementAcceptances.nodeRevisionAtAcceptance,
+      decision: requirementAcceptances.decision,
+      comment: requirementAcceptances.comment,
     })
     .from(requirementAcceptances)
     .innerJoin(users, eq(users.id, requirementAcceptances.userId))
     .where(and(eq(requirementAcceptances.mapId, mapId), isNull(requirementAcceptances.revokedAt)));
-  return rows.map((r) => ({ ...r, acceptedAt: toIso(r.acceptedAt) }));
+  return rows.map((r) => ({
+    ...r,
+    acceptedAt: toIso(r.acceptedAt),
+    decision: (r.decision as AcceptanceDecision) ?? 'accepted',
+  }));
 }
 
 /**
- * Accept a requirement node. Snapshots the derived progress and node
- * revision the acceptor saw. Returns the new acceptance, or null when
- * an active acceptance by this user already exists (idempotent accept —
- * the 23505 on the partial unique index is mapped to null so a double
- * click never errors).
+ * Record a verdict (accept or reject) on a requirement node. Snapshots
+ * the derived progress and node revision the reviewer saw. Returns the
+ * new row, or null when this user already has an ACTIVE verdict on the
+ * node (idempotent — the 23505 on the partial unique index is mapped to
+ * null so a double click never errors). Switching verdict = revoke the
+ * old row first, then record the new one.
  */
 export async function accept(
   mapId: string,
@@ -59,11 +72,13 @@ export async function accept(
   userId: string,
   progressAtAcceptance: number,
   nodeRevisionAtAcceptance: number,
+  decision: AcceptanceDecision = 'accepted',
+  comment: string | null = null,
 ): Promise<Acceptance | null> {
   try {
     const [row] = await db
       .insert(requirementAcceptances)
-      .values({ mapId, nodeId, userId, progressAtAcceptance, nodeRevisionAtAcceptance })
+      .values({ mapId, nodeId, userId, progressAtAcceptance, nodeRevisionAtAcceptance, decision, comment })
       .returning();
     const [u] = await db.select({ name: users.name }).from(users).where(eq(users.id, userId));
     return {
@@ -75,6 +90,8 @@ export async function accept(
       acceptedAt: toIso(row.acceptedAt),
       progressAtAcceptance: row.progressAtAcceptance,
       nodeRevisionAtAcceptance: row.nodeRevisionAtAcceptance,
+      decision: (row.decision as AcceptanceDecision) ?? 'accepted',
+      comment: row.comment ?? null,
     };
   } catch (err) {
     const e = err as { code?: string; constraint?: string };

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -43,6 +43,8 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
       (get('requirementPriority', 'requirement_priority') as CoreNode['requirementPriority']) ?? null,
     requirementText: (get('requirementText', 'requirement_text') as string) ?? null,
     phaseId: (get('phaseId', 'phase_id') as string) ?? null,
+    verificationText: (get('verificationText', 'verification_text') as string) ?? null,
+    verificationUrl: (get('verificationUrl', 'verification_url') as string) ?? null,
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -794,6 +794,15 @@ export async function runMigrations(): Promise<void> {
       ON nodes (map_id, requirement_id)
       WHERE requirement_id IS NOT NULL AND deleted_at IS NULL
   `);
+  // verification_text: how to verify (Prüfanleitung, markdown) rendered on
+  // the review surface. verification_url: deep link (e.g. staging URL).
+  // Both business prose like requirement_text — never GitHub-synced.
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS verification_text TEXT
+  `);
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS verification_url TEXT
+  `);
 
   // ── Requirement acceptances (Abnahme) ──────────────────────────
   // Append-only sign-off history per requirement node per user.
@@ -820,6 +829,16 @@ export async function runMigrations(): Promise<void> {
   await db.execute(sql`
     CREATE INDEX IF NOT EXISTS requirement_acceptances_map_idx
       ON requirement_acceptances (map_id)
+  `);
+  // decision: 'accepted' | 'rejected' — the verdict of the sign-off row.
+  // Default 'accepted' keeps all pre-existing rows valid. comment: the
+  // reviewer's reasoning; the route makes it mandatory for rejections.
+  await db.execute(sql`
+    ALTER TABLE requirement_acceptances
+      ADD COLUMN IF NOT EXISTS decision TEXT NOT NULL DEFAULT 'accepted'
+  `);
+  await db.execute(sql`
+    ALTER TABLE requirement_acceptances ADD COLUMN IF NOT EXISTS comment TEXT
   `);
 
   // ── Phase column (nodes.phase_id + maps.phases) ────────────────

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -243,6 +243,8 @@ export interface CreateNodeInput {
   requirementPriority?: 'must' | 'should' | 'could' | null;
   requirementText?: string | null;
   phaseId?: string | null;
+  verificationText?: string | null;
+  verificationUrl?: string | null;
 }
 
 export async function createNode(
@@ -291,6 +293,8 @@ export async function createNode(
       requirementPriority: input.requirementPriority ?? null,
       requirementText: input.requirementText ?? null,
       phaseId: input.phaseId ?? null,
+      verificationText: input.verificationText ?? null,
+      verificationUrl: input.verificationUrl ?? null,
       assigneeIds: [],
       tags: [],
       customFields: {},
@@ -384,6 +388,8 @@ export interface UpdateNodeInput {
   requirementPriority?: 'must' | 'should' | 'could' | null;
   requirementText?: string | null;
   phaseId?: string | null;
+  verificationText?: string | null;
+  verificationUrl?: string | null;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -503,6 +509,8 @@ export async function updateNode(
   if (input.requirementPriority !== undefined) updates.requirementPriority = input.requirementPriority;
   if (input.requirementText !== undefined) updates.requirementText = input.requirementText;
   if (input.phaseId !== undefined) updates.phaseId = input.phaseId;
+  if (input.verificationText !== undefined) updates.verificationText = input.verificationText;
+  if (input.verificationUrl !== undefined) updates.verificationUrl = input.verificationUrl;
   // Orchestration substrate (#111)
   if (input.claimedBySession !== undefined) updates.claimedBySession = input.claimedBySession;
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -206,6 +206,10 @@ export const nodes = pgTable('nodes', {
   requirementPriority: text('requirement_priority'),
   // Business phrasing for register/doc export; NOT GitHub-synced.
   requirementText: text('requirement_text'),
+  // How to verify (Prüfanleitung, markdown) + deep link for the review
+  // surface. Like requirement_text, NOT GitHub-synced.
+  verificationText: text('verification_text'),
+  verificationUrl: text('verification_url'),
 
   // ── Phase ─────────────────────────────────────────────────────
   // References a PhaseDef.id from maps.phases (statusWorkflow idiom,
@@ -483,6 +487,12 @@ export const requirementAcceptances = pgTable('requirement_acceptances', {
   progressAtAcceptance: real('progress_at_acceptance').notNull(),
   nodeRevisionAtAcceptance: integer('node_revision_at_acceptance').notNull(),
   revokedAt: timestamp('revoked_at', { withTimezone: true }),
+  // Verdict of this sign-off: 'accepted' | 'rejected'. The partial unique
+  // index means one ACTIVE verdict per (node, user) — switching verdict is
+  // revoke + new row, same append-only semantics as re-acceptance.
+  decision: text('decision').notNull().default('accepted'),
+  // Reviewer comment — mandatory for 'rejected' (enforced in the route).
+  comment: text('comment'),
 });
 
 // ── Lint dismissals (plan-health panel, docs/plan-linter.md) ───────

--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure register-data tests for the requirements export: verdict rendering
+ * (✓ / ✗ with comment) and staleness suffix in the Abnahme column.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Node, MindMap, ComputedNodeValues, NodeId } from '@mindblown/core';
+import { buildRegisterData, acceptanceIsStale, renderMarkdown } from '../requirementsDoc.js';
+
+let seq = 0;
+function makeNode(overrides: Partial<Node> & { id: string }): Node {
+  seq++;
+  return {
+    mapId: 'm1',
+    parentId: null,
+    childrenIds: [],
+    text: overrides.id,
+    description: null,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    blockedReason: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    dependencies: [],
+    versionId: null,
+    cycleId: null,
+    externalLinks: [],
+    collapsed: false,
+    x: seq,
+    y: seq,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    requirementId: null,
+    requirementPriority: null,
+    requirementText: null,
+    verificationText: null,
+    verificationUrl: null,
+    claimedBySession: null,
+    claimedAt: null,
+    revision: 0,
+    ...overrides,
+  } as Node;
+}
+
+const map = { name: 'Testmap', rootNodeId: 'root' } as MindMap;
+
+function build(nodes: Node[], acceptances: Parameters<typeof buildRegisterData>[3]) {
+  const computed = new Map<NodeId, ComputedNodeValues>();
+  return buildRegisterData(map, nodes, computed, acceptances);
+}
+
+const baseAcc = {
+  userId: 'u1',
+  userName: 'T. Muster',
+  acceptedAt: '2026-07-17T10:00:00Z',
+  progressAtAcceptance: 100,
+  nodeRevisionAtAcceptance: 3,
+};
+
+describe('buildRegisterData — Abnahme verdicts', () => {
+  const nodes = [
+    makeNode({ id: 'root', childrenIds: ['ch'] }),
+    makeNode({ id: 'ch', parentId: 'root', childrenIds: ['r1'], text: 'Bereich' }),
+    makeNode({
+      id: 'r1',
+      parentId: 'ch',
+      requirementId: 'MAN-01',
+      percentComplete: 100,
+      revision: 3,
+    }),
+  ];
+
+  it('renders an acceptance as ✓ without comment', () => {
+    const data = build(nodes, [{ ...baseAcc, nodeId: 'r1', decision: 'accepted' }]);
+    expect(data.chapters[0].rows[0].abnahme).toEqual(['T. Muster ✓ 17.07.']);
+  });
+
+  it('renders a rejection as ✗ with the truncated comment', () => {
+    const data = build(nodes, [
+      { ...baseAcc, nodeId: 'r1', decision: 'rejected', comment: 'Rollen-Dropdown speichert nicht' },
+    ]);
+    expect(data.chapters[0].rows[0].abnahme).toEqual([
+      'T. Muster ✗ 17.07. («Rollen-Dropdown speichert nicht»)',
+    ]);
+  });
+
+  it('treats rows without a decision (pre-migration shape) as accepted', () => {
+    const data = build(nodes, [{ ...baseAcc, nodeId: 'r1' }]);
+    expect(data.chapters[0].rows[0].abnahme[0]).toContain('✓');
+  });
+
+  it('suffixes ⚠ when the requirement changed after the verdict', () => {
+    const data = build(nodes, [
+      { ...baseAcc, nodeId: 'r1', decision: 'rejected', comment: 'kaputt', nodeRevisionAtAcceptance: 1 },
+    ]);
+    expect(data.chapters[0].rows[0].abnahme[0]).toMatch(/⚠$/);
+  });
+
+  it('renders verdicts into the markdown table', () => {
+    const data = build(nodes, [
+      { ...baseAcc, nodeId: 'r1', decision: 'rejected', comment: 'kaputt' },
+    ]);
+    const md = renderMarkdown(data);
+    expect(md).toContain('T. Muster ✗ 17.07. («kaputt»)');
+  });
+});
+
+describe('acceptanceIsStale', () => {
+  it('flags revision drift and >1pt progress drift, tolerates rounding', () => {
+    const acc = { ...baseAcc };
+    expect(acceptanceIsStale(acc, 100, 3)).toBe(false);
+    expect(acceptanceIsStale(acc, 99.5, 3)).toBe(false); // within 1pt
+    expect(acceptanceIsStale(acc, 90, 3)).toBe(true);
+    expect(acceptanceIsStale(acc, 100, 4)).toBe(true);
+  });
+});

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -21,6 +21,10 @@ export interface AcceptanceInfo {
   acceptedAt: string; // ISO
   progressAtAcceptance: number;
   nodeRevisionAtAcceptance: number;
+  /** Verdict — optional so pre-decision callers/rows read as 'accepted'. */
+  decision?: 'accepted' | 'rejected';
+  /** Reviewer comment; always present on rejections. */
+  comment?: string | null;
 }
 
 /**
@@ -58,6 +62,10 @@ export interface RegisterData {
 }
 
 const PRIO: Record<string, string> = { must: 'Muss', should: 'Soll', could: 'Kann' };
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
 
 // Doc buckets: S ≤ 2 Tage · M 3–5 · L 1–3 Wochen · XL > 3 Wochen
 function sizeOf(days: number): string {
@@ -121,6 +129,10 @@ export function buildRegisterData(
           const abnahme = (accByNode.get(n.id) ?? []).map((a) => {
             const d = a.acceptedAt.slice(5, 10).split('-').reverse().join('.');
             const stale = acceptanceIsStale(a, p, n.revision) ? ' ⚠' : '';
+            if (a.decision === 'rejected') {
+              const why = a.comment ? ` («${truncate(a.comment, 60)}»)` : '';
+              return `${a.userName} ✗ ${d}.${why}${stale}`;
+            }
             return `${a.userName} ✓ ${d}.${stale}`;
           });
           return {
@@ -150,6 +162,7 @@ const LEGEND = [
   '**Priorität:** Muss — Kernfunktion (MVP) · Soll — wichtig, nicht MVP-blockierend · Kann — wünschenswert',
   '**Status:** Umgesetzt · Teilweise · Offen (abgeleitet: 100 % / >0 % / 0 % Fortschritt)',
   '**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» bei Umgesetzt): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen',
+  '**Abnahme:** ✓ abgenommen · ✗ abgelehnt (mit Begründung) · ⚠ seit dem Urteil geändert',
 ];
 
 export function renderMarkdown(data: RegisterData): string {

--- a/packages/server/src/lint/__tests__/engine.test.ts
+++ b/packages/server/src/lint/__tests__/engine.test.ts
@@ -38,6 +38,8 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementPriority: null,
     requirementText: null,
     phaseId: null,
+    verificationText: null,
+    verificationUrl: null,
     claimedBySession: null,
     claimedAt: null,
     revision: 0,

--- a/packages/server/src/routes/acceptances.ts
+++ b/packages/server/src/routes/acceptances.ts
@@ -26,7 +26,11 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
     return reply.send({ acceptances: await acceptanceDb.listActiveAcceptances(req.params.id) });
   });
 
-  // ── POST /api/maps/:id/nodes/:nodeId/acceptance — accept ───────
+  // ── POST /api/maps/:id/nodes/:nodeId/acceptance — verdict ──────
+  // Body (optional): { decision: 'accepted' | 'rejected', comment }.
+  // Default 'accepted' keeps the #218 body-less accept working.
+  // Rejections require a non-empty comment — a ✗ without reasoning
+  // is not actionable for anyone.
   app.post<{ Params: { id: string; nodeId: string } }>(
     '/api/maps/:id/nodes/:nodeId/acceptance',
     async (req, reply) => {
@@ -34,6 +38,25 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
       if (!userId) {
         return reply.status(401).send({
           error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+        });
+      }
+      const body = (req.body ?? {}) as { decision?: string; comment?: string };
+      const decision = body.decision ?? 'accepted';
+      if (decision !== 'accepted' && decision !== 'rejected') {
+        return reply.status(400).send({
+          error: {
+            code: 'INVALID_DECISION',
+            message: "decision must be 'accepted' or 'rejected'",
+          },
+        });
+      }
+      const comment = typeof body.comment === 'string' ? body.comment.trim() : '';
+      if (decision === 'rejected' && comment.length === 0) {
+        return reply.status(400).send({
+          error: {
+            code: 'REJECTION_NEEDS_COMMENT',
+            message: 'Rejecting a requirement requires a comment explaining why',
+          },
         });
       }
       const perm = await permDb.getPermission(req.params.id, userId);
@@ -73,12 +96,15 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
         userId,
         progress,
         node.revision,
+        decision,
+        comment.length > 0 ? comment : null,
       );
       if (!acceptance) {
         return reply.status(409).send({
           error: {
             code: 'ALREADY_ACCEPTED',
-            message: 'You already have an active acceptance on this requirement',
+            message:
+              'You already have an active verdict on this requirement — revoke it first to change it',
           },
         });
       }

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -470,6 +470,8 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           requirementPriority: null,
           requirementText: null,
           phaseId: null,
+          verificationText: null,
+          verificationUrl: null,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -172,6 +172,8 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       requirementPriority?: 'must' | 'should' | 'could' | null;
       requirementText?: string | null;
       phaseId?: string | null;
+      verificationText?: string | null;
+      verificationUrl?: string | null;
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`
        * auto-link backstop (#58). Useful when the leading `#NNNN` is

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -587,6 +587,35 @@ describe('requirement fields', () => {
     });
   });
 
+  it('forwards verification fields on update', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      verificationText: '1. Einloggen\n2. Mandat öffnen\n\n**Erwartet:** Badge sichtbar',
+      verificationUrl: 'https://staging.example.com/mandates',
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({
+      verificationText: '1. Einloggen\n2. Mandat öffnen\n\n**Erwartet:** Badge sichtbar',
+      verificationUrl: 'https://staging.example.com/mandates',
+    });
+  });
+
+  it('forwards verification fields on create', async () => {
+    const recorder = makeRecordingBackend();
+    await createNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'Neue Anforderung',
+      verificationText: 'Prüfen im Admin-Panel',
+      verificationUrl: 'https://staging.example.com/admin',
+    } as never);
+    expect(recorder.lastCreate?.fields).toMatchObject({
+      verificationText: 'Prüfen im Admin-Panel',
+      verificationUrl: 'https://staging.example.com/admin',
+    });
+  });
+
   it('omits requirement fields from the backend call when not provided', async () => {
     const recorder = makeRecordingBackend();
     await updateNodeTool.handler(recorder.backend, {
@@ -596,6 +625,8 @@ describe('requirement fields', () => {
     } as never);
     expect('requirementId' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
     expect('requirementPriority' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+    expect('verificationText' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+    expect('verificationUrl' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
   });
 });
 

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -52,6 +52,16 @@ export const createNodeTool = defineTool({
       .describe(
         'Phase reference — the id of a PhaseDef from the map\'s `phases` list (shown by get_map). Must reference an existing phase; add new phases via update_map first. Same idiom as versionId.',
       ),
+    verificationText: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('How to verify this requirement (Prüfanleitung): markdown with numbered steps, expected result and test data, written for a non-technical reviewer. Shown on the review surface next to accept/reject. Not synced to GitHub.'),
+    verificationUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Deep link to where the requirement is verified (e.g. a staging URL). Rendered as an "open" button on the review surface.'),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -145,6 +155,16 @@ export const updateNodeTool = defineTool({
       .describe(
         'Phase reference — the id of a PhaseDef from the map\'s `phases` list (shown by get_map). Must reference an existing phase; add new phases via update_map first. null clears the phase. Same idiom as versionId.',
       ),
+    verificationText: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('How to verify this requirement (Prüfanleitung): markdown with numbered steps, expected result and test data, for a non-technical reviewer. Safe to edit freely — never pushed to GitHub. null clears it.'),
+    verificationUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Deep link to where the requirement is verified (e.g. a staging URL). null clears it.'),
     // Orchestration substrate (#111)
     scopes: z
       .array(z.string())


### PR DESCRIPTION
PR 1 of the requirements review ("Prüfen") surface — the data layer.

## What

**Verification how-to on requirement nodes.** `verificationText` (Prüfanleitung: markdown with numbered steps, expected result, test data — written for a non-technical reviewer) and `verificationUrl` (staging deep link). The Angela-card pattern from crm `apps/uat`, but as real columns instead of LLM-marker-comment parsing, since we own the data model here. Shipped through every layer per the definition-of-done: core type → Drizzle schema → idempotent migration → `dbNodeToCore` → REST → tool-kit zod (`create_node`/`update_node`) → PropertyPanel edit fields → tests. Like `requirementText`, never GitHub-synced.

**Reject-with-comment verdicts.** `requirement_acceptances` grows `decision` (`accepted`|`rejected`, default keeps all existing rows valid) and `comment`. Append-only semantics unchanged — the partial unique index now means one ACTIVE verdict per (node, user); switching verdict = revoke + new row. Staleness ⚠ applies to rejections too.

- REST: `POST …/acceptance` takes optional `{decision, comment}`; rejected without a non-empty comment → 400 `REJECTION_NEEDS_COMMENT`; bad decision → 400 `INVALID_DECISION`.
- MCP: new `reject_requirement` tool (comment mandatory); `requirements_overview` and the md/docx export render `✗ («comment»)`.
- Register UI: red ✗ chips with comment in tooltip, ✗ reject button (prompt for the mandatory comment), new "Abgelehnt" filter.

## Verification

- `pnpm turbo typecheck` + `test` clean across all packages (561 server / 77 tool-kit, new export-renderer tests included).
- E2E on a scratch DB (fresh migrations): field round-trip via REST (create, update, null-clear), verdict lifecycle (401/403 guards, invalid decision, comment-less reject 400, double-verdict 409, revoke idempotence, reject-with-comment, append-only history preserved), export shows ✗ + comment and flags ⚠ after a node edit — 20/20 checks green.
- MCP over stdio against the scratch server: `revoke_acceptance` → `reject_requirement` → `requirements_overview` shows `Abnahme: Thomas Muster ✗ («MCP-Test: Feld fehlt»)`.

## Follow-ups (planned, not blocked surfaces)

- PR 2: the Prüfen review-queue UI (desktop + mobile) rendering `verificationText` with big ✓/✗ actions.
- PR 3: backfill Prüfanleitungen for the 66 done (+41 partial) requirements on the roadmap map (AI-drafted, human-skimmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9M8dEf1hTfK4SiBfT5VyM