### PR TITLE
feat(requirements): filtered export + shareable release selection in URL

### DIFF
--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -371,8 +371,25 @@ export function revokeAcceptance(mapId: string, nodeId: string): Promise<{ succe
   });
 }
 
-export function exportRequirements(mapId: string): Promise<string> {
-  return requestText(`/api/maps/${mapId}/requirements-export`);
+export interface RequirementsExportFilter {
+  status?: 'open' | 'partial' | 'done';
+  priority?: 'must' | 'should' | 'could';
+  /** Version id, or 'none' for "no release assigned (own or inherited)". */
+  release?: string;
+  releaseMode?: 'cumulative' | 'exact';
+}
+
+export function exportRequirements(
+  mapId: string,
+  filter: RequirementsExportFilter = {},
+): Promise<string> {
+  const params = new URLSearchParams();
+  if (filter.status) params.set('status', filter.status);
+  if (filter.priority) params.set('priority', filter.priority);
+  if (filter.release) params.set('release', filter.release);
+  if (filter.releaseMode) params.set('releaseMode', filter.releaseMode);
+  const q = params.toString();
+  return requestText(`/api/maps/${mapId}/requirements-export${q ? `?${q}` : ''}`);
 }
 
 // ── Maps ────────────────────────────────────────────────────────

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -548,13 +548,40 @@ server.tool(
 
 server.tool(
   'requirements_export',
-  'Export the requirements register as a Markdown Anforderungsdokument: chapter per Bereich, one table row per requirement (ID, business text, Muss/Soll/Kann, derived status, Aufwand/Rest in S/M/L/XL buckets). Returns the full Markdown document — save it to a file or convert with pandoc for docx/pdf.',
+  'Export the requirements register as a Markdown Anforderungsdokument: chapter per Bereich, one table row per requirement (ID, business text, Muss/Soll/Kann, derived status, Aufwand/Rest in S/M/L/XL buckets). Optional filters scope the document (a filtered export is labeled "Gefilterter Auszug" in the header). Returns the full Markdown document — save it to a file or convert with pandoc for docx/pdf.',
   {
     mapId: z.string().describe('The map ID'),
+    status: z
+      .enum(['open', 'partial', 'done'])
+      .optional()
+      .describe('Only requirements in this derived status'),
+    requirementPriority: z
+      .enum(['must', 'should', 'could'])
+      .optional()
+      .describe('Only requirements with this MoSCoW priority'),
+    versionId: z
+      .string()
+      .optional()
+      .describe(
+        'Only requirements scheduled for a release: a version id (use list_versions), or the literal "none" for requirements with no release assigned anywhere in their subtree. Matches a requirement whose own versionId is this OR any descendant carries it — same semantics as requirements_overview and the Requirements view.',
+      ),
+    versionMode: z
+      .enum(['cumulative', 'exact'])
+      .optional()
+      .describe(
+        'With versionId: "cumulative" (default) includes everything due by that release or earlier; "exact" only that release. Ignored for versionId "none".',
+      ),
   },
-  async ({ mapId }) => {
+  async ({ mapId, status, requirementPriority, versionId, versionMode }) => {
     try {
-      return toolResult(await api.exportRequirements(mapId));
+      return toolResult(
+        await api.exportRequirements(mapId, {
+          status,
+          priority: requirementPriority,
+          release: versionId,
+          releaseMode: versionMode,
+        }),
+      );
     } catch (err) {
       return toolError(err);
     }

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { compareVersions, collectRequirementGhLinks } from '@mindblown/core';
 import type { Node, Version } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
+import { REQ_VERSION_NONE } from './urlState.js';
 import * as api from './api.js';
 
 // ── Derived requirement status ───────────────────────────────────
@@ -120,11 +121,13 @@ export function RequirementsView() {
 
   const [statusFilter, setStatusFilter] = useState<'' | ReqStatus>('');
   const [priorityFilter, setPriorityFilter] = useState<'' | 'must' | 'should' | 'could'>('');
-  // Index into sortedVersions + 1; 0 = "All releases" (no restriction).
-  const [versionSliderIndex, setVersionSliderIndex] = useState(0);
-  // cumulative = "through this release", exact = "only this release".
-  const [versionFilterMode, setVersionFilterMode] = useState<'cumulative' | 'exact'>('cumulative');
-  const [showUnscheduledOnly, setShowUnscheduledOnly] = useState(false);
+  // Release filter lives in the store (mirrored to ?rv= / ?rvm= by
+  // useUrlState) so the selection survives a copied link.
+  const reqVersionFilter = useMindmapStore((s) => s.reqVersionFilter);
+  const versionFilterMode = useMindmapStore((s) => s.reqVersionMode);
+  const setReqVersionFilter = useMindmapStore((s) => s.setReqVersionFilter);
+  const setVersionFilterMode = useMindmapStore((s) => s.setReqVersionMode);
+  const showUnscheduledOnly = reqVersionFilter === REQ_VERSION_NONE;
   const [hideDone, setHideDone] = useState(false);
   const [editingCell, setEditingCell] = useState<{ nodeId: string; field: string } | null>(null);
   const [showCreate, setShowCreate] = useState(false);
@@ -207,8 +210,12 @@ export function RequirementsView() {
     return t;
   }, [allRows]);
 
-  // Clamp against a version having been deleted out from under the slider.
-  const selectedVersionIndex = Math.min(versionSliderIndex, sortedVersions.length);
+  // Slider position derived from the selected version id; an id that no
+  // longer resolves (deleted version, stale link) falls back to 0 = all.
+  const selectedVersionIndex =
+    reqVersionFilter && reqVersionFilter !== REQ_VERSION_NONE
+      ? (versionRank.get(reqVersionFilter) ?? -1) + 1
+      : 0;
   const versionFilterActive = showUnscheduledOnly || selectedVersionIndex > 0;
   const versionLabel = showUnscheduledOnly
     ? 'No release'
@@ -455,7 +462,7 @@ export function RequirementsView() {
               <>
                 <button
                   onClick={() =>
-                    setVersionFilterMode((m) => (m === 'cumulative' ? 'exact' : 'cumulative'))
+                    setVersionFilterMode(versionFilterMode === 'cumulative' ? 'exact' : 'cumulative')
                   }
                   disabled={showUnscheduledOnly || selectedVersionIndex === 0}
                   title={
@@ -473,7 +480,10 @@ export function RequirementsView() {
                   max={sortedVersions.length}
                   value={selectedVersionIndex}
                   disabled={showUnscheduledOnly}
-                  onChange={(e) => setVersionSliderIndex(Number(e.target.value))}
+                  onChange={(e) => {
+                    const i = Number(e.target.value);
+                    setReqVersionFilter(i === 0 ? null : (sortedVersions[i - 1]?.id ?? null));
+                  }}
                   style={{ width: 110 }}
                   title={versionLabel}
                 />
@@ -490,7 +500,9 @@ export function RequirementsView() {
               {versionLabel}
             </span>
             <button
-              onClick={() => setShowUnscheduledOnly((v) => !v)}
+              onClick={() =>
+                setReqVersionFilter(showUnscheduledOnly ? null : REQ_VERSION_NONE)
+              }
               aria-pressed={showUnscheduledOnly}
               title="Show only requirements with no release assigned (own or inherited)"
               style={{
@@ -528,7 +540,15 @@ export function RequirementsView() {
               try {
                 // Word is what business consumers open — the Markdown
                 // variant stays available via ?format=md and the MCP tool.
-                const blob = await api.exportRequirementsDocx(currentMapId);
+                // The active filter bar travels along: you export what you see.
+                const blob = await api.exportRequirementsDocx(currentMapId, {
+                  status: statusFilter || undefined,
+                  priority: priorityFilter || undefined,
+                  release: reqVersionFilter ?? undefined,
+                  releaseMode: versionFilterMode === 'exact' ? 'exact' : undefined,
+                  hideDone: hideDone || undefined,
+                  acceptance: acceptanceFilter || undefined,
+                });
                 const a = document.createElement('a');
                 a.href = URL.createObjectURL(blob);
                 a.download = `anforderungsdokument-${new Date().toISOString().slice(0, 10)}.docx`;
@@ -539,7 +559,7 @@ export function RequirementsView() {
               }
             }}
             disabled={exporting}
-            title="Als Anforderungsdokument (Word) exportieren"
+            title="Als Anforderungsdokument (Word) exportieren — aktive Filter werden übernommen"
             style={secondaryButtonStyle(exporting)}
           >
             {exporting ? 'Exporting…' : 'Export Word'}

--- a/packages/mindmap/src/__tests__/urlState.test.ts
+++ b/packages/mindmap/src/__tests__/urlState.test.ts
@@ -72,6 +72,48 @@ describe('parseUrlState', () => {
   });
 });
 
+describe('requirements release filter (rv / rvm)', () => {
+  it('parses a version id and the exact mode', () => {
+    expect(parseUrlState('?rv=v1&rvm=exact')).toEqual(
+      state({ reqVersion: 'v1', reqVersionMode: 'exact' }),
+    );
+  });
+
+  it('parses the "none" sentinel', () => {
+    expect(parseUrlState('?rv=none').reqVersion).toBe('none');
+  });
+
+  it('drops an unknown rvm value rather than trusting it', () => {
+    expect(parseUrlState('?rv=v1&rvm=sideways').reqVersionMode).toBeNull();
+  });
+
+  it('round-trips through serialize', () => {
+    const original = state({ map: 'm1', reqVersion: 'v1', reqVersionMode: 'exact' });
+    expect(parseUrlState(serializeUrlState('', original))).toEqual(original);
+  });
+
+  it('omits the mode without a selected release, and for "none"', () => {
+    expect(serializeUrlState('', state({ reqVersionMode: 'exact' }))).toBe('');
+    expect(serializeUrlState('', state({ reqVersion: 'none', reqVersionMode: 'exact' }))).toBe(
+      '?rv=none',
+    );
+  });
+
+  it('validate keeps a resolving id and the "none" sentinel', () => {
+    const c = ctx({ versionIds: ['v1'] });
+    expect(validateUrlState(state({ reqVersion: 'v1' }), c).reqVersion).toBe('v1');
+    expect(validateUrlState(state({ reqVersion: 'none' }), c).reqVersion).toBe('none');
+  });
+
+  it('validate clears a deleted version instead of rendering an empty register', () => {
+    expect(validateUrlState(state({ reqVersion: 'gone' }), ctx()).reqVersion).toBeNull();
+  });
+
+  it('is a lens change, not navigation', () => {
+    expect(isNavChange(state(), state({ reqVersion: 'v1', reqVersionMode: 'exact' }))).toBe(false);
+  });
+});
+
 describe('serializeUrlState', () => {
   it('round-trips through parse', () => {
     const original = state({

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -585,9 +585,42 @@ export function updateMap(id: string, fields: Record<string, unknown>): Promise<
  * Fetch the requirements register as a Word document (docx) — the
  * format business consumers actually open. Returns a Blob for download.
  */
-export async function exportRequirementsDocx(mapId: string): Promise<Blob> {
+/**
+ * Filter mirror of the Requirements view's filter bar — forwarded to the
+ * export route so the document matches what's on screen.
+ */
+export interface RequirementsExportFilter {
+  status?: 'open' | 'partial' | 'done';
+  priority?: 'must' | 'should' | 'could';
+  /** Version id, or 'none' for "no release assigned". */
+  release?: string;
+  releaseMode?: 'cumulative' | 'exact';
+  hideDone?: boolean;
+  acceptance?: 'none' | 'mine-open' | 'rejected';
+}
+
+function requirementsExportQuery(format: string, filter: RequirementsExportFilter): string {
+  const params = new URLSearchParams({ format });
+  if (filter.status) params.set('status', filter.status);
+  if (filter.priority) params.set('priority', filter.priority);
+  if (filter.release) {
+    params.set('release', filter.release);
+    if (filter.releaseMode === 'exact' && filter.release !== 'none') {
+      params.set('releaseMode', 'exact');
+    }
+  }
+  if (filter.hideDone) params.set('hideDone', '1');
+  if (filter.acceptance) params.set('acceptance', filter.acceptance);
+  return `?${params.toString()}`;
+}
+
+export async function exportRequirementsDocx(
+  mapId: string,
+  filter: RequirementsExportFilter = {},
+): Promise<Blob> {
   const token = getToken();
-  const res = await fetch(`${BASE_URL}/api/maps/${mapId}/requirements-export?format=docx`, {
+  const query = requirementsExportQuery('docx', filter);
+  const res = await fetch(`${BASE_URL}/api/maps/${mapId}/requirements-export${query}`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (!res.ok) throw new Error(`Export failed: HTTP ${res.status}`);

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -92,6 +92,13 @@ export interface MindmapState {
   versions: Version[];
   activeVersionFilter: string | null;
 
+  // Requirements register release filter (shareable via URL, hence store
+  // state rather than component state). A version id, 'none' for "no
+  // release assigned", or null for all releases.
+  reqVersionFilter: string | null;
+  /** cumulative = "through this release", exact = "only this release". */
+  reqVersionMode: 'cumulative' | 'exact';
+
   // Phase state (PhaseDefs live on currentMap.phases; only the filter is store state)
   activePhaseFilter: string | null;
 
@@ -153,6 +160,8 @@ export interface MindmapState {
   updateVersion: (id: string, fields: Partial<api.CreateVersionFields>) => Promise<void>;
   deleteVersion: (id: string) => Promise<void>;
   setActiveVersionFilter: (versionId: string | null) => void;
+  setReqVersionFilter: (versionId: string | null) => void;
+  setReqVersionMode: (mode: 'cumulative' | 'exact') => void;
 
   // Actions — phase
   setActivePhaseFilter: (phaseId: string | null) => void;
@@ -229,6 +238,8 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
   activeCycleFilter: null,
   versions: [],
   activeVersionFilter: null,
+  reqVersionFilter: null,
+  reqVersionMode: 'cumulative' as const,
   activePhaseFilter: null,
   nodeActors: new Map(),
   nodeActorsMapId: null,
@@ -395,6 +406,8 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       maxDepth: 1,
       versions: [],
       activeVersionFilter: null,
+      reqVersionFilter: null,
+      reqVersionMode: 'cumulative',
       activePhaseFilter: null,
       wsConnected: false,
       presence: {},
@@ -663,6 +676,9 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
     if (state.activeVersionFilter === id) {
       set({ activeVersionFilter: null });
     }
+    if (state.reqVersionFilter === id) {
+      set({ reqVersionFilter: null });
+    }
     try {
       await api.deleteVersion(id);
     } catch (e: any) {
@@ -671,6 +687,10 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
   },
 
   setActiveVersionFilter: (versionId) => set({ activeVersionFilter: versionId }),
+
+  setReqVersionFilter: (versionId) => set({ reqVersionFilter: versionId }),
+
+  setReqVersionMode: (mode) => set({ reqVersionMode: mode }),
 
   // ── Phase actions ────────────────────────────────────────────
 

--- a/packages/mindmap/src/urlState.ts
+++ b/packages/mindmap/src/urlState.ts
@@ -38,7 +38,15 @@ const PARAM = {
   version: 'v',
   sprint: 's',
   phase: 'p',
+  // Requirements register release filter — distinct from `v` (the canvas
+  // scope filter): a version id, or 'none' for "no release assigned".
+  reqVersion: 'rv',
+  // 'exact' = "only this release"; absent = cumulative ("through").
+  reqVersionMode: 'rvm',
 } as const;
+
+/** The literal `rv` value meaning "only requirements with no release". */
+export const REQ_VERSION_NONE = 'none';
 
 /** Every param this module owns — used to clear stale keys on write. */
 const OWNED_PARAMS: readonly string[] = Object.values(PARAM);
@@ -79,6 +87,10 @@ export interface UrlState {
   version: string | null;
   sprint: string | null;
   phase: string | null;
+  /** Requirements register release filter: version id, 'none', or absent. */
+  reqVersion: string | null;
+  /** 'exact' when the register shows only the selected release; null = cumulative. */
+  reqVersionMode: 'exact' | null;
 }
 
 export const EMPTY_URL_STATE: UrlState = {
@@ -90,6 +102,8 @@ export const EMPTY_URL_STATE: UrlState = {
   version: null,
   sprint: null,
   phase: null,
+  reqVersion: null,
+  reqVersionMode: null,
 };
 
 /** Keys that count as navigation — these push a history entry. */
@@ -132,6 +146,8 @@ export function parseUrlState(search: string): UrlState {
     version: readId(params, PARAM.version),
     sprint: readId(params, PARAM.sprint),
     phase: readId(params, PARAM.phase),
+    reqVersion: readId(params, PARAM.reqVersion),
+    reqVersionMode: readId(params, PARAM.reqVersionMode) === 'exact' ? 'exact' : null,
   };
 }
 
@@ -159,6 +175,14 @@ export function serializeUrlState(search: string, state: UrlState): string {
   if (state.version) params.set(PARAM.version, state.version);
   if (state.sprint) params.set(PARAM.sprint, state.sprint);
   if (state.phase) params.set(PARAM.phase, state.phase);
+  if (state.reqVersion) {
+    params.set(PARAM.reqVersion, state.reqVersion);
+    // Mode only matters alongside a concrete release — 'none' and "all
+    // releases" ignore it, so don't let it linger in the URL.
+    if (state.reqVersionMode === 'exact' && state.reqVersion !== REQ_VERSION_NONE) {
+      params.set(PARAM.reqVersionMode, state.reqVersionMode);
+    }
+  }
 
   const str = params.toString();
   return str === '' ? '' : `?${str}`;
@@ -199,6 +223,12 @@ export function validateUrlState(state: UrlState, ctx: UrlStateContext): UrlStat
     version: state.version && ctx.versionIds.has(state.version) ? state.version : null,
     sprint: state.sprint && ctx.sprintIds.has(state.sprint) ? state.sprint : null,
     phase: state.phase && ctx.phaseIds.has(state.phase) ? state.phase : null,
+    reqVersion:
+      state.reqVersion &&
+      (state.reqVersion === REQ_VERSION_NONE || ctx.versionIds.has(state.reqVersion))
+        ? state.reqVersion
+        : null,
+    reqVersionMode: state.reqVersionMode,
   };
 }
 

--- a/packages/mindmap/src/useUrlState.ts
+++ b/packages/mindmap/src/useUrlState.ts
@@ -63,6 +63,8 @@ function readStoreUrlState(): UrlState {
     version: s.activeVersionFilter,
     sprint: s.activeCycleFilter,
     phase: s.activePhaseFilter,
+    reqVersion: s.reqVersionFilter,
+    reqVersionMode: s.reqVersionMode === 'exact' ? 'exact' : null,
   };
 }
 
@@ -78,6 +80,8 @@ function applyToStore(state: UrlState): void {
   s.setActiveVersionFilter(state.version);
   s.setActiveCycleFilter(state.sprint);
   s.setActivePhaseFilter(state.phase);
+  s.setReqVersionFilter(state.reqVersion);
+  s.setReqVersionMode(state.reqVersionMode === 'exact' ? 'exact' : 'cumulative');
   s.setFocusNode(state.focus);
   s.selectNode(state.node);
 }

--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -166,6 +166,104 @@ describe('buildRegisterData — status detail', () => {
   });
 });
 
+describe('buildRegisterData — filters (export mirrors the filter bar)', () => {
+  const versions = [
+    { id: 'v2', name: 'V2', sortOrder: 1, targetDate: null },
+    { id: 'v1', name: 'V1', sortOrder: 0, targetDate: null },
+  ] as Parameters<typeof buildRegisterData>[4];
+
+  // MAN-01 done+v1 · MAN-02 partial+v2 · MAN-03 open, v1 via child ·
+  // MAN-04 open, unscheduled, priority could.
+  const nodes = [
+    makeNode({ id: 'root', childrenIds: ['ch'] }),
+    makeNode({ id: 'ch', parentId: 'root', childrenIds: ['r1', 'r2', 'r3', 'r4'], text: 'Bereich' }),
+    makeNode({ id: 'r1', parentId: 'ch', requirementId: 'MAN-01', requirementPriority: 'must', percentComplete: 100, versionId: 'v1' }),
+    makeNode({ id: 'r2', parentId: 'ch', requirementId: 'MAN-02', requirementPriority: 'must', percentComplete: 50, versionId: 'v2' }),
+    makeNode({ id: 'r3', parentId: 'ch', requirementId: 'MAN-03', childrenIds: ['r3c'] }),
+    makeNode({ id: 'r3c', parentId: 'r3', versionId: 'v1', percentComplete: 0 }),
+    makeNode({ id: 'r4', parentId: 'ch', requirementId: 'MAN-04', requirementPriority: 'could', percentComplete: 0 }),
+  ];
+
+  const acceptances = [
+    { ...baseAcc, nodeId: 'r1', userId: 'u1', decision: 'accepted' as const, nodeRevisionAtAcceptance: 0 },
+    { ...baseAcc, nodeId: 'r2', userId: 'u2', decision: 'rejected' as const, comment: 'Falsche Maske', nodeRevisionAtAcceptance: 0 },
+  ];
+
+  const buildF = (filter: Parameters<typeof buildRegisterData>[5]) =>
+    buildRegisterData(map, nodes, new Map(), acceptances, versions, filter);
+  const ids = (filter: Parameters<typeof buildRegisterData>[5]) =>
+    buildF(filter).chapters.flatMap((c) => c.rows.map((r) => r.id));
+
+  it('includes everything and no label when unfiltered', () => {
+    const data = buildF({});
+    expect(data.total).toBe(4);
+    expect(data.totalAll).toBe(4);
+    expect(data.filterLabel).toBeNull();
+  });
+
+  it('filters by derived status', () => {
+    expect(ids({ status: 'done' })).toEqual(['MAN-01']);
+    expect(ids({ status: 'partial' })).toEqual(['MAN-02']);
+    expect(ids({ status: 'open' })).toEqual(['MAN-03', 'MAN-04']);
+  });
+
+  it('hideDone drops implemented requirements', () => {
+    expect(ids({ hideDone: true })).toEqual(['MAN-02', 'MAN-03', 'MAN-04']);
+  });
+
+  it('filters by MoSCoW priority', () => {
+    expect(ids({ priority: 'could' })).toEqual(['MAN-04']);
+  });
+
+  it('release exact matches own and descendant versions', () => {
+    expect(ids({ release: 'v1', releaseMode: 'exact' })).toEqual(['MAN-01', 'MAN-03']);
+  });
+
+  it('release cumulative includes everything due by that release, and is the default', () => {
+    expect(ids({ release: 'v2', releaseMode: 'cumulative' })).toEqual(['MAN-01', 'MAN-02', 'MAN-03']);
+    expect(ids({ release: 'v1' })).toEqual(['MAN-01', 'MAN-03']);
+  });
+
+  it('release "none" keeps only requirements unscheduled through their whole subtree', () => {
+    expect(ids({ release: 'none' })).toEqual(['MAN-04']);
+  });
+
+  it('acceptance filters mirror the register UI', () => {
+    expect(ids({ acceptance: 'rejected' })).toEqual(['MAN-02']);
+    expect(ids({ acceptance: 'none' })).toEqual(['MAN-03', 'MAN-04']);
+    expect(ids({ acceptance: 'mine-open', currentUserId: 'u1' })).toEqual(['MAN-02', 'MAN-03', 'MAN-04']);
+  });
+
+  it('counts reflect the filtered set, totalAll the whole register', () => {
+    const data = buildF({ hideDone: true });
+    expect(data.total).toBe(3);
+    expect(data.totalAll).toBe(4);
+    expect(data.counts).toEqual({ Umgesetzt: 0, Teilweise: 1, Offen: 2 });
+  });
+
+  it('describes the active filter in German', () => {
+    expect(buildF({ release: 'v2' }).filterLabel).toBe('Release: bis V2');
+    expect(buildF({ release: 'v1', releaseMode: 'exact' }).filterLabel).toBe('Release: nur V1');
+    expect(buildF({ release: 'none' }).filterLabel).toBe('Release: ohne Zuordnung');
+    expect(buildF({ status: 'open', hideDone: true, priority: 'must' }).filterLabel).toBe(
+      'Status: Offen · ohne Umgesetzte · Priorität: Muss',
+    );
+  });
+
+  it('marks the rendered Markdown as a filtered Auszug with X von Y', () => {
+    const md = renderMarkdown(buildF({ release: 'none' }));
+    expect(md).toContain('Gefilterter Auszug');
+    expect(md).toContain('Release: ohne Zuordnung');
+    expect(md).toContain('**Stand:** 1 von 4 Anforderungen');
+  });
+
+  it('renders an unfiltered document without the Auszug banner', () => {
+    const md = renderMarkdown(buildF({}));
+    expect(md).not.toContain('Gefilterter Auszug');
+    expect(md).toContain('**Stand:** 4 Anforderungen');
+  });
+});
+
 describe('acceptanceIsStale', () => {
   it('flags revision drift and >1pt progress drift, tolerates rounding', () => {
     const acc = { ...baseAcc };

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -5,6 +5,7 @@ import type {
   NodeId,
   Version,
 } from '@mindblown/core';
+import { compareVersions } from '@mindblown/core';
 import {
   Document,
   HeadingLevel,
@@ -67,11 +68,34 @@ export interface RegisterData {
   title: string;
   generatedAt: string; // YYYY-MM-DD
   total: number;
+  /** Requirement count before filtering — equals `total` on an unfiltered export. */
+  totalAll: number;
+  /** Human-readable description of the active filter, null when unfiltered. */
+  filterLabel: string | null;
   counts: { Umgesetzt: number; Teilweise: number; Offen: number };
   chapters: Array<{ name: string; rows: RegisterRow[] }>;
 }
 
+/**
+ * Mirror of the Requirements view's filter bar, so "Export" gives you the
+ * document for exactly what's on screen. Semantics match RequirementsView's
+ * `filteredRows` predicate one for one.
+ */
+export interface RegisterFilter {
+  status?: 'open' | 'partial' | 'done';
+  priority?: 'must' | 'should' | 'could';
+  /** A version id, or 'none' for "no release anywhere in the subtree". */
+  release?: string;
+  /** cumulative = due by this release or earlier; exact = only this release. */
+  releaseMode?: 'cumulative' | 'exact';
+  hideDone?: boolean;
+  acceptance?: 'none' | 'mine-open' | 'rejected';
+  /** Needed by acceptance: 'mine-open' — whose verdict counts as "mine". */
+  currentUserId?: string | null;
+}
+
 const PRIO: Record<string, string> = { must: 'Muss', should: 'Soll', could: 'Kann' };
+const STATUS_DE: Record<string, string> = { open: 'Offen', partial: 'Teilweise', done: 'Umgesetzt' };
 
 function truncate(s: string, max: number): string {
   return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
@@ -88,27 +112,26 @@ export function buildRegisterData(
   computed: Map<NodeId, ComputedNodeValues>,
   acceptances: Array<AcceptanceInfo & { nodeId: string }> = [],
   versions: Version[] = [],
+  filter: RegisterFilter = {},
 ): RegisterData {
   const accByNode = new Map<string, Array<AcceptanceInfo & { nodeId: string }>>();
   for (const a of acceptances) {
     (accByNode.get(a.nodeId) ?? accByNode.set(a.nodeId, []).get(a.nodeId)!).push(a);
   }
   const byId = new Map(nodes.map((n) => [n.id, n]));
-  const requirements = nodes.filter((n) => n.requirementId != null);
+  const allRequirements = nodes.filter((n) => n.requirementId != null);
 
   const progressOf = (n: CoreNode): number =>
     n.childrenIds.length > 0
       ? (computed.get(n.id)?.computedProgress ?? 0)
       : (n.percentComplete ?? 0);
-  const statusOf = (p: number): string =>
-    p >= 99.5 ? 'Umgesetzt' : p > 0 ? 'Teilweise' : 'Offen';
+  const statusEnOf = (p: number): 'open' | 'partial' | 'done' =>
+    p >= 99.5 ? 'done' : p > 0 ? 'partial' : 'open';
+  const statusOf = (p: number): string => STATUS_DE[statusEnOf(p)];
 
-  // Release label, mirroring the register UI: the version tagged on the
-  // requirement itself, else the one(s) carried by the work below it —
-  // requirements are usually scheduled through their children, not directly.
-  const versionName = new Map(versions.map((v) => [v.id, v.name]));
-  const releaseOf = (n: CoreNode): string => {
-    if (n.versionId) return versionName.get(n.versionId) ?? '—';
+  // A requirement is usually scheduled through its children, not directly —
+  // and can be split across releases, so this is a full descendant walk.
+  const descendantVersionsOf = (n: CoreNode): string[] => {
     const below = new Set<string>();
     const stack = [...n.childrenIds];
     while (stack.length) {
@@ -117,10 +140,86 @@ export function buildRegisterData(
       if (c.versionId) below.add(c.versionId);
       stack.push(...c.childrenIds);
     }
-    if (below.size === 0) return '—';
-    if (below.size === 1) return `↳ ${versionName.get([...below][0]) ?? '—'}`;
-    return `↳ ${below.size} Releases`;
+    return [...below];
   };
+
+  // Release label, mirroring the register UI: the version tagged on the
+  // requirement itself, else the one(s) carried by the work below it.
+  const versionName = new Map(versions.map((v) => [v.id, v.name]));
+  const releaseOf = (n: CoreNode): string => {
+    if (n.versionId) return versionName.get(n.versionId) ?? '—';
+    const below = descendantVersionsOf(n);
+    if (below.length === 0) return '—';
+    if (below.length === 1) return `↳ ${versionName.get(below[0]) ?? '—'}`;
+    return `↳ ${below.length} Releases`;
+  };
+
+  // Release order for the cumulative ("due by V1") mode.
+  const versionRank = new Map(
+    [...versions].sort(compareVersions).map((v, i) => [v.id, i] as const),
+  );
+
+  const matchesFilter = (n: CoreNode): boolean => {
+    const st = statusEnOf(progressOf(n));
+    if (filter.hideDone && st === 'done') return false;
+    if (filter.status && st !== filter.status) return false;
+    if (filter.priority && n.requirementPriority !== filter.priority) return false;
+    if (filter.release === 'none') {
+      // "No release" means nothing below it is scheduled either.
+      if (n.versionId || descendantVersionsOf(n).length > 0) return false;
+    } else if (filter.release) {
+      if (filter.releaseMode === 'exact') {
+        // A split requirement matches every release it touches.
+        if (n.versionId !== filter.release && !descendantVersionsOf(n).includes(filter.release)) {
+          return false;
+        }
+      } else {
+        const selectedRank = versionRank.get(filter.release);
+        if (selectedRank == null) return false;
+        const ownRank = n.versionId ? versionRank.get(n.versionId) : undefined;
+        const touchesUpToHere =
+          (ownRank != null && ownRank <= selectedRank) ||
+          descendantVersionsOf(n).some((id) => {
+            const rank = versionRank.get(id);
+            return rank != null && rank <= selectedRank;
+          });
+        if (!touchesUpToHere) return false;
+      }
+    }
+    if (filter.acceptance) {
+      const accs = accByNode.get(n.id) ?? [];
+      if (filter.acceptance === 'none' && accs.length > 0) return false;
+      if (
+        filter.acceptance === 'mine-open' &&
+        accs.some((a) => a.userId === filter.currentUserId)
+      ) {
+        return false;
+      }
+      if (filter.acceptance === 'rejected' && !accs.some((a) => a.decision === 'rejected')) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const requirements = allRequirements.filter(matchesFilter);
+
+  // Spell the filter out in the document itself: a filtered Auszug that
+  // looks like the complete Anforderungsdokument is worse than no export.
+  const filterParts: string[] = [];
+  if (filter.release === 'none') filterParts.push('Release: ohne Zuordnung');
+  else if (filter.release) {
+    filterParts.push(
+      `Release: ${filter.releaseMode === 'exact' ? 'nur' : 'bis'} ${versionName.get(filter.release) ?? filter.release}`,
+    );
+  }
+  if (filter.status) filterParts.push(`Status: ${STATUS_DE[filter.status]}`);
+  if (filter.hideDone) filterParts.push('ohne Umgesetzte');
+  if (filter.priority) filterParts.push(`Priorität: ${PRIO[filter.priority]}`);
+  if (filter.acceptance === 'none') filterParts.push('Abnahme: ohne Urteil');
+  if (filter.acceptance === 'mine-open') filterParts.push('Abnahme: eigenes Urteil ausstehend');
+  if (filter.acceptance === 'rejected') filterParts.push('Abnahme: abgelehnt');
+  const filterLabel = filterParts.length > 0 ? filterParts.join(' · ') : null;
 
   // Depth-first order for chapter (= parent) sorting.
   const dfs = new Map<string, number>();
@@ -185,6 +284,8 @@ export function buildRegisterData(
     title: `${map.name} — Anforderungsdokument`,
     generatedAt: new Date().toISOString().slice(0, 10),
     total: requirements.length,
+    totalAll: allRequirements.length,
+    filterLabel,
     counts,
     chapters: orderedChapters,
   };
@@ -207,13 +308,17 @@ export function renderMarkdown(data: RegisterData): string {
   L.push(
     `*Generiert aus MindBlown am ${data.generatedAt} — Status abgeleitet aus dem Projektstand (Rollup), nicht manuell gepflegt.*`,
   );
+  if (data.filterLabel) {
+    L.push('');
+    L.push(`**Gefilterter Auszug** — ${data.filterLabel}. Nicht das vollständige Dokument.`);
+  }
   for (const line of LEGEND) {
     L.push('');
     L.push(line);
   }
   L.push('');
   L.push(
-    `**Stand:** ${data.total} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
+    `**Stand:** ${data.total}${data.filterLabel ? ` von ${data.totalAll}` : ''} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
   );
   L.push('');
   L.push('---');
@@ -279,6 +384,20 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
       ],
     }),
   );
+  if (data.filterLabel) {
+    children.push(
+      new Paragraph({
+        spacing: { before: 120 },
+        children: [
+          new TextRun({
+            text: `Gefilterter Auszug — ${data.filterLabel}. Nicht das vollständige Dokument.`,
+            bold: true,
+            size: 18,
+          }),
+        ],
+      }),
+    );
+  }
   for (const line of LEGEND) {
     // Strip the markdown bold markers for the docx paragraphs.
     children.push(
@@ -293,7 +412,7 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
       spacing: { before: 160, after: 240 },
       children: [
         new TextRun({
-          text: `Stand: ${data.total} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
+          text: `Stand: ${data.total}${data.filterLabel ? ` von ${data.totalAll}` : ''} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
           bold: true,
           size: 20,
         }),

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -244,7 +244,22 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
   // buckets. ?format=md (default, text/markdown) or ?format=docx
   // (Word download for business consumers). Rendering lives in
   // ../export/requirementsDoc.ts.
-  app.get<{ Params: { id: string }; Querystring: { format?: string } }>(
+  //
+  // Filter params mirror the Requirements view's filter bar so the export
+  // matches what's on screen: ?status=, ?priority=, ?release=<versionId|none>,
+  // ?releaseMode=cumulative|exact, ?hideDone=1, ?acceptance=none|mine-open|rejected.
+  app.get<{
+    Params: { id: string };
+    Querystring: {
+      format?: string;
+      status?: string;
+      priority?: string;
+      release?: string;
+      releaseMode?: string;
+      hideDone?: string;
+      acceptance?: string;
+    };
+  }>(
     '/api/maps/:id/requirements-export',
     async (req, reply) => {
       const userId = req.userId;
@@ -267,8 +282,49 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       const computed = computeTree(data.nodes, data.map.healthThreshold);
       const acceptances = await listActiveAcceptances(req.params.id);
       const versions = await versionDb.listVersions(req.params.id);
-      const register = buildRegisterData(data.map, data.nodes, computed, acceptances, versions);
-      const format = (req.query as { format?: string }).format ?? 'md';
+
+      const q = req.query;
+      const oneOf = <T extends string>(value: string | undefined, allowed: readonly T[]): T | undefined =>
+        value !== undefined && (allowed as readonly string[]).includes(value)
+          ? (value as T)
+          : undefined;
+      for (const [key, allowed] of [
+        ['status', ['open', 'partial', 'done']],
+        ['priority', ['must', 'should', 'could']],
+        ['releaseMode', ['cumulative', 'exact']],
+        ['acceptance', ['none', 'mine-open', 'rejected']],
+      ] as const) {
+        const value = q[key];
+        if (value !== undefined && !(allowed as readonly string[]).includes(value)) {
+          return reply.status(400).send({
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: `Unknown ${key} "${value}" — use ${allowed.join(', ')}`,
+            },
+          });
+        }
+      }
+      // A stale release id must fail loudly: silently exporting an empty
+      // document would look like the requirements vanished.
+      if (q.release && q.release !== 'none' && !versions.some((v) => v.id === q.release)) {
+        return reply.status(400).send({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: `Unknown release "${q.release}" — use a version id from this map, or "none"`,
+          },
+        });
+      }
+
+      const register = buildRegisterData(data.map, data.nodes, computed, acceptances, versions, {
+        status: oneOf(q.status, ['open', 'partial', 'done']),
+        priority: oneOf(q.priority, ['must', 'should', 'could']),
+        release: q.release,
+        releaseMode: oneOf(q.releaseMode, ['cumulative', 'exact']),
+        hideDone: q.hideDone === '1' || q.hideDone === 'true',
+        acceptance: oneOf(q.acceptance, ['none', 'mine-open', 'rejected']),
+        currentUserId: req.userId ?? null,
+      });
+      const format = q.format ?? 'md';
 
       if (format === 'docx') {
         const buf = await renderDocx(register);


### PR DESCRIPTION
Two register improvements requested by Dan:

**1. Export uses the active filter.** The Export-Word button (and `?format=md`) now forwards the filter bar — status, priority, release (through/only/no-release), hide-done, acceptance — to the export route, which applies the exact same predicate as `filteredRows` in the view. A filtered document is labeled **"Gefilterter Auszug — <filter>"** and its stand line reads "X von Y Anforderungen", so a partial export can't be mistaken for the full register. Unknown release ids 400 instead of silently producing an empty document.

**2. Release selection is shareable via URL.** The release slider/mode/no-release state moved from component state into the store and mirrors to `?rv=<versionId|none>&rvm=exact` (cumulative is the default and stays out of the URL). Copied links restore the selection; a deleted version degrades to "all releases" via the existing `validateUrlState` path. Works on mobile too since `MobileApp` round-trips unknown-to-it params.

**MCP surface:** `requirements_export` gains `status` / `requirementPriority` / `versionId` (incl. `"none"`) / `versionMode`, matching `requirements_overview` semantics — same PR per the definition-of-done rule.

Tests: 11 new filter cases in `requirementsDoc.test.ts`, 8 new `rv`/`rvm` cases in `urlState.test.ts`; `pnpm turbo typecheck` + `test` green across packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCrgTpxWKh596uj1vjjgFV