### PR TITLE
fix(velocity): rework = keyword AND reference (was OR — over-fired to 92%)

### DIFF
--- a/packages/core/src/__tests__/velocity.test.ts
+++ b/packages/core/src/__tests__/velocity.test.ts
@@ -75,18 +75,19 @@ describe('scopedCapacityDays', () => {
 });
 
 describe('analyzeRepoThroughput', () => {
-  it('classifies correction keywords + references to in-window PRs as rework', () => {
+  it('rework = correction keyword AND reference to an in-window PR (both required)', () => {
     const prs = [
       pr(1, 'feat(a): new thing', 0, 0.5),
       pr(2, 'feat(b): another', 1, 1.4),
-      pr(3, 'fix(a): correct #1 regression', 2, 2.5), // keyword + ref
-      pr(4, 'follow-up to #2', 3, 3.2),               // keyword + ref
-      pr(5, 'feat(c): builds on #1', 4, 4.3),         // ref only (in-window) → rework
+      pr(3, 'fix(a): correct #1 regression', 2, 2.5), // keyword + ref → rework
+      pr(4, 'follow-up to #2', 3, 3.2),               // keyword + ref → rework
+      pr(5, 'feat(c): builds on #1', 4, 4.3),         // ref only, NO keyword → NOT rework
+      pr(6, 'fix(z): standalone bug', 5, 5.3),        // keyword only, NO ref → NOT rework
     ];
     const rt = analyzeRepoThroughput(prs);
-    expect(rt.merged).toBe(5);
-    expect(rt.reworkCount).toBe(3); // #3, #4, #5
-    expect(rt.reworkFraction).toBeCloseTo(0.6, 6);
+    expect(rt.merged).toBe(6);
+    expect(rt.reworkCount).toBe(2); // only #3, #4
+    expect(rt.reworkFraction).toBeCloseTo(2 / 6, 6);
   });
 
   it('computes review-latency stats and offline (>6h) merges', () => {

--- a/packages/core/src/velocity.ts
+++ b/packages/core/src/velocity.ts
@@ -89,10 +89,11 @@ export function scopedCapacityDays(
 //     separate signal (it paces delivery but isn't a rework loss).
 //
 // v1 detects rework by signal, not file-overlap: a merged PR is rework if its
-// title/body carries a correction keyword OR references (#NNN) another PR that
-// also merged in the window. That is "same work-item", cheap (no per-PR file
-// fetch), and tighter than a bare keyword match. File-level same-area is a
-// documented follow-up refinement.
+// title/body carries a correction keyword AND references (#NNN) another PR that
+// also merged in the window — a correction that points at recent work. Both are
+// required (reference-alone over-fires in a high-volume repo where nearly every
+// PR cross-references; keyword-alone counts standalone net-new bug fixes).
+// File-level same-area is a documented follow-up refinement.
 
 /** Correction-intent keywords in a PR title/body → likely rework. */
 const REWORK_KEYWORD = /\b(fix|fixup|hotfix|revert|reverts|redo|rework|re-?work|follow-?ups?|followup|regress\w*|correct\w*|amend|nit|nits)\b/i;
@@ -151,11 +152,16 @@ export function analyzeRepoThroughput(prs: PrRecord[]): RepoThroughput {
       latencies.push(hours);
       if (hours > OFFLINE_MERGE_HOURS) offline++;
     }
+    // Rework = a *correction* (keyword) that *points at recent work* (references
+    // another PR merged in the same window). Both are required: in a repo
+    // merging dozens of PRs a day almost every PR cross-references another, so
+    // reference-alone flags nearly everything; keyword-alone counts standalone
+    // net-new bug fixes as rework. The AND is "redoing something just done."
     const keyword = REWORK_KEYWORD.test(pr.title) || REWORK_KEYWORD.test(pr.body ?? '');
     const refsRecent = referencedNumbers(pr).some(
       (n) => n !== pr.number && mergedSet.has(n),
     );
-    if (keyword || refsRecent) rework++;
+    if (keyword && refsRecent) rework++;
   }
 
   latencies.sort((a, b) => a - b);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1794,7 +1794,7 @@ server.tool(
         lines.push(`Gross rate:           ${rt.grossRatePerDay.toFixed(2)} ${unit}/day (what you'd forecast off — inflated)`);
         lines.push(`NET rate:             ${rt.netRatePerDay.toFixed(2)} ${unit}/day  ← forecast off THIS (gross × (1 − rework))`);
         lines.push(`Review latency:       median ${rt.medianLatencyHours.toFixed(1)}h | mean ${rt.meanLatencyHours.toFixed(1)}h | max ${rt.maxLatencyHours.toFixed(1)}h | ${rt.offlineMergeCount} waited >6h (reviewer offline)`);
-        lines.push(`Rework detection is signal-based (correction keywords + references to other in-window PRs), not file-overlap — an approximation; treat rework% as indicative.`);
+        lines.push(`Rework detection: correction keyword AND a reference to another in-window PR (a fixup pointing at recent work) — not file-overlap; treat rework% as indicative.`);
       }
 
       lines.push('');


### PR DESCRIPTION
Follow-up to #229. Live test showed rework over-firing to 92% (net collapsed to 0.27/day) because "keyword OR reference" flags nearly every PR in a repo merging ~36/day. Require BOTH (a fixup that references recent work). Core tests updated (14 velocity tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)