### PR TITLE
test(mcp): cover requirements_overview's version-scoping walk

### DIFF
--- a/packages/mcp/src/__tests__/requirementScope.test.ts
+++ b/packages/mcp/src/__tests__/requirementScope.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Version-scoping for the requirements register: requirements_overview's
+ * versionId filter mirrors RequirementsView.tsx's release filter/slider —
+ * a requirement matches a release if its own versionId is that release, OR
+ * any node anywhere below it (not just direct children) carries it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { descendantVersionIds, requirementMatchesVersion } from '../requirementScope.js';
+import type { NodeWithComputed } from '../api.js';
+
+function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWithComputed {
+  return {
+    mapId: 'm1',
+    parentId: null,
+    childrenIds: [],
+    text: overrides.id,
+    description: null,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    blockedReason: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    dependencies: [],
+    versionId: null,
+    cycleId: null,
+    externalLinks: [],
+    collapsed: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    completedAt: null,
+    revision: 1,
+    requirementId: null,
+    requirementPriority: null,
+    requirementText: null,
+    phaseId: null,
+    verificationText: null,
+    verificationUrl: null,
+    claimedBySession: null,
+    claimedAt: null,
+    computedEffort: 0,
+    computedProgress: 0,
+    healthSignal: 'on_track',
+    isBlocked: false,
+    blockedBy: { manual: false, predecessorIds: [], blockedDescendantCount: 0 },
+    ...overrides,
+  };
+}
+
+/**
+ * Tree:
+ *   root
+ *   ├── req-a (requirementId: A, versionId: null)
+ *   │   ├── a1 (leaf, versionId: v1)
+ *   │   └── a2
+ *   │       └── a2-req (requirementId: A2, versionId: v2)  -- nested requirement
+ *   ├── req-b (requirementId: B, versionId: v1)             -- own versionId set
+ *   │   └── b1 (leaf, no version)
+ *   └── req-c (requirementId: C, versionId: null)            -- version nowhere below
+ *       └── c1 (leaf, no version)
+ */
+function makeNodeById(): Map<string, NodeWithComputed> {
+  const nodes = [
+    makeNode({ id: 'root', childrenIds: ['req-a', 'req-b', 'req-c'] }),
+    makeNode({ id: 'req-a', parentId: 'root', childrenIds: ['a1', 'a2'], requirementId: 'A' }),
+    makeNode({ id: 'a1', parentId: 'req-a', versionId: 'v1' }),
+    makeNode({ id: 'a2', parentId: 'req-a', childrenIds: ['a2-req'] }),
+    makeNode({ id: 'a2-req', parentId: 'a2', requirementId: 'A2', versionId: 'v2' }),
+    makeNode({ id: 'req-b', parentId: 'root', childrenIds: ['b1'], requirementId: 'B', versionId: 'v1' }),
+    makeNode({ id: 'b1', parentId: 'req-b' }),
+    makeNode({ id: 'req-c', parentId: 'root', childrenIds: ['c1'], requirementId: 'C' }),
+    makeNode({ id: 'c1', parentId: 'req-c' }),
+  ];
+  return new Map(nodes.map((n) => [n.id, n]));
+}
+
+describe('descendantVersionIds', () => {
+  it('collects a version on a direct-child leaf', () => {
+    const nodeById = makeNodeById();
+    expect(descendantVersionIds(nodeById, 'req-a')).toContain('v1');
+  });
+
+  it('collects a version several levels down, past a nested requirement node', () => {
+    const nodeById = makeNodeById();
+    // v2 sits on a2-req, which is a grandchild of req-a AND its own
+    // requirement — the walk must not stop or special-case at it.
+    expect(descendantVersionIds(nodeById, 'req-a')).toContain('v2');
+  });
+
+  it('returns both versions for a requirement split across releases', () => {
+    const nodeById = makeNodeById();
+    const versions = descendantVersionIds(nodeById, 'req-a');
+    expect(versions.sort()).toEqual(['v1', 'v2']);
+  });
+
+  it('does not leak a sibling subtree\'s version', () => {
+    const nodeById = makeNodeById();
+    // req-b's own versionId is v1, but nothing BELOW req-b carries a
+    // version — descendantVersionIds only walks children, so this must
+    // be empty (req-b's own versionId is a separate check).
+    expect(descendantVersionIds(nodeById, 'req-b')).toEqual([]);
+  });
+
+  it('returns empty when no version exists anywhere below', () => {
+    const nodeById = makeNodeById();
+    expect(descendantVersionIds(nodeById, 'req-c')).toEqual([]);
+  });
+
+  it('returns empty for an unknown node id', () => {
+    const nodeById = makeNodeById();
+    expect(descendantVersionIds(nodeById, 'does-not-exist')).toEqual([]);
+  });
+});
+
+describe('requirementMatchesVersion', () => {
+  it('matches via descendant versionId when the requirement itself has none', () => {
+    const nodeById = makeNodeById();
+    expect(requirementMatchesVersion(nodeById, 'req-a', 'v1')).toBe(true);
+    expect(requirementMatchesVersion(nodeById, 'req-a', 'v2')).toBe(true);
+  });
+
+  it('matches via the requirement\'s own versionId even with no tagged descendants', () => {
+    const nodeById = makeNodeById();
+    expect(requirementMatchesVersion(nodeById, 'req-b', 'v1')).toBe(true);
+  });
+
+  it('does not match an unrelated version', () => {
+    const nodeById = makeNodeById();
+    expect(requirementMatchesVersion(nodeById, 'req-b', 'v2')).toBe(false);
+    expect(requirementMatchesVersion(nodeById, 'req-c', 'v1')).toBe(false);
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -26,6 +26,7 @@ import { allTools as sharedTools, type ToolSpec } from '@mindblown/tool-kit';
 import { clampFocusFactor, scopedCapacityDays, assessCalibration, calibrationSamplesFromNodes } from '@mindblown/core';
 import * as api from './api.js';
 import { scopedLeaves } from './scope.js';
+import { descendantVersionIds } from './requirementScope.js';
 import { httpBackend } from './backend.js';
 import { formatMapTree, filterMapData, formatHealthReport, formatScheduleReport, formatSprintOverview, formatNodeDetail } from './formatters.js';
 
@@ -622,21 +623,6 @@ server.tool(
         return dfsOrder.get(parentId) ?? Infinity;
       };
 
-      // Versions touched anywhere below a requirement (not just direct
-      // children) — a requirement can be split across releases.
-      const descendantVersionIds = (id: string): string[] => {
-        const found = new Set<string>();
-        const stack = [...(nodeById.get(id)?.childrenIds ?? [])];
-        while (stack.length) {
-          const cid = stack.pop()!;
-          const n = nodeById.get(cid);
-          if (!n) continue;
-          if (n.versionId) found.add(n.versionId);
-          stack.push(...(n.childrenIds ?? []));
-        }
-        return [...found];
-      };
-
       // Progress: rollup for parents, own percentComplete for leaves.
       const progressOf = (n: (typeof requirements)[number]): number =>
         (n.childrenIds?.length ?? 0) > 0 ? n.computedProgress : (n.percentComplete ?? 0);
@@ -704,7 +690,7 @@ server.tool(
         rows = rows.filter(
           (r) =>
             r.node.versionId === versionId ||
-            descendantVersionIds(r.node.id).includes(versionId),
+            descendantVersionIds(nodeById, r.node.id).includes(versionId),
         );
       }
 

--- a/packages/mcp/src/requirementScope.ts
+++ b/packages/mcp/src/requirementScope.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared version-scoping for the requirements register (requirements_overview,
+ * RequirementsView.tsx's release filter/slider mirrors this in the frontend).
+ *
+ * A requirement matches a release if its OWN versionId is that release, OR
+ * ANY node anywhere below it in the tree carries that versionId — a
+ * requirement can be split across releases (part of it ships in MVP, the
+ * rest in V1), so this is a full descendant walk, not just direct children.
+ */
+import type { NodeWithComputed } from './api.js';
+
+export function descendantVersionIds(
+  nodeById: Map<string, NodeWithComputed>,
+  id: string,
+): string[] {
+  const found = new Set<string>();
+  const stack = [...(nodeById.get(id)?.childrenIds ?? [])];
+  while (stack.length) {
+    const cid = stack.pop()!;
+    const n = nodeById.get(cid);
+    if (!n) continue;
+    if (n.versionId) found.add(n.versionId);
+    stack.push(...(n.childrenIds ?? []));
+  }
+  return [...found];
+}
+
+export function requirementMatchesVersion(
+  nodeById: Map<string, NodeWithComputed>,
+  requirementId: string,
+  versionId: string,
+): boolean {
+  const own = nodeById.get(requirementId)?.versionId;
+  return own === versionId || descendantVersionIds(nodeById, requirementId).includes(versionId);
+}


### PR DESCRIPTION
## Summary
- #255 added the `versionId` filter to `requirements_overview` with zero test coverage — only verified via one live smoke-check. Extracts the descendant-version walk into `requirementScope.ts` (mirroring the existing `scope.ts` pattern) so it's directly unit-testable, and adds 9 tests: own versionId, deep descendant, split-across-releases, sibling isolation, no-version-anywhere, unknown id, and a nested-requirement-node edge case.

## Test plan
- [x] `pnpm turbo typecheck` clean across all packages
- [x] `pnpm turbo test` clean (mcp package: 26 tests, up from 17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz3jEptXTpWBu5tbya1ghQ