### PR TITLE
feat(requirements): Release chip on mobile + hide-done toggle

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -117,6 +117,7 @@ export function RequirementsView() {
   const [priorityFilter, setPriorityFilter] = useState<'' | 'must' | 'should' | 'could'>('');
   // '' = all, 'none' = no release (own or inherited), otherwise a versionId
   const [versionFilter, setVersionFilter] = useState<string>('');
+  const [hideDone, setHideDone] = useState(false);
   const [editingCell, setEditingCell] = useState<{ nodeId: string; field: string } | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [createFields, setCreateFields] = useState({
@@ -198,6 +199,7 @@ export function RequirementsView() {
   const filteredRows = useMemo(
     () =>
       allRows.filter((r) => {
+        if (hideDone && r.status === 'done') return false;
         if (statusFilter && r.status !== statusFilter) return false;
         if (priorityFilter && r.node.requirementPriority !== priorityFilter) return false;
         if (versionFilter === 'none') {
@@ -221,7 +223,16 @@ export function RequirementsView() {
         }
         return true;
       }),
-    [allRows, statusFilter, priorityFilter, versionFilter, acceptanceFilter, accByNode, user],
+    [
+      allRows,
+      hideDone,
+      statusFilter,
+      priorityFilter,
+      versionFilter,
+      acceptanceFilter,
+      accByNode,
+      user,
+    ],
   );
 
   // Depth-first tree order — used to sort chapter groups so the register
@@ -350,14 +361,36 @@ export function RequirementsView() {
           <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>
             {allRows.length} requirement{allRows.length === 1 ? '' : 's'} · {totals.done} done ·{' '}
             {totals.partial} partial · {totals.open} open
-            {(statusFilter || priorityFilter || versionFilter) &&
+            {(hideDone || statusFilter || priorityFilter || versionFilter) &&
               ` · showing ${filteredRows.length} (filtered)`}
           </div>
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <button
+            onClick={() => setHideDone((v) => !v)}
+            aria-pressed={hideDone}
+            title={
+              hideDone
+                ? `${totals.done} done requirement${totals.done === 1 ? '' : 's'} hidden — click to show`
+                : 'Hide requirements that are 100% complete'
+            }
+            style={{
+              ...secondaryButtonStyle(false),
+              ...(hideDone
+                ? { background: '#eef2ff', borderColor: '#c7d2fe', color: '#3730a3' }
+                : {}),
+            }}
+          >
+            {hideDone ? `Done hidden (${totals.done})` : 'Hide done'}
+          </button>
           <select
             value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value as '' | ReqStatus)}
+            onChange={(e) => {
+              const v = e.target.value as '' | ReqStatus;
+              setStatusFilter(v);
+              // Asking for Done while hiding Done would show an empty table.
+              if (v === 'done') setHideDone(false);
+            }}
             style={filterSelectStyle}
           >
             <option value="">All statuses</option>

--- a/packages/mindmap/src/mobile/MobileRequirementsView.tsx
+++ b/packages/mindmap/src/mobile/MobileRequirementsView.tsx
@@ -1,12 +1,14 @@
 import { useMemo, useState } from 'react';
-import type { MindMap } from '@mindblown/core';
+import type { MindMap, Version } from '@mindblown/core';
 import type { NodeWithComputed } from '../api.js';
 
 // Requirement status is never stored — always derived from the progress
 // rollup, mirroring the desktop RequirementsView.
 
 type ReqStatus = 'open' | 'partial' | 'done';
-type Filter = 'all' | ReqStatus;
+// 'todo' is the "hide done" button — open + partial in one tap, which is
+// what you want on a phone far more often than any single status.
+type Filter = 'all' | 'todo' | ReqStatus;
 
 const STATUS_LABEL: Record<ReqStatus, string> = {
   done: 'Done',
@@ -29,6 +31,7 @@ const PRIORITY_LABEL: Record<string, string> = {
 interface Props {
   nodes: NodeWithComputed[];
   map: MindMap;
+  versions: Version[];
   onSelect: (nodeId: string) => void;
 }
 
@@ -36,25 +39,54 @@ interface ReqRow {
   node: NodeWithComputed;
   status: ReqStatus;
   chapterText: string;
+  /** Release label; null when neither the requirement nor its subtree is scheduled. */
+  releaseLabel: string | null;
+  /** True when the label comes from the work below, not the requirement itself. */
+  releaseInherited: boolean;
 }
 
 function statusOf(progress: number): ReqStatus {
   return progress >= 100 ? 'done' : progress > 0 ? 'partial' : 'open';
 }
 
-export function MobileRequirementsView({ nodes, map, onSelect }: Props) {
+export function MobileRequirementsView({ nodes, map, versions, onSelect }: Props) {
   const [filter, setFilter] = useState<Filter>('all');
 
   const rows = useMemo<ReqRow[]>(() => {
     const byId = new Map(nodes.map((n) => [n.id, n]));
+    const versionName = new Map(versions.map((v) => [v.id, v.name]));
+
+    // Requirements are usually tagged only on the work below them, so an
+    // untagged one falls back to what its subtree carries (desktop parity).
+    const descendantVersions = (id: string): string[] => {
+      const found = new Set<string>();
+      const stack = [...(byId.get(id)?.childrenIds ?? [])];
+      while (stack.length) {
+        const n = byId.get(stack.pop()!);
+        if (!n) continue;
+        if (n.versionId) found.add(n.versionId);
+        stack.push(...n.childrenIds);
+      }
+      return [...found];
+    };
+
     return nodes
       .filter((n) => n.requirementId != null)
       .map((n) => {
         const parent = n.parentId ? byId.get(n.parentId) : undefined;
+        const below = n.versionId ? [] : descendantVersions(n.id);
         return {
           node: n,
           status: statusOf(n.computedProgress ?? 0),
           chapterText: parent && parent.id !== map.rootNodeId ? parent.text : '',
+          releaseLabel: n.versionId
+            ? (versionName.get(n.versionId) ?? '?')
+            : below.length === 0
+              ? null
+              : below.length === 1
+                ? (versionName.get(below[0]) ?? '?')
+                : `${below.length} releases`,
+          releaseInherited: !n.versionId,
         };
       })
       .sort((a, b) =>
@@ -62,15 +94,23 @@ export function MobileRequirementsView({ nodes, map, onSelect }: Props) {
           numeric: true,
         }),
       );
-  }, [nodes, map.rootNodeId]);
+  }, [nodes, map.rootNodeId, versions]);
 
   const counts = useMemo(() => {
-    const c = { all: rows.length, open: 0, partial: 0, done: 0 };
-    for (const r of rows) c[r.status] += 1;
+    const c = { all: rows.length, todo: 0, open: 0, partial: 0, done: 0 };
+    for (const r of rows) {
+      c[r.status] += 1;
+      if (r.status !== 'done') c.todo += 1;
+    }
     return c;
   }, [rows]);
 
-  const filtered = filter === 'all' ? rows : rows.filter((r) => r.status === filter);
+  const filtered =
+    filter === 'all'
+      ? rows
+      : filter === 'todo'
+        ? rows.filter((r) => r.status !== 'done')
+        : rows.filter((r) => r.status === filter);
 
   if (rows.length === 0) {
     return (
@@ -86,14 +126,14 @@ export function MobileRequirementsView({ nodes, map, onSelect }: Props) {
   return (
     <div className="mb-body" style={{ paddingTop: 8 }}>
       <div className="mb-filter-row">
-        {(['all', 'open', 'partial', 'done'] as const).map((f) => (
+        {(['all', 'todo', 'open', 'partial', 'done'] as const).map((f) => (
           <button
             key={f}
             className="mb-filter-chip"
             aria-pressed={filter === f}
             onClick={() => setFilter(f)}
           >
-            {f === 'all' ? 'All' : STATUS_LABEL[f]}
+            {f === 'all' ? 'All' : f === 'todo' ? 'Hide done' : STATUS_LABEL[f]}
             <span className="mb-filter-count">{counts[f]}</span>
           </button>
         ))}
@@ -105,7 +145,7 @@ export function MobileRequirementsView({ nodes, map, onSelect }: Props) {
         </div>
       )}
 
-      {filtered.map(({ node, status, chapterText }) => {
+      {filtered.map(({ node, status, chapterText, releaseLabel, releaseInherited }) => {
         const sc = STATUS_COLOR[status];
         const pct = Math.round(node.computedProgress ?? 0);
         return (
@@ -122,6 +162,19 @@ export function MobileRequirementsView({ nodes, map, onSelect }: Props) {
               {node.requirementPriority && (
                 <span className="mb-req-priority">
                   {PRIORITY_LABEL[node.requirementPriority] ?? node.requirementPriority}
+                </span>
+              )}
+              {releaseLabel && (
+                <span
+                  className="mb-req-release"
+                  title={
+                    releaseInherited
+                      ? 'Inherited from the work below this requirement'
+                      : 'Release tagged on this requirement'
+                  }
+                  style={releaseInherited ? { fontStyle: 'italic', opacity: 0.75 } : undefined}
+                >
+                  {releaseInherited ? `↳ ${releaseLabel}` : releaseLabel}
                 </span>
               )}
             </div>

--- a/packages/mindmap/src/mobile/MobileViewer.tsx
+++ b/packages/mindmap/src/mobile/MobileViewer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { Node } from '@mindblown/core';
+import type { Node, Version } from '@mindblown/core';
 import * as api from '../api.js';
 import type { MapDetail, MapSummary, NodeWithComputed } from '../api.js';
 import { MobileListView } from './MobileListView.js';
@@ -45,11 +45,24 @@ export function MobileViewer({ map }: Props) {
   const [view, setView] = useState<ViewKey>(readDefaultView);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
+  // Names for the Requirements release chips. Small payload, and versions
+  // don't change under an editing session — fetched once per map, not with
+  // the debounced node reload.
+  const [versions, setVersions] = useState<Version[]>([]);
 
   useEffect(() => {
     let cancelled = false;
     setDetail(null);
     setError(null);
+    setVersions([]);
+    api
+      .fetchVersions(map.id)
+      .then((v) => {
+        if (!cancelled) setVersions(v);
+      })
+      .catch(() => {
+        // Release chips just stay empty — not worth failing the map load over.
+      });
     api
       .fetchMap(map.id, { omit: OMIT_FIELDS })
       .then((d) => {
@@ -208,6 +221,7 @@ export function MobileViewer({ map }: Props) {
             <MobileRequirementsView
               nodes={nodes}
               map={detail.map}
+              versions={versions}
               onSelect={setSelectedId}
             />
           )}

--- a/packages/mindmap/src/mobile/mobile.css
+++ b/packages/mindmap/src/mobile/mobile.css
@@ -907,6 +907,16 @@ body.mobile {
   padding: 1px 8px;
 }
 
+.mb-req-release {
+  font-size: 11px;
+  color: #3730a3;
+  background: #eef2ff;
+  border: 1px solid #e0e7ff;
+  border-radius: 999px;
+  padding: 1px 8px;
+  white-space: nowrap;
+}
+
 .mb-req-text {
   font-size: 14px;
   color: #0f172a;


### PR DESCRIPTION
Follow-ups to #235.

**Mobile parity.** The Requirements tab on the phone showed ID / status / priority / chapter but not the release — so the view you actually read in a meeting couldn't answer "when does this land?". Cards now carry a release chip with the same inheritance rule as desktop: own `versionId`, else what the subtree carries (`↳ V2`, or `↳ 3 releases` when split), italic + dimmed when inherited. Display only; mobile edits go through the node sheet.

Version names come from a per-map `fetchVersions` in `MobileViewer`, deliberately outside the debounced node reload — versions don't change under an editing session, and a failed fetch just leaves chips off instead of failing the map load.

**Hide done.** Desktop gets a "Hide done" toggle button that reports the hidden count and composes with the existing filters; picking "Done" in the status dropdown clears it, since that combination can only produce an empty table. Mobile gets it as a "Hide done" chip (open + partial), matching how filtering already works there.

## Verification
- `pnpm turbo typecheck test` — 16/16 tasks green

No new `Node` field; `versionId` already spans DB/REST/MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dnXCVetEcC6d7g7fJVraj