### PR TITLE
feat(mi): phaseId scoping for completion_forecast, remaining_work, risk_scan, search_nodes

### DIFF
--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -53,22 +53,26 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
 /**
  * Tree:
  *   root
- *   ├── a (versionId: v1)
+ *   ├── a (versionId: v1, phaseId: p1)
  *   │   ├── a1 (leaf)
- *   │   └── a2 (leaf, versionId: v2)
+ *   │   └── a2 (leaf, versionId: v2, phaseId: p2)
  *   └── b
  *       └── b1 (leaf)
  */
 function makeMap(): MapDetail {
   const nodes = [
     makeNode({ id: 'root', childrenIds: ['a', 'b'] }),
-    makeNode({ id: 'a', parentId: 'root', childrenIds: ['a1', 'a2'], versionId: 'v1' }),
+    makeNode({ id: 'a', parentId: 'root', childrenIds: ['a1', 'a2'], versionId: 'v1', phaseId: 'p1' }),
     makeNode({ id: 'a1', parentId: 'a' }),
-    makeNode({ id: 'a2', parentId: 'a', versionId: 'v2' }),
+    makeNode({ id: 'a2', parentId: 'a', versionId: 'v2', phaseId: 'p2' }),
     makeNode({ id: 'b', parentId: 'root', childrenIds: ['b1'] }),
     makeNode({ id: 'b1', parentId: 'b' }),
   ];
-  return { map: { id: 'm1' }, nodes } as unknown as MapDetail;
+  const phases = [
+    { id: 'p1', name: 'MVP', position: 0 },
+    { id: 'p2', name: 'Later', position: 1 },
+  ];
+  return { map: { id: 'm1', phases }, nodes } as unknown as MapDetail;
 }
 
 describe('scopedLeaves', () => {
@@ -113,6 +117,35 @@ describe('scopedLeaves', () => {
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.leaves).toEqual([]);
+  });
+
+  it('scopes by phase with nearest-tagged-ancestor semantics', () => {
+    // a1 inherits p1 from parent a; a2's own p2 overrides the inherited p1.
+    const p1 = scopedLeaves(makeMap(), { phaseId: 'p1' });
+    expect(p1.ok).toBe(true);
+    if (!p1.ok) return;
+    expect(p1.leaves.map((l) => l.id)).toEqual(['a1']);
+    expect(p1.scopeLabel).toBe('phase "MVP"');
+
+    const p2 = scopedLeaves(makeMap(), { phaseId: 'p2' });
+    expect(p2.ok).toBe(true);
+    if (!p2.ok) return;
+    expect(p2.leaves.map((l) => l.id)).toEqual(['a2']);
+  });
+
+  it('intersects nodeId and phaseId scopes', () => {
+    const res = scopedLeaves(makeMap(), { nodeId: 'b', phaseId: 'p1' });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.leaves).toEqual([]);
+  });
+
+  it('errors on an unknown phaseId, listing the known phases', () => {
+    const res = scopedLeaves(makeMap(), { phaseId: 'nope' });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toContain('nope');
+    expect(res.error).toContain('MVP');
   });
 
   it('errors on an unknown nodeId', () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -360,16 +360,17 @@ server.tool(
 
 server.tool(
   'remaining_work',
-  'Report how much work is left for a node/subtree/version. Returns remaining effort, incomplete leaf count, weighted % done, and count of leaves with no estimate. Answers "how much is left?" — the basic MI question. Scope with one of nodeId (subtree) or versionId; omit both to report on the whole map.',
+  'Report how much work is left for a node/subtree/version/phase. Returns remaining effort, incomplete leaf count, weighted % done, and count of leaves with no estimate. Answers "how much is left?" — the basic MI question. Scope with nodeId (subtree), versionId, or phaseId; omit all to report on the whole map.',
   {
     mapId: z.string().describe('The map ID'),
     nodeId: z.string().optional().describe('Scope to this node and its descendants'),
     versionId: z.string().optional().describe('Scope to leaves tagged with this version (directly or via an ancestor)'),
+    phaseId: z.string().optional().describe('Scope to leaves in this phase (nearest phaseId on the leaf→root path decides, like the UI phase filter)'),
   },
-  async ({ mapId, nodeId, versionId }) => {
+  async ({ mapId, nodeId, versionId, phaseId }) => {
     try {
       const data = await api.getMap(mapId);
-      const scope = scopedLeaves(data, { nodeId, versionId });
+      const scope = scopedLeaves(data, { nodeId, versionId, phaseId });
       if (!scope.ok) return toolError(scope.error);
       const { leaves, scopeLabel } = scope;
 
@@ -724,16 +725,17 @@ server.tool(
 
 server.tool(
   'completion_forecast',
-  'Forecast "when will it be done?" for a node/subtree/version. Reports: planned finish date (scheduler-based, respects dependencies), velocity-adjusted finish date (scales by past estimation accuracy from get_estimation_accuracy), target date (from version or node dueDates), and slip vs target. Scope with one of nodeId or versionId; omit both to forecast the whole map.',
+  'Forecast "when will it be done?" for a node/subtree/version/phase. Reports: planned finish date (scheduler-based, respects dependencies), velocity-adjusted finish date (scales by past estimation accuracy from get_estimation_accuracy), target date (from version/phase or node dueDates), and slip vs target. Scope with nodeId (subtree), versionId, or phaseId; omit all to forecast the whole map.',
   {
     mapId: z.string().describe('The map ID'),
     nodeId: z.string().optional().describe('Scope to this node and its descendants'),
     versionId: z.string().optional().describe('Scope to leaves tagged with this version (directly or via an ancestor)'),
+    phaseId: z.string().optional().describe('Scope to leaves in this phase (nearest phaseId on the leaf→root path decides, like the UI phase filter)'),
   },
-  async ({ mapId, nodeId, versionId }) => {
+  async ({ mapId, nodeId, versionId, phaseId }) => {
     try {
       const data = await api.getMap(mapId);
-      const scope = scopedLeaves(data, { nodeId, versionId });
+      const scope = scopedLeaves(data, { nodeId, versionId, phaseId });
       if (!scope.ok) return toolError(scope.error);
       const { leaves, scopeLabel } = scope;
 
@@ -794,7 +796,7 @@ server.tool(
       // finish off the whole-map scheduler — its leaves land behind the entire
       // backlog there, so the date reflects the backlog, not the milestone.
       // Project the scope's own remaining effort against team capacity instead.
-      const scoped = Boolean(versionId || nodeId);
+      const scoped = Boolean(versionId || nodeId || phaseId);
       const workers = Math.max(1, Math.floor(sched.workerCount ?? 1));
       let plannedFinishCalendarDays: number;
       let velocityFinishCalendarDays: number;
@@ -862,6 +864,13 @@ server.tool(
           }
         } catch {
           /* fall through to node dueDates */
+        }
+      }
+      if (!targetDate && phaseId) {
+        const phase = (data.map.phases ?? []).find((p) => p.id === phaseId);
+        if (phase?.targetDate) {
+          targetDate = phase.targetDate.slice(0, 10);
+          targetSource = `phase "${phase.name}"`;
         }
       }
       if (!targetDate && targetDates.length > 0) {
@@ -935,11 +944,12 @@ server.tool(
 
 server.tool(
   'risk_scan',
-  'Surface project risks across a map/subtree/version: stalled in-progress work, leaves without estimates, in-flight overruns (actual > estimate), fragile critical-path nodes (on CP with problems), and unassigned P0/P1 leaves. Use this before planning sessions to catch problems early. Pass `category` to drill into one bucket; pass `limit` (default 20, max 1000) to see more than the top of each list.',
+  'Surface project risks across a map/subtree/version/phase: stalled in-progress work, leaves without estimates, in-flight overruns (actual > estimate), fragile critical-path nodes (on CP with problems), and unassigned P0/P1 leaves. Use this before planning sessions to catch problems early. Pass `category` to drill into one bucket; pass `limit` (default 20, max 1000) to see more than the top of each list.',
   {
     mapId: z.string().describe('The map ID'),
     nodeId: z.string().optional().describe('Scope to this node and its descendants'),
     versionId: z.string().optional().describe('Scope to leaves tagged with this version'),
+    phaseId: z.string().optional().describe('Scope to leaves in this phase (nearest phaseId on the leaf→root path decides, like the UI phase filter)'),
     stalledDays: z.number().int().min(1).default(7).describe('Days since last update before in-progress work is flagged as stalled (default 7)'),
     category: z
       .enum(['stalled', 'no_estimate', 'overruns', 'unassigned_high_prio', 'fragile_cp'])
@@ -953,10 +963,10 @@ server.tool(
       .default(20)
       .describe('Max items shown per category before the "… and N more" truncation footer (default 20, max 1000).'),
   },
-  async ({ mapId, nodeId, versionId, stalledDays, category, limit }) => {
+  async ({ mapId, nodeId, versionId, phaseId, stalledDays, category, limit }) => {
     try {
       const data = await api.getMap(mapId);
-      const scope = scopedLeaves(data, { nodeId, versionId });
+      const scope = scopedLeaves(data, { nodeId, versionId, phaseId });
       if (!scope.ok) return toolError(scope.error);
       const { leaves, scopeLabel } = scope;
 

--- a/packages/mcp/src/scope.ts
+++ b/packages/mcp/src/scope.ts
@@ -6,7 +6,10 @@
  * - `nodeId` restricts to the leaves of that subtree.
  * - `versionId` filters by inherited tag: a leaf is in scope if it OR any
  *   ancestor carries the version. Combines with `nodeId` (intersection).
- * - Neither → all leaves of the map.
+ * - `phaseId` filters by effective phase: nearest non-null `phaseId` on the
+ *   leaf→root path decides (same explicit-assignment-wins semantics as the
+ *   frontend scopeFilter.ts walk). Combines with the others (intersection).
+ * - None → all leaves of the map.
  */
 import type { MapDetail, NodeWithComputed } from './api.js';
 
@@ -16,9 +19,9 @@ export type ScopeResult =
 
 export function scopedLeaves(
   data: MapDetail,
-  opts: { nodeId?: string; versionId?: string } = {},
+  opts: { nodeId?: string; versionId?: string; phaseId?: string } = {},
 ): ScopeResult {
-  const { nodeId, versionId } = opts;
+  const { nodeId, versionId, phaseId } = opts;
   const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
 
   const ancestorVersions = (leafId: string): Set<string> => {
@@ -59,6 +62,26 @@ export function scopedLeaves(
   if (versionId) {
     scopeLabel = `version ${versionId}` + (nodeId ? ` within ${scopeLabel}` : '');
     leaves = leaves.filter((n) => ancestorVersions(n.id).has(versionId));
+  }
+
+  if (phaseId) {
+    const phases = data.map.phases ?? [];
+    const phase = phases.find((p) => p.id === phaseId);
+    if (phases.length > 0 && !phase) {
+      const known = phases.map((p) => `"${p.name}" (${p.id})`).join(', ');
+      return { ok: false, error: `Phase ${phaseId} not found on map ${data.map.id}. Known phases: ${known}.` };
+    }
+    const phaseFragment = `phase ${phase ? `"${phase.name}"` : phaseId}`;
+    scopeLabel = scopeLabel === 'whole map' ? phaseFragment : `${phaseFragment} within ${scopeLabel}`;
+    const effectivePhase = (leafId: string): string | null => {
+      let cur = nodeById.get(leafId);
+      while (cur) {
+        if (cur.phaseId != null) return cur.phaseId;
+        cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
+      }
+      return null;
+    };
+    leaves = leaves.filter((n) => effectivePhase(n.id) === phaseId);
   }
 
   return { ok: true, leaves, scopeLabel };

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -510,6 +510,90 @@ describe('search_nodes tool — versionId ancestor-walk', () => {
   });
 });
 
+describe('search_nodes tool — phaseId ancestor-walk', () => {
+  function buildPhaseMap(): MapDetail {
+    const node = (
+      id: string,
+      parentId: string | null,
+      childrenIds: string[],
+      phaseId: string | null,
+    ): NodeWithComputed =>
+      ({
+        id,
+        mapId: 'm1',
+        parentId,
+        childrenIds,
+        text: id,
+        description: null,
+        effortEstimate: null,
+        actualEffort: null,
+        percentComplete: null,
+        status: null,
+        assigneeIds: [],
+        priority: null,
+        dueDate: null,
+        startDate: null,
+        tags: [],
+        dependencies: [],
+        versionId: null,
+        cycleId: null,
+        phaseId,
+        externalLinks: [],
+        collapsed: false,
+        createdAt: '2026-07-19T00:00:00Z',
+        updatedAt: '2026-07-19T00:00:00Z',
+        claimedBySession: null,
+        claimedAt: null,
+        computedEffort: 0,
+        computedProgress: 0,
+        healthSignal: 'on_track',
+      }) as unknown as NodeWithComputed;
+    return {
+      map: {
+        id: 'm1',
+        rootNodeId: 'root',
+        phases: [
+          { id: 'ph-mvp', name: 'MVP', position: 0 },
+          { id: 'ph-later', name: 'Later', position: 1 },
+        ],
+      } as unknown as MapDetail['map'],
+      nodes: [
+        node('root', null, ['epic'], null),
+        node('epic', 'root', ['leaf-inherits', 'leaf-later'], 'ph-mvp'),
+        node('leaf-inherits', 'epic', [], null),
+        node('leaf-later', 'epic', [], 'ph-later'),
+      ],
+    };
+  }
+
+  it('inherits the ancestor phase, with an explicit child phase overriding', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildPhaseMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      phaseId: 'ph-mvp',
+    } as never);
+    expect(out).toContain('id: epic');
+    expect(out).toContain('id: leaf-inherits');
+    expect(out).not.toContain('id: leaf-later');
+    expect(out).not.toContain('id: root');
+  });
+
+  it('matches an explicitly-phased leaf under a differently-phased epic', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildPhaseMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      phaseId: 'ph-later',
+    } as never);
+    expect(out).toContain('id: leaf-later');
+    expect(out).not.toContain('id: epic');
+    expect(out).not.toContain('id: leaf-inherits');
+  });
+});
+
 // Requirements register — requirementId marks a node as a business
 // requirement (unique per map); requirementPriority is MoSCoW. Both must
 // round-trip through create_node AND update_node or the register is

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -294,7 +294,7 @@ export const clearBlockerTool = defineTool({
 export const searchNodesTool = defineTool({
   name: 'search_nodes',
   description:
-    'Search nodes by text across a map, with optional structured filters. Pass an empty string or "*" as query to match all nodes and filter by status/priority/tag/unestimated/leavesOnly/versionId/parentId only. Use parentId to enumerate the direct children of a specific node (e.g. before merging duplicate buckets or flattening a wrapper chain): query="*", parentId:"<id>". Common pre-flight check: query="*", unestimated:true, versionId:"<id>" to find any V-N leaves still missing estimates.',
+    'Search nodes by text across a map, with optional structured filters. Pass an empty string or "*" as query to match all nodes and filter by status/priority/tag/unestimated/leavesOnly/versionId/phaseId/parentId only. Use parentId to enumerate the direct children of a specific node (e.g. before merging duplicate buckets or flattening a wrapper chain): query="*", parentId:"<id>". Common pre-flight check: query="*", unestimated:true, versionId:"<id>" to find any V-N leaves still missing estimates.',
   schema: {
     mapId: z.string().describe('The map ID'),
     query: z
@@ -321,12 +321,16 @@ export const searchNodesTool = defineTool({
       .string()
       .optional()
       .describe('Filter by version. Matches nodes whose own versionId is this OR any ancestor on the path inherits it.'),
+    phaseId: z
+      .string()
+      .optional()
+      .describe('Filter by phase. Matches nodes whose effective phase is this — nearest non-null phaseId on the node→root path decides, like the UI phase filter.'),
     parentId: z
       .string()
       .optional()
       .describe('Filter to direct children of this node id. Combine with query="*" to enumerate the contents of a specific bucket — the only way to do so, since get_map truncates on large maps.'),
   },
-  handler: async (backend, { mapId, query, status, notStatus, priority, tag, unestimated, leavesOnly, versionId, parentId }) => {
+  handler: async (backend, { mapId, query, status, notStatus, priority, tag, unestimated, leavesOnly, versionId, phaseId, parentId }) => {
     const data = await backend.getMap(mapId);
     const trimmedQ = query.trim();
     const matchAll = trimmedQ === '' || trimmedQ === '*';
@@ -368,6 +372,21 @@ export const searchNodesTool = defineTool({
       };
       matches = matches.filter((n) => inVersion(n.id));
     }
+    if (phaseId) {
+      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+      // Same explicit-assignment-wins walk as versionId above (and the
+      // frontend scopeFilter.ts): the nearest non-null phaseId on the
+      // node→root path decides membership.
+      const inPhase = (id: string): boolean => {
+        let cur = nodeById.get(id);
+        while (cur) {
+          if (cur.phaseId != null) return cur.phaseId === phaseId;
+          cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
+        }
+        return false;
+      };
+      matches = matches.filter((n) => inPhase(n.id));
+    }
 
     if (matches.length === 0) {
       const filters = [
@@ -378,6 +397,7 @@ export const searchNodesTool = defineTool({
         unestimated !== undefined && `unestimated=${unestimated}`,
         leavesOnly && `leavesOnly=true`,
         versionId && `versionId=${versionId}`,
+        phaseId && `phaseId=${phaseId}`,
         parentId && `parentId=${parentId}`,
       ].filter(Boolean);
       const filterStr = filters.length > 0 ? ` (filters: ${filters.join(', ')})` : '';


### PR DESCRIPTION
## Why

The phases migration (#226–#228) moved the Fulcrum roadmap map from pseudo-versions to phases and deleted the version rows. Every version-scoped MI call there now returns "No leaf nodes in scope" — the scoped-forecast capability from #223 is dead for phase-organized maps.

## What

- `scopedLeaves` (shared MI scoping helper) gains `phaseId` with nearest-tagged-ancestor semantics, matching the frontend `scopeFilter.ts` walk. Unknown phaseId → error listing the map's known phases.
- `completion_forecast`, `remaining_work`, `risk_scan` accept `phaseId`; forecast resolves the target date from `PhaseDef.targetDate`, so a phase-scoped forecast reports slip vs the phase deadline (e.g. MVP 2026-07-31).
- `search_nodes` gains a `phaseId` filter with the same explicit-assignment-wins walk as its `versionId` filter.

## Not in scope (noted for follow-up)

- `plan_lint` phase scoping (delegates to the server lint endpoint — needs a server-side change)
- `blocked_digest` / `get_wip_status` / `burnup` phase params
- Gantt: schedule endpoint has no phase scoping and bars stay whole-map-scheduled under a phase filter; phase targetDates invisible (separate audit, follow-up issue to come)

## Tests

- `scopedLeaves`: inheritance, explicit-child-override, nodeId∩phaseId intersection, unknown-phase error
- `search_nodes`: ancestor inheritance + explicit override walk
- `pnpm turbo typecheck` + `pnpm turbo test` clean (576 server tests + mcp/tool-kit suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXWEA642V5Z1pwKk2ViXPY