### PR TITLE
feat(versions): release ordering authority + Release column on the requirements register

### DIFF
--- a/packages/core/src/__tests__/versions.test.ts
+++ b/packages/core/src/__tests__/versions.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { compareVersions } from '../versions.js';
+
+function v(name: string, targetDate: string | null, sortOrder = 0) {
+  return { name, targetDate, sortOrder };
+}
+
+const order = (list: ReturnType<typeof v>[]) =>
+  [...list].sort(compareVersions).map((x) => x.name);
+
+describe('compareVersions', () => {
+  it('orders by target date ascending', () => {
+    expect(order([v('V2', '2026-10-31'), v('V1', '2026-08-21')])).toEqual(['V1', 'V2']);
+  });
+
+  it('puts undated versions last', () => {
+    expect(
+      order([v('V3', null), v('V1', '2026-08-21'), v('V2', null), v('MVP', '2026-06-15')]),
+    ).toEqual(['MVP', 'V1', 'V2', 'V3']);
+  });
+
+  it('breaks undated ties by semver, not lexically', () => {
+    // "V10" < "V2" lexically — the semver tiebreak has to win.
+    expect(order([v('V10', null), v('V2', null)])).toEqual(['V2', 'V10']);
+  });
+
+  it('honours sortOrder as the manual override when dates match', () => {
+    expect(
+      order([v('B', '2026-08-21', 2), v('A', '2026-08-21', 1)]),
+    ).toEqual(['A', 'B']);
+  });
+
+  it('is a total order — sorting is stable and idempotent', () => {
+    const list = [v('V1.5', '2026-10-31'), v('V1', '2026-08-21'), v('V2', null)];
+    const once = [...list].sort(compareVersions);
+    const twice = [...once].sort(compareVersions);
+    expect(twice.map((x) => x.name)).toEqual(once.map((x) => x.name));
+  });
+
+  it('regression: a dated follow-up does not sort ahead of the release it follows', () => {
+    // The Fulcrum CRM case — "V1.5 follow-up" dated before V1.5 chained
+    // ahead of it in the forecast. Fixed by dating it after V1.5.
+    expect(
+      order([v('V1.5 follow-up', '2026-11-30'), v('V1.5', '2026-10-31')]),
+    ).toEqual(['V1.5', 'V1.5 follow-up']);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,10 @@ export {
   buildTodoIds,
 } from './statusWorkflow.js';
 
+// Release ordering
+export { compareVersions } from './versions.js';
+export type { VersionOrderFields } from './versions.js';
+
 // Velocity & capacity helpers
 export {
   FOCUS_FACTOR_MIN,

--- a/packages/core/src/versions.ts
+++ b/packages/core/src/versions.ts
@@ -1,0 +1,44 @@
+/**
+ * Canonical release ordering.
+ *
+ * Versions are ordered chronologically by target date, with undated
+ * versions last — an undated version is one nobody has committed to a
+ * date for, so it belongs after everything that has one.
+ *
+ * The order is load-bearing, not cosmetic: computeReleaseForecast walks
+ * versions with a running cursor, chaining each non-shipped release onto
+ * the previous one's finish. Two surfaces disagreeing on the order would
+ * produce two different forecasts for the same map.
+ *
+ * Ties fall back to sortOrder (the manual override), then to the semver
+ * parsed from the name so undated V2/V10 don't sort lexically, then to
+ * the name itself for stability.
+ */
+export interface VersionOrderFields {
+  name: string;
+  sortOrder: number;
+  targetDate?: string | null;
+}
+
+/** "V1" → [1, 0]; "V1.5" → [1, 5]; "MVP: Onboarding" → [∞, ∞] (sorts last). */
+function parseSemver(name: string): [number, number] {
+  const m = name.match(/^V(\d+)(?:\.(\d+))?/i);
+  if (!m) return [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER];
+  return [parseInt(m[1], 10), m[2] ? parseInt(m[2], 10) : 0];
+}
+
+export function compareVersions(a: VersionOrderFields, b: VersionOrderFields): number {
+  const at = a.targetDate ?? null;
+  const bt = b.targetDate ?? null;
+  if (at !== bt) {
+    if (at === null) return 1;
+    if (bt === null) return -1;
+    return at < bt ? -1 : 1;
+  }
+  if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+  const [aMaj, aMin] = parseSemver(a.name);
+  const [bMaj, bMin] = parseSemver(b.name);
+  if (aMaj !== bMaj) return aMaj - bMaj;
+  if (aMin !== bMin) return aMin - bMin;
+  return a.name.localeCompare(b.name);
+}

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { compareVersions } from '@mindblown/core';
 import type { Version } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import * as api from './api.js';
@@ -181,10 +182,12 @@ export function ReleasesView() {
 
   // Merge store versions (authoritative list, includes empty ones) with
   // the forecast rows (richer stats for versions that have linked leaves).
-  // We iterate over versions (sorted by sortOrder), attaching the forecast
-  // row when it exists — versions with 0 leaves show up as "no scope" rows.
+  // We iterate over versions in release order (compareVersions — target
+  // date ascending, undated last, same authority the forecast chain uses),
+  // attaching the forecast row when it exists — versions with 0 leaves
+  // show up as "no scope" rows.
   const sortedVersions = useMemo(
-    () => [...versions].sort((a, b) => a.sortOrder - b.sortOrder),
+    () => [...versions].sort(compareVersions),
     [versions],
   );
   const forecastById = useMemo(() => {
@@ -270,7 +273,7 @@ export function ReleasesView() {
             {displayVersions.length} version{displayVersions.length === 1 ? '' : 's'} · {totalLeaves} linked leaves
             {forecast && (
               <>
-                {' · sequential by sortOrder, '}
+                {' · sequential by target date, '}
                 {forecast.dailyCapacity} {unit}/day capacity
                 {fudge != null && ` · ${fudge.toFixed(2)}× velocity`}
                 {forecast.focusFactor < 1 && ` · ${Math.round(forecast.focusFactor * 100)}% focus`}

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { Node } from '@mindblown/core';
+import { compareVersions } from '@mindblown/core';
+import type { Node, Version } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import * as api from './api.js';
 
@@ -45,6 +46,12 @@ interface ReqRow {
   unestimated: number;
   health: string;
   ghLinks: Array<{ id: string; url: string }>;
+  /** Version set on the requirement node itself. */
+  versionId: string | null;
+  /** Distinct versions found below it — the requirement may be split across releases. */
+  descendantVersionIds: string[];
+  /** What the register treats as "the" release: own, else a unanimous descendant one. */
+  effectiveVersionId: string | null;
 }
 
 function statusOf(progress: number): ReqStatus {
@@ -70,6 +77,14 @@ export function RequirementsView() {
   const setFocusNode = useMindmapStore((s) => s.setFocusNode);
   const setActiveView = useMindmapStore((s) => s.setActiveView);
   const effortUnit = useMindmapStore((s) => s.currentMap?.effortUnit ?? 'days');
+  const versions = useMindmapStore((s) => s.versions);
+
+  const sortedVersions = useMemo(() => [...versions].sort(compareVersions), [versions]);
+  const versionById = useMemo(() => {
+    const m = new Map<string, Version>();
+    for (const v of versions) m.set(v.id, v);
+    return m;
+  }, [versions]);
 
   const user = useMindmapStore((s) => s.user);
   const [acceptances, setAcceptances] = useState<api.AcceptanceRow[]>([]);
@@ -100,6 +115,8 @@ export function RequirementsView() {
 
   const [statusFilter, setStatusFilter] = useState<'' | ReqStatus>('');
   const [priorityFilter, setPriorityFilter] = useState<'' | 'must' | 'should' | 'could'>('');
+  // '' = all, 'none' = no release (own or inherited), otherwise a versionId
+  const [versionFilter, setVersionFilter] = useState<string>('');
   const [editingCell, setEditingCell] = useState<{ nodeId: string; field: string } | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [createFields, setCreateFields] = useState({
@@ -127,10 +144,23 @@ export function RequirementsView() {
       return count;
     };
 
+    const descendantVersions = (id: string): string[] => {
+      const found = new Set<string>();
+      const stack = [...(nodes[id]?.childrenIds ?? [])];
+      while (stack.length) {
+        const n = nodes[stack.pop()!];
+        if (!n) continue;
+        if (n.versionId) found.add(n.versionId);
+        stack.push(...n.childrenIds);
+      }
+      return [...found];
+    };
+
     return Object.values(nodes)
       .filter((n) => n.requirementId != null)
       .map((node) => {
         const cv = computed.get(node.id);
+        const descendantVersionIds = descendantVersions(node.id);
         const isLeaf = node.childrenIds.length === 0;
         const progress = isLeaf ? (node.percentComplete ?? 0) : (cv?.computedProgress ?? 0);
         // Chapter = the requirement's parent node. In a doc-shaped map the
@@ -150,6 +180,11 @@ export function RequirementsView() {
           ghLinks: node.externalLinks
             .filter((l) => l.provider === 'github')
             .map((l) => ({ id: l.externalId, url: l.url })),
+          versionId: node.versionId ?? null,
+          descendantVersionIds,
+          effectiveVersionId:
+            node.versionId ??
+            (descendantVersionIds.length === 1 ? descendantVersionIds[0] : null),
         };
       });
   }, [nodes, computed]);
@@ -165,6 +200,15 @@ export function RequirementsView() {
       allRows.filter((r) => {
         if (statusFilter && r.status !== statusFilter) return false;
         if (priorityFilter && r.node.requirementPriority !== priorityFilter) return false;
+        if (versionFilter === 'none') {
+          // "No release" means nothing below it is scheduled either.
+          if (r.versionId || r.descendantVersionIds.length > 0) return false;
+        } else if (versionFilter) {
+          // A split requirement matches every release it touches.
+          if (r.versionId !== versionFilter && !r.descendantVersionIds.includes(versionFilter)) {
+            return false;
+          }
+        }
         if (acceptanceFilter) {
           const accs = accByNode.get(r.node.id) ?? [];
           if (acceptanceFilter === 'none' && accs.length > 0) return false;
@@ -177,7 +221,7 @@ export function RequirementsView() {
         }
         return true;
       }),
-    [allRows, statusFilter, priorityFilter, acceptanceFilter, accByNode, user],
+    [allRows, statusFilter, priorityFilter, versionFilter, acceptanceFilter, accByNode, user],
   );
 
   // Depth-first tree order — used to sort chapter groups so the register
@@ -306,7 +350,8 @@ export function RequirementsView() {
           <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>
             {allRows.length} requirement{allRows.length === 1 ? '' : 's'} · {totals.done} done ·{' '}
             {totals.partial} partial · {totals.open} open
-            {(statusFilter || priorityFilter) && ` · showing ${filteredRows.length} (filtered)`}
+            {(statusFilter || priorityFilter || versionFilter) &&
+              ` · showing ${filteredRows.length} (filtered)`}
           </div>
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
@@ -331,6 +376,19 @@ export function RequirementsView() {
             <option value="must">Must</option>
             <option value="should">Should</option>
             <option value="could">Could</option>
+          </select>
+          <select
+            value={versionFilter}
+            onChange={(e) => setVersionFilter(e.target.value)}
+            style={filterSelectStyle}
+          >
+            <option value="">All releases</option>
+            <option value="none">No release</option>
+            {sortedVersions.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.name}
+              </option>
+            ))}
           </select>
           <select
             value={acceptanceFilter}
@@ -452,6 +510,7 @@ export function RequirementsView() {
                 <th style={{ ...thStyle, width: 110 }}>ID</th>
                 <th style={thStyle}>Requirement</th>
                 <th style={{ ...thStyle, width: 80 }}>Priority</th>
+                <th style={{ ...thStyle, width: 110 }}>Release</th>
                 <th style={{ ...thStyle, width: 80 }}>Status</th>
                 <th style={{ ...thStyle, width: 130 }}>Progress</th>
                 <th style={{ ...thStyle, width: 130, textAlign: 'right' }}>Remaining</th>
@@ -466,6 +525,8 @@ export function RequirementsView() {
                   chapterText={rows[0].chapterText}
                   rows={rows}
                   effortUnit={effortUnit}
+                  sortedVersions={sortedVersions}
+                  versionById={versionById}
                   isEditing={isEditing}
                   setEditingCell={setEditingCell}
                   updateNode={updateNode}
@@ -490,6 +551,8 @@ function ChapterGroup({
   chapterText,
   rows,
   effortUnit,
+  sortedVersions,
+  versionById,
   isEditing,
   setEditingCell,
   updateNode,
@@ -502,6 +565,8 @@ function ChapterGroup({
   chapterText: string;
   rows: ReqRow[];
   effortUnit: string;
+  sortedVersions: Version[];
+  versionById: Map<string, Version>;
   isEditing: (nodeId: string, field: string) => boolean;
   setEditingCell: (cell: { nodeId: string; field: string } | null) => void;
   updateNode: (id: string, updates: Partial<Node>) => void;
@@ -515,7 +580,7 @@ function ChapterGroup({
   return (
     <>
       <tr>
-        <td colSpan={8} style={groupHeaderStyle}>
+        <td colSpan={9} style={groupHeaderStyle}>
           {chapterText}
           <span style={{ fontWeight: 400, color: '#64748b', marginLeft: 8 }}>
             {rows.length} req · {done} done
@@ -648,6 +713,42 @@ function ChapterGroup({
               <option value="must">Must</option>
               <option value="should">Should</option>
               <option value="could">Could</option>
+            </select>
+          </td>
+
+          {/* Release — own versionId; falls back to what's tagged below it */}
+          <td style={tdStyle} onClick={(e) => e.stopPropagation()}>
+            <select
+              value={r.versionId ?? ''}
+              onChange={(e) => updateNode(r.node.id, { versionId: e.target.value || null })}
+              onKeyDown={(e) => e.stopPropagation()}
+              title={
+                r.versionId
+                  ? 'Release tagged on this requirement'
+                  : r.descendantVersionIds.length === 0
+                    ? 'Not scheduled for any release'
+                    : `Inherited from work below it: ${r.descendantVersionIds
+                        .map((id) => versionById.get(id)?.name ?? '?')
+                        .join(', ')}`
+              }
+              style={{
+                ...inlineSelectStyle,
+                color: r.versionId ? '#334155' : '#94a3b8',
+                fontStyle: r.versionId ? 'normal' : 'italic',
+              }}
+            >
+              <option value="">
+                {r.descendantVersionIds.length === 0
+                  ? '—'
+                  : r.descendantVersionIds.length === 1
+                    ? `↳ ${versionById.get(r.descendantVersionIds[0])?.name ?? '?'}`
+                    : `↳ ${r.descendantVersionIds.length} releases`}
+              </option>
+              {sortedVersions.map((v) => (
+                <option key={v.id} value={v.id}>
+                  {v.name}
+                </option>
+              ))}
             </select>
           </td>
 

--- a/packages/server/src/db/versions.ts
+++ b/packages/server/src/db/versions.ts
@@ -1,6 +1,7 @@
-import { eq, asc } from 'drizzle-orm';
+import { eq, asc, sql } from 'drizzle-orm';
 import { db } from './connection.js';
 import { versions, cycles, nodes, maps } from './schema.js';
+import { compareVersions } from '@mindblown/core';
 import type { Version } from '@mindblown/core';
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -60,12 +61,17 @@ export async function createVersion(input: CreateVersionInput): Promise<Version>
 // ── List ──────────────────────────────────────────────────────────────
 
 export async function listVersions(mapId: string): Promise<Version[]> {
+  // Release order: target date ascending, undated last. Sorted in SQL so
+  // paging/streaming callers see the same order, then re-sorted through
+  // compareVersions so the semver tiebreak matches the forecast chain.
   const rows = await db.select()
     .from(versions)
     .where(eq(versions.mapId, mapId))
-    .orderBy(asc(versions.sortOrder));
+    .orderBy(sql`${versions.targetDate} asc nulls last`, asc(versions.sortOrder), asc(versions.name));
 
-  return rows.map((r) => dbVersionToCore(r as unknown as Record<string, unknown>));
+  return rows
+    .map((r) => dbVersionToCore(r as unknown as Record<string, unknown>))
+    .sort(compareVersions);
 }
 
 // ── Get ───────────────────────────────────────────────────────────────

--- a/packages/server/src/lib/releaseForecast.ts
+++ b/packages/server/src/lib/releaseForecast.ts
@@ -1,5 +1,5 @@
 import type { Node as CoreNode, MindMap, Version } from '@mindblown/core';
-import { clampFocusFactor } from '@mindblown/core';
+import { clampFocusFactor, compareVersions } from '@mindblown/core';
 
 /**
  * Release forecast row for a single version.
@@ -42,7 +42,8 @@ export interface ReleaseForecastResult {
  *   1. Capacity-constrained: plannedFinish = effStart +
  *      ceil(remainingEffort / dailyCapacity). Does NOT assume infinite
  *      parallelism.
- *   2. Sequential by sortOrder: non-shipped versions chain — each
+ *   2. Sequential by release order (target date, undated last):
+ *      non-shipped versions chain — each
  *      effective start is clamped to the previous release's finish.
  *   3. Wall-clock anchored: the first cursor starts at max(today,
  *      projectStartDate). If the project is already underway with
@@ -120,26 +121,10 @@ export function computeReleaseForecast(
   };
   const allLeaves = nodes.filter((n) => (n.childrenIds?.length ?? 0) === 0);
 
-  // ── Walk versions in sortOrder with two cursors ──
-  // Primary sort: sortOrder (user-controlled override).
-  // Secondary: parsed semver from the name — "V1", "V1.5", "V2", "V3:
-  // Verticals" → (1,0), (1,5), (2,0), (3,0). Stops new versions from
-  // landing wrong-place when they inherit a default sortOrder that
-  // ties with existing rows.
-  // Tertiary: name for stability.
-  const parseSemver = (name: string): [number, number] => {
-    const m = name.match(/^V(\d+)(?:\.(\d+))?/i);
-    if (!m) return [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER];
-    return [parseInt(m[1], 10), m[2] ? parseInt(m[2], 10) : 0];
-  };
-  const sorted = [...versions].sort((a, b) => {
-    if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
-    const [aMaj, aMin] = parseSemver(a.name);
-    const [bMaj, bMin] = parseSemver(b.name);
-    if (aMaj !== bMaj) return aMaj - bMaj;
-    if (aMin !== bMin) return aMin - bMin;
-    return a.name.localeCompare(b.name);
-  });
+  // ── Walk versions in release order with two cursors ──
+  // compareVersions (core) is the single ordering authority — target
+  // date ascending, undated last, ties broken by sortOrder then semver.
+  const sorted = [...versions].sort(compareVersions);
   let plannedCursor = anchor;
   let velocityCursor = anchor;
 


### PR DESCRIPTION
Two related changes to how releases are presented.

**1. `compareVersions` as the single ordering authority** (348c33f)

`listVersions` ordered by `sortOrder` alone and every version is created with the default `sortOrder` 0 — so they all tie and Postgres returns arbitrary order, while `releaseForecast` had its own private comparator. Two surfaces, two orders, two forecasts for one map. Now: target date ascending, undated last, ties broken by sortOrder then semver-from-name — used on all three surfaces.

**2. Release column on the Requirements register** (this branch's second commit)

The register answered *what* and *how far*, but not *when it lands*. Adds an inline `versionId` select per requirement plus an All/No release/`<version>` filter.

Requirements are usually tagged only on the work below them, so an untagged row displays its subtree's tagging instead — `↳ V2` when unanimous, `↳ 3 releases` when split — in grey italics so inherited never reads as own. The filter matches own version OR any release below; "No release" means nothing underneath is scheduled either.

## Verification
- `pnpm turbo typecheck` clean
- `pnpm turbo test` clean (core versions tests + mindmap suites)

No new `Node` field — `versionId` already exists across DB/REST/MCP, so no cross-layer surface work applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dnXCVetEcC6d7g7fJVraj