### PR TITLE
feat(forecast): independent ticket-rate model beside the day model

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -802,6 +802,12 @@ export interface VelocityResponse {
     netRatePerDay: number;
     truncated: boolean;
   } | null;
+  /** Distilled NET rates (evidence-gated null) — what the forecasts run on. */
+  rates?: {
+    netEffortPerDay: number | null;
+    netTicketsPerDay: number | null;
+    windowDays?: number;
+  };
 }
 
 export function getVelocity(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -753,7 +753,7 @@ server.tool(
 
 server.tool(
   'completion_forecast',
-  'Forecast "when will it be done?" for a node/subtree/version/phase. Reports: planned finish date (scheduler-based, respects dependencies), velocity-adjusted finish date (scales by past estimation accuracy from get_estimation_accuracy), target date (from version/phase or node dueDates), and slip vs target. Scope with nodeId (subtree), versionId, or phaseId; omit all to forecast the whole map.',
+  'Forecast "when will it be done?" for a node/subtree/version/phase. Reports THREE dates: planned finish (scheduler-based, respects dependencies), velocity-adjusted finish (remaining effort ÷ measured NET rate), and the independent ticket model (open leaves ÷ net ticket completion rate — counts tickets instead of summing estimates, so unestimated work still weighs in). Plus target date (from version/phase or node dueDates) and slip vs target per model. The day and ticket models disagreeing hard means the estimate scale has drifted from ticket granularity. Scope with nodeId (subtree), versionId, or phaseId; omit all to forecast the whole map.',
   {
     mapId: z.string().describe('The map ID'),
     nodeId: z.string().optional().describe('Scope to this node and its descendants'),
@@ -775,6 +775,8 @@ server.tool(
       let remainingEffort = 0;
       let totalEffort = 0;
       let noEstimateLeaves = 0;
+      let remainingTickets = 0; // open leaves — the ticket model's numerator
+      let remainingTicketsUnestimated = 0; // open AND unestimated: invisible to the day model
       const targetDates: string[] = [];
       for (const leaf of leaves) {
         if (leaf.effortEstimate == null) noEstimateLeaves++;
@@ -782,6 +784,10 @@ server.tool(
         const progress = leaf.percentComplete ?? 0;
         totalEffort += estimate;
         remainingEffort += estimate * (1 - progress / 100);
+        if (progress < 99.5) {
+          remainingTickets++;
+          if (leaf.effortEstimate == null) remainingTicketsUnestimated++;
+        }
         if (leaf.dueDate) targetDates.push(leaf.dueDate);
       }
 
@@ -858,14 +864,32 @@ server.tool(
       // rework — use it directly: calendar days = remaining ÷ net rate.
       // Falls back to the focus-based line when unavailable.
       let velocityBasis = `fudge ${effectiveFudge.toFixed(2)}x${focusFactor < 1 ? `, focus ${focusFactor.toFixed(2)}` : ''}`;
-      if (remainingEffort > 0) {
+      // ── Independent ticket model: open leaves ÷ net ticket rate ──
+      // Counts tickets instead of summing estimates, so unestimated open
+      // work (invisible to the day model) still weighs in. The two models
+      // disagreeing hard is itself a signal: the estimate scale has
+      // drifted from the ticket granularity.
+      let ticketFinishDate: Date | null = null;
+      let netTicketsPerDay: number | null = null;
+      let ticketWindowDays: number | null = null;
+      if (remainingEffort > 0 || remainingTickets > 0) {
         try {
           const vel = await api.getVelocity(mapId);
           const rt = vel.repoThroughput;
-          if (rt && rt.netRatePerDay > 0) {
+          if (remainingEffort > 0 && rt && rt.netRatePerDay > 0) {
             velocityFinishCalendarDays = remainingEffort / rt.netRatePerDay;
             velocityFinishDate = addCalendarDays(anchor, velocityFinishCalendarDays);
             velocityBasis = `net rate ${rt.netRatePerDay.toFixed(2)} ${data.map.effortUnit ?? 'units'}/day, ${Math.round(rt.reworkFraction * 100)}% rework — measured ${vel.windowDays}d`;
+          }
+          const ticketsRate =
+            vel.rates?.netTicketsPerDay ??
+            (vel.completionEvents >= 3
+              ? (vel.completionEvents / vel.windowDays) * (1 - (rt?.reworkFraction ?? 0))
+              : null);
+          if (ticketsRate != null && ticketsRate > 0 && remainingTickets > 0) {
+            netTicketsPerDay = ticketsRate;
+            ticketWindowDays = vel.rates?.windowDays ?? vel.windowDays;
+            ticketFinishDate = addCalendarDays(anchor, remainingTickets / ticketsRate);
           }
         } catch {
           /* velocity/repo unavailable — keep the focus-based line */
@@ -936,6 +960,15 @@ server.tool(
       } else {
         lines.push(`Velocity-adjusted:   already complete`);
       }
+      if (ticketFinishDate != null && netTicketsPerDay != null) {
+        const unestNote =
+          remainingTicketsUnestimated > 0
+            ? `; counts ${remainingTicketsUnestimated} unestimated leaf(s) the day model can't see`
+            : '';
+        lines.push(`Ticket model:        ${iso(ticketFinishDate)} (${remainingTickets} open tickets ÷ ${netTicketsPerDay.toFixed(2)}/day — measured ${ticketWindowDays}d${unestNote})`);
+      } else if (remainingTickets > 0) {
+        lines.push(`Ticket model:        unavailable (${remainingTickets} open tickets; need ≥3 organic completions in the window)`);
+      }
 
       if (targetDate) {
         lines.push('');
@@ -948,6 +981,10 @@ server.tool(
         if (remainingEffort > 0) {
           const slipVel = daysBetween(velocityFinishDate, targetDateObj);
           lines.push(`Slip (velocity):     ${slipVel >= 0 ? '+' : ''}${slipVel} days`);
+        }
+        if (ticketFinishDate != null) {
+          const slipTicket = daysBetween(ticketFinishDate, targetDateObj);
+          lines.push(`Slip (ticket model): ${slipTicket >= 0 ? '+' : ''}${slipTicket} days`);
         }
       } else {
         lines.push('');

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -368,6 +368,7 @@ export function ReleasesView() {
                 <th style={thStyle}>Start</th>
                 <th style={thStyle}>Target</th>
                 <th style={thStyle}>Projected</th>
+                <th style={thStyle} title="Independent second model: open leaves ÷ net ticket completion rate. Counts tickets instead of summing estimates, so unestimated work still weighs in.">Ticket model</th>
                 <th style={thStyle}>Slip</th>
                 <th style={{ ...thStyle, width: 220 }}>Scope</th>
                 <th style={{ ...thStyle, textAlign: 'right' }}>Leaves</th>
@@ -454,6 +455,14 @@ export function ReleasesView() {
                           }
                           return null;
                         })()}
+                    </td>
+                    <td style={tdStyle}>
+                      <div>{formatDate(row?.ticketModelFinishDate ?? null)}</div>
+                      {row && row.ticketModelFinishDate && (
+                        <div style={{ fontSize: 10, color: '#94a3b8', marginTop: 2 }}>
+                          {row.remainingTickets} open
+                        </div>
+                      )}
                     </td>
                     <td style={{ ...tdStyle, color: slip.color, fontWeight: 500 }}>{slip.text}</td>
                     <td style={tdStyle}>

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -889,11 +889,16 @@ export interface ReleaseForecastRow {
   noEstimateLeaves: number;
   totalEffort: number;
   remainingEffort: number;
+  /** Open (progress < 99.5%) leaves in scope — the ticket model's numerator. */
+  remainingTickets: number;
   effectiveStartDate: string | null;
   plannedFinishDate: string | null;
   velocityAdjustedFinishDate: string | null;
+  /** Independent second model: open leaves ÷ net ticket rate, chained. */
+  ticketModelFinishDate: string | null;
   slipPlannedDays: number | null;
   slipVelocityDays: number | null;
+  slipTicketDays: number | null;
   // 7-day trend — positive = slipped later, negative = pulled in.
   // null until the snapshot job has a row from 7 days ago.
   plannedFinishDeltaDays7d: number | null;

--- a/packages/server/src/lib/__tests__/releaseForecast.test.ts
+++ b/packages/server/src/lib/__tests__/releaseForecast.test.ts
@@ -69,3 +69,76 @@ describe('computeReleaseForecast — focusFactor', () => {
     expect(result.releases[0].velocityAdjustedFinishDate).toBe('2026-01-11');
   });
 });
+
+describe('computeReleaseForecast — measured rates', () => {
+  it('measured net effort rate replaces the knob-based velocity line', () => {
+    // focus 0.5 would say 20 cal days; the measured 0.5/day net rate says
+    // 10 ÷ 0.5 = 20 too — use a distinct rate to prove measurement wins:
+    // 1.25/day → 8 cal days → 2026-01-09.
+    const result = computeReleaseForecast(makeMap(0.5), [root, leaf], [version], NOW, {
+      netEffortPerDay: 1.25,
+    });
+    expect(result.releases[0].velocityAdjustedFinishDate).toBe('2026-01-09');
+    expect(result.netEffortPerDay).toBe(1.25);
+  });
+
+  it('ticket model: open leaves ÷ net ticket rate, counting unestimated leaves', () => {
+    const unestimated: CoreNode = {
+      id: 'leaf-2',
+      parentId: 'root',
+      childrenIds: [],
+      effortEstimate: null, // invisible to the day model...
+      percentComplete: 0, // ...but an open ticket all the same
+      versionId: 'v1',
+    } as unknown as CoreNode;
+    const root2 = { ...root, childrenIds: ['leaf-1', 'leaf-2'] } as CoreNode;
+    const result = computeReleaseForecast(
+      makeMap(1),
+      [root2, leaf, unestimated],
+      [version],
+      NOW,
+      { netTicketsPerDay: 0.5 },
+    );
+    const row = result.releases[0];
+    expect(row.remainingTickets).toBe(2);
+    // 2 tickets ÷ 0.5/day = 4 cal days → 2026-01-05.
+    expect(row.ticketModelFinishDate).toBe('2026-01-05');
+  });
+
+  it('ticket model chains across sequential releases like the other cursors', () => {
+    const leafB: CoreNode = {
+      id: 'leaf-b',
+      parentId: 'root',
+      childrenIds: [],
+      effortEstimate: 2,
+      percentComplete: 0,
+      versionId: 'v2',
+    } as unknown as CoreNode;
+    const root2 = { ...root, childrenIds: ['leaf-1', 'leaf-b'] } as CoreNode;
+    const v2: Version = {
+      id: 'v2',
+      name: 'V2',
+      status: 'planning',
+      sortOrder: 1,
+      targetDate: null,
+    } as unknown as Version;
+    const result = computeReleaseForecast(
+      makeMap(1),
+      [root2, leaf, leafB],
+      [version, v2],
+      NOW,
+      { netTicketsPerDay: 1 },
+    );
+    // V1: 1 ticket ÷ 1/day → 01-02; V2 starts where V1's ticket cursor ended.
+    expect(result.releases[0].ticketModelFinishDate).toBe('2026-01-02');
+    expect(result.releases[1].ticketModelFinishDate).toBe('2026-01-03');
+  });
+
+  it('no rates → ticket date null, velocity falls back to knobs', () => {
+    const result = computeReleaseForecast(makeMap(0.5), [root, leaf], [version], NOW);
+    expect(result.releases[0].ticketModelFinishDate).toBeNull();
+    expect(result.releases[0].remainingTickets).toBe(1);
+    expect(result.releases[0].velocityAdjustedFinishDate).toBe('2026-01-21');
+    expect(result.netTicketsPerDay).toBeNull();
+  });
+});

--- a/packages/server/src/lib/releaseForecast.ts
+++ b/packages/server/src/lib/releaseForecast.ts
@@ -23,11 +23,16 @@ export interface ReleaseForecastRow {
   noEstimateLeaves: number;
   totalEffort: number;
   remainingEffort: number;
+  /** Open (progress < 99.5%) leaves in scope — the ticket model's numerator. */
+  remainingTickets: number;
   effectiveStartDate: string | null;
   plannedFinishDate: string | null;
   velocityAdjustedFinishDate: string | null;
+  /** Independent second model: remainingTickets ÷ net ticket rate, chained. */
+  ticketModelFinishDate: string | null;
   slipPlannedDays: number | null;
   slipVelocityDays: number | null;
+  slipTicketDays: number | null;
 }
 
 export interface ReleaseForecastResult {
@@ -39,6 +44,10 @@ export interface ReleaseForecastResult {
   calibrationLeafCount: number;
   /** Why the fudge factor is withheld (null when it is applied or no samples). */
   calibrationNote: string | null;
+  /** Measured net rates used, when provided (null = knob-based fallback). */
+  netEffortPerDay: number | null;
+  netTicketsPerDay: number | null;
+  ratesWindowDays: number | null;
   releases: ReleaseForecastRow[];
 }
 
@@ -61,11 +70,21 @@ export interface ReleaseForecastResult {
  * but do NOT advance the cumulative cursor — they represent shipped
  * work with no wall-clock cost on future releases.
  */
+export interface MeasuredRates {
+  /** Net effort units per calendar day (gross × (1 − rework)); null = unmeasured. */
+  netEffortPerDay?: number | null;
+  /** Net completed tickets per calendar day (organic events × (1 − rework)); null = unmeasured. */
+  netTicketsPerDay?: number | null;
+  /** Look-back window the rates were measured over, for display. */
+  windowDays?: number;
+}
+
 export function computeReleaseForecast(
   map: MindMap,
   nodes: CoreNode[],
   versions: Version[],
   now: Date = new Date(),
+  rates?: MeasuredRates,
 ): ReleaseForecastResult {
   // ── Constants ──
   const MS_PER_DAY = 86_400_000;
@@ -130,6 +149,16 @@ export function computeReleaseForecast(
   const sorted = [...versions].sort(compareVersions);
   let plannedCursor = anchor;
   let velocityCursor = anchor;
+  let ticketCursor = anchor;
+
+  // Measured rates (net of rework), when the caller could measure them.
+  // The velocity line prefers the measured effort rate over the manual
+  // fudge/focus knobs — measurement beats knob. The ticket model is a
+  // fully independent second opinion: it counts open leaves instead of
+  // summing estimates, so unestimated work (invisible to the day model)
+  // still weighs in.
+  const netEffortPerDay = rates?.netEffortPerDay ?? null;
+  const netTicketsPerDay = rates?.netTicketsPerDay ?? null;
 
   const releases: ReleaseForecastRow[] = sorted.map((v) => {
     const scopedLeaves = allLeaves.filter((l) => ancestorVersions(l.id).has(v.id));
@@ -137,18 +166,21 @@ export function computeReleaseForecast(
     let totalEffort = 0;
     let remainingEffort = 0;
     let noEstimateLeaves = 0;
+    let remainingTickets = 0;
     for (const leaf of scopedLeaves) {
       if (leaf.effortEstimate == null) noEstimateLeaves++;
       const est = leaf.effortEstimate ?? 0;
       const prog = leaf.percentComplete ?? 0;
       totalEffort += est;
       remainingEffort += est * (1 - prog / 100);
+      if (prog < 99.5) remainingTickets++;
     }
 
     const isSequenced = v.status !== 'released' && v.status !== 'archived';
     let effectiveStartDate: string | null = null;
     let plannedFinishDate: string | null = null;
     let velocityAdjustedFinishDate: string | null = null;
+    let ticketModelFinishDate: string | null = null;
 
     if (isSequenced && scopedLeaves.length > 0) {
       effectiveStartDate = iso(plannedCursor);
@@ -158,10 +190,19 @@ export function computeReleaseForecast(
       plannedFinishDate = iso(plannedFinish);
       plannedCursor = plannedFinish;
 
-      const velCalDays = (remainingEffort * effectiveFudge) / (dailyCapacity * focusFactor);
+      const velCalDays =
+        netEffortPerDay != null && netEffortPerDay > 0
+          ? remainingEffort / netEffortPerDay
+          : (remainingEffort * effectiveFudge) / (dailyCapacity * focusFactor);
       const velFinish = addCalendarDays(velocityCursor, velCalDays);
       velocityAdjustedFinishDate = iso(velFinish);
       velocityCursor = velFinish;
+
+      if (netTicketsPerDay != null && netTicketsPerDay > 0 && remainingTickets > 0) {
+        const ticketFinish = addCalendarDays(ticketCursor, remainingTickets / netTicketsPerDay);
+        ticketModelFinishDate = iso(ticketFinish);
+        ticketCursor = ticketFinish;
+      }
     }
 
     let slipPlannedDays: number | null = null;
@@ -186,11 +227,17 @@ export function computeReleaseForecast(
       noEstimateLeaves,
       totalEffort,
       remainingEffort,
+      remainingTickets,
       effectiveStartDate,
       plannedFinishDate,
       velocityAdjustedFinishDate,
+      ticketModelFinishDate,
       slipPlannedDays,
       slipVelocityDays,
+      slipTicketDays:
+        v.targetDate && ticketModelFinishDate
+          ? daysBetween(new Date(ticketModelFinishDate), new Date(v.targetDate))
+          : null,
     };
   });
 
@@ -202,6 +249,9 @@ export function computeReleaseForecast(
     focusFactor,
     calibrationLeafCount: calibration.sampleCount,
     calibrationNote: calibration.note,
+    netEffortPerDay,
+    netTicketsPerDay,
+    ratesWindowDays: rates?.windowDays ?? null,
     releases,
   };
 }

--- a/packages/server/src/lib/releaseSnapshots.ts
+++ b/packages/server/src/lib/releaseSnapshots.ts
@@ -4,6 +4,7 @@ import { releaseSnapshots, maps as mapsTable } from '../db/schema.js';
 import * as mapDb from '../db/maps.js';
 import * as versionDb from '../db/versions.js';
 import { computeReleaseForecast } from './releaseForecast.js';
+import { measureMapVelocity } from './velocityMeasure.js';
 import type { ReleaseForecastResult } from './releaseForecast.js';
 
 /**
@@ -27,7 +28,13 @@ export async function snapshotReleaseForecastForMap(
     const data = await mapDb.getMap(mapId);
     if (!data) return 0;
     const versions = await versionDb.listVersions(data.map.id);
-    result = computeReleaseForecast(data.map, data.nodes, versions);
+    // Measured rates make the snapshot record what the forecast actually
+    // said (net-rate velocity + ticket model), not a knob-based shadow of
+    // it. Measurement failure degrades to knobs — never blocks the cron.
+    const rates = await measureMapVelocity(mapId, data, 56)
+      .then((m) => m.rates)
+      .catch(() => undefined);
+    result = computeReleaseForecast(data.map, data.nodes, versions, new Date(), rates);
   }
 
   const snapshotDate = new Date().toISOString().slice(0, 10);

--- a/packages/server/src/lib/velocityMeasure.ts
+++ b/packages/server/src/lib/velocityMeasure.ts
@@ -1,0 +1,118 @@
+import { analyzeRepoThroughput, netDeliveryRate, type RepoThroughput } from '@mindblown/core';
+import { computeVelocity, MIN_SAMPLE_EVENTS, type VelocityResult } from './velocity.js';
+import { getGitHubContextForMap } from './githubContext.js';
+import { fetchMergedPrsSince } from './repoThroughput.js';
+import * as events from '../db/events.js';
+import type { MeasuredRates } from './releaseForecast.js';
+import type { MindMap, Node as CoreNode } from '@mindblown/core';
+
+/**
+ * One measurement, three consumers.
+ *
+ * Gathers the map's organic completion velocity (change_events, bulk writes
+ * excluded) plus the connected repo's rework share, and distils them into
+ * the two NET rates the forecasts run on:
+ *
+ *   netEffortPerDay  — estimate-units/day × (1 − rework). The day model.
+ *   netTicketsPerDay — completion events/day × (1 − rework). The ticket
+ *                      model: counts open leaves instead of summing
+ *                      estimates, so unestimated work still weighs in.
+ *
+ * Used by GET /velocity, GET /completion-forecast, the release-forecast
+ * routes and the hourly snapshot job — one implementation so the models
+ * can never quietly diverge between surfaces.
+ *
+ * Rates are null when the evidence is too thin (< MIN_SAMPLE_EVENTS
+ * organic completions) — callers fall back to knob-based projections.
+ * A missing repo context degrades rework to 0 (net == gross) rather than
+ * failing: gross is optimistic but still a measurement.
+ */
+export interface MapVelocityMeasurement {
+  velocity: VelocityResult;
+  /** True when the change_events query hit its 10k limit (window undercounted). */
+  eventsTruncated: boolean;
+  repoThroughput:
+    | (RepoThroughput & {
+        repo: string;
+        grossRatePerDay: number;
+        netRatePerDay: number;
+        truncated: boolean;
+      })
+    | null;
+  rates: MeasuredRates;
+}
+
+export async function measureMapVelocity(
+  mapId: string,
+  data: { map: MindMap; nodes: CoreNode[] },
+  windowDays = 56,
+  log?: { warn: (obj: unknown, msg: string) => void },
+): Promise<MapVelocityMeasurement> {
+  const since = new Date(Date.now() - windowDays * 86_400_000);
+
+  // Current estimate per leaf — the weight for progress deltas (same proxy
+  // burnup uses; cross-time estimate drift is rare enough to ignore).
+  const estimateByNodeId = new Map<string, number>();
+  for (const n of data.nodes) {
+    if ((n.childrenIds?.length ?? 0) === 0 && n.effortEstimate != null) {
+      estimateByNodeId.set(n.id, n.effortEstimate);
+    }
+  }
+
+  const progressEvents = await events.listEvents({
+    mapId,
+    fieldName: 'percentComplete',
+    since,
+    limit: 10_000,
+  });
+
+  const unitsPerDay = data.map.effortUnit === 'hours' ? (data.map.hoursPerDay ?? 8) : 1;
+  const workerCount = Math.max(1, Math.min(100, Math.floor(data.map.workerCount ?? 1)));
+
+  const velocity = computeVelocity({
+    windowDays,
+    unitsPerDay,
+    workerCount,
+    currentFocusFactor: data.map.focusFactor ?? 1,
+    estimateByNodeId,
+    progressEvents: progressEvents.map((e) => ({
+      nodeId: e.nodeId,
+      oldValue: e.oldValue,
+      newValue: e.newValue,
+      createdAt: e.createdAt,
+    })),
+  });
+
+  let repoThroughput: MapVelocityMeasurement['repoThroughput'] = null;
+  try {
+    const ctx = await getGitHubContextForMap(mapId);
+    if (ctx) {
+      const { prs, truncated } = await fetchMergedPrsSince(ctx, since.getTime());
+      const rt = analyzeRepoThroughput(prs);
+      repoThroughput = {
+        ...rt,
+        repo: `${ctx.owner}/${ctx.repo}`,
+        grossRatePerDay: velocity.deliveryRate,
+        netRatePerDay: netDeliveryRate(velocity.deliveryRate, rt.reworkFraction),
+        truncated,
+      };
+    }
+  } catch (err) {
+    log?.warn({ err }, 'repo throughput fetch failed — rates degrade to gross');
+  }
+
+  const rework = repoThroughput?.reworkFraction ?? 0;
+  const sufficient = velocity.completionEvents >= MIN_SAMPLE_EVENTS;
+  const rates: MeasuredRates = {
+    netEffortPerDay:
+      sufficient && velocity.deliveryRate > 0
+        ? netDeliveryRate(velocity.deliveryRate, rework)
+        : null,
+    netTicketsPerDay: sufficient
+      ? (velocity.completionEvents / windowDays) * (1 - rework)
+      : null,
+    windowDays,
+  };
+
+  return { velocity, eventsTruncated: progressEvents.length >= 10_000, repoThroughput, rates };
+}

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, analyzeRepoThroughput, netDeliveryRate, assessCalibration, calibrationSamplesFromNodes } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, assessCalibration, calibrationSamplesFromNodes } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
@@ -10,9 +10,7 @@ import * as versionDb from '../db/versions.js';
 import * as cycleDb from '../db/cycles.js';
 import { computeReleaseForecast } from '../lib/releaseForecast.js';
 import { snapshotReleaseForecastForMap } from '../lib/releaseSnapshots.js';
-import { computeVelocity } from '../lib/velocity.js';
-import { getGitHubContextForMap } from '../lib/githubContext.js';
-import { fetchMergedPrsSince } from '../lib/repoThroughput.js';
+import { measureMapVelocity } from '../lib/velocityMeasure.js';
 import * as events from '../db/events.js';
 import {
   buildCalendarIcs,
@@ -711,10 +709,12 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       leaves = leaves.filter((n) => ancestorVersions(n.id).has(versionId));
     }
 
-    // ── Remaining effort ──
+    // ── Remaining effort + open-ticket count ──
     let remainingEffort = 0;
     let totalEffort = 0;
     let noEstimateLeaves = 0;
+    let remainingTickets = 0; // open leaves — the ticket model's numerator
+    let remainingTicketsUnestimated = 0; // open AND unestimated: invisible to the day model
     const leafDueDates: string[] = [];
     for (const leaf of leaves) {
       if (leaf.effortEstimate == null) noEstimateLeaves++;
@@ -722,6 +722,10 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       const prog = leaf.percentComplete ?? 0;
       totalEffort += est;
       remainingEffort += est * (1 - prog / 100);
+      if (prog < 99.5) {
+        remainingTickets++;
+        if (leaf.effortEstimate == null) remainingTicketsUnestimated++;
+      }
       if (leaf.dueDate) leafDueDates.push(leaf.dueDate);
     }
 
@@ -763,16 +767,16 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     let maxScopedEnd = 0;
     const scoped = Boolean(versionId || nodeId);
     const workers = Math.max(1, Math.min(100, Math.floor(data.map.workerCount ?? 1)));
-    try {
-      const addCalendarDays = (base: Date, days: number): Date => {
-        const d = new Date(base.getTime());
-        d.setUTCDate(d.getUTCDate() + Math.ceil(days));
-        return d;
-      };
-      const today = new Date();
-      today.setUTCHours(0, 0, 0, 0);
-      const anchor = today > projectStart ? today : projectStart;
+    const addCalendarDays = (base: Date, days: number): Date => {
+      const d = new Date(base.getTime());
+      d.setUTCDate(d.getUTCDate() + Math.ceil(days));
+      return d;
+    };
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const anchor = today > projectStart ? today : projectStart;
 
+    try {
       if (scoped) {
         // A scoped forecast (version/milestone or subtree) must project the
         // scope's OWN remaining effort against capacity. Reading a finish off
@@ -824,6 +828,35 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       /* scheduler errors (e.g. circular deps) — leave dates null */
     }
 
+    // ── Measured rates: fold net effort rate into the velocity line, and
+    // run the independent ticket model (open leaves ÷ net ticket rate).
+    // Measurement beats knob: when the net rate is available it replaces
+    // the fudge/focus projection, matching the MCP surface (#232).
+    let velocityBasis: string = `fudge ${effectiveFudge.toFixed(2)}x, focus ${focusFactor.toFixed(2)}`;
+    let netEffortPerDay: number | null = null;
+    let netTicketsPerDay: number | null = null;
+    let ticketModelFinishDate: string | null = null;
+    let ratesWindowDays: number | null = null;
+    try {
+      const m = await measureMapVelocity(req.params.id, data, 56, req.log);
+      ratesWindowDays = m.rates.windowDays ?? null;
+      netEffortPerDay = m.rates.netEffortPerDay ?? null;
+      netTicketsPerDay = m.rates.netTicketsPerDay ?? null;
+      if (netEffortPerDay != null && netEffortPerDay > 0 && remainingEffort > 0) {
+        velocityAdjustedFinishDate = addCalendarDays(anchor, remainingEffort / netEffortPerDay)
+          .toISOString()
+          .slice(0, 10);
+        velocityBasis = `net rate ${netEffortPerDay.toFixed(2)}/day — measured ${ratesWindowDays}d`;
+      }
+      if (netTicketsPerDay != null && netTicketsPerDay > 0 && remainingTickets > 0) {
+        ticketModelFinishDate = addCalendarDays(anchor, remainingTickets / netTicketsPerDay)
+          .toISOString()
+          .slice(0, 10);
+      }
+    } catch (err) {
+      req.log.warn({ err }, 'velocity measurement failed — knob-based forecast only');
+    }
+
     // ── Target date resolution ──
     let targetDate: string | null = null;
     let targetSource: string | null = null;
@@ -851,6 +884,10 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       targetDate && velocityAdjustedFinishDate
         ? daysBetween(velocityAdjustedFinishDate, targetDate)
         : null;
+    const slipTicketDays =
+      targetDate && ticketModelFinishDate
+        ? daysBetween(ticketModelFinishDate, targetDate)
+        : null;
 
     return reply.send({
       scopeLabel,
@@ -858,11 +895,19 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       noEstimateLeaves,
       totalEffort,
       remainingEffort,
+      remainingTickets,
+      remainingTicketsUnestimated,
       effortUnit: data.map.effortUnit,
       fudgeFactor,
       focusFactor,
       calibrationLeafCount: calibration.sampleCount,
       calibrationNote: calibration.note,
+      velocityBasis,
+      netEffortPerDay,
+      netTicketsPerDay,
+      ratesWindowDays,
+      ticketModelFinishDate,
+      slipTicketDays,
       projectStartDate: projectStart.toISOString().slice(0, 10),
       plannedFinishDate,
       velocityAdjustedFinishDate,
@@ -894,71 +939,17 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     const windowDays = req.query.windowDays
       ? Math.max(7, Math.min(365, Math.floor(Number(req.query.windowDays))))
       : 56; // default 8 weeks
-    const since = new Date(Date.now() - windowDays * 86_400_000);
 
-    // Current estimate per leaf — the weight for progress deltas (same proxy
-    // burnup uses; cross-time estimate drift is rare enough to ignore for v1).
-    const estimateByNodeId = new Map<string, number>();
-    for (const n of data.nodes) {
-      if ((n.childrenIds?.length ?? 0) === 0 && n.effortEstimate != null) {
-        estimateByNodeId.set(n.id, n.effortEstimate);
-      }
-    }
-
-    // High limit so a busy window isn't silently truncated; percentComplete
-    // events are far fewer than estimate edits, so this comfortably covers it.
-    const progressEvents = await events.listEvents({
-      mapId: req.params.id,
-      fieldName: 'percentComplete',
-      since,
-      limit: 10_000,
-    });
-
-    const unitsPerDay = data.map.effortUnit === 'hours' ? (data.map.hoursPerDay ?? 8) : 1;
-    const workerCount = Math.max(1, Math.min(100, Math.floor(data.map.workerCount ?? 1)));
-
-    const result = computeVelocity({
-      windowDays,
-      unitsPerDay,
-      workerCount,
-      currentFocusFactor: data.map.focusFactor ?? 1,
-      estimateByNodeId,
-      progressEvents: progressEvents.map((e) => ({
-        nodeId: e.nodeId,
-        oldValue: e.oldValue,
-        newValue: e.newValue,
-        createdAt: e.createdAt,
-      })),
-    });
-
-    // ── Repo throughput: net-of-rework rate + review latency ──
-    // The MindBlown velocity above is *gross* completion. Live-read the
-    // connected repo's merged PRs to expose the *net* rate — gross overstates
-    // progress because a large share of merges are corrections of prior work.
-    // Only for GitHub-connected maps; null otherwise (net == gross).
-    let repoThroughput: Record<string, unknown> | null = null;
-    try {
-      const ctx = await getGitHubContextForMap(req.params.id);
-      if (ctx) {
-        const { prs, truncated: prTruncated } = await fetchMergedPrsSince(ctx, since.getTime());
-        const rt = analyzeRepoThroughput(prs);
-        repoThroughput = {
-          ...rt,
-          repo: `${ctx.owner}/${ctx.repo}`,
-          grossRatePerDay: result.deliveryRate,
-          netRatePerDay: netDeliveryRate(result.deliveryRate, rt.reworkFraction),
-          truncated: prTruncated,
-        };
-      }
-    } catch (err) {
-      req.log.warn({ err }, 'repo throughput fetch failed');
-    }
+    // Shared measurement (lib/velocityMeasure) — the same rates the
+    // completion/release forecasts and the snapshot job run on.
+    const m = await measureMapVelocity(req.params.id, data, windowDays, req.log);
 
     return reply.send({
-      ...result,
+      ...m.velocity,
       effortUnit: data.map.effortUnit,
-      truncated: progressEvents.length >= 10_000,
-      repoThroughput,
+      truncated: m.eventsTruncated,
+      repoThroughput: m.repoThroughput,
+      rates: m.rates,
     });
   });
 
@@ -986,7 +977,12 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
 
     // Compute current forecast via the shared helper — same code path
     // as the hourly snapshot job, so the two surfaces never disagree.
-    const forecast = computeReleaseForecast(data.map, data.nodes, allVersions);
+    // Measured rates power the velocity line + the ticket model; a failed
+    // measurement degrades to the knob-based projection, never to an error.
+    const rates = await measureMapVelocity(req.params.id, data, 56, req.log)
+      .then((m) => m.rates)
+      .catch(() => undefined);
+    const forecast = computeReleaseForecast(data.map, data.nodes, allVersions, new Date(), rates);
 
     // Optional manual refresh — writes today's snapshot before reading
     // deltas, so a button click produces a fresh history row.


### PR DESCRIPTION
## Why

The day model (remaining estimate-days ÷ net rate) assumes the estimate scale means something — but 1115 leaves on the live map carry no estimate, invisible to it, and under fleet execution the stable unit of work is a **ticket**. PR 2 of the estimation-realism series (PR 1 = #242).

## What

A second, fully independent forecast: **open leaves ÷ net ticket completion rate** (organic `change_events` completions/day × (1 − rework)). Shown beside the day model on every forecast surface. Hard disagreement between the models = the estimate scale has drifted from ticket granularity.

- **`lib/velocityMeasure.ts`** — one shared measurement feeding GET /velocity, GET /completion-forecast, the release-forecast route and the hourly snapshot job. Rates evidence-gated (null below 3 organic completions); missing repo context degrades rework to 0 instead of failing.
- **`computeReleaseForecast`** — optional `MeasuredRates`; velocity cursor prefers measured net rate over fudge/focus knobs; third chained ticket cursor → `ticketModelFinishDate` + `slipTicketDays` per release.
- **completion-forecast HTTP route** — now folds the measured net rate into the velocity date (parity with MCP, #232) and reports the ticket model incl. unestimated open leaves it counts.
- **MCP `completion_forecast`** — ticket-model line + slip; description updated.
- **ReleasesView** — "Ticket model" column.

## Tests

4 new in `releaseForecast.test.ts`: measurement beats knob, unestimated leaves counted, cursor chaining across releases, knob fallback without rates. Full suite: typecheck 11/11, tests 9/9 tasks / 44 server files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbDkW5JYRF1eF8Gr13n1UY