### PR TITLE
feat(sync): auto-confirm high-confidence closed-issue skips

### DIFF
--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -412,6 +412,17 @@ vi.mock('../../sync/triage.js', () => ({
   computeInputHash: vi.fn(() => 'mock-hash'),
   markTriageDebounce: vi.fn(),
   isWithinDebounceWindow: vi.fn(() => false),
+  // Mirror the real gate (skip + closed + conf >= 95) so the
+  // reclassify route's auto-confirm-skip branch is exercised.
+  shouldAutoConfirmSkip: vi.fn(
+    (
+      decision: { decision: string; confidence: number },
+      issueState: 'open' | 'closed',
+    ) =>
+      decision.decision === 'skip' &&
+      issueState === 'closed' &&
+      decision.confidence >= 95,
+  ),
 }));
 
 vi.mock('../../sync/mapContext.js', () => ({
@@ -1098,6 +1109,56 @@ describe('POST .../confirm', () => {
 // ── POST /reclassify ─────────────────────────────────────────────
 
 describe('POST .../reclassify', () => {
+  it('reclassify → skip ≥95 on a closed issue lands already-reviewed (auto-confirm lever)', async () => {
+    seedRow({
+      id: 'tr-1',
+      issueState: 'closed',
+      decision: 'uncertain',
+      confidence: 0,
+      reason: 'triage_error: old junk',
+    });
+    triageIssueMock.mockResolvedValueOnce({
+      decision: 'skip',
+      reason: 'closed tactical PR, no epic fit',
+      confidence: 97,
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/reclassify',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const row = triageRows.get('tr-1')!;
+    expect(row.decision).toBe('skip');
+    // decidedBy stays 'auto', but the row skips the operator queue.
+    expect(row.decidedBy).toBe('auto');
+    expect(row.reviewed).toBe(true);
+    expect(row.reviewedAt).toBeInstanceOf(Date);
+  });
+
+  it('reclassify → skip ≥95 on an OPEN issue still queues for review', async () => {
+    seedRow({ id: 'tr-1', issueState: 'open' });
+    triageIssueMock.mockResolvedValueOnce({
+      decision: 'skip',
+      reason: 'vendor chatter',
+      confidence: 99,
+    });
+    permissionLevel = 'edit';
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/triage-decisions/tr-1/reclassify',
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const row = triageRows.get('tr-1')!;
+    expect(row.decision).toBe('skip');
+    expect(row.reviewed).toBe(false);
+    expect(row.reviewedAt).toBeNull();
+  });
+
   it('re-runs triageIssue and updates the row in place', async () => {
     seedRow({
       id: 'tr-1',

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -62,7 +62,11 @@ import { notDeleted } from '../db/nodes.js';
 import * as permDb from '../db/permissions.js';
 import { broadcast } from '../ws.js';
 import { buildMapContext } from '../sync/mapContext.js';
-import { triageIssue, clearTriageDebounce } from '../sync/triage.js';
+import {
+  triageIssue,
+  clearTriageDebounce,
+  shouldAutoConfirmSkip,
+} from '../sync/triage.js';
 import { recordTriageHistory } from '../sync/triageHistory.js';
 import { applyTriageLabel } from '../sync/triageLabelWriteback.js';
 import { getGitHubContextForMap } from '../lib/githubContext.js';
@@ -1812,6 +1816,13 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
       // (force is intentionally unused for now; documented in the
       // route comment above.)
       void req.query.force;
+      // Same auto-confirm-skip lever as the ingest path: a reclassify
+      // that lands on a high-confidence skip for a closed issue doesn't
+      // need to re-enter the operator queue.
+      const autoConfirmSkip = shouldAutoConfirmSkip(
+        decision,
+        row.issueState === 'closed' ? 'closed' : 'open',
+      );
       await db
         .update(triageDecisions)
         .set({
@@ -1821,8 +1832,8 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           suggestedParentNodeId: newSuggestedParentNodeId,
           decidedBy: 'auto',
           decidedAt: new Date(),
-          reviewed: false,
-          reviewedAt: null,
+          reviewed: autoConfirmSkip,
+          reviewedAt: autoConfirmSkip ? new Date() : null,
           reviewedBy: null,
           lastInputHash: null,
           ...(clearPlacedNode ? { placedNodeId: null } : {}),

--- a/packages/server/src/sync/__tests__/githubIngest.test.ts
+++ b/packages/server/src/sync/__tests__/githubIngest.test.ts
@@ -431,6 +431,18 @@ vi.mock('../triage.js', () => ({
     return { ...triageMockResponse };
   }),
   TRIAGE_AUTO_APPLY_CONFIDENCE: 75,
+  TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE: 95,
+  // Mirror the real gate (skip + closed + conf >= 95) so ingest tests
+  // exercise the auto-confirm lever without importing the real module.
+  shouldAutoConfirmSkip: vi.fn(
+    (
+      decision: { decision: string; confidence: number },
+      issueState: 'open' | 'closed',
+    ) =>
+      decision.decision === 'skip' &&
+      issueState === 'closed' &&
+      decision.confidence >= 95,
+  ),
   // #142 cost-opt helpers. computeInputHash returns a deterministic
   // string derived from the issue inputs so hash-match tests can
   // pre-seed dbState.triageDecisions.lastInputHash with the same
@@ -1224,7 +1236,93 @@ describe('ensureNodeForIssue — triage fork', () => {
     expect(createNodeCalls.length).toBe(0);
     const rows = [...dbState.triageDecisions.values()];
     expect(rows.length).toBe(1);
-    expect(rows[0]).toMatchObject({ decision: 'skip' });
+    expect(rows[0]).toMatchObject({ decision: 'skip', reviewed: false });
+  });
+
+  it('skip ≥95 on a CLOSED issue → persisted already-reviewed (auto-confirm lever)', async () => {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'Pattern 1 (closed-no-fit): tactical PR below roadmap granularity',
+      confidence: 96,
+    };
+
+    const result = await ensureNodeForIssue(
+      'm1',
+      'inbox-1',
+      issue(104, { state: 'closed', closed_at: new Date().toISOString() }),
+      ctx,
+      { allowClosedWithinDays: 30 },
+    );
+
+    expect(result.status).toBe('triaged_skip');
+    expect(createNodeCalls.length).toBe(0);
+    const rows = [...dbState.triageDecisions.values()];
+    expect(rows.length).toBe(1);
+    // reviewed=true at persist time, but decidedBy stays 'auto' so a
+    // later webhook or reclassify can still overwrite the row.
+    expect(rows[0]).toMatchObject({
+      decision: 'skip',
+      reviewed: true,
+      decidedBy: 'auto',
+    });
+    expect(rows[0].reviewedAt).toBeInstanceOf(Date);
+  });
+
+  it('skip ≥95 on an OPEN issue → still queues for review (lever is closed-only)', async () => {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'vendor coordination, not coding work',
+      confidence: 98,
+    };
+
+    const result = await ensureNodeForIssue('m1', 'inbox-1', issue(105), ctx);
+
+    expect(result.status).toBe('triaged_skip');
+    const rows = [...dbState.triageDecisions.values()];
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({ decision: 'skip', reviewed: false });
+  });
+
+  it('skip at 94 on a CLOSED issue → below threshold, queues for review', async () => {
+    dbState.maps.set('m1', {
+      rootNodeId: 'root-1',
+      inboxId: 'inbox-1',
+      createdBy: 'u1',
+      triageEnabled: true,
+    });
+    dbState.nodes.set('inbox-1', { id: 'inbox-1', mapId: 'm1', parentId: 'root-1', externalLinks: [] });
+    triageMockResponse = {
+      decision: 'skip',
+      reason: 'probably noise but not certain',
+      confidence: 94,
+    };
+
+    const result = await ensureNodeForIssue(
+      'm1',
+      'inbox-1',
+      issue(106, { state: 'closed', closed_at: new Date().toISOString() }),
+      ctx,
+      { allowClosedWithinDays: 30 },
+    );
+
+    expect(result.status).toBe('triaged_skip');
+    const rows = [...dbState.triageDecisions.values()];
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({ decision: 'skip', reviewed: false });
   });
 
   it('triage_enabled=true + uncertain → triage row persisted, no node created', async () => {

--- a/packages/server/src/sync/__tests__/triage.test.ts
+++ b/packages/server/src/sync/__tests__/triage.test.ts
@@ -28,6 +28,8 @@ import {
   clearTriageDebounce,
   _resetDebounceWindow,
   _setDebounceWindowMs,
+  shouldAutoConfirmSkip,
+  TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE,
   type TriageProvider,
 } from '../triage.js';
 
@@ -534,5 +536,43 @@ describe('debounce window', () => {
     _resetDebounceWindow();
     expect(isWithinDebounceWindow('m1', 'o/r#1')).toBe(false);
     expect(isWithinDebounceWindow('m1', 'o/r#2')).toBe(false);
+  });
+});
+
+describe('shouldAutoConfirmSkip', () => {
+  it('fires for a closed-issue skip at/above the threshold', () => {
+    expect(
+      shouldAutoConfirmSkip(
+        { decision: 'skip', confidence: TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE },
+        'closed',
+      ),
+    ).toBe(true);
+    expect(
+      shouldAutoConfirmSkip({ decision: 'skip', confidence: 100 }, 'closed'),
+    ).toBe(true);
+  });
+
+  it('never fires for open issues, regardless of confidence', () => {
+    expect(
+      shouldAutoConfirmSkip({ decision: 'skip', confidence: 100 }, 'open'),
+    ).toBe(false);
+  });
+
+  it('never fires below the threshold', () => {
+    expect(
+      shouldAutoConfirmSkip(
+        { decision: 'skip', confidence: TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE - 1 },
+        'closed',
+      ),
+    ).toBe(false);
+  });
+
+  it('never fires for place or uncertain decisions', () => {
+    expect(
+      shouldAutoConfirmSkip({ decision: 'place', confidence: 100 }, 'closed'),
+    ).toBe(false);
+    expect(
+      shouldAutoConfirmSkip({ decision: 'uncertain', confidence: 100 }, 'closed'),
+    ).toBe(false);
   });
 });

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -54,6 +54,7 @@ import { applyTriageLabel } from './triageLabelWriteback.js';
 import {
   triageIssue,
   TRIAGE_AUTO_APPLY_CONFIDENCE,
+  shouldAutoConfirmSkip,
   computeInputHash,
   isWithinDebounceWindow,
   markTriageDebounce,
@@ -906,6 +907,13 @@ async function ensureNodeForIssueViaTriage(
     const isTriageError = decision.reason.startsWith('triage_error');
     const nextInputHash: string | null = isTriageError ? null : incomingHash;
 
+    // Auto-confirm-skip lever: a high-confidence skip on a CLOSED issue
+    // is persisted already-reviewed so it never queues for the operator.
+    // decidedBy stays 'auto' — the operator-protect precheck above only
+    // shields decidedBy='operator' rows, so a later webhook can still
+    // overwrite this decision.
+    const autoConfirmSkip = shouldAutoConfirmSkip(decision, issue.state);
+
     const [decisionRow] = await tx
       .insert(triageDecisions)
       .values({
@@ -919,7 +927,8 @@ async function ensureNodeForIssueViaTriage(
         placedNodeId: null,
         suggestedParentNodeId,
         decidedBy: 'auto',
-        reviewed: false,
+        reviewed: autoConfirmSkip,
+        reviewedAt: autoConfirmSkip ? new Date() : null,
         lastInputHash: nextInputHash,
       })
       .onConflictDoUpdate({
@@ -937,7 +946,9 @@ async function ensureNodeForIssueViaTriage(
           suggestedParentNodeId,
           decidedAt: new Date(),
           decidedBy: 'auto',
-          reviewed: false,
+          reviewed: autoConfirmSkip,
+          reviewedAt: autoConfirmSkip ? new Date() : null,
+          reviewedBy: null,
           // Refresh the input hash on every successful LLM call so
           // the next webhook can short-circuit. On triage_error we
           // pass `null` to clear a stale hash — better to re-call

--- a/packages/server/src/sync/triage.ts
+++ b/packages/server/src/sync/triage.ts
@@ -91,10 +91,51 @@ export const TRIAGE_AUTO_APPLY_CONFIDENCE = parseConfidenceEnv(
   75,
 );
 
-function parseConfidenceEnv(raw: string | undefined, fallback: number): number {
+/**
+ * Confidence threshold at/above which a `skip` decision on a CLOSED
+ * issue is persisted as already-reviewed (reviewed=true), so it never
+ * enters the operator queue. `place` had this lever from day one
+ * (TRIAGE_AUTO_APPLY_CONFIDENCE); skip did not, so every high-confidence
+ * "closed tactical PR, no epic fit" row waited for a human ack — the
+ * dominant review-burden pattern in production (~85% of skips).
+ *
+ * Scope is deliberately narrow: open-issue skips always queue for
+ * review (a skipped open issue is potentially lost planning signal),
+ * and `decidedBy` stays 'auto' so a later webhook or reclassify can
+ * still overwrite the row — auto-confirm is not operator curation.
+ *
+ * Range 0-101; 101 disables the lever (confidence caps at 100).
+ */
+export const TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE = parseConfidenceEnv(
+  process.env.TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE,
+  95,
+  101,
+);
+
+/**
+ * Gate for the auto-confirm-skip lever. Callers pass the freshly
+ * decided (or re-decided) triage outcome plus the issue state captured
+ * at decision time.
+ */
+export function shouldAutoConfirmSkip(
+  decision: Pick<TriageDecision, 'decision' | 'confidence'>,
+  issueState: 'open' | 'closed',
+): boolean {
+  return (
+    decision.decision === 'skip' &&
+    issueState === 'closed' &&
+    decision.confidence >= TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE
+  );
+}
+
+function parseConfidenceEnv(
+  raw: string | undefined,
+  fallback: number,
+  max = 100,
+): number {
   if (!raw) return fallback;
   const n = parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0 || n > 100) return fallback;
+  if (!Number.isFinite(n) || n < 0 || n > max) return fallback;
   return n;
 }
 


### PR DESCRIPTION
## Problem

Skip decisions from auto-triage always land `reviewed=false` — there is no skip equivalent of `TRIAGE_AUTO_APPLY_CONFIDENCE`. Production data (2026-06-09 analysis, re-confirmed in today's 454-row backlog clearing): ~85% of pending skips are the "closed in GitHub, tactical PR below roadmap granularity" pattern at 90-100 confidence. They queue forever and rebuild at ~5-10 rows/day.

## Change

- `TRIAGE_AUTO_CONFIRM_SKIP_CONFIDENCE` in `sync/triage.ts` — env-tunable, default 95, `101` disables.
- `shouldAutoConfirmSkip(decision, issueState)` gate: `skip` + `closed` + `confidence >= threshold`.
- Applied in the webhook-ingest upsert (`sync/githubIngest.ts`) and the reclassify route (`routes/triage.ts`): qualifying rows are persisted `reviewed=true, reviewedAt=now()`.
- **Open-issue skips always queue** — a skipped open issue is potentially lost planning signal.
- `decidedBy` stays `'auto'`: the operator-protect precheck only shields `decidedBy='operator'`, so a later webhook or reclassify can still overwrite an auto-confirmed row. Auto-confirm is queue hygiene, not curation.
- Label writeback is unchanged (already fires at decision time for skips).

## Tests

- Unit: `shouldAutoConfirmSkip` gate (threshold boundary, open-issue exclusion, place/uncertain exclusion).
- Ingest: closed ≥95 → `reviewed=true, decidedBy='auto'`; open ≥95 → queues; closed 94 → queues.
- Reclassify route: closed ≥95 lands reviewed; open ≥95 queues.
- `pnpm turbo typecheck` + `pnpm turbo test` clean across all packages.

No MCP/tool-kit surface change needed: the lever is persist-time server behavior; `list_triage_decisions` (reviewed filter) and `confirm_triage`/`override_triage` semantics are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LXrNAHKQ4AmSXaaBZ34Az