### PR TITLE
fix(mindmap): label the requirements version slider

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -449,6 +449,7 @@ export function RequirementsView() {
             <option value="could">Could</option>
           </select>
           <div style={versionSliderContainerStyle}>
+            <span style={{ fontSize: 11, fontWeight: 600, color: '#64748b' }}>Versions</span>
             {sortedVersions.length > 0 && (
               <>
                 <button


### PR DESCRIPTION
## Summary
- Adds a "Versions" label to the requirements-page slider control (follow-up polish on #250 — Dan noted it was unlabeled compared to the other filters).

## Test plan
- [x] `pnpm turbo typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4Abgda1xrxhtSq85A33fo