### PR TITLE
feat(requirements): fade GitHub links to closed issues in the register

### DIFF
--- a/packages/core/src/__tests__/requirements.test.ts
+++ b/packages/core/src/__tests__/requirements.test.ts
@@ -4,13 +4,19 @@ import { collectRequirementGhLinks } from '../requirements.js';
 type N = {
   id: string;
   childrenIds?: string[];
-  externalLinks?: Array<{ provider: string; externalId: string; url: string }>;
+  externalLinks?: Array<{
+    provider: string;
+    externalId: string;
+    url: string;
+    state?: 'open' | 'closed';
+  }>;
 };
 
-const gh = (n: number) => ({
+const gh = (n: number, state?: 'open' | 'closed') => ({
   provider: 'github',
   externalId: `FulcrumCRM/crm#${n}`,
   url: `https://github.com/FulcrumCRM/crm/issues/${n}`,
+  ...(state ? { state } : {}),
 });
 
 function lookup(nodes: N[]) {
@@ -90,5 +96,27 @@ describe('collectRequirementGhLinks', () => {
 
   it('tolerates a missing node id', () => {
     expect(collectRequirementGhLinks(lookup([]), 'nope')).toEqual([]);
+  });
+
+  it('carries the closed state through', () => {
+    const get = lookup([{ id: 'r', externalLinks: [gh(1, 'closed')] }]);
+    expect(collectRequirementGhLinks(get, 'r')).toEqual([
+      { externalId: 'FulcrumCRM/crm#1', url: expect.any(String), inherited: false, state: 'closed' },
+    ]);
+  });
+
+  it('leaves state undefined for links written before the field existed', () => {
+    const get = lookup([{ id: 'r', externalLinks: [gh(1)] }]);
+    expect(collectRequirementGhLinks(get, 'r')[0].state).toBeUndefined();
+  });
+
+  it('own link wins with its own state even if a child has a different one', () => {
+    const get = lookup([
+      { id: 'r', childrenIds: ['w'], externalLinks: [gh(5, 'open')] },
+      { id: 'w', externalLinks: [gh(5, 'closed')] },
+    ]);
+    const got = collectRequirementGhLinks(get, 'r');
+    expect(got).toHaveLength(1);
+    expect(got[0].state).toBe('open');
   });
 });

--- a/packages/core/src/requirements.ts
+++ b/packages/core/src/requirements.ts
@@ -11,7 +11,12 @@
  * requirement and on a child, it is reported once, as not-inherited.
  */
 export interface GhLinkSource {
-  externalLinks?: Array<{ provider: string; externalId: string; url: string }> | null;
+  externalLinks?: Array<{
+    provider: string;
+    externalId: string;
+    url: string;
+    state?: 'open' | 'closed';
+  }> | null;
   childrenIds?: string[] | null;
 }
 
@@ -20,6 +25,8 @@ export interface RequirementGhLink {
   url: string;
   /** true = found on a descendant, not on the requirement node itself */
   inherited: boolean;
+  /** Absent when the link predates the state field, or provider isn't synced */
+  state?: 'open' | 'closed';
 }
 
 export function collectRequirementGhLinks<T extends GhLinkSource>(
@@ -32,7 +39,12 @@ export function collectRequirementGhLinks<T extends GhLinkSource>(
   const byId = new Map<string, RequirementGhLink>();
   for (const l of node.externalLinks ?? []) {
     if (l.provider === 'github' && !byId.has(l.externalId)) {
-      byId.set(l.externalId, { externalId: l.externalId, url: l.url, inherited: false });
+      byId.set(l.externalId, {
+        externalId: l.externalId,
+        url: l.url,
+        inherited: false,
+        state: l.state,
+      });
     }
   }
 
@@ -48,7 +60,12 @@ export function collectRequirementGhLinks<T extends GhLinkSource>(
     if (!child) continue;
     for (const l of child.externalLinks ?? []) {
       if (l.provider === 'github' && !byId.has(l.externalId)) {
-        byId.set(l.externalId, { externalId: l.externalId, url: l.url, inherited: true });
+        byId.set(l.externalId, {
+          externalId: l.externalId,
+          url: l.url,
+          inherited: true,
+          state: l.state,
+        });
       }
     }
     queue.push(...(child.childrenIds ?? []));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,13 @@ export interface ExternalLink {
   lastSyncedAt: string | null; // ISO 8601
 
   /**
+   * The external item's own open/closed state, as of last sync. Absent
+   * on links written before this field existed — treat as unknown, not
+   * open, in that case.
+   */
+  state?: 'open' | 'closed';
+
+  /**
    * Node state captured the moment the external system drove the node
    * to "complete". Used to revert progress/status when the external
    * system reopens the item (e.g. GitHub issue reopened).

--- a/packages/integrations/src/github.ts
+++ b/packages/integrations/src/github.ts
@@ -151,6 +151,7 @@ function buildExternalLink(
     url: issue.html_url,
     syncEnabled: true,
     lastSyncedAt: new Date().toISOString(),
+    state: issue.state,
   };
 }
 

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -45,7 +45,7 @@ interface ReqRow {
   remaining: number;
   unestimated: number;
   health: string;
-  ghLinks: Array<{ id: string; url: string; inherited: boolean }>;
+  ghLinks: Array<{ id: string; url: string; inherited: boolean; state?: 'open' | 'closed' }>;
   /** Version set on the requirement node itself. */
   versionId: string | null;
   /** Distinct versions found below it — the requirement may be split across releases. */
@@ -190,6 +190,7 @@ export function RequirementsView() {
             id: l.externalId,
             url: l.url,
             inherited: l.inherited,
+            state: l.state,
           })),
           versionId: node.versionId ?? null,
           descendantVersionIds,
@@ -940,27 +941,32 @@ function ChapterGroup({
             {r.ghLinks.length === 0 ? (
               <span style={{ color: '#cbd5e1' }}>—</span>
             ) : (
-              r.ghLinks.map((l, i) => (
-                <a
-                  key={l.id}
-                  href={l.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  title={
-                    l.inherited
-                      ? 'Issue on work below this requirement, not on the requirement itself'
-                      : undefined
-                  }
-                  style={{
-                    color: l.inherited ? '#93c5fd' : '#3b82f6',
-                    textDecoration: 'none',
-                    marginLeft: i > 0 ? 6 : 0,
-                  }}
-                >
-                  {l.id.includes('#') ? `#${l.id.split('#')[1]}` : l.id}
-                </a>
-              ))
+              r.ghLinks.map((l, i) => {
+                const titleParts = [
+                  l.inherited
+                    ? 'Issue on work below this requirement, not on the requirement itself'
+                    : null,
+                  l.state === 'closed' ? 'Issue is closed' : null,
+                ].filter(Boolean);
+                return (
+                  <a
+                    key={l.id}
+                    href={l.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    title={titleParts.length > 0 ? titleParts.join(' — ') : undefined}
+                    style={{
+                      color: l.inherited ? '#93c5fd' : '#3b82f6',
+                      opacity: l.state === 'closed' ? 0.5 : 1,
+                      textDecoration: 'none',
+                      marginLeft: i > 0 ? 6 : 0,
+                    }}
+                  >
+                    {l.id.includes('#') ? `#${l.id.split('#')[1]}` : l.id}
+                  </a>
+                );
+              })
             )}
           </td>
 

--- a/packages/server/src/routes/integrations.ts
+++ b/packages/server/src/routes/integrations.ts
@@ -461,6 +461,7 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         url: issue.html_url,
         syncEnabled: true,
         lastSyncedAt: new Date().toISOString(),
+        state: issue.state,
       };
 
       // Add to existing external links
@@ -1514,6 +1515,7 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
           previousPercentComplete: node.percentComplete,
           previousStatus: node.status,
           lastSyncedAt: new Date().toISOString(),
+          state: 'closed',
         };
         updates = {
           percentComplete: 100,
@@ -1530,6 +1532,7 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
           previousPercentComplete: null,
           previousStatus: null,
           lastSyncedAt: new Date().toISOString(),
+          state: 'open',
         };
         updates = {
           percentComplete: savedPct !== undefined ? savedPct : null,


### PR DESCRIPTION
## Summary
- The requirements register showed GitHub issue links with zero visual distinction between open and closed — reported against MAN-04's link to `#670`, which looks identical whether the issue is open or long closed.
- Root cause: `ExternalLink` never carried the issue's own open/closed state at all (only sync bookkeeping like `previousStatus`), so there was no data to render a "closed" style from.
- Adds `ExternalLink.state: 'open' | 'closed'`, populated at every real write site — all of which already have the GitHub issue's state in scope, so this is purely additive:
  - `buildExternalLink()` in `packages/integrations/src/github.ts` (shared by `createGitHubIssue` and the bulk-import path)
  - the manual `POST .../github/link` route
  - the `issues.closed` / `issues.reopened` webhook branch
- Threads `state` through `collectRequirementGhLinks` (own link wins on dedupe, same precedence as the existing inherited-vs-own logic) and fades closed links to 50% opacity in `RequirementsView.tsx`.
- MCP tool-kit surfaces (`link_github_issue`, `create_github_issue_from_node`, `import_github_issues`) are thin HTTP wrappers over the same routes — verified, no separate change needed.
- Links written before this field existed have `state: undefined` — treated as unknown (unfaded), not assumed open; they'll pick up real state on next sync.

## Test plan
- [x] `pnpm turbo typecheck` clean across core/integrations/server/mindmap
- [x] `pnpm --filter @mindblown/core test` — 152/152 (3 new: closed-state carried through, undefined for legacy links, own link's state wins over a differing child state)
- [x] `pnpm --filter @mindblown/mindmap test` — 71/71
- [x] `pnpm --filter @mindblown/server test` — 631/631
- [ ] After deploy, reload the Requirements tab and confirm MAN-04's `#670` link renders faded (closed) while an open-issue link on another row does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz3jEptXTpWBu5tbya1ghQ