### PR TITLE
feat(sync): flip linked nodes to in-progress on work-start signals

### DIFF
--- a/packages/server/src/routes/__tests__/work-start-webhook.test.ts
+++ b/packages/server/src/routes/__tests__/work-start-webhook.test.ts
@@ -1,0 +1,300 @@
+/**
+ * #245 — work-start sync: inbound "someone started working on this
+ * ticket" signals flip the linked node into the map's in-progress
+ * status, so the kanban board shows in-flight work instead of leaving
+ * it in Unset/Todo until the PR merges.
+ *
+ * Exercises the REAL `markWorkStarted` (sync/workStartSync.ts) through
+ * the webhook route:
+ *
+ *   1. pull_request.opened with `Closes #N` → linked node (no status)
+ *      transitions to `in_progress` and broadcasts.
+ *   2. pull_request.synchronize re-covers PRs opened before this
+ *      feature existed (self-heal on next push).
+ *   3. Done nodes are never downgraded by PR activity.
+ *   4. issues.assigned transitions the node AND still applies the
+ *      assignee list via the processWebhook fall-through.
+ *
+ * Guard-matrix coverage (custom workflows, unknown statuses, 100%%
+ * nodes) lives in sync/__tests__/workStartSync.test.ts — this file
+ * covers the route wiring.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const DEFAULT_WORKFLOW = [
+  { id: 'todo', name: 'Todo', category: 'todo', color: '#9ca3af', position: 0 },
+  { id: 'in_progress', name: 'In Progress', category: 'in_progress', color: '#3b82f6', position: 1 },
+  { id: 'done', name: 'Done', category: 'done', color: '#22c55e', position: 2 },
+];
+
+const mocks = vi.hoisted(() => ({
+  // Per-table select dispatch: workStartSync reads `nodes` and `maps`,
+  // the route's signature loop reads `integrations`.
+  nodeRowsMock: vi.fn((): unknown[] => []),
+  mapRowsMock: vi.fn((): unknown[] => []),
+  getNodeMock: vi.fn(),
+  updateNodeMock: vi.fn(),
+  broadcastMock: vi.fn(),
+  verifySignatureMock: vi.fn(async () => true),
+}));
+
+vi.mock('@mindblown/integrations', async () => {
+  const actual = await vi.importActual<typeof import('@mindblown/integrations')>(
+    '@mindblown/integrations',
+  );
+  return {
+    ...actual,
+    createGitHubIssue: vi.fn(),
+    getGitHubIssue: vi.fn(),
+    importGitHubIssues: vi.fn(),
+    extractVersionFromMilestone: vi.fn(),
+    verifyWebhookSignature: mocks.verifySignatureMock,
+    mintInstallationToken: vi.fn(),
+    isGitHubAppConfigured: vi.fn(() => true),
+  };
+});
+
+vi.mock('../../db/connection.js', () => ({
+  db: {
+    select: () => ({
+      from: (table: { __name?: string } | undefined) => ({
+        where: async () => {
+          if (table?.__name === 'maps') return mocks.mapRowsMock();
+          if (table?.__name === 'nodes') return mocks.nodeRowsMock();
+          return [];
+        },
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+    insert: () => ({ values: () => ({ returning: async () => [] }) }),
+    transaction: async <T,>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb({}),
+  },
+}));
+
+vi.mock('../../db/schema.js', () => ({
+  integrations: { __name: 'integrations' },
+  versions: { __name: 'versions' },
+  nodes: { __name: 'nodes' },
+  maps: { __name: 'maps' },
+  triageDecisions: { __name: 'triageDecisions' },
+}));
+
+vi.mock('../../db/nodes.js', () => ({
+  getNode: mocks.getNodeMock,
+  createNode: vi.fn(),
+  updateNode: mocks.updateNodeMock,
+  notDeleted: { __pred: true, check: () => true },
+}));
+
+vi.mock('../../sync/githubCatchup.js', () => ({ reconcileRepo: vi.fn() }));
+vi.mock('../../sync/driftAudit.js', () => ({ runDriftAudit: vi.fn() }));
+vi.mock('../../sync/webhookAuthCheck.js', () => ({ recordWebhookCall: vi.fn() }));
+vi.mock('../../auth.js', () => ({ requireAdmin: vi.fn() }));
+vi.mock('../../sync/parentEpicRollup.js', () => ({
+  rollupParentsForChildTitle: vi.fn(),
+}));
+vi.mock('../../sync/githubIngest.js', () => ({
+  ingestNewIssuesForRepo: vi.fn(async () => ({ created: 0, errored: 0 })),
+  ensureInboxNode: vi.fn(),
+  ensureNodeForIssue: vi.fn(),
+  findNodesByExternalIds: vi.fn(),
+  syncIssueLabelsToNodes: vi.fn(),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: mocks.broadcastMock }));
+vi.mock('../../sync/triage.js', () => ({
+  triageIssue: vi.fn(),
+  clearTriageDebounce: vi.fn(),
+  computeInputHash: vi.fn(),
+  markTriageDebounce: vi.fn(),
+  isWithinDebounceWindow: vi.fn(() => false),
+}));
+vi.mock('../../sync/mapContext.js', () => ({ buildMapContext: vi.fn() }));
+vi.mock('../../sync/triageHistory.js', () => ({ recordTriageHistory: vi.fn() }));
+vi.mock('../../sync/triageLabelWriteback.js', () => ({ applyTriageLabel: vi.fn() }));
+vi.mock('../../lib/githubContext.js', () => ({
+  getGitHubContextForMap: vi.fn(async () => null),
+}));
+// linkedPr mirroring has its own tests — stub it so PR events exercise
+// only the work-start path here.
+vi.mock('../../sync/prSync.js', () => ({
+  handlePrSnapshot: vi.fn(async () => 0),
+  handleReviewSubmitted: vi.fn(async () => 0),
+  handleCheckSuiteCompleted: vi.fn(async () => 0),
+  handlePrClosed: vi.fn(async () => 0),
+  parseClosesIssues: vi.fn(() => []),
+}));
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({ __pred: true, check: () => true })),
+  and: vi.fn(() => ({ __pred: true, check: () => true })),
+}));
+
+import { integrationRoutes } from '../integrations.js';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(integrationRoutes);
+  return app;
+}
+
+interface SeedOpts {
+  nodeId: string;
+  externalId: string;
+  status?: string | null;
+  percentComplete?: number | null;
+}
+
+function seedNode(opts: SeedOpts): void {
+  const row = {
+    id: opts.nodeId,
+    mapId: 'map-1',
+    status: opts.status ?? null,
+    percentComplete: opts.percentComplete ?? null,
+    externalLinks: [
+      {
+        provider: 'github',
+        externalId: opts.externalId,
+        url: `https://github.com/${opts.externalId.replace('#', '/issues/')}`,
+        syncEnabled: true,
+        lastSyncedAt: null,
+      },
+    ],
+  };
+  mocks.nodeRowsMock.mockReturnValue([row]);
+  mocks.mapRowsMock.mockReturnValue([{ statusWorkflow: DEFAULT_WORKFLOW }]);
+  mocks.getNodeMock.mockResolvedValue(row);
+  mocks.updateNodeMock.mockImplementation(
+    async (id: string, updates: Record<string, unknown>) => ({ ...row, ...updates }),
+  );
+}
+
+function prPayload(action: string, body: string | null): Record<string, unknown> {
+  return {
+    action,
+    pull_request: {
+      number: 42,
+      merged: false,
+      draft: false,
+      state: 'open',
+      html_url: 'https://github.com/owner/repo/pull/42',
+      title: 'feat: thing',
+      body,
+      head: { ref: 'feat/thing', sha: 'abc123' },
+      base: { ref: 'main' },
+      user: { login: 'session-bot' },
+      mergeable: null,
+    },
+    repository: { full_name: 'owner/repo', default_branch: 'main' },
+  };
+}
+
+function post(app: FastifyInstance, event: string, payload: Record<string, unknown>) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/webhooks/github',
+    headers: {
+      'x-github-event': event,
+      'x-hub-signature-256': 'sha256=anything',
+    },
+    payload,
+  });
+}
+
+function statusCalls(): Array<[string, Record<string, unknown>]> {
+  return mocks.updateNodeMock.mock.calls.filter(
+    (call: unknown[]) => (call[1] as Record<string, unknown> | undefined)?.status !== undefined,
+  ) as Array<[string, Record<string, unknown>]>;
+}
+
+beforeEach(() => {
+  mocks.nodeRowsMock.mockReset().mockReturnValue([]);
+  mocks.mapRowsMock.mockReset().mockReturnValue([]);
+  mocks.getNodeMock.mockReset();
+  mocks.updateNodeMock.mockReset();
+  mocks.broadcastMock.mockReset();
+  mocks.verifySignatureMock.mockReset().mockResolvedValue(true);
+  process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-secret';
+});
+
+describe('webhook: work-start sync (#245)', () => {
+  it('pull_request.opened with Closes #N flips a status-less node to in_progress', async () => {
+    seedNode({ nodeId: 'n-7', externalId: 'owner/repo#7' });
+
+    const app = await buildApp();
+    const res = await post(app, 'pull_request', prPayload('opened', 'Closes #7'));
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(statusCalls()).toEqual([['n-7', { status: 'in_progress' }]]);
+    expect(mocks.broadcastMock).toHaveBeenCalledWith(
+      'map-1',
+      expect.objectContaining({
+        type: 'node:updated',
+        nodeId: 'n-7',
+        source: 'github_webhook_pr_open',
+      }),
+    );
+  });
+
+  it('pull_request.synchronize also triggers the transition (self-heal for older PRs)', async () => {
+    seedNode({ nodeId: 'n-8', externalId: 'owner/repo#8', status: 'todo' });
+
+    const app = await buildApp();
+    const res = await post(app, 'pull_request', prPayload('synchronize', 'fixes #8'));
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(statusCalls()).toEqual([['n-8', { status: 'in_progress' }]]);
+  });
+
+  it('never downgrades a done node on PR activity', async () => {
+    seedNode({
+      nodeId: 'n-9',
+      externalId: 'owner/repo#9',
+      status: 'done',
+      percentComplete: 100,
+    });
+
+    const app = await buildApp();
+    const res = await post(app, 'pull_request', prPayload('opened', 'Closes #9'));
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(statusCalls()).toEqual([]);
+  });
+
+  it('issues.assigned flips the node and still applies assigneeIds', async () => {
+    seedNode({ nodeId: 'n-10', externalId: 'owner/repo#10' });
+
+    const app = await buildApp();
+    const res = await post(app, 'issues', {
+      action: 'assigned',
+      issue: {
+        id: 1010,
+        number: 10,
+        title: 'MAN-14 1/5',
+        body: null,
+        state: 'open',
+        labels: [],
+        assignees: [{ login: 'session-bot', id: 99 }],
+        milestone: null,
+        html_url: 'https://github.com/owner/repo/issues/10',
+        created_at: '2026-07-01T00:00:00Z',
+        updated_at: '2026-07-23T00:00:00Z',
+      },
+      assignee: { login: 'session-bot', id: 99 },
+      repository: { full_name: 'owner/repo', default_branch: 'main' },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(statusCalls()).toEqual([['n-10', { status: 'in_progress' }]]);
+    // processWebhook fall-through still syncs the assignee list.
+    const assigneeCalls = mocks.updateNodeMock.mock.calls.filter(
+      (call: unknown[]) =>
+        (call[1] as Record<string, unknown> | undefined)?.assigneeIds !== undefined,
+    );
+    expect(assigneeCalls).toEqual([['n-10', { assigneeIds: ['session-bot'] }]]);
+  });
+});

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -28,6 +28,7 @@ import {
   syncIssueLabelsToNodes,
 } from '../sync/githubIngest.js';
 import * as PrSync from '../sync/prSync.js';
+import { markWorkStarted } from '../sync/workStartSync.js';
 import { triageIssue } from '../sync/triage.js';
 import { buildMapContext } from '../sync/mapContext.js';
 import { recordTriageHistory } from '../sync/triageHistory.js';
@@ -1431,6 +1432,31 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       }
     }
 
+    // ── issues.assigned → node flips to in-progress (#245) ──────────
+    // The processWebhook fall-through below still applies the assignee
+    // list; this block only handles the status transition. Assignment
+    // is the human-flow work-start signal (the PR-open block above is
+    // the agent-flow one). Best-effort: a failure here must not stop
+    // the assignee sync.
+    if (
+      event === 'issues' &&
+      issuePayload?.number != null &&
+      repoFullName &&
+      payloadAction === 'assigned'
+    ) {
+      try {
+        await markWorkStarted(
+          [`${repoFullName}#${issuePayload.number}`],
+          'github_webhook_assigned',
+        );
+      } catch (err) {
+        console.warn(
+          '[work-start] assigned transition failed:',
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
     if (
       event === 'issues' &&
       issuePayload?.number != null &&
@@ -1570,6 +1596,43 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       } catch (err) {
         console.warn(
           '[pr-sync] handlePrSnapshot failed:',
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    // ── pull_request activity → linked-issue nodes flip to in-progress ─
+    //
+    // Work-start sync (#245): an open PR referencing `Closes #N` is the
+    // strongest inbound signal that work on the ticket has started, but
+    // until now nothing moved node status before the merge — actively
+    // worked tickets sat in the kanban's Unset/Todo columns until they
+    // jumped straight to Done. `synchronize` (new commits pushed) is
+    // included so PRs that predate this handler get picked up on their
+    // next push. Guards in markWorkStarted keep this idempotent and
+    // stop it from downgrading done/custom statuses.
+    if (
+      event === 'pull_request' &&
+      repoFullName &&
+      (payloadAction === 'opened' ||
+        payloadAction === 'reopened' ||
+        payloadAction === 'ready_for_review' ||
+        payloadAction === 'synchronize')
+    ) {
+      try {
+        const pr = payload.pull_request as
+          | { title?: string; body?: string | null }
+          | undefined;
+        const refs = extractClosingIssueRefs(`${pr?.title ?? ''} ${pr?.body ?? ''}`);
+        if (refs.length > 0) {
+          await markWorkStarted(
+            refs.map((n) => `${repoFullName}#${n}`),
+            'github_webhook_pr_open',
+          );
+        }
+      } catch (err) {
+        console.warn(
+          '[work-start] pr-activity transition failed:',
           err instanceof Error ? err.message : err,
         );
       }

--- a/packages/server/src/sync/__tests__/workStartSync.test.ts
+++ b/packages/server/src/sync/__tests__/workStartSync.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import type { StatusDef } from '@mindblown/core';
+import { computeWorkStartStatus } from '../workStartSync.js';
+
+const DEFAULT_WORKFLOW: StatusDef[] = [
+  { id: 'todo', name: 'Todo', category: 'todo', color: '#9ca3af', position: 0 },
+  { id: 'in_progress', name: 'In Progress', category: 'in_progress', color: '#3b82f6', position: 1 },
+  { id: 'done', name: 'Done', category: 'done', color: '#22c55e', position: 2 },
+];
+
+describe('computeWorkStartStatus', () => {
+  it('transitions a null-status node to in_progress', () => {
+    expect(computeWorkStartStatus(null, null, DEFAULT_WORKFLOW)).toBe('in_progress');
+  });
+
+  it('transitions a todo-category node to in_progress', () => {
+    expect(computeWorkStartStatus('todo', 0, DEFAULT_WORKFLOW)).toBe('in_progress');
+  });
+
+  it('matches todo by display name, case-insensitive', () => {
+    expect(computeWorkStartStatus('Todo', null, DEFAULT_WORKFLOW)).toBe('in_progress');
+  });
+
+  it('leaves an already-in-progress node alone', () => {
+    expect(computeWorkStartStatus('in_progress', 30, DEFAULT_WORKFLOW)).toBeNull();
+  });
+
+  it('leaves a done node alone', () => {
+    expect(computeWorkStartStatus('done', null, DEFAULT_WORKFLOW)).toBeNull();
+  });
+
+  it('leaves a done-by-progress node alone even with a stale status', () => {
+    expect(computeWorkStartStatus('todo', 100, DEFAULT_WORKFLOW)).toBeNull();
+    expect(computeWorkStartStatus(null, 100, DEFAULT_WORKFLOW)).toBeNull();
+  });
+
+  it('does not clobber an unrecognized custom status string', () => {
+    expect(computeWorkStartStatus('waiting-on-legal', 10, DEFAULT_WORKFLOW)).toBeNull();
+  });
+
+  it('picks the lowest-position in_progress status in a custom workflow', () => {
+    const custom: StatusDef[] = [
+      { id: 'backlog', name: 'Backlog', category: 'todo', color: '#999', position: 0 },
+      { id: 'review', name: 'In Review', category: 'in_progress', color: '#f90', position: 2 },
+      { id: 'doing', name: 'Doing', category: 'in_progress', color: '#39f', position: 1 },
+      { id: 'shipped', name: 'Shipped', category: 'done', color: '#2c5', position: 3 },
+    ];
+    expect(computeWorkStartStatus('backlog', null, custom)).toBe('doing');
+  });
+
+  it('does not downgrade a custom in_progress state (In Review stays)', () => {
+    const custom: StatusDef[] = [
+      { id: 'doing', name: 'Doing', category: 'in_progress', color: '#39f', position: 0 },
+      { id: 'review', name: 'In Review', category: 'in_progress', color: '#f90', position: 1 },
+    ];
+    expect(computeWorkStartStatus('review', 60, custom)).toBeNull();
+  });
+
+  it('falls back to the in_progress literal when the workflow has no in_progress entry', () => {
+    const odd: StatusDef[] = [
+      { id: 'open', name: 'Open', category: 'todo', color: '#999', position: 0 },
+      { id: 'closed', name: 'Closed', category: 'done', color: '#2c5', position: 1 },
+    ];
+    expect(computeWorkStartStatus('open', null, odd)).toBe('in_progress');
+    expect(computeWorkStartStatus(null, null, [])).toBe('in_progress');
+  });
+});

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -32,6 +32,7 @@ import {
   applyRollupForFetchedIssues,
 } from './parentEpicRollup.js';
 import { ingestNewIssuesForRepo } from './githubIngest.js';
+import { markWorkStarted } from './workStartSync.js';
 import { pushKumaHeartbeat } from './kumaPush.js';
 import { sdNotifyWatchdog } from './sdNotify.js';
 
@@ -132,6 +133,11 @@ export interface ReconcileResult {
    * tick re-fetches the failed issues instead of orphaning them.
    */
   ingestErrored: number;
+  /**
+   * Nodes flipped to in-progress by the work-start backstop (#245).
+   * Absent on error-path results — the backstop never ran.
+   */
+  workStarted?: number;
   durationMs: number;
   since: string | null;
   error?: string;          // present when reconcile failed before completion
@@ -402,6 +408,34 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
     }
   }
 
+  // ── Work-start backstop (#245) ───────────────────────────────────
+  // The webhook owns the realtime "PR opened / issue assigned →
+  // in_progress" transition; this pass heals assignments whose webhook
+  // was missed. Only the assigned signal is reconciled here — the
+  // already-fetched issue slice carries `assignees`, whereas PR-open
+  // drift would need an extra PR-list fetch per repo (and the
+  // `synchronize` webhook trigger re-covers open PRs on their next
+  // push anyway). Best-effort: a failure is logged but doesn't block
+  // the cursor — the transition is idempotent and an assigned issue
+  // stays assigned, so any later change to it retries naturally.
+  const assignedOpenIds = issues
+    .filter((i) => i.state === 'open' && (i.assignees?.length ?? 0) > 0)
+    .map((i) => `${target.owner}/${target.repo}#${i.number}`)
+    .filter((id) => linkIndex.has(id));
+  let workStarted = 0;
+  if (assignedOpenIds.length > 0) {
+    try {
+      workStarted = await markWorkStarted(assignedOpenIds, 'github_catchup');
+    } catch (err) {
+      console.warn(
+        '[catchup] work-start backstop failed for',
+        repoLabel,
+        ':',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
   // ── Auto-ingest of new issues (gap-closer for between-import tickets) ─
   // For every map opted into auto-import on this repo, create a node for
   // any issue we haven't seen yet. Reuses the already-fetched `issues`
@@ -490,6 +524,7 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
     stateSyncErrored,
     ingested: ingestCreated,
     ingestErrored,
+    workStarted,
     durationMs: Date.now() - startedAt.getTime(),
     since,
   };

--- a/packages/server/src/sync/workStartSync.ts
+++ b/packages/server/src/sync/workStartSync.ts
@@ -1,0 +1,141 @@
+/**
+ * Work-start sync: inbound GitHub signals that someone STARTED working
+ * on a ticket → flip the linked node into the map's in-progress status.
+ *
+ * The existing sync only moves status at the END of the lifecycle
+ * (issue closed / PR merged → done), so a ticket that is actively being
+ * worked looks identical to untouched backlog — on the kanban board it
+ * sits in "Unset"/"Todo" until the moment it jumps to "Done".
+ *
+ * Signals that count as "work started":
+ *   - a PR referencing the issue via `Closes #N` is opened / reopened /
+ *     marked ready-for-review / pushed to (webhook path)
+ *   - the issue is assigned (webhook path)
+ *   - catchup backstop: an open issue with assignees (poll path — heals
+ *     assignments missed while webhooks were down)
+ *
+ * Deliberately conservative: only nodes whose status is NULL or resolves
+ * to a `todo`-category status are transitioned. Nodes that are done,
+ * already in progress (possibly a custom state like "In Review"), or
+ * carry an unrecognized status string are left alone. percentComplete
+ * is never touched — progress stays owned by the close/reopen sync and
+ * the user.
+ */
+
+import { eq } from 'drizzle-orm';
+import { resolveStatusDef } from '@mindblown/core';
+import type { ExternalLink, StatusDef } from '@mindblown/core';
+
+import { db } from '../db/connection.js';
+import { nodes, maps } from '../db/schema.js';
+import * as nodeDb from '../db/nodes.js';
+import { broadcast } from '../ws.js';
+
+/**
+ * Decide the status to write for a work-start signal, or null for
+ * "leave the node alone". Pure — exported for unit tests.
+ *
+ * Rules:
+ *   - percentComplete === 100 → null (done-by-progress; the close sync
+ *     owns that state even when `status` lags behind)
+ *   - status resolves to a non-`todo` category (in_progress, done) → null
+ *   - status is a non-null string the workflow doesn't know → null
+ *     (custom value someone set on purpose; don't clobber it)
+ *   - otherwise → the map's first in_progress-category status id,
+ *     falling back to the literal 'in_progress' when the workflow has
+ *     no in_progress entry (matches the reopen-fallback convention in
+ *     githubCatchup.computeStateUpdates).
+ */
+export function computeWorkStartStatus(
+  status: string | null,
+  percentComplete: number | null,
+  workflow: StatusDef[],
+): string | null {
+  if (percentComplete === 100) return null;
+  const def = resolveStatusDef(workflow, status);
+  if (status != null && !def) return null;
+  if (def && def.category !== 'todo') return null;
+
+  const target = workflow
+    .filter((s) => s.category === 'in_progress')
+    .sort((a, b) => a.position - b.position)[0];
+  return target?.id ?? 'in_progress';
+}
+
+interface MatchedNode {
+  id: string;
+  mapId: string;
+  status: string | null;
+  percentComplete: number | null;
+}
+
+/**
+ * Transition every node linked to one of `externalIds` (github
+ * `owner/repo#N` keys) into its map's in-progress status, subject to
+ * the computeWorkStartStatus guards. Broadcasts `node:updated` with the
+ * given `source` for each write. Returns the number of nodes updated.
+ *
+ * Errors from individual node writes propagate — callers (webhook
+ * blocks, catchup) wrap the whole call in try/catch and treat the
+ * transition as best-effort.
+ */
+export async function markWorkStarted(
+  externalIds: string[],
+  source: string,
+): Promise<number> {
+  if (externalIds.length === 0) return 0;
+  const wanted = new Set(externalIds);
+
+  const rows = await db
+    .select({
+      id: nodes.id,
+      mapId: nodes.mapId,
+      status: nodes.status,
+      percentComplete: nodes.percentComplete,
+      externalLinks: nodes.externalLinks,
+    })
+    .from(nodes)
+    .where(nodeDb.notDeleted);
+
+  const matched: MatchedNode[] = [];
+  for (const row of rows) {
+    const links = (row.externalLinks as ExternalLink[]) ?? [];
+    if (links.some((l) => l.provider === 'github' && l.externalId && wanted.has(l.externalId))) {
+      matched.push({
+        id: row.id,
+        mapId: row.mapId,
+        status: (row.status as string | null) ?? null,
+        percentComplete: (row.percentComplete as number | null) ?? null,
+      });
+    }
+  }
+  if (matched.length === 0) return 0;
+
+  // One workflow lookup per distinct map in the batch.
+  const workflows = new Map<string, StatusDef[]>();
+  for (const m of matched) {
+    if (workflows.has(m.mapId)) continue;
+    const [mapRow] = await db
+      .select({ statusWorkflow: maps.statusWorkflow })
+      .from(maps)
+      .where(eq(maps.id, m.mapId));
+    workflows.set(m.mapId, (mapRow?.statusWorkflow as StatusDef[]) ?? []);
+  }
+
+  let updated = 0;
+  for (const m of matched) {
+    const next = computeWorkStartStatus(m.status, m.percentComplete, workflows.get(m.mapId) ?? []);
+    if (next == null || next === m.status) continue;
+    const node = await nodeDb.updateNode(m.id, { status: next });
+    if (!node) continue;
+    updated += 1;
+    broadcast(node.mapId, {
+      type: 'node:updated',
+      nodeId: m.id,
+      fields: ['status'],
+      node,
+      source,
+    });
+  }
+  return updated;
+}


### PR DESCRIPTION
## Problem

Actively-worked CRM tickets don't show up on the kanban board. The inbound GitHub sync only moves node status at the *end* of the lifecycle (issue closed / PR merged → done), so a ticket in flight looks identical to untouched backlog: it sits in the Unset/Todo column until it jumps straight to Done. The 5 nodes currently in "In Progress" on the Fulcrum CRM Roadmap were all set by hand.

Same gap class as #240 (Hill Chart/Workload): a field the view reads but nothing in the pipeline writes.

## Fix

New `sync/workStartSync.ts`: `markWorkStarted(externalIds, source)` flips linked nodes into the map's first `in_progress`-category status. Wired to three signals:

- **PR activity** (webhook): `pull_request` opened / reopened / ready_for_review / synchronize whose title/body references `Closes #N`. `synchronize` is included so PRs that predate this feature self-heal on their next push.
- **Issue assigned** (webhook): `issues.assigned` — the human-flow signal. The existing assignee-list fall-through is unchanged.
- **Catchup backstop**: open issues with assignees in the already-fetched catchup slice heal assignments whose webhook was missed. Reported as `workStarted` in `ReconcileResult`.

## Guards (deliberately conservative)

Only nodes whose status is NULL or resolves to a `todo`-category status transition. Left untouched: done nodes, done-by-progress (100%) nodes, nodes already in any in-progress-category state (incl. custom ones like "In Review"), and unrecognized custom status strings. `percentComplete` is never written.

## Tests

- `sync/__tests__/workStartSync.test.ts` — guard matrix on the pure `computeWorkStartStatus`
- `routes/__tests__/work-start-webhook.test.ts` — route wiring through the real `markWorkStarted` (PR opened, synchronize self-heal, done-node no-downgrade, assigned + assignee fall-through)
- Full server suite: 617 passing; repo-wide typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpNiraxAuWHj87qjibotDK