### PR TITLE
feat(export): Release column + derived percentage in the Anforderungsdokument

### DIFF
--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -109,6 +109,63 @@ describe('buildRegisterData — Abnahme verdicts', () => {
   });
 });
 
+describe('buildRegisterData — Release column', () => {
+  const versions = [
+    { id: 'v1', name: 'V1' },
+    { id: 'v2', name: 'V2' },
+  ] as Parameters<typeof buildRegisterData>[4];
+
+  const withChildren = (reqOverrides: Partial<Node>, childVersions: Array<string | null>) => {
+    const childIds = childVersions.map((_, i) => `c${i}`);
+    return [
+      makeNode({ id: 'root', childrenIds: ['ch'] }),
+      makeNode({ id: 'ch', parentId: 'root', childrenIds: ['r1'], text: 'Bereich' }),
+      makeNode({ id: 'r1', parentId: 'ch', requirementId: 'MAN-01', childrenIds: childIds, ...reqOverrides }),
+      ...childVersions.map((v, i) => makeNode({ id: `c${i}`, parentId: 'r1', versionId: v })),
+    ];
+  };
+
+  const release = (nodes: Node[]) => {
+    const computed = new Map<NodeId, ComputedNodeValues>();
+    return buildRegisterData(map, nodes, computed, [], versions).chapters[0].rows[0].release;
+  };
+
+  it('uses the version tagged on the requirement itself', () => {
+    expect(release(withChildren({ versionId: 'v1' }, ['v2']))).toBe('V1');
+  });
+
+  it('inherits a unanimous version from the work below', () => {
+    expect(release(withChildren({}, ['v2', 'v2']))).toBe('↳ V2');
+  });
+
+  it('reports a count when the requirement is split across releases', () => {
+    expect(release(withChildren({}, ['v1', 'v2']))).toBe('↳ 2 Releases');
+  });
+
+  it('renders — when nothing below it is scheduled', () => {
+    expect(release(withChildren({}, [null]))).toBe('—');
+  });
+});
+
+describe('buildRegisterData — status detail', () => {
+  const req = (percentComplete: number | null) => [
+    makeNode({ id: 'root', childrenIds: ['ch'] }),
+    makeNode({ id: 'ch', parentId: 'root', childrenIds: ['r1'], text: 'Bereich' }),
+    makeNode({ id: 'r1', parentId: 'ch', requirementId: 'MAN-01', percentComplete }),
+  ];
+  const detail = (p: number | null) =>
+    buildRegisterData(map, req(p), new Map(), []).chapters[0].rows[0].statusDetail;
+
+  it('appends the derived percentage to partial rows', () => {
+    expect(detail(42)).toBe('Teilweise · 42 %');
+  });
+
+  it('leaves Umgesetzt and Offen without a percentage', () => {
+    expect(detail(100)).toBe('Umgesetzt');
+    expect(detail(null)).toBe('Offen');
+  });
+});
+
 describe('acceptanceIsStale', () => {
   it('flags revision drift and >1pt progress drift, tolerates rounding', () => {
     const acc = { ...baseAcc };

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -1,4 +1,10 @@
-import type { Node as CoreNode, MindMap, ComputedNodeValues, NodeId } from '@mindblown/core';
+import type {
+  Node as CoreNode,
+  MindMap,
+  ComputedNodeValues,
+  NodeId,
+  Version,
+} from '@mindblown/core';
 import {
   Document,
   HeadingLevel,
@@ -46,7 +52,11 @@ export interface RegisterRow {
   id: string;
   text: string;
   prio: string;
+  /** Version name, "↳ V2" when inherited from the work below, "—" when unscheduled. */
+  release: string;
   status: string;
+  /** Status with the derived percentage on partial rows, e.g. "Teilweise · 42 %". */
+  statusDetail: string;
   aufwand: string;
   rest: string;
   /** e.g. "D. Haas ✓ 15.07." — one entry per active acceptance, ⚠-suffixed when stale. */
@@ -77,6 +87,7 @@ export function buildRegisterData(
   nodes: CoreNode[],
   computed: Map<NodeId, ComputedNodeValues>,
   acceptances: Array<AcceptanceInfo & { nodeId: string }> = [],
+  versions: Version[] = [],
 ): RegisterData {
   const accByNode = new Map<string, Array<AcceptanceInfo & { nodeId: string }>>();
   for (const a of acceptances) {
@@ -91,6 +102,25 @@ export function buildRegisterData(
       : (n.percentComplete ?? 0);
   const statusOf = (p: number): string =>
     p >= 99.5 ? 'Umgesetzt' : p > 0 ? 'Teilweise' : 'Offen';
+
+  // Release label, mirroring the register UI: the version tagged on the
+  // requirement itself, else the one(s) carried by the work below it —
+  // requirements are usually scheduled through their children, not directly.
+  const versionName = new Map(versions.map((v) => [v.id, v.name]));
+  const releaseOf = (n: CoreNode): string => {
+    if (n.versionId) return versionName.get(n.versionId) ?? '—';
+    const below = new Set<string>();
+    const stack = [...n.childrenIds];
+    while (stack.length) {
+      const c = byId.get(stack.pop()!);
+      if (!c) continue;
+      if (c.versionId) below.add(c.versionId);
+      stack.push(...c.childrenIds);
+    }
+    if (below.size === 0) return '—';
+    if (below.size === 1) return `↳ ${versionName.get([...below][0]) ?? '—'}`;
+    return `↳ ${below.size} Releases`;
+  };
 
   // Depth-first order for chapter (= parent) sorting.
   const dfs = new Map<string, number>();
@@ -139,7 +169,11 @@ export function buildRegisterData(
             id: n.requirementId ?? '',
             text: (n.requirementText ?? n.text).replace(/\n/g, ' '),
             prio: PRIO[n.requirementPriority ?? ''] ?? '—',
+            release: releaseOf(n),
             status,
+            // "Teilweise" alone reads the same at 5 % and 95 % — the number
+            // is the whole point of a derived status.
+            statusDetail: status === 'Teilweise' ? `${status} · ${Math.round(p)} %` : status,
             aufwand: sizeOf(effort),
             rest: status === 'Umgesetzt' ? '—' : sizeOf(effort * (1 - p / 100)),
             abnahme,
@@ -160,7 +194,8 @@ export function buildRegisterData(
 
 const LEGEND = [
   '**Priorität:** Muss — Kernfunktion (MVP) · Soll — wichtig, nicht MVP-blockierend · Kann — wünschenswert',
-  '**Status:** Umgesetzt · Teilweise · Offen (abgeleitet: 100 % / >0 % / 0 % Fortschritt)',
+  '**Release:** geplante Version · **↳** = aus den darunterliegenden Arbeitspaketen abgeleitet · «—» noch keiner Version zugeordnet',
+  '**Status:** Umgesetzt · Teilweise (mit Fortschritt) · Offen (abgeleitet: 100 % / >0 % / 0 % Fortschritt)',
   '**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» bei Umgesetzt): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen',
   '**Abnahme:** ✓ abgenommen · ✗ abgelehnt (mit Begründung) · ⚠ seit dem Urteil geändert',
 ];
@@ -186,11 +221,11 @@ export function renderMarkdown(data: RegisterData): string {
     L.push('');
     L.push(`## ${i + 1}. ${ch.name}`);
     L.push('');
-    L.push('| ID | Anforderung | Priorität | Status | Aufwand | Rest | Abnahme |');
-    L.push('|---|---|---|---|---|---|---|');
+    L.push('| ID | Anforderung | Priorität | Release | Status | Aufwand | Rest | Abnahme |');
+    L.push('|---|---|---|---|---|---|---|---|');
     for (const r of ch.rows) {
       L.push(
-        `| ${r.id} | ${r.text.replace(/\|/g, '\\|')} | ${r.prio} | ${r.status} | ${r.aufwand} | ${r.rest} | ${r.abnahme.join(' · ') || '—'} |`,
+        `| ${r.id} | ${r.text.replace(/\|/g, '\\|')} | ${r.prio} | ${r.release} | ${r.statusDetail} | ${r.aufwand} | ${r.rest} | ${r.abnahme.join(' · ') || '—'} |`,
       );
     }
   });
@@ -206,11 +241,12 @@ const STATUS_FILL: Record<string, string> = {
   Offen: 'f1f5f9',
 };
 
-// Column widths as % of table width: ID, Anforderung, Priorität, Status,
-// Aufwand, Rest, Abnahme. LibreOffice ignores percentage widths that only
-// sit on header cells — the table needs an explicit grid (columnWidths, in
-// DXA) and fixed layout, and every cell must carry its column width.
-const COL_PCT = [9, 43, 9, 11, 7, 7, 14];
+// Column widths as % of table width: ID, Anforderung, Priorität, Release,
+// Status, Aufwand, Rest, Abnahme. LibreOffice ignores percentage widths that
+// only sit on header cells — the table needs an explicit grid (columnWidths,
+// in DXA) and fixed layout, and every cell must carry its column width.
+// Release is paid for out of Anforderung; Status widened for the "· 42 %".
+const COL_PCT = [8, 35, 8, 10, 13, 6, 6, 14];
 // Usable A4 portrait width with the docx default 1440-twip margins.
 const TABLE_DXA = 11906 - 2 * 1440;
 const COL_DXA = COL_PCT.map((p) => Math.round((TABLE_DXA * p) / 100));
@@ -279,10 +315,11 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
         cell('ID', { bold: true, fill: 'e2e8f0', width: COL_PCT[0] }),
         cell('Anforderung', { bold: true, fill: 'e2e8f0', width: COL_PCT[1] }),
         cell('Priorität', { bold: true, fill: 'e2e8f0', width: COL_PCT[2] }),
-        cell('Status', { bold: true, fill: 'e2e8f0', width: COL_PCT[3] }),
-        cell('Aufwand', { bold: true, fill: 'e2e8f0', width: COL_PCT[4] }),
-        cell('Rest', { bold: true, fill: 'e2e8f0', width: COL_PCT[5] }),
-        cell('Abnahme', { bold: true, fill: 'e2e8f0', width: COL_PCT[6] }),
+        cell('Release', { bold: true, fill: 'e2e8f0', width: COL_PCT[3] }),
+        cell('Status', { bold: true, fill: 'e2e8f0', width: COL_PCT[4] }),
+        cell('Aufwand', { bold: true, fill: 'e2e8f0', width: COL_PCT[5] }),
+        cell('Rest', { bold: true, fill: 'e2e8f0', width: COL_PCT[6] }),
+        cell('Abnahme', { bold: true, fill: 'e2e8f0', width: COL_PCT[7] }),
       ],
     });
     const rows = ch.rows.map(
@@ -292,10 +329,11 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
             cell(r.id, { bold: true, width: COL_PCT[0] }),
             cell(r.text, { width: COL_PCT[1] }),
             cell(r.prio, { width: COL_PCT[2] }),
-            cell(r.status, { fill: STATUS_FILL[r.status], width: COL_PCT[3] }),
-            cell(r.aufwand, { width: COL_PCT[4] }),
-            cell(r.rest, { width: COL_PCT[5] }),
-            cell(r.abnahme.join('\n') || '—', { width: COL_PCT[6] }),
+            cell(r.release, { width: COL_PCT[3] }),
+            cell(r.statusDetail, { fill: STATUS_FILL[r.status], width: COL_PCT[4] }),
+            cell(r.aufwand, { width: COL_PCT[5] }),
+            cell(r.rest, { width: COL_PCT[6] }),
+            cell(r.abnahme.join('\n') || '—', { width: COL_PCT[7] }),
           ],
         }),
     );

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -267,7 +267,8 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
 
       const computed = computeTree(data.nodes, data.map.healthThreshold);
       const acceptances = await listActiveAcceptances(req.params.id);
-      const register = buildRegisterData(data.map, data.nodes, computed, acceptances);
+      const versions = await versionDb.listVersions(req.params.id);
+      const register = buildRegisterData(data.map, data.nodes, computed, acceptances, versions);
       const format = (req.query as { format?: string }).format ?? 'md';
 
       if (format === 'docx') {


### PR DESCRIPTION
The register page grew a Release column (#235 / #236) but the Word + Markdown export didn't — so the artefact actually handed to stakeholders was the one surface that couldn't answer "when does this land?".

**Release column.** Same rule as both UI surfaces: version tagged on the requirement, else what the work below carries — `↳ V2` unanimous, `↳ 2 Releases` when split, `—` when nothing underneath is scheduled. Requirements are usually scheduled through their children, so without the fallback nearly every row would read `—`.

**Derived percentage.** Partial rows now render `Teilweise · 42 %`. Bare "Teilweise" reads the same at 5 % and 95 %, which defeats the point of a rollup-derived status.

**Table geometry.** Release is paid for out of Anforderung (43 → 35 %), Status widens to 13 %. The DXA grid regenerates from the percentages, so LibreOffice keeps honouring the fixed layout.

Deliberately unchanged: Aufwand/Rest stay S/M/L/XL buckets (no day-level estimates in a stakeholder doc), GitHub links and the health dot stay out, and the ⚠-unestimated marker stays a planning-side signal.

Both formats share one route, so `requirements_export` (MCP) picks this up too.

## Verification
- 4 new tests for the Release fallback chain (own / unanimous / split / unscheduled) + 2 for the status detail
- `pnpm turbo typecheck test` — 16/16 tasks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dnXCVetEcC6d7g7fJVraj