### PR TITLE
feat(properties): assignee editor, the write surface assigneeIds never had

### DIFF
--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -675,6 +675,9 @@ function PropertyPanelInner({
           />
         </Field>
 
+        {/* Assignees */}
+        <AssigneeField nodeId={nodeId} assigneeIds={node.assigneeIds} />
+
         {/* Sprint / Cycle */}
         <CycleField nodeId={nodeId} currentCycleId={node.cycleId} />
 
@@ -694,6 +697,98 @@ function PropertyPanelInner({
         <CommentsPanel mapId={node.mapId} nodeId={nodeId} />
       </div>
     </div>
+  );
+}
+
+// ── Assignee Field ───────────────────────────────────────────────
+//
+// The write surface `assigneeIds` never had. Every other view already
+// renders assignees (Kanban avatars, List column, Calendar, Workload
+// bars) but nothing could set one, so the field was empty everywhere and
+// those surfaces silently degraded.
+//
+// Candidates come from the map's member list (everyone with a permission
+// on it). Ids already on a node that no longer resolve to a member — a
+// revoked collaborator, or an id written over MCP — are still listed and
+// still removable, so opening the panel can never silently drop data the
+// picker doesn't understand.
+
+function AssigneeField({ nodeId, assigneeIds }: { nodeId: string; assigneeIds: string[] }) {
+  const members = useMindmapStore((s) => s.members);
+  const loadMembers = useMindmapStore((s) => s.loadMembers);
+  const currentMapId = useMindmapStore((s) => s.currentMapId);
+  const updateNode = useMindmapStore((s) => s.updateNode);
+
+  useEffect(() => {
+    void loadMembers();
+  }, [currentMapId, loadMembers]);
+
+  const toggle = useCallback(
+    (userId: string) => {
+      const next = assigneeIds.includes(userId)
+        ? assigneeIds.filter((id) => id !== userId)
+        : [...assigneeIds, userId];
+      updateNode(nodeId, { assigneeIds: next });
+    },
+    [nodeId, assigneeIds, updateNode],
+  );
+
+  const known = new Set(members.map((m) => m.userId));
+  const orphans = assigneeIds.filter((id) => !known.has(id));
+
+  return (
+    <Field label="Assignees">
+      {members.length === 0 && orphans.length === 0 ? (
+        <div style={{ fontSize: 12, color: '#94a3b8' }}>
+          Nobody has access to this map yet — share it to assign work.
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {members.map((m) => {
+            const active = assigneeIds.includes(m.userId);
+            return (
+              <button
+                key={m.userId}
+                onClick={() => toggle(m.userId)}
+                title={m.email}
+                style={{
+                  padding: '4px 10px',
+                  borderRadius: 999,
+                  border: active ? '1px solid #4f46e5' : '1px solid #e2e8f0',
+                  background: active ? '#eef2ff' : '#fff',
+                  color: active ? '#3730a3' : '#64748b',
+                  fontSize: 12,
+                  fontWeight: active ? 600 : 400,
+                  fontFamily: 'inherit',
+                  cursor: 'pointer',
+                }}
+              >
+                {m.name}
+              </button>
+            );
+          })}
+          {orphans.map((id) => (
+            <button
+              key={id}
+              onClick={() => toggle(id)}
+              title={`${id} — no longer has access to this map. Click to remove.`}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 999,
+                border: '1px dashed #cbd5e1',
+                background: '#f8fafc',
+                color: '#94a3b8',
+                fontSize: 12,
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+              }}
+            >
+              {id.length > 12 ? `${id.slice(0, 10)}…` : id} ✕
+            </button>
+          ))}
+        </div>
+      )}
+    </Field>
   );
 }
 

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -279,6 +279,22 @@ export function fetchPermissions(mapId: string): Promise<PermissionsResponse> {
   return request<PermissionsResponse>(`/api/maps/${mapId}/permissions`);
 }
 
+export interface MapMember {
+  userId: string;
+  name: string;
+  email: string;
+  permission: 'view' | 'edit' | 'admin';
+}
+
+/**
+ * People who can be assigned work on this map. Unlike fetchPermissions,
+ * readable by anyone with view access — the assignee picker needs the
+ * candidate list without exposing the sharing surface.
+ */
+export function fetchMapMembers(mapId: string): Promise<{ members: MapMember[] }> {
+  return request<{ members: MapMember[] }>(`/api/maps/${mapId}/members`);
+}
+
 export function shareMap(mapId: string, email: string, permission: string): Promise<Permission | PendingInvite> {
   return request<Permission | PendingInvite>(`/api/maps/${mapId}/share`, {
     method: 'POST',

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -99,6 +99,10 @@ export interface MindmapState {
   nodeActors: Map<string, { userId: string; userName: string }>;
   nodeActorsMapId: string | null;
 
+  // People who can be assigned work on this map (loaded on demand)
+  members: api.MapMember[];
+  membersMapId: string | null;
+
   // UI state
   activeView: ActiveView;
   loading: boolean;
@@ -155,6 +159,9 @@ export interface MindmapState {
 
   // Actions — workload attribution
   loadNodeActors: () => Promise<void>;
+
+  // Actions — map members (assignee picker)
+  loadMembers: () => Promise<void>;
 
   // Actions — layout
   setLayoutType: (layout: 'tree-lr' | 'tree-tb' | 'radial' | 'org-chart') => void;
@@ -225,6 +232,8 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
   activePhaseFilter: null,
   nodeActors: new Map(),
   nodeActorsMapId: null,
+  members: [],
+  membersMapId: null,
   activeView: 'mindmap',
   loading: false,
   error: null,
@@ -592,6 +601,28 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       });
     } catch {
       set({ nodeActors: new Map(), nodeActorsMapId: mapId });
+    }
+  },
+
+  /**
+   * Fetch the assignable people for the current map. Cached per map id;
+   * on failure the list stays empty, which degrades the assignee picker
+   * to "show whatever ids the node already carries" rather than blocking
+   * the panel.
+   */
+  loadMembers: async () => {
+    const state = get();
+    const mapId = state.currentMapId;
+    if (!mapId) {
+      set({ members: [], membersMapId: null });
+      return;
+    }
+    if (state.membersMapId === mapId) return;
+    try {
+      const { members } = await api.fetchMapMembers(mapId);
+      set({ members, membersMapId: mapId });
+    } catch {
+      set({ members: [], membersMapId: mapId });
     }
   },
 

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -245,6 +245,7 @@ export interface CreateNodeInput {
   phaseId?: string | null;
   verificationText?: string | null;
   verificationUrl?: string | null;
+  assigneeIds?: string[];
 }
 
 export async function createNode(
@@ -295,7 +296,7 @@ export async function createNode(
       phaseId: input.phaseId ?? null,
       verificationText: input.verificationText ?? null,
       verificationUrl: input.verificationUrl ?? null,
-      assigneeIds: [],
+      assigneeIds: input.assigneeIds ?? [],
       tags: [],
       customFields: {},
       dependencies: [],

--- a/packages/server/src/routes/__tests__/map-members-route.test.ts
+++ b/packages/server/src/routes/__tests__/map-members-route.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Route tests for GET /api/maps/:mapId/members — the candidate list the
+ * assignee picker reads.
+ *
+ * The interesting property is the permission gate. /permissions is
+ * admin-only because it exposes the sharing surface; members answers a
+ * different question ("who works on this map?") and must be readable by
+ * anyone with view access, or an editor could never populate the picker
+ * they are allowed to write to.
+ *
+ * Mock pattern mirrors phase-node-routes.test.ts — stub the DB layer,
+ * exercise route wiring without Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const getPermissionMock = vi.fn();
+const listPermissionsMock = vi.fn();
+
+vi.mock('../../db/permissions.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/permissions.js')>();
+  return {
+    ...actual,
+    getPermission: (...args: unknown[]) => getPermissionMock(...args),
+    listPermissions: (...args: unknown[]) => listPermissionsMock(...args),
+  };
+});
+vi.mock('../../lib/email.js', () => ({ sendMapInvitationEmail: vi.fn() }));
+
+import { permissionRoutes } from '../permissions.js';
+
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+const CALLER = 'uuuu-uuuu-uuuu-uuuu';
+
+async function buildApp(authed = true): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    if (authed) req.userId = CALLER;
+  });
+  await app.register(permissionRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  getPermissionMock.mockReset();
+  listPermissionsMock.mockReset();
+  listPermissionsMock.mockResolvedValue([
+    { mapId: MAP_ID, userId: 'u-dan', permission: 'admin', userName: 'Daniel Haas', userEmail: 'dan@example.com' },
+    { mapId: MAP_ID, userId: 'u-tom', permission: 'edit', userName: 'Thomas', userEmail: 'tom@example.com' },
+  ]);
+});
+
+describe('GET /api/maps/:mapId/members', () => {
+  it('returns the assignable people, flattened for the picker', async () => {
+    getPermissionMock.mockResolvedValueOnce('edit');
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/members` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().members).toEqual([
+      { userId: 'u-dan', name: 'Daniel Haas', email: 'dan@example.com', permission: 'admin' },
+      { userId: 'u-tom', name: 'Thomas', email: 'tom@example.com', permission: 'edit' },
+    ]);
+  });
+
+  it('is readable with view access — not admin-gated like /permissions', async () => {
+    getPermissionMock.mockResolvedValueOnce('view');
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/members` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().members).toHaveLength(2);
+  });
+
+  it('403s for a caller with no permission on the map', async () => {
+    getPermissionMock.mockResolvedValueOnce(null);
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/members` });
+    await app.close();
+
+    expect(res.statusCode).toBe(403);
+    expect(listPermissionsMock).not.toHaveBeenCalled();
+  });
+
+  it('401s when unauthenticated', async () => {
+    const app = await buildApp(false);
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/members` });
+    await app.close();
+
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/server/src/routes/__tests__/node-assignees-route.test.ts
+++ b/packages/server/src/routes/__tests__/node-assignees-route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Route tests for assigneeIds on the node write surface.
+ *
+ * The field existed on the type, the column, and update_node, but had no
+ * write surface a person could reach — no editor in the UI — and the DB
+ * create path hardcoded an empty array, so even an API caller passing it
+ * on create got it silently dropped. These tests lock down the REST half:
+ * both create and update must forward the field verbatim to the DB layer.
+ *
+ * Mock pattern mirrors phase-node-routes.test.ts — stub the DB layer +
+ * side-effect modules, exercise route wiring without Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const createNodeMock = vi.fn();
+const updateNodeMock = vi.fn();
+const getNodeMock = vi.fn(async () => null);
+
+vi.mock('../../db/nodes.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/nodes.js')>();
+  return {
+    ...actual,
+    createNode: (...args: unknown[]) => createNodeMock(...args),
+    updateNode: (...args: unknown[]) => updateNodeMock(...args),
+    getNode: (...args: unknown[]) => getNodeMock(),
+  };
+});
+
+vi.mock('../../db/maps.js', () => ({ updateMap: vi.fn() }));
+vi.mock('../../db/events.js', () => ({
+  recordEvent: vi.fn(async () => {}),
+  recordFieldChanges: vi.fn(async () => {}),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../../ai/embeddings.js', () => ({ scheduleEmbedNode: vi.fn() }));
+vi.mock('@mindblown/integrations', () => ({
+  updateGitHubIssue: vi.fn(),
+  getGitHubIssue: vi.fn(),
+}));
+vi.mock('../integrations.js', () => ({
+  getGitHubContextForMap: vi.fn(async () => null),
+}));
+
+import { nodeRoutes } from '../nodes.js';
+
+// ── Test harness ──────────────────────────────────────────────────
+
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+const NODE_ID = 'nnnn-nnnn-nnnn-nnnn';
+
+/** Minimal CoreNode-shaped stub the routes can broadcast/sync safely. */
+function stubNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: NODE_ID,
+    mapId: MAP_ID,
+    parentId: 'pppp-pppp',
+    childrenIds: [],
+    text: 'stub node',
+    externalLinks: [],
+    assigneeIds: [],
+    ...overrides,
+  };
+}
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    req.userId = 'uuuu-uuuu-uuuu-uuuu';
+  });
+  await app.register(nodeRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  createNodeMock.mockReset();
+  updateNodeMock.mockReset();
+  getNodeMock.mockReset();
+  getNodeMock.mockResolvedValue(null as never);
+});
+
+// ── Cases ─────────────────────────────────────────────────────────
+
+describe('POST /api/maps/:id/nodes — assigneeIds', () => {
+  it('forwards assigneeIds to createNode', async () => {
+    createNodeMock.mockResolvedValueOnce(stubNode({ assigneeIds: ['u-dan'] }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/maps/${MAP_ID}/nodes`,
+      payload: { parentId: 'pppp-pppp', text: 'assigned task', assigneeIds: ['u-dan'] },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(201);
+    expect(createNodeMock.mock.calls[0][0]).toMatchObject({ assigneeIds: ['u-dan'] });
+    expect(res.json().assigneeIds).toEqual(['u-dan']);
+  });
+
+  it('omits assigneeIds entirely when the caller does not send it', async () => {
+    createNodeMock.mockResolvedValueOnce(stubNode());
+    const app = await buildApp();
+    await app.inject({
+      method: 'POST',
+      url: `/api/maps/${MAP_ID}/nodes`,
+      payload: { parentId: 'pppp-pppp', text: 'plain task' },
+    });
+    await app.close();
+
+    expect(createNodeMock.mock.calls[0][0].assigneeIds).toBeUndefined();
+  });
+});
+
+describe('PUT /api/maps/:id/nodes/:nodeId — assigneeIds', () => {
+  it('forwards an assignee set', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ assigneeIds: ['u-dan', 'u-tom'] }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { assigneeIds: ['u-dan', 'u-tom'] },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ assigneeIds: ['u-dan', 'u-tom'] });
+  });
+
+  it('forwards an empty array as a clear — unassigning must not read as "no change"', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ assigneeIds: [] }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { assigneeIds: [] },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ assigneeIds: [] });
+  });
+});

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -174,6 +174,7 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       phaseId?: string | null;
       verificationText?: string | null;
       verificationUrl?: string | null;
+      assigneeIds?: string[];
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`
        * auto-link backstop (#58). Useful when the leading `#NNNN` is

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -99,6 +99,39 @@ export async function permissionRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
+  // ── GET /api/maps/:mapId/members — Assignable people ────────────
+  //
+  // The same rows as /permissions, minus the invite list and the admin
+  // gate. The assignee picker needs to know who can be assigned, and an
+  // editor who can set an assignee must be able to see the candidates —
+  // /permissions is admin-only because it exposes the sharing surface,
+  // which is a different question from "who works on this map".
+  app.get<{ Params: { mapId: string } }>('/api/maps/:mapId/members', async (req, reply) => {
+    const userId = req.userId;
+    if (!userId) {
+      return reply.status(401).send({
+        error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+      });
+    }
+
+    const callerPerm = await permDb.getPermission(req.params.mapId, userId);
+    if (!permDb.hasPermission(callerPerm, 'view')) {
+      return reply.status(403).send({
+        error: { code: 'FORBIDDEN', message: 'No access to this map' },
+      });
+    }
+
+    const rows = await permDb.listPermissions(req.params.mapId);
+    return reply.send({
+      members: rows.map((r) => ({
+        userId: r.userId,
+        name: r.userName,
+        email: r.userEmail,
+        permission: r.permission,
+      })),
+    });
+  });
+
   // ── DELETE /api/maps/:mapId/permissions/:userId — Revoke ────────
   app.delete<{ Params: { mapId: string; userId: string } }>(
     '/api/maps/:mapId/permissions/:userId',

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -211,6 +211,33 @@ describe('create_node tool', () => {
     expect(recorder.lastCreate?.fields).toMatchObject({ autoProgress: 'children' });
   });
 
+  // assigneeIds was settable on update_node but absent from create_node,
+  // and the DB create path hardcoded an empty array — so an agent could
+  // only assign work in a second call, and only ever discovered that by
+  // reading the round trip. Both halves are covered: schema accepts it,
+  // handler forwards it.
+  it('accepts assigneeIds in the schema (symmetry with update_node)', () => {
+    const schema = z.object(createNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'assigned task',
+      assigneeIds: ['u-dan', 'u-mike'],
+    });
+    expect(parsed.assigneeIds).toEqual(['u-dan', 'u-mike']);
+  });
+
+  it('forwards assigneeIds to the backend on create', async () => {
+    const recorder = makeRecordingBackend();
+    await createNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'assigned task',
+      assigneeIds: ['u-dan'],
+    } as never);
+    expect(recorder.lastCreate?.fields).toMatchObject({ assigneeIds: ['u-dan'] });
+  });
+
   // Bug 2bee313d — created nodes without an estimate were silently
   // shipped as unestimated leaves, breaking forecasts and ready-node
   // picks. The handler must flag missing estimates back to the caller.
@@ -238,6 +265,28 @@ describe('create_node tool', () => {
 });
 
 // ── Soft-delete / restore (#107) ────────────────────────────────
+
+describe('update_node tool — assigneeIds', () => {
+  it('forwards an assignee set to the backend', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      assigneeIds: ['u-dan', 'u-mike'],
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({ assigneeIds: ['u-dan', 'u-mike'] });
+  });
+
+  it('forwards an empty array as a clear, not an omission', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      assigneeIds: [],
+    } as never);
+    expect(recorder.lastUpdate?.fields.assigneeIds).toEqual([]);
+  });
+});
 
 describe('restore_node tool', () => {
   it('forwards recursive: true through to the backend', async () => {

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -15,6 +15,12 @@ export const createNodeTool = defineTool({
     dueDate: z.string().optional().describe('Due date (ISO 8601)'),
     startDate: z.string().optional().describe('Start date (ISO 8601)'),
     versionId: z.string().optional().describe('Version ID to assign this node to'),
+    assigneeIds: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Assignee user IDs — must be users with access to the map (same list the Assignees picker in the UI offers). Drives the Workload view and the assignee chips in Kanban/List/Calendar.',
+      ),
     autoProgress: z
       .enum(['off', 'children'])
       .optional()
@@ -116,7 +122,12 @@ export const updateNodeTool = defineTool({
       .describe(
         'Tags to remove from the existing set (no-op for tags not present). Use to clear a single bookkeeping tag like NEEDS-PRIORITY without touching the rest. Cannot be combined with `tags`.',
       ),
-    assigneeIds: z.array(z.string()).optional().describe('Assignee user IDs'),
+    assigneeIds: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Assignee user IDs (REPLACE mode — overwrites the existing set; pass [] to clear). Must be users with access to the map. Drives the Workload view and the assignee chips in Kanban/List/Calendar.',
+      ),
     versionId: z.string().nullable().optional().describe('Version ID (null to unassign)'),
     autoProgress: z
       .enum(['off', 'children'])


### PR DESCRIPTION
Follow-up to #240. Every view already renders assignees — Kanban avatars, the List column, Calendar chips, Workload bars — but nothing could set one. The only writers were the MCP update tools, which no caller has ever used, so the field is empty on all 8 prod maps and every one of those surfaces silently degrades.

## The editor

PropertyPanel gets an **Assignees** field between Tags and Sprint/Cycle: toggle chips over the map's members, multi-select, written straight through `updateNode`.

Assignee ids already on a node that don't resolve to a current member (a revoked collaborator, or an id written over MCP) are still listed — dashed, with the raw id — and still removable. Opening the panel can never silently drop data the picker doesn't understand.

## New endpoint

`GET /api/maps/:id/members` — the same rows as `/permissions`, minus the invite list and the admin gate.

`/permissions` is admin-only because it exposes the sharing surface. "Who works on this map" is a different question, and an editor who is allowed to *set* an assignee has to be able to *see* the candidates. Gated on `view`.

## Two gaps found while wiring it

Either one makes the feature a no-op on its own surface, so both are fixed here rather than filed:

- **`createNode` hardcoded `assigneeIds: []`** — the field was dropped on create even when an API caller passed it. Now honours `input.assigneeIds`.
- **`create_node` had no `assigneeIds` in its MCP schema** (`update_node` did), so agents could only assign in a second call, and would only discover that by reading the round trip. Added. Both descriptions now state what the field drives and that update is replace-mode (`[]` clears).

## Tests

- `map-members-route.test.ts` — payload shape, readable at `view` (the point of the separate endpoint), 403 without permission, 401 unauthenticated.
- `node-assignees-route.test.ts` — POST and PUT both forward the field verbatim; `[]` survives as a clear rather than reading as "no change"; absent stays absent.
- `node.test.ts` (tool-kit) — schema + handler round trip on `create_node` and `update_node`.
- `pnpm turbo typecheck test` clean (16 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dnXCVetEcC6d7g7fJVraj