### PR TITLE
fix(views): give Hill Chart and Workload a data source that exists

### DIFF
--- a/packages/mindmap/src/HillChart.tsx
+++ b/packages/mindmap/src/HillChart.tsx
@@ -158,6 +158,7 @@ export function HillChart() {
           <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: '#1e293b' }}>Hill Chart</h2>
           <p style={{ margin: '4px 0 0', fontSize: 12, color: '#94a3b8' }}>
             Drag dots along the hill. Left = figuring it out, Right = making it happen.
+            Faded dots are auto-placed from rolled-up progress until you drag them.
           </p>
         </div>
         {/* Legend */}
@@ -262,8 +263,18 @@ export function HillChart() {
             const isDragging = branch.node.id === dragging;
             const isHovered = branch.node.id === hovered;
 
+            // Neighbours along the hill alternate label heights, so two
+            // dots that end up close together don't overprint each other.
+            const labelY = cy - r - (branch.rank % 2 === 0 ? 8 : 22);
+
             return (
               <g key={branch.node.id}>
+                <title>
+                  {branch.node.text}
+                  {branch.isDerived
+                    ? ` — auto-placed from ${Math.round(branch.computed.computedProgress)}% progress. Drag to set it yourself.`
+                    : ` — placed at ${Math.round(branch.hillPosition)}`}
+                </title>
                 {/* Drop shadow */}
                 {(isHovered || isDragging) && (
                   <circle cx={cx} cy={cy} r={r + 4} fill={color} opacity="0.2" />
@@ -282,14 +293,16 @@ export function HillChart() {
                   />
                 )}
 
-                {/* Main dot */}
+                {/* Main dot — auto-placed dots read as provisional */}
                 <circle
                   cx={cx}
                   cy={cy}
                   r={r}
                   fill={color}
+                  fillOpacity={branch.isDerived ? 0.65 : 1}
                   stroke="#fff"
                   strokeWidth="2"
+                  strokeDasharray={branch.isDerived ? '3,2' : undefined}
                   style={{ cursor: 'grab', transition: isDragging ? 'none' : 'cx 0.15s, cy 0.15s' }}
                   onPointerDown={(e) => handlePointerDown(branch.node.id, e)}
                   onPointerEnter={() => setHovered(branch.node.id)}
@@ -314,7 +327,7 @@ export function HillChart() {
                 {/* Label */}
                 <text
                   x={cx}
-                  y={cy - r - 8}
+                  y={labelY}
                   textAnchor="middle"
                   fill="#334155"
                   fontSize="11"

--- a/packages/mindmap/src/WorkloadView.tsx
+++ b/packages/mindmap/src/WorkloadView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMindmapStore } from './store.js';
 import { computeWorkloads } from './viewScope.js';
 
@@ -28,6 +28,15 @@ export function WorkloadView() {
   const activeVersionFilter = useMindmapStore((s) => s.activeVersionFilter);
   const activeCycleFilter = useMindmapStore((s) => s.activeCycleFilter);
   const activePhaseFilter = useMindmapStore((s) => s.activePhaseFilter);
+  const nodeActors = useMindmapStore((s) => s.nodeActors);
+  const loadNodeActors = useMindmapStore((s) => s.loadNodeActors);
+  const currentMapId = useMindmapStore((s) => s.currentMapId);
+
+  // Attribution fallback — fetched here rather than in loadMap because
+  // this is the only view that needs it and it queries the change log.
+  useEffect(() => {
+    void loadNodeActors();
+  }, [currentMapId, loadNodeActors]);
 
   const [capacity, setCapacity] = useState(40);
   const [editingCapacity, setEditingCapacity] = useState(false);
@@ -46,8 +55,9 @@ export function WorkloadView() {
       computeWorkloads(
         getVisibleNodes({ respectFocus: false, respectDepth: false, respectCollapsed: false }),
         statusWorkflow,
+        nodeActors,
       ),
-    [nodes, rootNodeId, getVisibleNodes, activeVersionFilter, activeCycleFilter, activePhaseFilter, statusWorkflow],
+    [nodes, rootNodeId, getVisibleNodes, activeVersionFilter, activeCycleFilter, activePhaseFilter, statusWorkflow, nodeActors],
   );
 
   const maxEffort = Math.max(capacity, ...workloads.map((w) => w.total));
@@ -93,7 +103,9 @@ export function WorkloadView() {
         <div>
           <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: '#1e293b' }}>Workload</h2>
           <p style={{ margin: '4px 0 0', fontSize: 12, color: '#94a3b8' }}>
-            Effort distribution by assignee. Click a bar segment to see tasks.
+            Effort distribution by person. Click a bar segment to see tasks.
+            Names marked <span style={{ color: '#94a3b8' }}>~</span> are inferred from who last
+            edited the work; assign a node to make it authoritative.
           </p>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
@@ -176,7 +188,7 @@ export function WorkloadView() {
           >
             {activeVersionFilter || activeCycleFilter || activePhaseFilter
               ? 'No assigned tasks with effort estimates match the active filter.'
-              : 'No assigned tasks with effort estimates found. Assign tasks and add effort estimates to leaf nodes.'}
+              : 'No leaf nodes with effort estimates found. Add effort estimates to leaf nodes.'}
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -200,9 +212,20 @@ export function WorkloadView() {
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',
                     }}
-                    title={w.assigneeId}
+                    title={
+                      w.source === 'assignee'
+                        ? `${w.label} — assigned`
+                        : w.source === 'claim'
+                          ? `${w.label} — claimed by this session`
+                          : `${w.label} — inferred from who last edited these nodes (nothing is assigned)`
+                    }
                   >
-                    {w.assigneeId}
+                    {w.label}
+                    {w.source !== 'assignee' && (
+                      <span style={{ color: '#cbd5e1', fontWeight: 400 }}>
+                        {w.source === 'claim' ? ' ⧗' : ' ~'}
+                      </span>
+                    )}
                   </div>
 
                   {/* Bar container */}

--- a/packages/mindmap/src/__tests__/viewScope.test.ts
+++ b/packages/mindmap/src/__tests__/viewScope.test.ts
@@ -183,9 +183,55 @@ describe('scope-only getVisibleNodes as the data basis for HillChart/WorkloadVie
       );
       expect(branches.map((b) => b.node.id)).toEqual(['epicA', 'epicB']);
       expect(branches[0].hillPosition).toBe(30); // customFields passthrough
-      expect(branches[1].hillPosition).toBe(0); // default
+      expect(branches[0].isDerived).toBe(false);
+      // Never dragged → falls back to rolled-up progress (b1 2h@100% + b2 8h@0%)
+      expect(branches[1].hillPosition).toBe(20);
+      expect(branches[1].isDerived).toBe(true);
       // Aggregates come from computeTree, over the branch subtree
       expect(branches[0].computed.computedEffort).toBe(8); // a1 5h + a2 3h
+    });
+
+    it('spreads auto-placed dots that would otherwise pile up, leaving dragged ones anchored', () => {
+      // Both branches land on the same derived progress → the exact blob
+      // this fix exists for (14 dots on one point, on the real map).
+      patchNode('epicA', { customFields: {} });
+      patchNode('a1', { percentComplete: 20 });
+      patchNode('a2', { percentComplete: 20 });
+      useMindmapStore.setState({
+        computed: computeTree(Object.values(useMindmapStore.getState().nodes)),
+      });
+      const raw = useMindmapStore.getState().computed;
+      expect(raw.get('epicA')!.computedProgress).toBe(raw.get('epicB')!.computedProgress);
+      const branches = selectHillBranches(
+        useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY),
+        useMindmapStore.getState().computed,
+        10,
+      );
+      const [a, b] = branches;
+      expect(a.isDerived && b.isDerived).toBe(true);
+      expect(Math.abs(a.hillPosition - b.hillPosition)).toBeGreaterThanOrEqual(10);
+      expect(a.hillPosition).toBeGreaterThanOrEqual(0);
+      expect(b.hillPosition).toBeLessThanOrEqual(100);
+    });
+
+    it('never moves a dot the user dragged, even when a derived dot wants its spot', () => {
+      patchNode('epicA', { customFields: { hillPosition: 20 } }); // same as epicB's derived 20
+      const branches = selectHillBranches(
+        useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY),
+        useMindmapStore.getState().computed,
+        10,
+      );
+      expect(branches[0].hillPosition).toBe(20); // anchored
+      expect(Math.abs(branches[1].hillPosition - 20)).toBeGreaterThanOrEqual(10);
+    });
+
+    it('clamps an out-of-range manual position instead of drawing off-chart', () => {
+      patchNode('epicA', { customFields: { hillPosition: 340 } });
+      const branches = selectHillBranches(
+        useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY),
+        useMindmapStore.getState().computed,
+      );
+      expect(branches[0].hillPosition).toBe(100);
     });
 
     it('drops branches outside the active version filter', () => {
@@ -236,6 +282,52 @@ describe('scope-only getVisibleNodes as the data basis for HillChart/WorkloadVie
       const w = workloadsNow();
       expect(w.map((x) => x.assigneeId)).toEqual(['alice']);
       expect(w[0]).toMatchObject({ todo: 0, inProgress: 0, done: 2, total: 2 });
+    });
+
+    it('falls back to the last editor when a leaf has no assignee and no claim', () => {
+      // The real-world case: no node anywhere has an assignee.
+      for (const id of ['a1', 'a2', 'b1', 'b2']) patchNode(id, { assigneeIds: [] });
+      const actors = new Map([
+        ['a1', { userId: 'u-dan', userName: 'Daniel Haas' }],
+        ['a2', { userId: 'u-mike', userName: 'Mike' }],
+        ['b1', { userId: 'u-dan', userName: 'Daniel Haas' }],
+        // b2 deliberately unattributed → drops out entirely
+      ]);
+      const w = computeWorkloads(
+        useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY),
+        workflow,
+        actors,
+      );
+      expect(w.map((x) => x.label)).toEqual(['Daniel Haas', 'Mike']);
+      expect(w[0]).toMatchObject({ source: 'author', todo: 5, done: 2, total: 7 });
+      expect(w[1]).toMatchObject({ source: 'author', inProgress: 3, total: 3 });
+    });
+
+    it('prefers an explicit assignee over the claim, and a claim over authorship', () => {
+      patchNode('a1', { assigneeIds: ['alice'], claimedBySession: 'sess-1' });
+      patchNode('a2', { assigneeIds: [], claimedBySession: 'sess-1' });
+      patchNode('b1', { assigneeIds: [] });
+      patchNode('b2', { assigneeIds: [] });
+      const actors = new Map([
+        ['a1', { userId: 'u-dan', userName: 'Daniel Haas' }],
+        ['a2', { userId: 'u-dan', userName: 'Daniel Haas' }],
+        ['b1', { userId: 'u-dan', userName: 'Daniel Haas' }],
+        ['b2', { userId: 'u-dan', userName: 'Daniel Haas' }],
+      ]);
+      const w = computeWorkloads(
+        useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY),
+        workflow,
+        actors,
+      );
+      const byId = Object.fromEntries(w.map((x) => [x.assigneeId, x]));
+      expect(byId['alice']).toMatchObject({ source: 'assignee', total: 5 }); // a1 only
+      expect(byId['sess-1']).toMatchObject({ source: 'claim', total: 3 }); // a2, claim beats author
+      expect(byId['u-dan']).toMatchObject({ source: 'author', total: 10 }); // b1 2h + b2 8h
+    });
+
+    it('without any attribution source, a leaf contributes to nobody', () => {
+      for (const id of ['a1', 'a2', 'b1', 'b2']) patchNode(id, { assigneeIds: [] });
+      expect(workloadsNow()).toEqual([]);
     });
 
     it('keeps aggregating ALL leaves under drill-down focus, depth limit, and collapse', () => {

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -530,6 +530,17 @@ export function fetchNode(mapId: string, nodeId: string): Promise<Node> {
   return request<Node>(`/api/maps/${mapId}/nodes/${nodeId}`);
 }
 
+export interface NodeActor {
+  nodeId: string;
+  userId: string;
+  userName: string;
+}
+
+/** Who last touched each node — the Workload view's attribution fallback. */
+export function fetchNodeActors(mapId: string): Promise<{ actors: NodeActor[] }> {
+  return request<{ actors: NodeActor[] }>(`/api/maps/${mapId}/nodes/actors`);
+}
+
 export function createMap(name: string): Promise<MindMap> {
   // createdBy will be inferred from the auth token on the server,
   // but we send it as fallback for compatibility

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -95,6 +95,10 @@ export interface MindmapState {
   // Phase state (PhaseDefs live on currentMap.phases; only the filter is store state)
   activePhaseFilter: string | null;
 
+  // Workload attribution — who last touched each node (loaded on demand)
+  nodeActors: Map<string, { userId: string; userName: string }>;
+  nodeActorsMapId: string | null;
+
   // UI state
   activeView: ActiveView;
   loading: boolean;
@@ -148,6 +152,9 @@ export interface MindmapState {
 
   // Actions — phase
   setActivePhaseFilter: (phaseId: string | null) => void;
+
+  // Actions — workload attribution
+  loadNodeActors: () => Promise<void>;
 
   // Actions — layout
   setLayoutType: (layout: 'tree-lr' | 'tree-tb' | 'radial' | 'org-chart') => void;
@@ -216,6 +223,8 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
   versions: [],
   activeVersionFilter: null,
   activePhaseFilter: null,
+  nodeActors: new Map(),
+  nodeActorsMapId: null,
   activeView: 'mindmap',
   loading: false,
   error: null,
@@ -556,6 +565,33 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       set({ versions });
     } catch (e: any) {
       set({ error: e.message ?? 'Failed to load versions' });
+    }
+  },
+
+  /**
+   * Fetch the per-node "who last touched this" map for the current map.
+   *
+   * Only the Workload view needs it, and it costs a query over the whole
+   * change log, so it is loaded on demand when that view mounts rather
+   * than as part of loadMap. Cached per map id; a failure leaves the map
+   * empty, which just degrades attribution back to assignees/claims.
+   */
+  loadNodeActors: async () => {
+    const state = get();
+    const mapId = state.currentMapId;
+    if (!mapId) {
+      set({ nodeActors: new Map(), nodeActorsMapId: null });
+      return;
+    }
+    if (state.nodeActorsMapId === mapId) return;
+    try {
+      const { actors } = await api.fetchNodeActors(mapId);
+      set({
+        nodeActors: new Map(actors.map((a) => [a.nodeId, { userId: a.userId, userName: a.userName }])),
+        nodeActorsMapId: mapId,
+      });
+    } catch {
+      set({ nodeActors: new Map(), nodeActorsMapId: mapId });
     }
   },
 

--- a/packages/mindmap/src/viewScope.ts
+++ b/packages/mindmap/src/viewScope.ts
@@ -31,7 +31,72 @@ export interface ScopedVisibleNode {
 export interface HillBranch {
   node: Node;
   computed: ComputedNodeValues;
-  hillPosition: number; // 0-100
+  hillPosition: number; // 0-100, after the de-overlap pass
+  /** True when nobody has dragged this dot — position came from progress. */
+  isDerived: boolean;
+  /** Rank along the hill (left to right), for staggering labels. */
+  rank: number;
+}
+
+/**
+ * Where a dot sits when nobody has ever dragged it.
+ *
+ * `hillPosition` is a manual, drag-only field, so on a map where it was
+ * never touched every branch defaults to the same value and the dots pile
+ * up in one blob at the left foot of the hill — the chart reads as broken.
+ * Falling back to rolled-up progress spreads them along the arc the way
+ * the metaphor already implies: uphill is the unresolved part, the peak is
+ * "we know how to do this", downhill is execution. A drag still wins and
+ * persists, which is what makes the manual field worth keeping.
+ */
+export function deriveHillPosition(computed: ComputedNodeValues): number {
+  return clampPosition(computed.computedProgress);
+}
+
+function clampPosition(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, n));
+}
+
+/**
+ * Minimum spacing between two dots, in hill-position units.
+ *
+ * The chart maps 100 units onto ~680px, so 6 units ≈ 41px — enough to
+ * keep two mid-sized dots from merging into one blob. Only derived dots
+ * are moved to honour it (see `spreadDerived`).
+ */
+export const MIN_DOT_GAP = 6;
+
+/**
+ * Nudge auto-placed dots apart so clustered progress values stay readable.
+ *
+ * Manually dragged dots are anchors: they never move, because a dot the
+ * user parked at 50 must stay at 50. Derived dots are free to slide, since
+ * their exact position was already an inference. Runs left-to-right then
+ * back, so a cluster that would overflow the right edge spills leftward
+ * instead of stacking on 100.
+ */
+function spreadDerived(branches: HillBranch[], minGap: number): void {
+  const order = [...branches].sort((a, b) => a.hillPosition - b.hillPosition);
+
+  for (let i = 1; i < order.length; i++) {
+    const prev = order[i - 1];
+    const cur = order[i];
+    if (cur.isDerived && cur.hillPosition < prev.hillPosition + minGap) {
+      cur.hillPosition = clampPosition(prev.hillPosition + minGap);
+    }
+  }
+  for (let i = order.length - 2; i >= 0; i--) {
+    const next = order[i + 1];
+    const cur = order[i];
+    if (cur.isDerived && cur.hillPosition > next.hillPosition - minGap) {
+      cur.hillPosition = clampPosition(next.hillPosition - minGap);
+    }
+  }
+
+  order.forEach((b, i) => {
+    b.rank = i;
+  });
 }
 
 /**
@@ -48,15 +113,24 @@ export interface HillBranch {
 export function selectHillBranches(
   visibleNodes: ScopedVisibleNode[],
   computed: Map<string, ComputedNodeValues>,
+  minGap: number = MIN_DOT_GAP,
 ): HillBranch[] {
   const branches: HillBranch[] = [];
   for (const vn of visibleNodes) {
     if (vn.isDimmed || vn.depth !== 1) continue;
     const comp = computed.get(vn.node.id);
     if (!comp) continue;
-    const hp = (vn.node.customFields?.hillPosition as number) ?? 0;
-    branches.push({ node: vn.node, computed: comp, hillPosition: hp });
+    const manual = vn.node.customFields?.hillPosition;
+    const isDerived = typeof manual !== 'number';
+    branches.push({
+      node: vn.node,
+      computed: comp,
+      hillPosition: isDerived ? deriveHillPosition(comp) : clampPosition(manual as number),
+      isDerived,
+      rank: 0,
+    });
   }
+  spreadDerived(branches, minGap);
   return branches;
 }
 
@@ -70,8 +144,17 @@ export interface StatusWorkflowStep {
   category: string;
 }
 
+/** How a leaf got attributed to a person — weakest source wins last. */
+export type WorkloadSource = 'assignee' | 'claim' | 'author';
+
+/** Who last touched a node, keyed by node id. Empty when unavailable. */
+export type NodeActors = ReadonlyMap<string, { userId: string; userName: string }>;
+
 export interface AssigneeWorkload {
   assigneeId: string;
+  /** Display name — the actor's name for authored work, else the raw id. */
+  label: string;
+  source: WorkloadSource;
   todo: number;
   inProgress: number;
   done: number;
@@ -98,38 +181,90 @@ export function statusCategory(
 }
 
 /**
- * Aggregate per-assignee effort from the leaf nodes of the visible set.
+ * Who a leaf's effort should count against, strongest signal first.
+ *
+ * `assigneeIds` is the field the model intends for this, but nothing
+ * writes it — there is no assignee editor in the UI and no MCP caller has
+ * ever set one — and `claimedBySession` only holds a value while an agent
+ * has work in flight. Grouping on those alone left the Workload view
+ * permanently empty on every real map. Authorship from the change log is
+ * the fallback that actually has data: whoever last edited a node is, in
+ * practice, the person carrying it. Returns `[]` when nothing attributes
+ * the leaf, so it drops out rather than landing in an "unknown" bucket.
+ */
+function attributionFor(
+  leaf: Node,
+  actors: NodeActors,
+): Array<{ id: string; label: string; source: WorkloadSource }> {
+  if (leaf.assigneeIds.length > 0) {
+    return leaf.assigneeIds.map((id) => ({ id, label: id, source: 'assignee' as const }));
+  }
+  if (leaf.claimedBySession) {
+    return [{ id: leaf.claimedBySession, label: leaf.claimedBySession, source: 'claim' }];
+  }
+  const actor = actors.get(leaf.id);
+  if (actor) {
+    return [{ id: actor.userId, label: actor.userName, source: 'author' }];
+  }
+  return [];
+}
+
+/**
+ * Aggregate per-person effort from the leaf nodes of the visible set.
  *
  * A leaf is a node without children (raw `childrenIds`, same notion
  * CalendarView uses); dimmed drill-down context siblings are skipped.
  * Only leaves that survived the active version/sprint filter contribute,
  * so the Workload bars reflect the same scope the filter chip announces.
- * Result is sorted by total effort descending.
+ * Attribution falls back through assignee → claim → author, see
+ * `attributionFor`. Result is sorted by total effort descending.
  */
 export function computeWorkloads(
   visibleNodes: ScopedVisibleNode[],
   statusWorkflow: StatusWorkflowStep[],
+  actors: NodeActors = new Map(),
 ): AssigneeWorkload[] {
   const map = new Map<
     string,
-    { todo: number; inProgress: number; done: number; todoNodes: Node[]; ipNodes: Node[]; doneNodes: Node[] }
+    {
+      label: string;
+      source: WorkloadSource;
+      todo: number;
+      inProgress: number;
+      done: number;
+      todoNodes: Node[];
+      ipNodes: Node[];
+      doneNodes: Node[];
+    }
   >();
 
   for (const vn of visibleNodes) {
     if (vn.isDimmed) continue;
     const leaf = vn.node;
     if (leaf.childrenIds.length !== 0) continue;
-    if (leaf.assigneeIds.length === 0) continue;
     const effort = leaf.effortEstimate ?? 0;
     if (effort === 0) continue;
 
     const cat = statusCategory(leaf, statusWorkflow);
 
-    for (const assignee of leaf.assigneeIds) {
+    for (const { id: assignee, label, source } of attributionFor(leaf, actors)) {
       let entry = map.get(assignee);
       if (!entry) {
-        entry = { todo: 0, inProgress: 0, done: 0, todoNodes: [], ipNodes: [], doneNodes: [] };
+        entry = {
+          label,
+          source,
+          todo: 0,
+          inProgress: 0,
+          done: 0,
+          todoNodes: [],
+          ipNodes: [],
+          doneNodes: [],
+        };
         map.set(assignee, entry);
+      } else if (source === 'assignee' && entry.source !== 'assignee') {
+        // A stronger signal upgrades the bucket's provenance mid-walk.
+        entry.source = source;
+        entry.label = label;
       }
       if (cat === 'todo') {
         entry.todo += effort;
@@ -148,6 +283,8 @@ export function computeWorkloads(
   for (const [assigneeId, data] of map.entries()) {
     result.push({
       assigneeId,
+      label: data.label,
+      source: data.source,
       todo: data.todo,
       inProgress: data.inProgress,
       done: data.done,

--- a/packages/server/src/db/events.ts
+++ b/packages/server/src/db/events.ts
@@ -140,6 +140,48 @@ export async function listEvents(opts: ListEventsOptions): Promise<ChangeEvent[]
   }));
 }
 
+/**
+ * Who last touched each node of a map, from the change log.
+ *
+ * The Workload view needs a person per leaf. `assigneeIds` is the field
+ * built for that, but nothing writes it (no UI, and no MCP caller ever
+ * has), and `claimedBySession` only holds a value while work is in
+ * flight — so on a real map both are empty and the view has nothing to
+ * group by. Authorship is the one signal that is actually populated:
+ * whoever last edited a node is, in practice, the person carrying it.
+ *
+ * Falls back to `nodes.created_by` for nodes with no attributed event
+ * (imports, seeds, anything predating the change log). Nodes whose only
+ * events have a null `user_id` — MCP/agent writes without a session
+ * user — are omitted rather than bucketed under a fake actor.
+ */
+export async function getLastActorByNode(
+  mapId: string,
+): Promise<Array<{ nodeId: string; userId: string; userName: string }>> {
+  const rows = await db.execute(sql`
+    with attributed as (
+      select distinct on (e.node_id)
+        e.node_id, e.user_id
+      from change_events e
+      where e.map_id = ${mapId} and e.node_id is not null and e.user_id is not null
+      order by e.node_id, e.created_at desc
+    )
+    select n.id as node_id,
+           coalesce(a.user_id, n.created_by) as user_id,
+           u.name as user_name
+    from nodes n
+    left join attributed a on a.node_id = n.id
+    join users u on u.id = coalesce(a.user_id, n.created_by)
+    where n.map_id = ${mapId} and n.deleted_at is null
+  `);
+
+  return (rows.rows as Array<{ node_id: string; user_id: string; user_name: string }>).map((r) => ({
+    nodeId: r.node_id,
+    userId: r.user_id,
+    userName: r.user_name,
+  }));
+}
+
 /** Count events per event_type + field for a scope. Used by digest/burnup. */
 export async function countEventsByType(
   mapId: string,

--- a/packages/server/src/routes/__tests__/node-actors-route.test.ts
+++ b/packages/server/src/routes/__tests__/node-actors-route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Route test for GET /api/maps/:id/nodes/actors — the Workload view's
+ * attribution fallback.
+ *
+ * The one thing worth locking down here is routing, not SQL: the path
+ * sits under the same prefix as GET /api/maps/:id/nodes/:nodeId, so a
+ * regression in registration order (or a rename to a param-shaped path)
+ * would silently route "actors" into the single-node handler and return
+ * a 404 NODE_NOT_FOUND instead of the actor map. That failure looks like
+ * "Workload is empty again", which is exactly the bug this whole change
+ * set exists to fix.
+ *
+ * Mock pattern mirrors phase-node-routes.test.ts — stub the DB layer,
+ * exercise route wiring without Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const getLastActorByNodeMock = vi.fn();
+const getNodeMock = vi.fn(async () => null);
+
+vi.mock('../../db/nodes.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/nodes.js')>();
+  return { ...actual, getNode: () => getNodeMock() };
+});
+
+vi.mock('../../db/maps.js', () => ({ updateMap: vi.fn() }));
+vi.mock('../../db/events.js', () => ({
+  recordEvent: vi.fn(async () => {}),
+  recordFieldChanges: vi.fn(async () => {}),
+  listEvents: vi.fn(async () => []),
+  getLastActorByNode: (...args: unknown[]) => getLastActorByNodeMock(...args),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../../ai/embeddings.js', () => ({ scheduleEmbedNode: vi.fn() }));
+vi.mock('@mindblown/integrations', () => ({
+  updateGitHubIssue: vi.fn(),
+  getGitHubIssue: vi.fn(),
+}));
+vi.mock('../integrations.js', () => ({
+  getGitHubContextForMap: vi.fn(async () => null),
+}));
+
+import { nodeRoutes } from '../nodes.js';
+
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    req.userId = 'uuuu-uuuu-uuuu-uuuu';
+  });
+  await app.register(nodeRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  getLastActorByNodeMock.mockReset();
+  getNodeMock.mockReset();
+  getNodeMock.mockResolvedValue(null as never);
+});
+
+describe('GET /api/maps/:id/nodes/actors', () => {
+  it('returns the actor map for the requested map', async () => {
+    getLastActorByNodeMock.mockResolvedValueOnce([
+      { nodeId: 'n1', userId: 'u-dan', userName: 'Daniel Haas' },
+      { nodeId: 'n2', userId: 'u-mike', userName: 'Mike' },
+    ]);
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/nodes/actors` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(getLastActorByNodeMock).toHaveBeenCalledWith(MAP_ID);
+    expect(res.json().actors).toEqual([
+      { nodeId: 'n1', userId: 'u-dan', userName: 'Daniel Haas' },
+      { nodeId: 'n2', userId: 'u-mike', userName: 'Mike' },
+    ]);
+  });
+
+  it('is not shadowed by the /nodes/:nodeId handler', async () => {
+    getLastActorByNodeMock.mockResolvedValueOnce([]);
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/nodes/actors` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ actors: [] });
+    expect(getNodeMock).not.toHaveBeenCalled(); // would mean "actors" was read as a node id
+  });
+
+  it('still resolves a real node id on the sibling route', async () => {
+    getNodeMock.mockResolvedValueOnce({ id: 'n1', mapId: MAP_ID } as never);
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/nodes/n1` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().id).toBe('n1');
+    expect(getLastActorByNodeMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -636,4 +636,14 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
     });
     return reply.send({ events: rows });
   });
+
+  // ── Who last touched each node (Workload view) ────────────────
+  //
+  // Returns one entry per live node of the map. The Workload view uses it
+  // as the last fallback for "whose work is this?", behind assigneeIds and
+  // claimedBySession — see `computeWorkloads`.
+  app.get<{ Params: { id: string } }>('/api/maps/:id/nodes/actors', async (req, reply) => {
+    const actors = await events.getLastActorByNode(req.params.id);
+    return reply.send({ actors });
+  });
 }


### PR DESCRIPTION
Both views render correctly and both look broken, for the same reason: each consumes exactly one field that nothing in the product ever writes.

Verified against prod (`mind.project.li`): **zero** nodes across all 8 maps have `customFields.hillPosition`, and **zero** have `assigneeIds`.

## Hill Chart

`hillPosition` is drag-only, so every branch fell back to `0` — 14 overlapping circles at the left foot of the hill on the Fulcrum map, labels on top of each other.

An un-dragged dot now derives its position from rolled-up progress, which is what the metaphor already implies (uphill = the unresolved part, peak = we know how, downhill = execution). On the Fulcrum map that spreads the branches across 0–96 instead of stacking them on 0. Derived dots are nudged apart when their progress values cluster, and drawn faded + dashed so "auto-placed" reads differently from "someone put it here". A drag still wins and persists; dragged dots are anchors the spread pass never moves.

## Workload

`assigneeIds` has no write surface at all — no editor in the UI, and the only writers are the MCP update tools, which nothing has ever called. So the view was permanently its own empty state.

Attribution now falls through `assigneeIds` → `claimedBySession` → last editor from the change log, via a new `GET /api/maps/:id/nodes/actors`.

`claimedBySession` alone would not have fixed it — it has never held a value either, and it clears when a node goes done. Authorship is the signal with actual data behind it: on the Fulcrum map it attributes 952 leaves / 2620h to Daniel Haas and 50 leaves / 51h to Demo User. Bars sourced from authorship are marked with `~`, since inference is not assignment.

Expect thin bars for now: most maps resolve to a single person, because agent writes carry the operating user's token. That's the honest shape of the data, not a display bug.

## Not a regression

Nothing to do with the URL-state change (#239) — these two views have never had data.

## Tests

- `viewScope.test.ts`: derived vs manual position, the spread pass with clustered progress, manual dots staying anchored, out-of-range clamp, and the full assignee → claim → author fallback chain incl. "no attribution → contributes to nobody".
- `node-actors-route.test.ts`: the new route is not shadowed by the sibling `/nodes/:nodeId` handler — that failure mode would look exactly like "Workload is empty again".
- `pnpm turbo typecheck test` clean (16 tasks, 585 server tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dnXCVetEcC6d7g7fJVraj