### PR TITLE
fix(mcp): don't show unestimated-leaf warning on done requirements

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -722,7 +722,7 @@ server.tool(
           if (r.status !== 'done' && r.remaining > 0) {
             parts.push(`· ${r.remaining.toFixed(1)} ${unit} remaining`);
           }
-          if (r.unestimated > 0) {
+          if (r.status !== 'done' && r.unestimated > 0) {
             parts.push(`· ⚠ ${r.unestimated} unestimated leaf(s) — effort under-counts`);
           }
           if (r.ghLinks.length > 0) {


### PR DESCRIPTION
## Summary
- The requirements register's `⚠ N unestimated leaf(s) — effort under-counts` caveat fired unconditionally, even on requirements already at 100% progress.
- For `done` requirements the caveat can never resolve into a visible number — the neighboring "remaining effort" line is already gated on `status !== 'done'` — so it was pure noise on the ~1,300 historical leaves across the Fulcrum CRM map that shipped without ever getting an effort estimate.
- Gates the warning the same way the remaining-effort line already is.

## Test plan
- [x] `pnpm --filter @mindblown/mcp typecheck`
- [x] `pnpm --filter @mindblown/mcp test`
- [ ] Reconnect the `mindblown` MCP session and re-run `requirements_overview` on the Fulcrum CRM map to confirm `done` requirements (e.g. MAN-01) no longer show the warning while open/in-progress ones still do

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz3jEptXTpWBu5tbya1ghQ