### PR TITLE
perf: cache repo-throughput crawl, instant Releases first paint

### DIFF
--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -253,13 +253,9 @@ export function ReleasesView() {
     );
   }
 
-  if (loading && !forecast) {
-    return (
-      <div style={containerStyle}>
-        <div style={{ padding: 40, color: '#64748b', fontSize: 13 }}>Loading releases…</div>
-      </div>
-    );
-  }
+  // The version list comes from the store and renders immediately; only the
+  // forecast columns wait for the (potentially slow) forecast fetch.
+  const forecastPending = loading && !forecast;
 
   const unit = forecast?.effortUnit ?? 'days';
   const fudge = forecast?.fudgeFactor ?? null;
@@ -281,6 +277,7 @@ export function ReleasesView() {
                 {formatAge(forecast.lastSnapshotAt)}
               </>
             )}
+            {forecastPending && ' · loading forecast…'}
             {activeVersionFilter && ' · filtered'}
           </div>
         </div>
@@ -474,7 +471,9 @@ export function ReleasesView() {
                           </div>
                         </>
                       ) : (
-                        <span style={{ fontSize: 11, color: '#94a3b8' }}>No scope yet</span>
+                        <span style={{ fontSize: 11, color: '#94a3b8' }}>
+                          {forecastPending ? '…' : 'No scope yet'}
+                        </span>
                       )}
                     </td>
                     <td style={{ ...tdStyle, textAlign: 'right', color: '#64748b', fontSize: 11 }}>
@@ -490,6 +489,8 @@ export function ReleasesView() {
                             </div>
                           )}
                         </>
+                      ) : forecastPending ? (
+                        '…'
                       ) : (
                         '0'
                       )}

--- a/packages/server/src/lib/__tests__/repoThroughput.test.ts
+++ b/packages/server/src/lib/__tests__/repoThroughput.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchMergedPrsSince, clearThroughputCache } from '../repoThroughput.js';
+import type { GitHubMapContext } from '../githubContext.js';
+
+const ctx: GitHubMapContext = { owner: 'acme', repo: 'widgets', token: 't' };
+
+const DAY = 86_400_000;
+
+function ghPr(number: number, mergedAt: string) {
+  return {
+    number,
+    title: `PR ${number}`,
+    body: null,
+    created_at: mergedAt,
+    merged_at: mergedAt,
+    updated_at: mergedAt,
+  };
+}
+
+// Serves `rows` on page 1 and an empty page afterwards, so one crawl
+// makes exactly one request instead of paging to the cap.
+function mockFetchReturning(rows: unknown[]) {
+  return vi.fn(async (url: string) => ({
+    ok: true,
+    json: async () => (url.endsWith('&page=1') ? rows : []),
+  })) as unknown as typeof fetch;
+}
+
+describe('fetchMergedPrsSince cache', () => {
+  beforeEach(() => {
+    clearThroughputCache();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('serves a second call from cache without hitting GitHub', async () => {
+    const since = Date.now() - 56 * DAY;
+    const fetchMock = mockFetchReturning([ghPr(1, new Date(since + DAY).toISOString())]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await fetchMergedPrsSince(ctx, since);
+    const second = await fetchMergedPrsSince(ctx, since);
+
+    expect(first.prs).toHaveLength(1);
+    expect(second.prs).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-filters cached PRs against the newer window edge', async () => {
+    const now = Date.now();
+    const edge = now - 56 * DAY;
+    // One PR just inside the original window, one comfortably inside.
+    const fetchMock = mockFetchReturning([
+      ghPr(1, new Date(edge + 1000).toISOString()),
+      ghPr(2, new Date(now - DAY).toISOString()),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await fetchMergedPrsSince(ctx, edge);
+    expect(first.prs).toHaveLength(2);
+
+    // Window edge moved forward past PR 1's merge time (still within the
+    // TTL tolerance) — the cached result must drop it.
+    const second = await fetchMergedPrsSince(ctx, edge + 60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.prs.map((p) => p.number)).toEqual([2]);
+  });
+
+  it('bypassCache forces a re-crawl and refreshes the cache', async () => {
+    const since = Date.now() - 56 * DAY;
+    const fetchMock = mockFetchReturning([ghPr(1, new Date(since + DAY).toISOString())]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchMergedPrsSince(ctx, since);
+    await fetchMergedPrsSince(ctx, since, undefined, { bypassCache: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // The bypass call re-warmed the cache — a plain call hits it again.
+    await fetchMergedPrsSince(ctx, since);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('a different look-back window misses the cache', async () => {
+    const now = Date.now();
+    const fetchMock = mockFetchReturning([]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchMergedPrsSince(ctx, now - 56 * DAY);
+    await fetchMergedPrsSince(ctx, now - 7 * DAY);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches per repo', async () => {
+    const since = Date.now() - 56 * DAY;
+    const fetchMock = mockFetchReturning([]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchMergedPrsSince(ctx, since);
+    await fetchMergedPrsSince({ ...ctx, repo: 'other' }, since);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/server/src/lib/releaseSnapshots.ts
+++ b/packages/server/src/lib/releaseSnapshots.ts
@@ -31,7 +31,9 @@ export async function snapshotReleaseForecastForMap(
     // Measured rates make the snapshot record what the forecast actually
     // said (net-rate velocity + ticket model), not a knob-based shadow of
     // it. Measurement failure degrades to knobs — never blocks the cron.
-    const rates = await measureMapVelocity(mapId, data, 56)
+    const rates = await measureMapVelocity(mapId, data, 56, undefined, {
+      freshThroughput: true, // hourly cron re-crawls and keeps the cache warm
+    })
       .then((m) => m.rates)
       .catch(() => undefined);
     result = computeReleaseForecast(data.map, data.nodes, versions, new Date(), rates);

--- a/packages/server/src/lib/repoThroughput.ts
+++ b/packages/server/src/lib/repoThroughput.ts
@@ -18,6 +18,20 @@ export interface FetchMergedPrsResult {
   truncated: boolean; // hit the page cap — window may be partially covered
 }
 
+// The crawl below costs up to `maxPages` sequential GitHub round-trips and
+// feeds a signal (rework share) that moves on a scale of weeks, so results
+// are cached in-process for an hour. The hourly snapshot cron passes
+// `bypassCache` and thereby keeps the cache warm for interactive loads.
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const throughputCache = new Map<
+  string,
+  { fetchedAt: number; sinceMs: number; result: FetchMergedPrsResult }
+>();
+
+export function clearThroughputCache(): void {
+  throughputCache.clear();
+}
+
 /**
  * Page `GET /repos/:owner/:repo/pulls?state=closed` (sorted by most-recently
  * updated) and collect PRs whose `merged_at` falls on/after `sinceMs`. Stops
@@ -27,6 +41,35 @@ export async function fetchMergedPrsSince(
   ctx: GitHubMapContext,
   sinceMs: number,
   maxPages = 8,
+  opts?: { bypassCache?: boolean },
+): Promise<FetchMergedPrsResult> {
+  const cacheKey = `${ctx.owner}/${ctx.repo}`;
+  const cached = throughputCache.get(cacheKey);
+  if (
+    !opts?.bypassCache &&
+    cached &&
+    Date.now() - cached.fetchedAt < CACHE_TTL_MS &&
+    // Same look-back window: two calls with equal windowDays made within the
+    // TTL differ in sinceMs by < TTL; different windows differ by days.
+    Math.abs(cached.sinceMs - sinceMs) < CACHE_TTL_MS
+  ) {
+    return {
+      // The window's leading edge moved forward since the fetch — drop PRs
+      // that no longer fall inside it.
+      prs: cached.result.prs.filter((p) => Date.parse(p.mergedAt) >= sinceMs),
+      truncated: cached.result.truncated,
+    };
+  }
+
+  const result = await fetchMergedPrsUncached(ctx, sinceMs, maxPages);
+  throughputCache.set(cacheKey, { fetchedAt: Date.now(), sinceMs, result });
+  return result;
+}
+
+async function fetchMergedPrsUncached(
+  ctx: GitHubMapContext,
+  sinceMs: number,
+  maxPages: number,
 ): Promise<FetchMergedPrsResult> {
   const out: PrRecord[] = [];
   let page = 1;
@@ -70,11 +113,14 @@ export async function fetchMergedPrsSince(
       }
     }
 
+    // A partial page is the last page — no need to request the next one.
+    if (rows.length < PER_PAGE) break;
+
     // Once the whole page's activity predates the window, older pages can't
     // contain in-window merges (sorted by updated desc).
     const pageAllOld = rows.every((r) => Date.parse(r.updated_at) < sinceMs);
     if (pageAllOld) break;
-    if (page === maxPages && rows.length === PER_PAGE) truncated = true;
+    if (page === maxPages) truncated = true;
   }
 
   return { prs: out, truncated };

--- a/packages/server/src/lib/velocityMeasure.ts
+++ b/packages/server/src/lib/velocityMeasure.ts
@@ -47,6 +47,12 @@ export async function measureMapVelocity(
   data: { map: MindMap; nodes: CoreNode[] },
   windowDays = 56,
   log?: { warn: (obj: unknown, msg: string) => void },
+  opts?: {
+    /** Re-crawl the repo even if a fresh cached throughput result exists.
+     *  Passed by the hourly snapshot cron (keeps the cache warm) and by
+     *  the explicit ?refresh=1 flow. */
+    freshThroughput?: boolean;
+  },
 ): Promise<MapVelocityMeasurement> {
   const since = new Date(Date.now() - windowDays * 86_400_000);
 
@@ -87,7 +93,9 @@ export async function measureMapVelocity(
   try {
     const ctx = await getGitHubContextForMap(mapId);
     if (ctx) {
-      const { prs, truncated } = await fetchMergedPrsSince(ctx, since.getTime());
+      const { prs, truncated } = await fetchMergedPrsSince(ctx, since.getTime(), undefined, {
+        bypassCache: opts?.freshThroughput,
+      });
       const rt = analyzeRepoThroughput(prs);
       repoThroughput = {
         ...rt,

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -976,18 +976,24 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
 
     const allVersions = await versionDb.listVersions(data.map.id);
 
+    const wantRefresh = req.query.refresh === '1' || req.query.refresh === 'true';
+
     // Compute current forecast via the shared helper — same code path
     // as the hourly snapshot job, so the two surfaces never disagree.
     // Measured rates power the velocity line + the ticket model; a failed
     // measurement degrades to the knob-based projection, never to an error.
-    const rates = await measureMapVelocity(req.params.id, data, 56, req.log)
+    // Plain loads run on the cached repo throughput (warmed hourly by the
+    // snapshot cron); the explicit Refresh button re-crawls the repo.
+    const rates = await measureMapVelocity(req.params.id, data, 56, req.log, {
+      freshThroughput: wantRefresh,
+    })
       .then((m) => m.rates)
       .catch(() => undefined);
     const forecast = computeReleaseForecast(data.map, data.nodes, allVersions, new Date(), rates);
 
     // Optional manual refresh — writes today's snapshot before reading
     // deltas, so a button click produces a fresh history row.
-    if (req.query.refresh === '1' || req.query.refresh === 'true') {
+    if (wantRefresh) {
       await snapshotReleaseForecastForMap(req.params.id, forecast).catch((err) => {
         req.log.error({ err, mapId: req.params.id }, 'manual snapshot failed');
       });


### PR DESCRIPTION
## Why

The Releases page took seconds to load. Its single blocking call, `GET /api/maps/:id/release-forecast`, crawled up to 8 sequential GitHub API pages (closed PRs) on **every** page load — all to compute one scalar (`reworkFraction`) that changes on a scale of weeks and is already re-measured hourly by the snapshot cron.

## What

- **In-process 1h TTL cache** for `fetchMergedPrsSince`, keyed by `owner/repo` (+ window match). Cached PRs are re-filtered against the newer window edge on read.
- **Cron + Refresh button bypass and re-warm the cache** (`freshThroughput` option through `measureMapVelocity`), so interactive loads always hit a warm cache and an explicit Refresh still re-crawls live. Numbers are unchanged — same measurement, reused.
- **Stop paging past a partial page** — the crawl previously always made one extra request to discover the empty page.
- **Instant first paint**: `ReleasesView` renders the version table from the store immediately; forecast columns show `…` until the fetch lands (header shows "loading forecast…").

## Verification

- 5 new tests for cache hit/miss/bypass/re-filter/per-repo keying (`repoThroughput.test.ts`)
- `pnpm turbo typecheck test` green across all packages after the last edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bmakma2KNrqprnAyhWknMt