### PR TITLE
feat(navigation): keep view state in the URL so links and reloads stay put

### DIFF
--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -26,6 +26,7 @@ import { GitHubSettingsDialog } from './GitHubPanel.js';
 import { AIChatPanel } from './AIChatPanel.js';
 import { MapChatPanel } from './MapChatPanel.js';
 import { useMapChatUnread } from './useMapChatUnread.js';
+import { useUrlState } from './useUrlState.js';
 import { Breadcrumb } from './Breadcrumb.js';
 import { WorkspaceSettings } from './WorkspaceSettings.js';
 import { HelpOverlay } from './HelpOverlay.js';
@@ -1593,22 +1594,6 @@ export function App() {
     return () => window.removeEventListener('keydown', handler);
   }, [currentMapId]);
 
-  // Mouse "back" button (XButton1) — pop one entry off the focus
-  // navigation history. When no history is available, the browser's
-  // default back navigation is preserved.
-  useEffect(() => {
-    if (!currentMapId) return;
-    const handler = (e: MouseEvent) => {
-      if (e.button !== 3) return;
-      const { focusHistory, popFocusHistory } = useMindmapStore.getState();
-      if (focusHistory.length === 0) return;
-      e.preventDefault();
-      popFocusHistory();
-    };
-    window.addEventListener('mousedown', handler);
-    return () => window.removeEventListener('mousedown', handler);
-  }, [currentMapId]);
-
   // Helper callbacks for command palette
   const handleFitToScreen = useCallback(() => {
     (window as any).__mindmapFitToScreen?.();
@@ -1633,42 +1618,11 @@ export function App() {
     }
   }, [currentMapId, loadCycles, loadVersions]);
 
-  // Auto-open if there's only one map
-  const autoOpened = useRef(false);
-
-  // URL → state: on first auth, open the map in ?map=<id> if present.
-  // Sets autoOpened so the single-map auto-opener doesn't race ahead.
-  const urlMapInitDone = useRef(false);
-  useEffect(() => {
-    if (!user || urlMapInitDone.current) return;
-    urlMapInitDone.current = true;
-    const mapId = new URLSearchParams(window.location.search).get('map');
-    if (mapId) {
-      autoOpened.current = true;
-      loadMap(mapId);
-    }
-  }, [user, loadMap]);
-
-  // State → URL: mirror currentMapId into ?map=<id> via replaceState so the
-  // URL is shareable / reload-safe without polluting browser history.
-  useEffect(() => {
-    const url = new URL(window.location.href);
-    const current = url.searchParams.get('map');
-    if (currentMapId && current !== currentMapId) {
-      url.searchParams.set('map', currentMapId);
-      window.history.replaceState({}, '', url.pathname + url.search + url.hash);
-    } else if (!currentMapId && current) {
-      url.searchParams.delete('map');
-      window.history.replaceState({}, '', url.pathname + url.search + url.hash);
-    }
-  }, [currentMapId]);
-
-  useEffect(() => {
-    if (!autoOpened.current && !currentMapId && !loading && maps.length === 1) {
-      autoOpened.current = true;
-      loadMap(maps[0].id);
-    }
-  }, [maps, currentMapId, loading, loadMap]);
+  // URL ⇄ view state: which map, view, drill-down focus, selection, depth
+  // and scope filters — so a copied link or a reload lands where you were.
+  // Also owns opening the map (from ?map= or the single-map auto-open), so
+  // that logic lives in one place instead of racing effects here.
+  useUrlState();
 
   const handleCreateMap = useCallback(() => {
     const name = prompt('Map name:');

--- a/packages/mindmap/src/__tests__/urlState.test.ts
+++ b/packages/mindmap/src/__tests__/urlState.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DEPTH,
+  DEFAULT_VIEW,
+  EMPTY_URL_STATE,
+  isNavChange,
+  parseUrlState,
+  resolveDepth,
+  resolveView,
+  serializeUrlState,
+  validateUrlState,
+  type UrlState,
+  type UrlStateContext,
+} from '../urlState.js';
+
+function state(patch: Partial<UrlState> = {}): UrlState {
+  return { ...EMPTY_URL_STATE, ...patch };
+}
+
+function ctx(patch: Partial<Record<keyof UrlStateContext, string[]>> = {}): UrlStateContext {
+  return {
+    nodeIds: new Set(patch.nodeIds ?? []),
+    versionIds: new Set(patch.versionIds ?? []),
+    sprintIds: new Set(patch.sprintIds ?? []),
+    phaseIds: new Set(patch.phaseIds ?? []),
+  };
+}
+
+describe('parseUrlState', () => {
+  it('reads every mirrored param', () => {
+    expect(
+      parseUrlState('?map=m1&view=list&focus=n1&node=n2&depth=3&v=v1&s=s1&p=p1'),
+    ).toEqual(
+      state({
+        map: 'm1',
+        view: 'list',
+        focus: 'n1',
+        node: 'n2',
+        depth: 3,
+        version: 'v1',
+        sprint: 's1',
+        phase: 'p1',
+      }),
+    );
+  });
+
+  it('returns all-null for an empty query string', () => {
+    expect(parseUrlState('')).toEqual(EMPTY_URL_STATE);
+    expect(parseUrlState('?')).toEqual(EMPTY_URL_STATE);
+  });
+
+  it('ignores params it does not own', () => {
+    expect(parseUrlState('?m=1&gh=connected&map=m1')).toEqual(state({ map: 'm1' }));
+  });
+
+  it('drops an unknown view rather than trusting it', () => {
+    expect(parseUrlState('?view=nonsense').view).toBeNull();
+  });
+
+  it('treats blank values as absent', () => {
+    expect(parseUrlState('?map=&focus=%20')).toEqual(EMPTY_URL_STATE);
+  });
+
+  describe('depth', () => {
+    it('keeps 0, which the store reads as unlimited', () => {
+      expect(parseUrlState('?depth=0').depth).toBe(0);
+    });
+
+    it.each(['-1', '999', '1.5', 'abc', ''])('rejects %o', (raw) => {
+      expect(parseUrlState(`?depth=${raw}`).depth).toBeNull();
+    });
+  });
+});
+
+describe('serializeUrlState', () => {
+  it('round-trips through parse', () => {
+    const original = state({
+      map: 'm1',
+      view: 'requirements',
+      focus: 'n1',
+      node: 'n2',
+      depth: 0,
+      version: 'v1',
+      sprint: 's1',
+      phase: 'p1',
+    });
+    expect(parseUrlState(serializeUrlState('', original))).toEqual(original);
+  });
+
+  it('omits defaults so the common case stays at ?map=<id>', () => {
+    const search = serializeUrlState(
+      '',
+      state({ map: 'm1', view: DEFAULT_VIEW, depth: DEFAULT_DEPTH }),
+    );
+    expect(search).toBe('?map=m1');
+  });
+
+  it('emits nothing when there is nothing to say', () => {
+    expect(serializeUrlState('', EMPTY_URL_STATE)).toBe('');
+  });
+
+  it('preserves params it does not own', () => {
+    const search = serializeUrlState('?m=1', state({ map: 'm1' }));
+    expect(parseUrlState(search).map).toBe('m1');
+    expect(new URLSearchParams(search).get('m')).toBe('1');
+  });
+
+  it('clears params that dropped out of the state', () => {
+    const search = serializeUrlState('?map=m1&view=list&v=v1', state({ map: 'm1' }));
+    expect(search).toBe('?map=m1');
+  });
+
+  it('is stable across repeated writes', () => {
+    const s = state({ map: 'm1', view: 'kanban' });
+    const once = serializeUrlState('', s);
+    expect(serializeUrlState(once, s)).toBe(once);
+  });
+});
+
+describe('validateUrlState', () => {
+  const full = state({
+    map: 'm1',
+    view: 'list',
+    focus: 'n1',
+    node: 'n2',
+    depth: 3,
+    version: 'v1',
+    sprint: 's1',
+    phase: 'p1',
+  });
+
+  it('keeps references that resolve', () => {
+    const resolved = validateUrlState(
+      full,
+      ctx({
+        nodeIds: ['n1', 'n2'],
+        versionIds: ['v1'],
+        sprintIds: ['s1'],
+        phaseIds: ['p1'],
+      }),
+    );
+    expect(resolved).toEqual(full);
+  });
+
+  it('clears a stale filter instead of rendering an empty map', () => {
+    const resolved = validateUrlState(full, ctx({ nodeIds: ['n1', 'n2'] }));
+    expect(resolved.version).toBeNull();
+    expect(resolved.sprint).toBeNull();
+    expect(resolved.phase).toBeNull();
+  });
+
+  it('falls back to root when the focused node is gone', () => {
+    expect(validateUrlState(full, ctx({ nodeIds: ['n2'] })).focus).toBeNull();
+  });
+
+  it('drops a selection pointing at a deleted node', () => {
+    expect(validateUrlState(full, ctx({ nodeIds: ['n1'] })).node).toBeNull();
+  });
+
+  it('leaves map, view and depth alone', () => {
+    const resolved = validateUrlState(full, ctx());
+    expect(resolved.map).toBe('m1');
+    expect(resolved.view).toBe('list');
+    expect(resolved.depth).toBe(3);
+  });
+});
+
+describe('resolve', () => {
+  it('maps an absent view or depth onto the default', () => {
+    expect(resolveView(null)).toBe(DEFAULT_VIEW);
+    expect(resolveDepth(null)).toBe(DEFAULT_DEPTH);
+  });
+
+  it('preserves depth 0 rather than treating it as absent', () => {
+    expect(resolveDepth(0)).toBe(0);
+  });
+});
+
+describe('isNavChange', () => {
+  it('is true when the view changes', () => {
+    expect(isNavChange(state({ view: 'list' }), state({ view: 'kanban' }))).toBe(true);
+  });
+
+  it.each<[string, Partial<UrlState>]>([
+    ['map', { map: 'm2' }],
+    ['focus', { focus: 'n9' }],
+    ['node', { node: 'n9' }],
+  ])('is true when %s changes', (_label, patch) => {
+    expect(isNavChange(state(), state(patch))).toBe(true);
+  });
+
+  it.each<[string, Partial<UrlState>]>([
+    ['depth', { depth: 4 }],
+    ['version', { version: 'v1' }],
+    ['sprint', { sprint: 's1' }],
+    ['phase', { phase: 'p1' }],
+  ])('is false when only %s changes', (_label, patch) => {
+    expect(isNavChange(state(), state(patch))).toBe(false);
+  });
+});

--- a/packages/mindmap/src/__tests__/viewScope.test.ts
+++ b/packages/mindmap/src/__tests__/viewScope.test.ts
@@ -124,7 +124,6 @@ function setStoreState(overrides: Record<string, unknown> = {}) {
     rootNodeId: 'root',
     computed: computeTree(Object.values(nodes)),
     focusNodeId: null,
-    focusHistory: [],
     maxDepth: 0,
     activeVersionFilter: null,
     activeCycleFilter: null,

--- a/packages/mindmap/src/mobile/MobileApp.tsx
+++ b/packages/mindmap/src/mobile/MobileApp.tsx
@@ -1,16 +1,41 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMindmapStore } from '../store.js';
 import { AuthScreen } from '../AuthScreen.js';
 import { MobileMapList } from './MobileMapList.js';
 import { MobileViewer } from './MobileViewer.js';
+import * as api from '../api.js';
 import type { MapSummary } from '../api.js';
+import { parseUrlState, serializeUrlState } from '../urlState.js';
 import './mobile.css';
+
+/**
+ * Mirror the picked map into `?map=`, matching the desktop param vocabulary
+ * so a link works on either surface. Mobile keeps its own map selection
+ * (a `MapSummary`, not the shared store's `currentMapId`), hence the local
+ * wiring instead of `useUrlState`.
+ */
+function writeMapParam(mapId: string | null, replace: boolean): void {
+  const search = serializeUrlState(window.location.search, {
+    ...parseUrlState(window.location.search),
+    map: mapId,
+  });
+  if (search === window.location.search) return;
+  const href = window.location.pathname + search + window.location.hash;
+  if (replace) {
+    window.history.replaceState({}, '', href);
+  } else {
+    window.history.pushState({}, '', href);
+  }
+}
 
 export function MobileApp() {
   const user = useMindmapStore((s) => s.user);
   const checkAuth = useMindmapStore((s) => s.checkAuth);
 
   const [selectedMap, setSelectedMap] = useState<MapSummary | null>(null);
+  const hydrateStarted = useRef(false);
+  /** Blocks the mirror effect while we're applying a URL ourselves. */
+  const suspended = useRef(true);
 
   useEffect(() => {
     document.body.classList.add('mobile');
@@ -22,6 +47,61 @@ export function MobileApp() {
   useEffect(() => {
     void checkAuth();
   }, [checkAuth]);
+
+  /** Resolve a map id from the URL against the map list. */
+  const resolveMap = useCallback(async (mapId: string): Promise<MapSummary | null> => {
+    try {
+      const maps = await api.fetchMaps();
+      return maps.find((m) => m.id === mapId) ?? null;
+    } catch {
+      // Fall back to the map list screen rather than an error wall — the
+      // link is still recoverable by tapping through.
+      return null;
+    }
+  }, []);
+
+  // URL → state, once, after auth.
+  useEffect(() => {
+    if (!user || hydrateStarted.current) return;
+    hydrateStarted.current = true;
+    void (async () => {
+      const { map } = parseUrlState(window.location.search);
+      if (map) {
+        const found = await resolveMap(map);
+        if (found) setSelectedMap(found);
+      }
+      suspended.current = false;
+      writeMapParam(map ?? null, true);
+    })();
+  }, [user, resolveMap]);
+
+  // State → URL. Opening/closing a map pushes, so Back returns to the list.
+  useEffect(() => {
+    if (suspended.current) return;
+    writeMapParam(selectedMap?.id ?? null, false);
+  }, [selectedMap]);
+
+  // Browser Back / Forward.
+  useEffect(() => {
+    const onPopState = () => {
+      const { map } = parseUrlState(window.location.search);
+      suspended.current = true;
+      void (async () => {
+        try {
+          if (!map) {
+            setSelectedMap(null);
+            return;
+          }
+          const found = await resolveMap(map);
+          setSelectedMap(found);
+        } finally {
+          suspended.current = false;
+        }
+      })();
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, [resolveMap]);
 
   if (!user) {
     return (

--- a/packages/mindmap/src/mobile/MobileViewer.tsx
+++ b/packages/mindmap/src/mobile/MobileViewer.tsx
@@ -9,6 +9,7 @@ import { MobileMindmapView } from './MobileMindmapView.js';
 import { MobileRequirementsView } from './MobileRequirementsView.js';
 import { MobileNodeDetailSheet } from './MobileNodeDetailSheet.js';
 import { MobileAddNodeSheet } from './MobileAddNodeSheet.js';
+import { parseUrlState, serializeUrlState } from '../urlState.js';
 
 type ViewKey = 'list' | 'kanban' | 'gantt' | 'mindmap' | 'requirements';
 
@@ -22,12 +23,34 @@ const VIEW_LABELS: Record<ViewKey, string> = {
   requirements: 'Reqs',
 };
 
+/**
+ * The URL wins over the sticky localStorage preference, so a shared link
+ * opens the tab it names. `view` uses the desktop param vocabulary, of
+ * which the mobile tabs are a subset — a desktop-only view (hill, workload)
+ * falls through to the remembered tab rather than rendering nothing.
+ */
 function readDefaultView(): ViewKey {
+  const fromUrl = parseUrlState(window.location.search).view;
+  if (fromUrl && fromUrl in VIEW_LABELS) return fromUrl as ViewKey;
   try {
     const v = localStorage.getItem(VIEW_KEY);
     if (v && v in VIEW_LABELS) return v as ViewKey;
   } catch {}
   return 'list';
+}
+
+/** Mirror the active tab into `?view=`, replacing so tabs don't stack up. */
+function writeViewParam(view: ViewKey): void {
+  const search = serializeUrlState(window.location.search, {
+    ...parseUrlState(window.location.search),
+    view,
+  });
+  if (search === window.location.search) return;
+  window.history.replaceState(
+    {},
+    '',
+    window.location.pathname + search + window.location.hash,
+  );
 }
 
 interface Props {
@@ -142,10 +165,18 @@ export function MobileViewer({ map }: Props) {
 
   const setViewPersist = (v: ViewKey) => {
     setView(v);
+    writeViewParam(v);
     try {
       localStorage.setItem(VIEW_KEY, v);
     } catch {}
   };
+
+  // Reflect the initial tab (URL or remembered) into the URL, so the link
+  // in the address bar is copy-ready without touching a tab first.
+  useEffect(() => {
+    writeViewParam(view);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const nodes: NodeWithComputed[] = detail?.nodes ?? [];
   const byId = new Map(nodes.map((n) => [n.id, n]));

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -82,7 +82,6 @@ export interface MindmapState {
 
   // Drill-down navigation
   focusNodeId: string | null;
-  focusHistory: (string | null)[];
   maxDepth: number;
 
   // Cycle / sprint state
@@ -175,7 +174,6 @@ export interface MindmapState {
 
   // Drill-down actions
   setFocusNode: (nodeId: string | null) => void;
-  popFocusHistory: () => void;
   setMaxDepth: (depth: number) => void;
 
   // Presence / follow mode actions
@@ -212,7 +210,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
   computed: new Map(),
   layoutType: 'tree-lr' as const,
   focusNodeId: null,
-  focusHistory: [],
   maxDepth: 1,
   cycles: [],
   activeCycleFilter: null,
@@ -330,7 +327,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
         editingNodeId: null,
         computed: recomputeValues(nodesMap),
         focusNodeId: null,
-        focusHistory: [],
         maxDepth: 1,
         loading: false,
         error: null,
@@ -378,7 +374,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       editingNodeId: null,
       computed: new Map(),
       focusNodeId: null,
-      focusHistory: [],
       maxDepth: 1,
       versions: [],
       activeVersionFilter: null,
@@ -625,24 +620,9 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
     // Validate node exists (or null for root)
     if (nodeId !== null && !state.nodes[nodeId]) return;
     if (nodeId === state.focusNodeId) return;
-    const history = state.focusHistory.concat(state.focusNodeId);
-    // Cap history to avoid unbounded growth
-    const trimmed = history.length > 50 ? history.slice(-50) : history;
-    set({ focusNodeId: nodeId, focusHistory: trimmed });
-  },
-
-  popFocusHistory: () => {
-    const { focusHistory, nodes } = get();
-    if (focusHistory.length === 0) return;
-    const next = focusHistory[focusHistory.length - 1];
-    const newHistory = focusHistory.slice(0, -1);
-    // If the historical node no longer exists, skip it
-    if (next !== null && !nodes[next]) {
-      set({ focusHistory: newHistory });
-      get().popFocusHistory();
-      return;
-    }
-    set({ focusNodeId: next, focusHistory: newHistory });
+    // The drill-down trail lives in browser history — focus changes push a
+    // URL entry (see useUrlState), so Back walks it natively.
+    set({ focusNodeId: nodeId });
   },
 
   setMaxDepth: (depth) => set({ maxDepth: depth }),

--- a/packages/mindmap/src/urlState.ts
+++ b/packages/mindmap/src/urlState.ts
@@ -1,0 +1,220 @@
+import type { ActiveView } from './store.js';
+
+/**
+ * URL ⇄ view-state mirroring.
+ *
+ * Everything the app needs to put you back where you were when a link is
+ * pasted or the page is reloaded. Pure functions only (no DOM, no store)
+ * so the parse / serialize / validate rules are unit-testable; the wiring
+ * lives in `useUrlState.ts` (desktop) and `mobile/MobileApp.tsx`.
+ *
+ * Design rules:
+ *
+ * - **Defaults are omitted from the URL.** A map opened on the mindmap at
+ *   depth 1 still serializes to plain `?map=<id>`, exactly the URL shape
+ *   that shipped before this module existed — old links keep working and
+ *   new ones don't grow noise. The flip side: absent means *default*, not
+ *   *unchanged*, so applying a parsed state must always write every key
+ *   (otherwise going back from `?view=list` would leave you on the list).
+ *
+ * - **Unknown params survive a round trip.** `serializeUrlState` edits the
+ *   caller's existing query string rather than building a fresh one, so
+ *   `?m=1` (mobile override) and the GitHub OAuth `?gh=…` handshake aren't
+ *   clobbered by a view switch.
+ *
+ * - **Ephemeral UI stays out.** Open panels, dialogs and modals are not
+ *   mirrored: a shared link that reopens a half-filled Share dialog is
+ *   worse than one that doesn't.
+ */
+
+// ── Param names ────────────────────────────────────────────────
+
+const PARAM = {
+  map: 'map',
+  view: 'view',
+  focus: 'focus',
+  node: 'node',
+  depth: 'depth',
+  version: 'v',
+  sprint: 's',
+  phase: 'p',
+} as const;
+
+/** Every param this module owns — used to clear stale keys on write. */
+const OWNED_PARAMS: readonly string[] = Object.values(PARAM);
+
+// ── Defaults ───────────────────────────────────────────────────
+
+export const DEFAULT_VIEW: ActiveView = 'mindmap';
+export const DEFAULT_DEPTH = 1;
+
+/** Upper bound for `depth`, mirroring the store's practical range. */
+const MAX_DEPTH = 20;
+
+const VIEW_IDS: ReadonlySet<string> = new Set<ActiveView>([
+  'mindmap',
+  'kanban',
+  'gantt',
+  'list',
+  'calendar',
+  'hill',
+  'workload',
+  'releases',
+  'requirements',
+]);
+
+// ── Shape ──────────────────────────────────────────────────────
+
+/**
+ * The mirrored slice of view state. `null` means "absent from the URL",
+ * which for `view` and `depth` resolves to the default rather than to a
+ * cleared value — see `resolveView` / `resolveDepth`.
+ */
+export interface UrlState {
+  map: string | null;
+  view: ActiveView | null;
+  focus: string | null;
+  node: string | null;
+  depth: number | null;
+  version: string | null;
+  sprint: string | null;
+  phase: string | null;
+}
+
+export const EMPTY_URL_STATE: UrlState = {
+  map: null,
+  view: null,
+  focus: null,
+  node: null,
+  depth: null,
+  version: null,
+  sprint: null,
+  phase: null,
+};
+
+/** Keys that count as navigation — these push a history entry. */
+export const NAV_KEYS: readonly (keyof UrlState)[] = ['map', 'view', 'focus', 'node'];
+
+// ── Parse ──────────────────────────────────────────────────────
+
+function readId(params: URLSearchParams, key: string): string | null {
+  const raw = params.get(key);
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+/**
+ * Read the mirrored state out of a query string. Malformed values are
+ * dropped rather than surfaced as errors — a hand-edited or truncated
+ * link should degrade to "sensible default", never to a crash.
+ */
+export function parseUrlState(search: string): UrlState {
+  const params = new URLSearchParams(search);
+
+  const rawView = readId(params, PARAM.view);
+  const view = rawView !== null && VIEW_IDS.has(rawView) ? (rawView as ActiveView) : null;
+
+  const rawDepth = readId(params, PARAM.depth);
+  let depth: number | null = null;
+  if (rawDepth !== null) {
+    const n = Number(rawDepth);
+    // 0 is meaningful here — the store reads it as "unlimited".
+    if (Number.isInteger(n) && n >= 0 && n <= MAX_DEPTH) depth = n;
+  }
+
+  return {
+    map: readId(params, PARAM.map),
+    view,
+    focus: readId(params, PARAM.focus),
+    node: readId(params, PARAM.node),
+    depth,
+    version: readId(params, PARAM.version),
+    sprint: readId(params, PARAM.sprint),
+    phase: readId(params, PARAM.phase),
+  };
+}
+
+// ── Serialize ──────────────────────────────────────────────────
+
+/**
+ * Write `state` into `search`, preserving any param this module doesn't
+ * own. Values equal to their default are deleted rather than written, so
+ * the common case stays at `?map=<id>`.
+ *
+ * Returns a query string including the leading `?`, or `''` when empty.
+ */
+export function serializeUrlState(search: string, state: UrlState): string {
+  const params = new URLSearchParams(search);
+
+  for (const key of OWNED_PARAMS) params.delete(key);
+
+  if (state.map) params.set(PARAM.map, state.map);
+  if (state.view && state.view !== DEFAULT_VIEW) params.set(PARAM.view, state.view);
+  if (state.focus) params.set(PARAM.focus, state.focus);
+  if (state.node) params.set(PARAM.node, state.node);
+  if (state.depth !== null && state.depth !== DEFAULT_DEPTH) {
+    params.set(PARAM.depth, String(state.depth));
+  }
+  if (state.version) params.set(PARAM.version, state.version);
+  if (state.sprint) params.set(PARAM.sprint, state.sprint);
+  if (state.phase) params.set(PARAM.phase, state.phase);
+
+  const str = params.toString();
+  return str === '' ? '' : `?${str}`;
+}
+
+// ── Validate ───────────────────────────────────────────────────
+
+/**
+ * What the loaded map actually contains, for checking a link against
+ * reality. Built by the caller after the map (and its versions / sprints)
+ * have loaded.
+ */
+export interface UrlStateContext {
+  nodeIds: ReadonlySet<string>;
+  versionIds: ReadonlySet<string>;
+  sprintIds: ReadonlySet<string>;
+  phaseIds: ReadonlySet<string>;
+}
+
+/**
+ * Drop references that no longer resolve.
+ *
+ * This is the difference between a stale link degrading gracefully and one
+ * that looks like data loss: a `?v=` pointing at a deleted version would
+ * otherwise filter every node out and render an empty map. Unknown ids are
+ * cleared, which falls back to root / no filter.
+ *
+ * `map` is deliberately not validated here — a wrong map id is a load
+ * failure the caller surfaces as an error, not something to silently drop.
+ */
+export function validateUrlState(state: UrlState, ctx: UrlStateContext): UrlState {
+  return {
+    map: state.map,
+    view: state.view,
+    focus: state.focus && ctx.nodeIds.has(state.focus) ? state.focus : null,
+    node: state.node && ctx.nodeIds.has(state.node) ? state.node : null,
+    depth: state.depth,
+    version: state.version && ctx.versionIds.has(state.version) ? state.version : null,
+    sprint: state.sprint && ctx.sprintIds.has(state.sprint) ? state.sprint : null,
+    phase: state.phase && ctx.phaseIds.has(state.phase) ? state.phase : null,
+  };
+}
+
+// ── Resolve ────────────────────────────────────────────────────
+
+export function resolveView(view: ActiveView | null): ActiveView {
+  return view ?? DEFAULT_VIEW;
+}
+
+export function resolveDepth(depth: number | null): number {
+  return depth ?? DEFAULT_DEPTH;
+}
+
+// ── Compare ────────────────────────────────────────────────────
+
+/** True when `a` and `b` differ in at least one navigation key. */
+export function isNavChange(a: UrlState, b: UrlState): boolean {
+  return NAV_KEYS.some((k) => a[k] !== b[k]);
+}

--- a/packages/mindmap/src/useUrlState.ts
+++ b/packages/mindmap/src/useUrlState.ts
@@ -1,0 +1,214 @@
+import { useEffect, useRef } from 'react';
+import { useMindmapStore } from './store.js';
+import {
+  EMPTY_URL_STATE,
+  isNavChange,
+  parseUrlState,
+  resolveDepth,
+  resolveView,
+  serializeUrlState,
+  validateUrlState,
+  type UrlState,
+  type UrlStateContext,
+} from './urlState.js';
+
+/**
+ * Keeps the browser URL and the view state in sync, both directions, so a
+ * copied link or a reload puts you back where you were.
+ *
+ * Owns three flows:
+ *
+ * 1. **Hydrate** — once, after auth: read the URL, load the map it names,
+ *    then apply the rest *after* the load resolves. Ordering matters:
+ *    `loadMap` resets focus, depth and selection, so applying first would
+ *    be silently undone.
+ * 2. **Mirror** — subscribe to the store and write changes back to the URL.
+ *    Navigation (map / view / focus / node) pushes a history entry; lens
+ *    adjustments (depth, filters) replace, so the back stack doesn't fill
+ *    with slider noise.
+ * 3. **Restore** — on `popstate`, apply the URL back onto the store.
+ *
+ * Because focus changes push history entries, browser Back now walks the
+ * drill-down trail natively. That replaced an in-store `focusHistory` stack
+ * driven by a mousedown handler on XButton1; two competing back-stacks
+ * fought each other, and the mouse-button approach never worked on mobile.
+ *
+ * Also owns opening the map when the URL doesn't name one (single-map
+ * auto-open), so that all "which map am I on" logic sits in one place
+ * rather than racing an effect in App.tsx.
+ */
+
+/** Debounce for non-navigation writes (filters, depth, selection churn). */
+const MIRROR_DEBOUNCE_MS = 300;
+
+function buildContext(): UrlStateContext {
+  const s = useMindmapStore.getState();
+  return {
+    nodeIds: new Set(Object.keys(s.nodes)),
+    versionIds: new Set(s.versions.map((v) => v.id)),
+    sprintIds: new Set(s.cycles.map((c) => c.id)),
+    phaseIds: new Set((s.currentMap?.phases ?? []).map((p) => p.id)),
+  };
+}
+
+/** The store's current view state, in URL terms. */
+function readStoreUrlState(): UrlState {
+  const s = useMindmapStore.getState();
+  return {
+    map: s.currentMapId,
+    view: s.activeView,
+    focus: s.focusNodeId,
+    node: s.selectedNodeId,
+    depth: s.maxDepth,
+    version: s.activeVersionFilter,
+    sprint: s.activeCycleFilter,
+    phase: s.activePhaseFilter,
+  };
+}
+
+/**
+ * Push a parsed URL state onto the store. Every key is written — absent
+ * params resolve to their default — so going back from `?view=list` to a
+ * bare URL actually returns you to the mindmap.
+ */
+function applyToStore(state: UrlState): void {
+  const s = useMindmapStore.getState();
+  s.setActiveView(resolveView(state.view));
+  s.setMaxDepth(resolveDepth(state.depth));
+  s.setActiveVersionFilter(state.version);
+  s.setActiveCycleFilter(state.sprint);
+  s.setActivePhaseFilter(state.phase);
+  s.setFocusNode(state.focus);
+  s.selectNode(state.node);
+}
+
+/** Load the sprint/version lists a filter id has to be validated against. */
+async function loadScopeLists(): Promise<void> {
+  const s = useMindmapStore.getState();
+  await Promise.all([s.loadCycles(), s.loadVersions()]);
+}
+
+export function useUrlState(): void {
+  const user = useMindmapStore((s) => s.user);
+  const maps = useMindmapStore((s) => s.maps);
+  const currentMapId = useMindmapStore((s) => s.currentMapId);
+  const loading = useMindmapStore((s) => s.loading);
+
+  /** Blocks store → URL writes while we're driving the store ourselves. */
+  const suspended = useRef(true);
+  /** Last state we wrote, to classify the next change as nav vs lens. */
+  const lastWritten = useRef<UrlState>(EMPTY_URL_STATE);
+  /** The landing URL is replaced, not pushed — no duplicate history entry. */
+  const firstWrite = useRef(true);
+  const hydrateStarted = useRef(false);
+  /** Set once a map has been opened, so auto-open doesn't fight hydration. */
+  const mapClaimed = useRef(false);
+
+  const writeUrl = useRef((): void => {
+    const current = readStoreUrlState();
+    const search = serializeUrlState(window.location.search, current);
+    // Landing on an already-correct URL still counts as the first write:
+    // clear the flag here too, or the next real navigation replaces the
+    // landing entry instead of pushing and Back skips straight out of the app.
+    const isFirst = firstWrite.current;
+    firstWrite.current = false;
+    if (search === window.location.search) {
+      lastWritten.current = current;
+      return;
+    }
+    const href = window.location.pathname + search + window.location.hash;
+    const replace = isFirst || !isNavChange(current, lastWritten.current);
+    if (replace) {
+      window.history.replaceState({}, '', href);
+    } else {
+      window.history.pushState({}, '', href);
+    }
+    lastWritten.current = current;
+  }).current;
+
+  // ── 1. Hydrate: URL → store, once, after auth ────────────────
+  useEffect(() => {
+    if (!user || hydrateStarted.current) return;
+    hydrateStarted.current = true;
+
+    void (async () => {
+      const target = parseUrlState(window.location.search);
+
+      if (target.map) {
+        mapClaimed.current = true;
+        await useMindmapStore.getState().loadMap(target.map);
+        // A dead map id leaves currentMapId unset and an error on the
+        // store — surface that rather than applying view state onto
+        // nothing.
+        if (useMindmapStore.getState().currentMapId === target.map) {
+          await loadScopeLists();
+          applyToStore(validateUrlState(target, buildContext()));
+        }
+      }
+
+      suspended.current = false;
+      writeUrl();
+    })();
+  }, [user, writeUrl]);
+
+  // ── Auto-open the only map, when the URL didn't name one ─────
+  useEffect(() => {
+    if (mapClaimed.current || currentMapId || loading) return;
+    if (maps.length !== 1) return;
+    mapClaimed.current = true;
+    void useMindmapStore.getState().loadMap(maps[0].id);
+  }, [maps, currentMapId, loading]);
+
+  // ── 2. Mirror: store → URL ───────────────────────────────────
+  useEffect(() => {
+    let timer: number | undefined;
+
+    const unsubscribe = useMindmapStore.subscribe(() => {
+      if (suspended.current) return;
+      const next = readStoreUrlState();
+      // Navigation lands immediately so a link copied right after a click
+      // is already correct; lens changes coalesce.
+      if (isNavChange(next, lastWritten.current)) {
+        window.clearTimeout(timer);
+        writeUrl();
+        return;
+      }
+      window.clearTimeout(timer);
+      timer = window.setTimeout(writeUrl, MIRROR_DEBOUNCE_MS);
+    });
+
+    return () => {
+      unsubscribe();
+      window.clearTimeout(timer);
+    };
+  }, [writeUrl]);
+
+  // ── 3. Restore: popstate → store ─────────────────────────────
+  useEffect(() => {
+    const onPopState = () => {
+      const target = parseUrlState(window.location.search);
+      suspended.current = true;
+
+      void (async () => {
+        try {
+          const store = useMindmapStore.getState();
+          if (target.map && target.map !== store.currentMapId) {
+            mapClaimed.current = true;
+            await store.loadMap(target.map);
+            if (useMindmapStore.getState().currentMapId !== target.map) return;
+            await loadScopeLists();
+          } else if (!target.map && store.currentMapId) {
+            store.closeMap();
+          }
+          applyToStore(validateUrlState(target, buildContext()));
+        } finally {
+          lastWritten.current = readStoreUrlState();
+          suspended.current = false;
+        }
+      })();
+    };
+
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+}


### PR DESCRIPTION
## The problem

Copy the address bar, or just hit reload, and you land back on the mindmap at depth 1 with no filters. Only `?map=` was ever mirrored into the URL — view, drill-down focus, selection, depth and the scope filters all lived in the zustand store and died with the page.

## What's in the URL now

| Param | State |
|---|---|
| `map` | current map (unchanged) |
| `view` | active tab |
| `focus` | drill-down node |
| `node` | selected node |
| `depth` | depth limit |
| `v` / `s` / `p` | version / sprint / phase filter |

Panels, dialogs and modals stay out — a shared link that reopens a half-filled Share dialog is worse than one that doesn't.

## Notes on the design

**Old links keep working, new ones stay short.** Values equal to their default are omitted, so a map opened on the mindmap at depth 1 still serializes to plain `?map=<id>` — the exact URL shape that shipped before. Params this module doesn't own (`?m=1`, the GitHub OAuth handshake) are preserved rather than clobbered.

**Hydration waits for the map.** `loadMap` resets focus, depth and selection, so applying URL state before it resolves would be silently undone. `useUrlState` owns the ordering, and also absorbs the single-map auto-open so "which map am I on" isn't split across racing effects in `App.tsx`.

**Navigation pushes, lens adjustments replace.** Changing map/view/focus/selection pushes a history entry; depth and filters replace, so the back stack doesn't fill with slider noise.

**Stale links degrade rather than looking like data loss.** A `?v=` naming a deleted version would otherwise filter every node out and render an empty map. Unresolvable ids are cleared back to root / no filter.

## Two things this changes

**The mouse-back hijack is gone.** Focus changes now push history entries, so browser Back walks the drill-down trail natively. That replaces the in-store `focusHistory` stack driven by a `mousedown` handler on XButton1 — two competing back-stacks that fought each other, and the mouse-button route never worked on mobile at all.

**Mobile joins in.** `src/mobile/` had no URL sync whatsoever, not even `?map=` — reload always dumped you at the map list. It now shares the param vocabulary, so a link opens the same place on either surface. Mobile deliberately stops at map + view; the node detail sheet is ephemeral UI.

## Verification

`pnpm turbo typecheck` and `pnpm turbo test` clean (65 mindmap tests, 885 across the monorepo).

32 unit tests cover the parse/serialize/validate rules. Because those can't tell you whether the *app* actually stays put, I also drove a real browser (Playwright, headless Chromium) against a locally seeded map — 23 assertions covering reload and copy-link round trips for every mirrored field, Back/Forward, stale ids, a dead map id, param preservation, and the mobile surface. One genuine bug surfaced that way and is fixed here: the hydration write short-circuits when the URL is already correct, and that path didn't clear the `firstWrite` flag, so the next navigation replaced instead of pushing and Back skipped straight out of the app.

Not covered by CI — the browser pass was manual and isn't checked in. No DB, API or MCP surface is touched, so the cross-cutting checklist in CLAUDE.md doesn't apply.