### PR TITLE
feat(calibration): evidence-gate the fudge factor; stop baking it into estimates

### DIFF
--- a/packages/core/src/__tests__/calibration.test.ts
+++ b/packages/core/src/__tests__/calibration.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assessCalibration,
+  calibrationSamplesFromNodes,
+  MIN_CALIBRATION_LEAVES,
+  CALIBRATION_BULK_THRESHOLD,
+} from '../calibration.js';
+
+const sample = (est: number, act: number, completedAt: string | null = null) => ({
+  effortEstimate: est,
+  actualEffort: act,
+  completedAt,
+});
+
+/** n organic samples, distinct timestamps, est=1 act=ratio each. */
+const organic = (n: number, ratio = 1.2) =>
+  Array.from({ length: n }, (_, i) => sample(1, ratio, `2026-07-${String((i % 28) + 1).padStart(2, '0')}T0${i % 10}:0${i % 6}:00Z`));
+
+describe('assessCalibration', () => {
+  it('withholds the factor on a thin sample', () => {
+    const r = assessCalibration(organic(5));
+    expect(r.fudgeFactor).toBeNull();
+    expect(r.rawFudge).toBeCloseTo(1.2);
+    expect(r.note).toContain('below evidence threshold');
+  });
+
+  it('applies the factor once both thresholds clear', () => {
+    // 20 samples × 1 day = 20 days ≥ 15; ratio 1.3 throughout.
+    const r = assessCalibration(organic(MIN_CALIBRATION_LEAVES, 1.3));
+    expect(r.fudgeFactor).toBeCloseTo(1.3);
+    expect(r.note).toBeNull();
+  });
+
+  it('count alone is not enough — estimate-days threshold also gates', () => {
+    // 25 tiny samples of 0.1d = 2.5 estimate-days < 15.
+    const r = assessCalibration(
+      Array.from({ length: 25 }, (_, i) => sample(0.1, 0.2, `2026-06-${String((i % 28) + 1).padStart(2, '0')}T00:0${i % 6}:00Z`)),
+    );
+    expect(r.fudgeFactor).toBeNull();
+  });
+
+  it('excludes bulk-entered samples — the retrospective-backfill case', () => {
+    // 22 samples sharing ONE timestamp (a bulk write) + 3 organic.
+    const bulk = Array.from({ length: 22 }, () => sample(1, 2, '2026-06-25T10:00:00Z'));
+    const r = assessCalibration([...bulk, ...organic(3)]);
+    expect(r.bulkCount).toBe(22);
+    expect(r.organicCount).toBe(3);
+    expect(r.fudgeFactor).toBeNull(); // 3 organic < 20
+    expect(r.note).toContain('22 bulk-entered excluded');
+  });
+
+  it(`groups below the bulk threshold (${CALIBRATION_BULK_THRESHOLD}) stay organic`, () => {
+    // 4 samples share a timestamp — under threshold, still organic.
+    const r = assessCalibration(Array.from({ length: 4 }, () => sample(1, 1, '2026-06-25T10:00:00Z')));
+    expect(r.bulkCount).toBe(0);
+    expect(r.organicCount).toBe(4);
+  });
+
+  it('missing completedAt counts as organic (bulk entry unprovable)', () => {
+    const r = assessCalibration(Array.from({ length: 21 }, () => sample(1, 1.1, null)));
+    expect(r.fudgeFactor).toBeCloseTo(1.1);
+  });
+
+  it('computes the gated factor from organic samples only', () => {
+    // Organic ratio 1.0; a bulk block at ratio 3.0 must not contaminate it.
+    const bulk = Array.from({ length: 10 }, () => sample(1, 3, '2026-06-25T10:00:00Z'));
+    const r = assessCalibration([...organic(20, 1.0), ...bulk]);
+    expect(r.fudgeFactor).toBeCloseTo(1.0);
+    expect(r.rawFudge).toBeGreaterThan(1.5); // raw still shows the naive blend
+  });
+
+  it('empty input → all null, no note', () => {
+    const r = assessCalibration([]);
+    expect(r.fudgeFactor).toBeNull();
+    expect(r.rawFudge).toBeNull();
+    expect(r.note).toBeNull();
+  });
+
+  it('regression: the real Fulcrum sample (10 leaves, 8 bulk) is rejected', () => {
+    // Mirrors the map that motivated the gate: 5.75 est / 7.25 act,
+    // 8 of 10 rows sharing one retrospective timestamp.
+    const rows = [
+      sample(0.5, 0.5, '2026-05-10T09:00:00Z'),
+      sample(0.5, 0.5, '2026-05-10T09:30:00Z'),
+      ...Array.from({ length: 8 }, () => sample(0.59, 0.78, '2026-06-25T12:00:00Z')),
+    ];
+    const r = assessCalibration(rows);
+    expect(r.fudgeFactor).toBeNull();
+    expect(r.rawFudge).toBeGreaterThan(1.1); // the seductive 1.26-ish number
+  });
+});
+
+describe('calibrationSamplesFromNodes', () => {
+  it('takes only completed leaves with both estimate and actual', () => {
+    const nodes = [
+      { childrenIds: [], effortEstimate: 1, actualEffort: 2, completedAt: 'ts' },
+      { childrenIds: ['x'], effortEstimate: 1, actualEffort: 2 }, // parent
+      { childrenIds: [], effortEstimate: 1, actualEffort: null }, // no actual
+      { childrenIds: [], effortEstimate: null, actualEffort: 2 }, // no estimate
+    ];
+    expect(calibrationSamplesFromNodes(nodes)).toEqual([
+      { effortEstimate: 1, actualEffort: 2, completedAt: 'ts' },
+    ]);
+  });
+});

--- a/packages/core/src/calibration.ts
+++ b/packages/core/src/calibration.ts
@@ -1,0 +1,124 @@
+/**
+ * Estimation-calibration evidence gate.
+ *
+ * The fudge factor (sum(actual) / sum(estimate) over completed leaves) is a
+ * multiplier applied to every forecast on the map. Applied from a thin or
+ * retrospectively bulk-entered sample it is not calibration — it is one
+ * anecdote scaling a 900-day plan. This module decides whether the evidence
+ * is strong enough to correct forecasts with, using the same bulk-write
+ * heuristic as the velocity measurement: rows whose completion timestamps
+ * are shared by many siblings were back-filled in one sitting, not recorded
+ * as the work finished, so they carry no independent information.
+ *
+ * Gate result semantics:
+ *   fudgeFactor  — null unless the ORGANIC sample clears both thresholds;
+ *                  when set, it is computed from organic samples only.
+ *   rawFudge     — the naive all-samples ratio, for transparent reporting
+ *                  (get_estimation_accuracy still shows what the data says).
+ *   note         — human-readable reason when the gate withholds the factor.
+ */
+
+/** Minimum organic samples before the fudge factor is applied to forecasts. */
+export const MIN_CALIBRATION_LEAVES = 20;
+/** Minimum summed estimate-days in the organic sample. */
+export const MIN_CALIBRATION_DAYS = 15;
+/** Samples sharing one exact completion timestamp beyond this = bulk entry. */
+export const CALIBRATION_BULK_THRESHOLD = 5;
+
+export interface CalibrationSample {
+  effortEstimate: number;
+  actualEffort: number;
+  /** ISO timestamp; missing/null counts as organic (bulk entry unprovable). */
+  completedAt?: string | null;
+}
+
+export interface CalibrationAssessment {
+  /** Gated factor — null means "insufficient evidence, apply 1.0". */
+  fudgeFactor: number | null;
+  /** Naive all-samples ratio, or null when there are no samples at all. */
+  rawFudge: number | null;
+  sampleCount: number;
+  organicCount: number;
+  bulkCount: number;
+  /** Summed estimate over organic samples. */
+  organicDays: number;
+  /** Set when fudgeFactor is null but samples exist — why the gate held. */
+  note: string | null;
+}
+
+export function assessCalibration(samples: CalibrationSample[]): CalibrationAssessment {
+  const total = samples.reduce(
+    (acc, s) => {
+      acc.est += s.effortEstimate;
+      acc.act += s.actualEffort;
+      return acc;
+    },
+    { est: 0, act: 0 },
+  );
+  const rawFudge = total.est > 0 ? total.act / total.est : null;
+
+  // Bulk detection: exact-timestamp groups above the threshold.
+  const byTimestamp = new Map<string, number>();
+  for (const s of samples) {
+    if (s.completedAt) byTimestamp.set(s.completedAt, (byTimestamp.get(s.completedAt) ?? 0) + 1);
+  }
+  const bulkTimestamps = new Set(
+    [...byTimestamp.entries()]
+      .filter(([, n]) => n >= CALIBRATION_BULK_THRESHOLD)
+      .map(([ts]) => ts),
+  );
+  const organic = samples.filter((s) => !s.completedAt || !bulkTimestamps.has(s.completedAt));
+  const organicDays = organic.reduce((s, x) => s + x.effortEstimate, 0);
+  const organicActual = organic.reduce((s, x) => s + x.actualEffort, 0);
+
+  const qualified =
+    organic.length >= MIN_CALIBRATION_LEAVES && organicDays >= MIN_CALIBRATION_DAYS;
+
+  let note: string | null = null;
+  if (!qualified && samples.length > 0) {
+    const parts = [
+      `${organic.length}/${MIN_CALIBRATION_LEAVES} organic samples`,
+      `${organicDays.toFixed(1)}/${MIN_CALIBRATION_DAYS} estimate-days`,
+    ];
+    if (samples.length - organic.length > 0) {
+      parts.push(`${samples.length - organic.length} bulk-entered excluded`);
+    }
+    note = `calibration below evidence threshold (${parts.join(', ')}) — forecasts apply 1.0`;
+  }
+
+  return {
+    fudgeFactor: qualified && organicDays > 0 ? organicActual / organicDays : null,
+    rawFudge,
+    sampleCount: samples.length,
+    organicCount: organic.length,
+    bulkCount: samples.length - organic.length,
+    organicDays,
+    note,
+  };
+}
+
+/**
+ * Convenience for the four call sites: pull calibration samples out of a
+ * node list (completed leaves carrying both estimate and actual).
+ */
+export function calibrationSamplesFromNodes(
+  nodes: Array<{
+    childrenIds?: string[] | null;
+    effortEstimate?: number | null;
+    actualEffort?: number | null;
+    completedAt?: string | null;
+  }>,
+): CalibrationSample[] {
+  return nodes
+    .filter(
+      (n) =>
+        (n.childrenIds?.length ?? 0) === 0 &&
+        n.effortEstimate != null &&
+        n.actualEffort != null,
+    )
+    .map((n) => ({
+      effortEstimate: n.effortEstimate as number,
+      actualEffort: n.actualEffort as number,
+      completedAt: n.completedAt ?? null,
+    }));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,16 @@ export {
 export { compareVersions } from './versions.js';
 export type { VersionOrderFields } from './versions.js';
 
+// Estimation-calibration evidence gate
+export {
+  assessCalibration,
+  calibrationSamplesFromNodes,
+  MIN_CALIBRATION_LEAVES,
+  MIN_CALIBRATION_DAYS,
+  CALIBRATION_BULK_THRESHOLD,
+} from './calibration.js';
+export type { CalibrationSample, CalibrationAssessment } from './calibration.js';
+
 // Requirements register helpers
 export { collectRequirementGhLinks } from './requirements.js';
 export type { GhLinkSource, RequirementGhLink } from './requirements.js';

--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -32,6 +32,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     collapsed: false,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
+    completedAt: null,
     revision: 1,
     requirementId: null,
     requirementPriority: null,

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -130,6 +130,8 @@ export interface NodeWithComputed {
   collapsed: boolean;
   createdAt: string;
   updatedAt: string;
+  /** Set when the node's status entered a done-category (core Node field). */
+  completedAt: string | null;
   revision: number;
   // Requirements register — non-null requirementId marks a requirement.
   requirementId: string | null;
@@ -859,12 +861,15 @@ export interface BraindumpNode {
 }
 
 export interface AiEstimateResult {
+  /** Raw planning units — velocity corrections happen at forecast time. */
   estimate: number;
   rawEstimate: number;
   confidence: 'low' | 'medium' | 'high';
   notes?: string;
   samplesUsed: number;
-  fudgeFactor: number;
+  /** Evidence-gated; null = calibration below threshold, forecasts use 1.0. */
+  fudgeFactor: number | null;
+  calibrationNote: string | null;
   effortUnit: string;
 }
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -23,7 +23,7 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { allTools as sharedTools, type ToolSpec } from '@mindblown/tool-kit';
-import { clampFocusFactor, scopedCapacityDays } from '@mindblown/core';
+import { clampFocusFactor, scopedCapacityDays, assessCalibration, calibrationSamplesFromNodes } from '@mindblown/core';
 import * as api from './api.js';
 import { scopedLeaves } from './scope.js';
 import { httpBackend } from './backend.js';
@@ -303,6 +303,14 @@ server.tool(
       const totalEstimate = candidates.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
       const totalActual = candidates.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
       const fudgeFactor = totalEstimate > 0 ? totalActual / totalEstimate : 0;
+      // Evidence assessment: does this sample clear the bar forecasts require?
+      const calibration = assessCalibration(
+        candidates.map((n) => ({
+          effortEstimate: n.effortEstimate as number,
+          actualEffort: n.actualEffort as number,
+          completedAt: n.completedAt ?? null,
+        })),
+      );
 
       // Distribution buckets by ratio per node
       const buckets = { under: 0, onTarget: 0, over: 0, wayOver: 0 };
@@ -328,7 +336,12 @@ server.tool(
       lines.push(`Nodes with both estimate + actual: ${candidates.length}`);
       lines.push(`Total estimated: ${totalEstimate.toFixed(2)} ${unit}`);
       lines.push(`Total actual:    ${totalActual.toFixed(2)} ${unit}`);
-      lines.push(`Fudge factor:    ${fudgeFactor.toFixed(2)}x (multiply future estimates by this)`);
+      if (calibration.fudgeFactor != null) {
+        lines.push(`Fudge factor:    ${fudgeFactor.toFixed(2)}x — applied by forecasts (${calibration.organicCount} organic samples)`);
+      } else {
+        lines.push(`Fudge factor:    ${fudgeFactor.toFixed(2)}x (raw ratio — NOT applied by forecasts)`);
+        if (calibration.note) lines.push(`⚠ ${calibration.note}`);
+      }
       lines.push('');
       lines.push('Distribution (per node ratio = actual / estimate):');
       lines.push(`  Underestimated by user (<0.8x):   ${buckets.under}`);
@@ -772,16 +785,9 @@ server.tool(
         if (leaf.dueDate) targetDates.push(leaf.dueDate);
       }
 
-      // ── Fudge factor from estimation accuracy ──
-      const calibrationLeaves = data.nodes.filter(
-        (n) =>
-          (n.childrenIds?.length ?? 0) === 0 &&
-          n.effortEstimate != null &&
-          n.actualEffort != null,
-      );
-      const calibEstimate = calibrationLeaves.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
-      const calibActual = calibrationLeaves.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
-      const fudgeFactor = calibEstimate > 0 ? calibActual / calibEstimate : null;
+      // ── Fudge factor from estimation accuracy (evidence-gated) ──
+      const calibration = assessCalibration(calibrationSamplesFromNodes(data.nodes));
+      const fudgeFactor = calibration.fudgeFactor;
       const effectiveFudge = fudgeFactor ?? 1.0;
 
       // ── Scheduler meta (project start, units, capacity, focus) ──
@@ -904,7 +910,9 @@ server.tool(
       lines.push(`Remaining:           ${remainingEffort.toFixed(2)} ${unit}`);
       lines.push('');
       if (fudgeFactor != null) {
-        lines.push(`Velocity calibration: ${calibrationLeaves.length} completed leaves, fudge = ${fudgeFactor.toFixed(2)}x`);
+        lines.push(`Velocity calibration: fudge = ${fudgeFactor.toFixed(2)}x (${calibration.organicCount} organic samples, ${calibration.organicDays.toFixed(1)} estimate-days)`);
+      } else if (calibration.note != null) {
+        lines.push(`Velocity calibration: ${calibration.note}`);
       } else {
         lines.push(`Velocity calibration: no data (need leaves with both estimate + actual); using 1.00x`);
       }
@@ -2877,7 +2885,7 @@ server.tool(
 
 server.tool(
   'ai_estimate',
-  'Generate a calibrated effort estimate for a task using the LLM. Uses up to 30 recently completed leaves (with both estimate and actual) as reference samples and applies a velocity fudge factor so the result is in the same calibrated space as the schedule projections. Pass either text (freeform) or nodeId (existing node — pulls its title, description, and ancestor path).',
+  'Generate an effort estimate for a task using the LLM, in RAW planning units — the same scale humans estimate in. Uses up to 30 recently completed leaves (with both estimate and actual) as reference samples. The velocity fudge factor is reported alongside but never multiplied into the estimate: forecasts apply it at read time, so stored estimates stay uncalibrated by design. Pass either text (freeform) or nodeId (existing node — pulls its title, description, and ancestor path).',
   {
     mapId: z.string().describe('The map ID'),
     text: z.string().optional().describe('Freeform text to estimate (alternative to nodeId)'),
@@ -2891,9 +2899,9 @@ server.tool(
       }
       const result = await api.aiEstimate(mapId, { text, nodeId, hint });
       const lines = [
-        `Estimate: ${result.estimate} ${result.effortUnit} (raw ${result.rawEstimate}, fudge ${result.fudgeFactor})`,
+        `Estimate: ${result.estimate} ${result.effortUnit} (raw planning units — forecasts apply velocity corrections at read time)`,
         `Confidence: ${result.confidence}`,
-        `Calibration samples: ${result.samplesUsed}`,
+        `Calibration samples: ${result.samplesUsed}${result.fudgeFactor != null ? `, fudge ${result.fudgeFactor}x (reported, not applied)` : ''}`,
       ];
       if (result.notes) lines.push(`Notes: ${result.notes}`);
       return toolResult(lines.join('\n'));

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -562,8 +562,10 @@ function PropertyPanelInner({
                 Suggested: {estimateResult.estimate} {estimateResult.effortUnit}
                 {' '}
                 <span style={{ fontWeight: 400, color: '#3b82f6' }}>
-                  ({estimateResult.confidence} confidence, {estimateResult.samplesUsed} samples,
-                  {' '}fudge ×{estimateResult.fudgeFactor})
+                  ({estimateResult.confidence} confidence, {estimateResult.samplesUsed} samples
+                  {estimateResult.fudgeFactor != null
+                    ? `, fudge ×${estimateResult.fudgeFactor} applied at forecast time`
+                    : ''})
                 </span>
               </div>
               {estimateResult.notes && (

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -855,6 +855,8 @@ export interface ForecastResult {
   effortUnit: string;
   fudgeFactor: number | null;
   calibrationLeafCount: number;
+  /** Why the fudge is withheld (evidence gate); null when applied or no samples. */
+  calibrationNote?: string | null;
   projectStartDate: string;
   plannedFinishDate: string | null;
   velocityAdjustedFinishDate: string | null;
@@ -906,6 +908,8 @@ export interface ReleaseForecastResponse {
   /** Fraction of calendar time reaching planned work (0.05–1.0); default 1. */
   focusFactor: number;
   calibrationLeafCount: number;
+  /** Why the fudge is withheld (evidence gate); null when applied or no samples. */
+  calibrationNote?: string | null;
   releases: ReleaseForecastRow[];
   lastSnapshotAt: string | null;
 }
@@ -1058,12 +1062,15 @@ export function aiRefineStructureApply(
 }
 
 export interface EstimateResult {
+  /** Raw planning units — velocity corrections happen at forecast time. */
   estimate: number;
   rawEstimate: number;
   confidence: 'low' | 'medium' | 'high';
   notes?: string;
   samplesUsed: number;
-  fudgeFactor: number;
+  /** Evidence-gated; null = calibration below threshold, forecasts use 1.0. */
+  fudgeFactor: number | null;
+  calibrationNote: string | null;
   effortUnit: string;
 }
 

--- a/packages/server/src/lib/releaseForecast.ts
+++ b/packages/server/src/lib/releaseForecast.ts
@@ -1,5 +1,10 @@
 import type { Node as CoreNode, MindMap, Version } from '@mindblown/core';
-import { clampFocusFactor, compareVersions } from '@mindblown/core';
+import {
+  assessCalibration,
+  calibrationSamplesFromNodes,
+  clampFocusFactor,
+  compareVersions,
+} from '@mindblown/core';
 
 /**
  * Release forecast row for a single version.
@@ -32,6 +37,8 @@ export interface ReleaseForecastResult {
   fudgeFactor: number | null;
   focusFactor: number;
   calibrationLeafCount: number;
+  /** Why the fudge factor is withheld (null when it is applied or no samples). */
+  calibrationNote: string | null;
   releases: ReleaseForecastRow[];
 }
 
@@ -89,16 +96,12 @@ export function computeReleaseForecast(
   // full-time worker. Mirrors unitsPerDay from the schedule route.
   const dailyCapacity = map.effortUnit === 'hours' ? (map.hoursPerDay ?? 8) : 1;
 
-  // ── Velocity fudge (all-time calibration) ──
-  const calibrationLeaves = nodes.filter(
-    (n) =>
-      (n.childrenIds?.length ?? 0) === 0 &&
-      n.effortEstimate != null &&
-      n.actualEffort != null,
-  );
-  const calibEstimate = calibrationLeaves.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
-  const calibActual = calibrationLeaves.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
-  const fudgeFactor = calibEstimate > 0 ? calibActual / calibEstimate : null;
+  // ── Velocity fudge (all-time calibration, evidence-gated) ──
+  // assessCalibration withholds the factor (null → 1.0) when the sample is
+  // too thin or retrospectively bulk-entered — one anecdote must not scale
+  // every forecast on the map.
+  const calibration = assessCalibration(calibrationSamplesFromNodes(nodes));
+  const fudgeFactor = calibration.fudgeFactor;
   const effectiveFudge = fudgeFactor ?? 1.0;
 
   // ── Focus factor (capacity leakage) ──
@@ -197,7 +200,8 @@ export function computeReleaseForecast(
     dailyCapacity,
     fudgeFactor,
     focusFactor,
-    calibrationLeafCount: calibrationLeaves.length,
+    calibrationLeafCount: calibration.sampleCount,
+    calibrationNote: calibration.note,
     releases,
   };
 }

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -13,7 +13,7 @@ import { semanticSearch, backfillMapEmbeddings, scheduleEmbedNode } from '../ai/
 import * as nodeDb from '../db/nodes.js';
 import * as mapDb from '../db/maps.js';
 import { broadcast } from '../ws.js';
-import { computeTree, type Node as CoreNode } from '@mindblown/core';
+import { computeTree, assessCalibration, type Node as CoreNode } from '@mindblown/core';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -812,16 +812,18 @@ Parent node: "${parentNode.text}"`;
     }
   });
 
-  // ── POST /api/ai/estimate — calibrated effort estimate ────────
+  // ── POST /api/ai/estimate — effort estimate in raw planning units ──
   //
   // Request:  { mapId, text?, nodeId?, hint? }
-  // Response: { estimate, confidence, notes?, samplesUsed, fudgeFactor }
+  // Response: { estimate, confidence, notes?, samplesUsed, fudgeFactor,
+  //             calibrationNote }
   //
   // Uses the same calibration set as get_estimation_accuracy: completed
   // leaves with both an estimate and an actualEffort. The LLM gets the
-  // samples as context and returns a raw estimate; we then scale by the
-  // fudge factor so the prediction is in the same calibrated space as
-  // completion_forecast's velocity-adjusted dates.
+  // samples as context and returns a RAW estimate — the same scale humans
+  // plan in. The (evidence-gated) fudge factor is reported alongside but
+  // never multiplied in: forecasts apply it to remaining effort at read
+  // time, so baking it into stored estimates double-corrected (fudge²).
 
   app.post('/api/ai/estimate', async (req, reply) => {
     if (!requireOllama(reply)) return;
@@ -880,9 +882,18 @@ Parent node: "${parentNode.text}"`;
       .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
       .slice(0, 30);
 
-    const calibEstimate = calibrationLeaves.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
-    const calibActual = calibrationLeaves.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
-    const fudgeFactor = calibEstimate > 0 ? calibActual / calibEstimate : 1.0;
+    // Evidence-gated fudge — REPORTED to the caller, never multiplied into
+    // the estimate. Baking it in double-corrected: the forecast applies the
+    // fudge to remaining effort again, so AI-estimated nodes got fudge².
+    // Estimates are stored in raw planning units; corrections happen at
+    // forecast time only.
+    const calibration = assessCalibration(
+      calibrationLeaves.map((n) => ({
+        effortEstimate: n.effortEstimate as number,
+        actualEffort: n.actualEffort as number,
+        completedAt: n.completedAt ?? null,
+      })),
+    );
     const effortUnit = mapDetail.map.effortUnit ?? 'days';
 
     const samplesText = calibrationLeaves.length > 0
@@ -898,7 +909,7 @@ Parent node: "${parentNode.text}"`;
 
 Rules:
 - Return ONLY a JSON object: {"estimate": <number>, "confidence": "low" | "medium" | "high", "notes": "<one short sentence>"}
-- The raw estimate you produce should be in ${effortUnit}, in the SAME scale the team uses when planning (not calibrated — the caller applies the fudge factor)
+- The raw estimate you produce should be in ${effortUnit}, in the SAME scale the team uses when planning (uncalibrated — velocity corrections happen at forecast time, never in stored estimates)
 - Confidence is "high" when multiple samples strongly match, "medium" when you're inferring from loose analogies, "low" when calibration data is thin or the task is unusual
 - Notes should be one brief sentence justifying the estimate (e.g. "Similar to #3 and #7; added buffer for migration")
 - No preamble, no markdown fences, no explanation outside the JSON`;
@@ -947,17 +958,23 @@ Title: "${targetText}"`;
           : 'low';
       const notes = typeof parsed.notes === 'string' ? parsed.notes.trim() : undefined;
 
-      // Apply calibration: the LLM's output is in planning space; multiply by
-      // the fudge factor so the caller sees a velocity-corrected estimate.
-      const calibratedEstimate = Math.round(rawEstimate * fudgeFactor * 100) / 100;
+      // The LLM's output stays in raw planning space — the same scale humans
+      // estimate in. The gated fudge is reported for transparency but NOT
+      // multiplied in: forecasts apply it to remaining effort, so pre-baking
+      // it here double-corrected every AI-estimated node (fudge²).
+      const estimate = Math.round(rawEstimate * 100) / 100;
 
       return {
-        estimate: calibratedEstimate,
+        estimate,
         rawEstimate,
         confidence,
         notes,
         samplesUsed: calibrationLeaves.length,
-        fudgeFactor: Math.round(fudgeFactor * 100) / 100,
+        fudgeFactor:
+          calibration.fudgeFactor != null
+            ? Math.round(calibration.fudgeFactor * 100) / 100
+            : null,
+        calibrationNote: calibration.note,
         effortUnit,
       };
     } catch (err: any) {

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, analyzeRepoThroughput, netDeliveryRate } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, analyzeRepoThroughput, netDeliveryRate, assessCalibration, calibrationSamplesFromNodes } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
@@ -726,15 +726,9 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     }
 
     // ── Velocity fudge factor from all-time calibration leaves ──
-    const calibrationLeaves = data.nodes.filter(
-      (n) =>
-        (n.childrenIds?.length ?? 0) === 0 &&
-        n.effortEstimate != null &&
-        n.actualEffort != null,
-    );
-    const calibEstimate = calibrationLeaves.reduce((s, n) => s + (n.effortEstimate ?? 0), 0);
-    const calibActual = calibrationLeaves.reduce((s, n) => s + (n.actualEffort ?? 0), 0);
-    const fudgeFactor = calibEstimate > 0 ? calibActual / calibEstimate : null;
+    // Evidence-gated: null (→1.0) when the sample is thin or bulk-entered.
+    const calibration = assessCalibration(calibrationSamplesFromNodes(data.nodes));
+    const fudgeFactor = calibration.fudgeFactor;
     const effectiveFudge = fudgeFactor ?? 1.0;
 
     // ── Focus factor (capacity leakage) — velocity line only ──
@@ -867,7 +861,8 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       effortUnit: data.map.effortUnit,
       fudgeFactor,
       focusFactor,
-      calibrationLeafCount: calibrationLeaves.length,
+      calibrationLeafCount: calibration.sampleCount,
+      calibrationNote: calibration.note,
       projectStartDate: projectStart.toISOString().slice(0, 10),
       plannedFinishDate,
       velocityAdjustedFinishDate,


### PR DESCRIPTION
## Problem

The fudge factor scaling every forecast rested on **10 of 1771 completed leaves (0.6%)** — 8 sharing one retrospective bulk timestamp, 5.75 estimate-days total, largest sample 3 days, all pre-fleet human work. One anecdote scaling a 900-day plan by 1.26×.

Compounding it: `ai_estimate` multiplied the fudge **into the stored estimate** (`ai.ts`: `calibratedEstimate = rawEstimate × fudgeFactor`), and `completion_forecast` applied `effectiveFudge` to remaining effort **again** — every AI-estimated node was corrected twice (1.26² ≈ 1.59×). It also poisoned the estimate scale: 20 leaves carry the literal value 1.26.

## Change

**1. Evidence gate (`assessCalibration` in core).** The factor is `null` → 1.0 unless the *organic* sample (bulk-timestamp groups ≥5 excluded — same heuristic as `velocity_report`) clears **≥20 leaves AND ≥15 estimate-days**. The raw ratio is still shown everywhere, labelled "NOT applied by forecasts". Applied at all four sites:

| Site | File |
|---|---|
| Release forecast | `packages/server/src/lib/releaseForecast.ts` |
| completion_forecast route | `packages/server/src/routes/maps.ts` |
| MCP completion_forecast + get_estimation_accuracy | `packages/mcp/src/index.ts` |
| ai_estimate route | `packages/server/src/routes/ai.ts` |

**2. Layering fix.** `ai_estimate` returns/stores the **raw** estimate; the gated fudge is reported alongside, never multiplied in. Estimates live in raw planning units; velocity corrections happen only at forecast time. This makes `velocity.ts`'s "assumes fudge ≈ 1" caveat true by construction — the focus factor no longer absorbs estimation bias twice.

## Effect on the live map

Forecasts drop the unearned 1.26× and print `calibration below evidence threshold (2/20 organic samples, 1.5/15 estimate-days, 8 bulk-entered excluded) — forecasts apply 1.0` until real history accumulates. `get_estimation_accuracy` keeps reporting the raw ratio with an explicit trust verdict.

## Tests

`packages/core/src/__tests__/calibration.test.ts` — 10 tests: thin-sample rejection, both thresholds independently, bulk exclusion, under-threshold groups staying organic, missing timestamps, organic-only factor computation (bulk block must not contaminate), empty input, and a regression test mirroring the exact 10-sample Fulcrum shape that motivated the gate.

- `pnpm turbo typecheck` — 11/11
- `pnpm turbo test` — 9/9 tasks, all files green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbDkW5JYRF1eF8Gr13n1UY