### PR TITLE
feat(tool-kit): search_nodes unversioned + statusIsNull filters (#189)

### DIFF
--- a/packages/server/src/routes/__tests__/triage-routes.test.ts
+++ b/packages/server/src/routes/__tests__/triage-routes.test.ts
@@ -362,8 +362,10 @@ const mocks = vi.hoisted(() => ({
     parentId: newParentId,
   })),
   triageIssueMock: vi.fn(async () => ({
-    decision: 'place' as const,
-    parentNodeId: 'epic-1',
+    // Widened so mockResolvedValueOnce can return skip/uncertain too
+    // (the auto-confirm-skip reclassify tests feed a 'skip' decision).
+    decision: 'place' as 'place' | 'skip' | 'uncertain',
+    parentNodeId: 'epic-1' as string | undefined,
     reason: 'reclassified, now matches Frontend',
     confidence: 88,
   })),
@@ -1119,6 +1121,7 @@ describe('POST .../reclassify', () => {
     });
     triageIssueMock.mockResolvedValueOnce({
       decision: 'skip',
+      parentNodeId: undefined,
       reason: 'closed tactical PR, no epic fit',
       confidence: 97,
     });
@@ -1142,6 +1145,7 @@ describe('POST .../reclassify', () => {
     seedRow({ id: 'tr-1', issueState: 'open' });
     triageIssueMock.mockResolvedValueOnce({
       decision: 'skip',
+      parentNodeId: undefined,
       reason: 'vendor chatter',
       confidence: 99,
     });

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -559,6 +559,155 @@ describe('search_nodes tool — versionId ancestor-walk', () => {
   });
 });
 
+describe('search_nodes tool — unversioned filter (#189)', () => {
+  // Same fixture as the versionId ancestor-walk suite: root has no
+  // version anywhere on its path; everything under `epic` has an
+  // effective version (own or inherited).
+  function buildMixedVersionMap(): MapDetail {
+    const node = (
+      id: string,
+      parentId: string | null,
+      childrenIds: string[],
+      versionId: string | null,
+    ): NodeWithComputed =>
+      ({
+        id,
+        mapId: 'm1',
+        parentId,
+        childrenIds,
+        text: id,
+        description: null,
+        effortEstimate: null,
+        actualEffort: null,
+        percentComplete: null,
+        status: null,
+        assigneeIds: [],
+        priority: null,
+        dueDate: null,
+        startDate: null,
+        tags: [],
+        dependencies: [],
+        versionId,
+        cycleId: null,
+        externalLinks: [],
+        collapsed: false,
+        createdAt: '2026-07-23T00:00:00Z',
+        updatedAt: '2026-07-23T00:00:00Z',
+        claimedBySession: null,
+        claimedAt: null,
+        computedEffort: 0,
+        computedProgress: 0,
+        healthSignal: 'on_track',
+      }) as unknown as NodeWithComputed;
+    return {
+      map: { id: 'm1', rootNodeId: 'root' } as unknown as MapDetail['map'],
+      nodes: [
+        node('root', null, ['epic', 'orphan-leaf'], null),
+        node('epic', 'root', ['leaf-v2', 'leaf-inherits'], 'unversioned-uuid'),
+        node('leaf-v2', 'epic', [], 'v2-uuid'),
+        node('leaf-inherits', 'epic', [], null),
+        // The §8.1 target: no version on itself OR any ancestor.
+        node('orphan-leaf', 'root', [], null),
+      ],
+    };
+  }
+
+  it('matches only nodes with no effective version on the whole ancestor path', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildMixedVersionMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      unversioned: true,
+    } as never);
+    expect(out).toContain('id: orphan-leaf');
+    expect(out).toContain('id: root');
+    // Inheriting leaf is covered by its epic's version — must NOT be
+    // reported, or the §8.1 sweep would re-assign it every tick.
+    expect(out).not.toContain('id: leaf-inherits');
+    expect(out).not.toContain('id: leaf-v2');
+    expect(out).not.toContain('id: epic');
+  });
+
+  it('combines with leavesOnly for the §8.1 sweep shape', async () => {
+    const recorder = makeRecordingBackend();
+    recorder.backend.getMap = async () => buildMixedVersionMap();
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      unversioned: true,
+      leavesOnly: true,
+    } as never);
+    expect(out).toContain('id: orphan-leaf');
+    expect(out).not.toContain('id: root');
+  });
+
+  it('reports the filter in the empty-result message', async () => {
+    const recorder = makeRecordingBackend();
+    const map = buildMixedVersionMap();
+    // Give every node an effective version → no unversioned nodes left.
+    map.nodes = map.nodes.map((n) =>
+      n.id === 'root' ? ({ ...n, versionId: 'v1-uuid' } as typeof n) : n,
+    );
+    recorder.backend.getMap = async () => map;
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      unversioned: true,
+    } as never);
+    expect(out).toContain('unversioned=true');
+    expect(out).toContain('No nodes');
+  });
+});
+
+describe('search_nodes tool — statusIsNull filter (#189 sibling, §8.5)', () => {
+  it('matches only nodes whose own status is null', async () => {
+    const recorder = makeRecordingBackend();
+    const base = {
+      mapId: 'm1',
+      description: null,
+      effortEstimate: null,
+      actualEffort: null,
+      percentComplete: null,
+      assigneeIds: [],
+      priority: null,
+      dueDate: null,
+      startDate: null,
+      tags: [],
+      dependencies: [],
+      versionId: null,
+      cycleId: null,
+      externalLinks: [],
+      collapsed: false,
+      createdAt: '2026-07-23T00:00:00Z',
+      updatedAt: '2026-07-23T00:00:00Z',
+      claimedBySession: null,
+      claimedAt: null,
+      computedEffort: 0,
+      computedProgress: 0,
+      healthSignal: 'on_track',
+    };
+    recorder.backend.getMap = async () =>
+      ({
+        map: { id: 'm1', rootNodeId: 'root' },
+        nodes: [
+          { ...base, id: 'root', parentId: null, childrenIds: ['a', 'b'], text: 'root', status: null },
+          { ...base, id: 'a', parentId: 'root', childrenIds: [], text: 'a', status: 'todo' },
+          { ...base, id: 'b', parentId: 'root', childrenIds: [], text: 'b', status: null },
+        ],
+      }) as unknown as MapDetail;
+    const out = await searchNodesTool.handler(recorder.backend, {
+      mapId: 'm1',
+      query: '*',
+      statusIsNull: true,
+      leavesOnly: true,
+    } as never);
+    expect(out).toContain('id: b');
+    expect(out).not.toContain('id: a');
+    expect(out).not.toContain('id: root');
+  });
+});
+
 describe('search_nodes tool — phaseId ancestor-walk', () => {
   function buildPhaseMap(): MapDetail {
     const node = (

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -305,7 +305,7 @@ export const clearBlockerTool = defineTool({
 export const searchNodesTool = defineTool({
   name: 'search_nodes',
   description:
-    'Search nodes by text across a map, with optional structured filters. Pass an empty string or "*" as query to match all nodes and filter by status/priority/tag/unestimated/leavesOnly/versionId/phaseId/parentId only. Use parentId to enumerate the direct children of a specific node (e.g. before merging duplicate buckets or flattening a wrapper chain): query="*", parentId:"<id>". Common pre-flight check: query="*", unestimated:true, versionId:"<id>" to find any V-N leaves still missing estimates.',
+    'Search nodes by text across a map, with optional structured filters. Pass an empty string or "*" as query to match all nodes and filter by status/priority/tag/unestimated/leavesOnly/versionId/unversioned/statusIsNull/phaseId/parentId only. Use parentId to enumerate the direct children of a specific node (e.g. before merging duplicate buckets or flattening a wrapper chain): query="*", parentId:"<id>". Common pre-flight checks: query="*", unestimated:true, versionId:"<id>" to find V-N leaves still missing estimates; query="*", unversioned:true, leavesOnly:true to find leaves with no version assigned (the §8.1 sweep).',
   schema: {
     mapId: z.string().describe('The map ID'),
     query: z
@@ -332,6 +332,18 @@ export const searchNodesTool = defineTool({
       .string()
       .optional()
       .describe('Filter by version. Matches nodes whose own versionId is this OR any ancestor on the path inherits it.'),
+    unversioned: z
+      .boolean()
+      .optional()
+      .describe(
+        'When true, only nodes with NO effective version — versionId is null on the node AND on every ancestor up to the root (same inheritance walk as the versionId filter, so leaves under a versioned epic do NOT count as unversioned). The §8.1 unversioned sweep: query="*", unversioned:true, leavesOnly:true. Mutually exclusive with versionId — combining both matches nothing.',
+      ),
+    statusIsNull: z
+      .boolean()
+      .optional()
+      .describe(
+        'When true, only nodes whose status was never set (null). Status is not inherited, so this checks the node itself. The §8.5 STATUS-UNSET sweep: query="*", statusIsNull:true, leavesOnly:true.',
+      ),
     phaseId: z
       .string()
       .optional()
@@ -341,7 +353,7 @@ export const searchNodesTool = defineTool({
       .optional()
       .describe('Filter to direct children of this node id. Combine with query="*" to enumerate the contents of a specific bucket — the only way to do so, since get_map truncates on large maps.'),
   },
-  handler: async (backend, { mapId, query, status, notStatus, priority, tag, unestimated, leavesOnly, versionId, phaseId, parentId }) => {
+  handler: async (backend, { mapId, query, status, notStatus, priority, tag, unestimated, leavesOnly, versionId, unversioned, statusIsNull, phaseId, parentId }) => {
     const data = await backend.getMap(mapId);
     const trimmedQ = query.trim();
     const matchAll = trimmedQ === '' || trimmedQ === '*';
@@ -361,6 +373,24 @@ export const searchNodesTool = defineTool({
     if (parentId) matches = matches.filter((n) => n.parentId === parentId);
     if (unestimated === true) matches = matches.filter((n) => n.effortEstimate == null);
     else if (unestimated === false) matches = matches.filter((n) => n.effortEstimate != null);
+    if (statusIsNull) matches = matches.filter((n) => n.status == null);
+    if (unversioned) {
+      const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+      // Effective-version walk, inverse of the versionId filter below:
+      // a node is unversioned only when NO node on its path to the root
+      // carries a versionId. A leaf under a versioned epic inherits that
+      // version and must not show up in the §8.1 sweep — otherwise the
+      // sweep would re-assign already-covered leaves every tick.
+      const hasEffectiveVersion = (id: string): boolean => {
+        let cur = nodeById.get(id);
+        while (cur) {
+          if (cur.versionId != null) return true;
+          cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
+        }
+        return false;
+      };
+      matches = matches.filter((n) => !hasEffectiveVersion(n.id));
+    }
     if (versionId) {
       const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
       // Explicit-assignment-wins inheritance: walk up the ancestor chain
@@ -406,6 +436,8 @@ export const searchNodesTool = defineTool({
         priority && `priority=${priority}`,
         tag && `tag=${tag}`,
         unestimated !== undefined && `unestimated=${unestimated}`,
+        statusIsNull && `statusIsNull=true`,
+        unversioned && `unversioned=true`,
         leavesOnly && `leavesOnly=true`,
         versionId && `versionId=${versionId}`,
         phaseId && `phaseId=${phaseId}`,


### PR DESCRIPTION
## Problem

`search_nodes` had no way to ask "which leaves have no version assigned?" — Jenna's JD §8.1 unversioned sweep has been structurally blocked, falling back to full-map dumps (~100K tokens on the Fulcrum CRM Roadmap). Same shape for §8.5 (STATUS-UNSET), explicitly named in #189 as an equally-blocked sibling.

## Change (tool-kit only — search is client-side over `backend.getMap`)

- `unversioned: boolean` — true matches nodes with **no effective version**: `versionId` null on the node and on every ancestor, using the same explicit-assignment-wins walk as the `versionId` filter. Leaves that inherit a version from their epic are excluded — otherwise §8.1 would re-assign already-covered leaves every tick (the 2026-06-11 re-bulk-assign loop, again).
- `statusIsNull: boolean` — true matches nodes whose own `status` is null (status is not inherited).
- Both appear in the empty-result filter echo and the tool description.

## Also

Fixes the `@mindblown/server` typecheck break introduced by #246's reclassify route tests (`triageIssueMock` return type was pinned to `decision: 'place'`).

## Tests

- unversioned: ancestor-walk semantics (inheriting leaf excluded), `leavesOnly` combo (§8.1 shape), empty-result filter echo.
- statusIsNull: own-status-only matching.
- `pnpm turbo typecheck` 11/11, `pnpm turbo test` 9/9.

Reachable through the MCP surface by definition — the change IS the tool-kit zod schema + handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LXrNAHKQ4AmSXaaBZ34Az