### PR TITLE
fix(mindmap): don't show unestimated-leaf warning on done requirements

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -848,7 +848,7 @@ function ChapterGroup({
             ) : (
               `${r.remaining.toFixed(1)} ${effortUnit}`
             )}
-            {r.unestimated > 0 && (
+            {r.status !== 'done' && r.unestimated > 0 && (
               <span
                 title={`${r.unestimated} unestimated leaf/leaves under this requirement — remaining under-counts`}
                 style={{ color: '#d97706', marginLeft: 6, cursor: 'help' }}


### PR DESCRIPTION
## Summary
- #248 gated the requirements register's `⚠ N unestimated leaf(s)` warning to non-done requirements — but only in the MCP tool's text formatter (`packages/mcp/src/index.ts`).
- The web app's Requirements tab (`packages/mindmap/src/RequirementsView.tsx`) is a completely separate, client-side implementation of the same rollup, and renders the `⚠N` badge as a sibling of the done-gated remaining-effort cell rather than nested inside it — so it kept showing the warning on `done` requirements after #248 merged.
- Applies the identical gate here: `r.status !== 'done' && r.unestimated > 0`.

## Test plan
- [x] `pnpm --filter @mindblown/mindmap typecheck`
- [x] `pnpm --filter @mindblown/mindmap test`
- [ ] After deploy, reload the Requirements tab on mind.project.li and confirm MAN-01 (and other `done` requirements) no longer show the `⚠` badge, while partial/open ones still do

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz3jEptXTpWBu5tbya1ghQ