### PR TITLE
feat(orchestration): Leidang pull queue — get_next_ticket + dispatch knobs

### DIFF
--- a/packages/core/src/__tests__/richtext.test.ts
+++ b/packages/core/src/__tests__/richtext.test.ts
@@ -1,0 +1,61 @@
+/**
+ * proseMirrorToPlainText — moved here from packages/server (mapContext)
+ * so packages/integrations can render GitHub issue bodies with the same
+ * walk. The server re-exports it; these tests pin the core behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { proseMirrorToPlainText } from '../richtext.js';
+
+describe('proseMirrorToPlainText', () => {
+  it('returns empty string for null/undefined/non-objects', () => {
+    expect(proseMirrorToPlainText(null)).toBe('');
+    expect(proseMirrorToPlainText(undefined)).toBe('');
+    expect(proseMirrorToPlainText(42)).toBe('');
+  });
+
+  it('passes legacy string descriptions through unchanged', () => {
+    expect(proseMirrorToPlainText('hello')).toBe('hello');
+  });
+
+  it('joins paragraphs with newlines', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'First line' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Second line' }] },
+      ],
+    };
+    expect(proseMirrorToPlainText(doc)).toBe('First line\nSecond line');
+  });
+
+  it('walks nested list structures', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'item one' }] },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'item two' }] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const out = proseMirrorToPlainText(doc);
+    expect(out).toContain('item one');
+    expect(out).toContain('item two');
+    // Never leaks JSON syntax into the rendering.
+    expect(out).not.toContain('{');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,9 @@ export {
 } from './calibration.js';
 export type { CalibrationSample, CalibrationAssessment } from './calibration.js';
 
+// Rich-text rendering
+export { proseMirrorToPlainText } from './richtext.js';
+
 // Requirements register helpers
 export { collectRequirementGhLinks } from './requirements.js';
 export type { GhLinkSource, RequirementGhLink } from './requirements.js';

--- a/packages/core/src/richtext.ts
+++ b/packages/core/src/richtext.ts
@@ -1,0 +1,46 @@
+/**
+ * ProseMirror rich-text helpers.
+ *
+ * Node descriptions are stored as ProseMirror JSON. Several consumers
+ * need a plain-text rendering (triage prompts, GitHub issue bodies,
+ * pull-queue ticket briefs), so the walk lives here in core where both
+ * the server and the integrations package can import it.
+ */
+
+/**
+ * Render a stored node description to plain text. Walks the ProseMirror
+ * doc and concatenates every leaf `text` node, joining block-level nodes
+ * with a single newline so readers see something readable without
+ * HTML/JSON noise.
+ *
+ * Strings pass through unchanged so we tolerate legacy nodes whose
+ * description was saved as a raw string before the ProseMirror migration.
+ * Returns empty string for null/undefined/unknown shapes.
+ */
+export function proseMirrorToPlainText(description: unknown): string {
+  if (description == null) return '';
+  if (typeof description === 'string') return description;
+  if (typeof description !== 'object') return '';
+
+  const lines: string[] = [];
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const obj = node as { type?: string; text?: unknown; content?: unknown };
+    if (obj.type === 'text' && typeof obj.text === 'string') {
+      lines.push(obj.text);
+      return;
+    }
+    if (Array.isArray(obj.content)) {
+      const before = lines.length;
+      for (const child of obj.content) walk(child);
+      // Treat block-level nodes as paragraph breaks. We don't try to
+      // recreate exact formatting; consumers only need the gist.
+      const isBlock = obj.type !== undefined && obj.type !== 'text' && obj.type !== 'doc';
+      if (isBlock && lines.length > before) {
+        lines.push('\n');
+      }
+    }
+  };
+  walk(description);
+  return lines.join('').replace(/\n{3,}/g, '\n\n').trim();
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -441,6 +441,32 @@ export interface MindMap {
    */
   focusFactor: number;
 
+  // ── Pull queue (Leidang) ──────────────────────────────────
+  /**
+   * Fleet-wide cap on concurrently claimed nodes for the pull queue
+   * (`get_next_ticket`). Counted across ALL sessions — the constraint it
+   * models (CI capacity) is shared, not per-worker. 0 = hold: the queue
+   * grants nothing and the fleet drains naturally. Default 0 so a map
+   * must opt in before workers can pull from it.
+   */
+  maxActiveClaims: number;
+  /**
+   * AND-filter fencing what `get_next_ticket` may hand out. Tiny
+   * deliberate vocabulary: `version:<versionId>` (effective version via
+   * the explicit-assignment-wins ancestor walk) and `type:bug` (node
+   * tagged "bug"). Empty = no fence. A ticket outside the gate is
+   * invisible to the pull queue, not deprioritized.
+   */
+  dispatchGate: string[];
+  /**
+   * Ordered sort keys ranking the gated ready set: `bugs` (bug-tagged
+   * first), `priority` (priorityRank then P0–P3), `size` (effort
+   * estimate ascending, nulls last), `age` (oldest first). Empty =
+   * default `["bugs", "priority", "age"]`. No weights, no expressions —
+   * an ordered list is the whole policy language.
+   */
+  dispatchPolicy: string[];
+
   // ── Metadata ──────────────────────────────────────────────
   createdAt: string;
   updatedAt: string;

--- a/packages/integrations/src/github.ts
+++ b/packages/integrations/src/github.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Node, ExternalLink, Priority } from '@mindblown/core';
+import { proseMirrorToPlainText } from '@mindblown/core';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -172,12 +173,10 @@ export async function createGitHubIssue(
   const priorityLabel = priorityToLabel(node.priority);
   if (priorityLabel) labels.push(priorityLabel);
 
-  // Build body from description
-  const body = typeof node.description === 'string'
-    ? node.description
-    : node.description
-      ? JSON.stringify(node.description)
-      : '';
+  // Render the ProseMirror description to plain text for the issue body.
+  // (Used to JSON.stringify non-string descriptions — the root cause of
+  // garbage issue bodies from create_github_issue_from_node.)
+  const body = proseMirrorToPlainText(node.description);
 
   const issue = await githubFetch<GitHubIssue>(
     `/repos/${repoOwner}/${repoName}/issues`,
@@ -221,11 +220,8 @@ export async function updateGitHubIssue(
   const priorityLabel = priorityToLabel(node.priority);
   if (priorityLabel) labels.push(priorityLabel);
 
-  const body = typeof node.description === 'string'
-    ? node.description
-    : node.description
-      ? JSON.stringify(node.description)
-      : undefined;
+  const renderedBody = proseMirrorToPlainText(node.description);
+  const body = renderedBody || undefined;
 
   const patchBody: Record<string, unknown> = {
     title: node.text,

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -419,6 +419,9 @@ export function updateMap(
     hoursPerDay?: number;
     workerCount?: number;
     focusFactor?: number;
+    maxActiveClaims?: number;
+    dispatchGate?: string[];
+    dispatchPolicy?: string[];
     autoImportNewIssues?: boolean;
     phases?: PhaseDef[];
   },
@@ -1219,6 +1222,40 @@ export function readyNodes(
   }
   const qs = params.toString();
   return request<ReadyNodesResultApi>(`/api/maps/${mapId}/nodes/ready${qs ? `?${qs}` : ''}`);
+}
+
+/** Mirrors tool-kit's GetNextTicketResult (this file stays import-free). */
+export interface GetNextTicketResultApi {
+  granted: boolean;
+  reason?: 'hold' | 'cap' | 'empty';
+  active: number;
+  cap: number;
+  ticket?: {
+    id: string;
+    mapId: string;
+    text: string;
+    description: string;
+    priority: string | null;
+    priorityRank: number | null;
+    tags: string[];
+    scopes: string[];
+    versionId: string | null;
+    effortEstimate: number | null;
+    githubLinks: Array<{ externalId: string; url: string }>;
+    claimedAt: string | null;
+  };
+  skipped: Array<{ id: string; text: string; reason: 'needs-brief' }>;
+}
+
+export function getNextTicket(
+  mapId: string,
+  sessionId: string,
+  profile?: string,
+): Promise<GetNextTicketResultApi> {
+  return request<GetNextTicketResultApi>(
+    `/api/maps/${mapId}/pull-next`,
+    { method: 'POST', body: JSON.stringify({ sessionId, ...(profile ? { profile } : {}) }) },
+  );
 }
 
 export function claimNode(

--- a/packages/mcp/src/backend.ts
+++ b/packages/mcp/src/backend.ts
@@ -28,6 +28,7 @@ export const httpBackend: ToolBackend = {
   listNotInMindBlown: (mapId, filters) => api.listNotInMindBlown(mapId, filters),
   // ── Orchestration substrate (#111) ──────────────────────────────
   readyNodes: (mapId, opts) => api.readyNodes(mapId, opts),
+  getNextTicket: (mapId, sessionId, profile) => api.getNextTicket(mapId, sessionId, profile),
   claimNode: (mapId, nodeId, sessionId) => api.claimNode(mapId, nodeId, sessionId),
   releaseNode: (mapId, nodeId, sessionId) => api.releaseNode(mapId, nodeId, sessionId),
   conflictScan: (mapId, candidateNodeId?) => api.conflictScan(mapId, candidateNodeId),

--- a/packages/server/src/ai/backend.ts
+++ b/packages/server/src/ai/backend.ts
@@ -252,6 +252,7 @@ export function createChatBackend(userId: string): ToolBackend {
     // Delegates to packages/server/src/services/orchestration.ts so the
     // chat backend and the HTTP routes share one implementation.
     readyNodes: (mapId, opts) => orchestrationService.readyNodes(mapId, opts),
+    getNextTicket: (mapId, sessionId, profile?) => orchestrationService.getNextTicket(mapId, sessionId, profile),
     claimNode: (mapId, nodeId, sessionId) => orchestrationService.claimNode(mapId, nodeId, sessionId),
     releaseNode: (mapId, nodeId, sessionId) => orchestrationService.releaseNode(mapId, nodeId, sessionId),
     conflictScan: (mapId, candidateNodeId?) => orchestrationService.conflictScan(mapId, candidateNodeId),

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -90,6 +90,9 @@ export function dbMapToCore(row: Record<string, unknown>): MindMap {
     hoursPerDay: (get('hoursPerDay', 'hours_per_day') as number) ?? 8,
     workerCount: (get('workerCount', 'worker_count') as number) ?? 1,
     focusFactor: (get('focusFactor', 'focus_factor') as number) ?? 1,
+    maxActiveClaims: (get('maxActiveClaims', 'max_active_claims') as number) ?? 0,
+    dispatchGate: (get('dispatchGate', 'dispatch_gate') as string[]) ?? [],
+    dispatchPolicy: (get('dispatchPolicy', 'dispatch_policy') as string[]) ?? [],
     createdAt: (get('createdAt', 'created_at') instanceof Date
       ? (get('createdAt', 'created_at') as Date).toISOString()
       : (get('createdAt', 'created_at') as string)),

--- a/packages/server/src/db/maps.ts
+++ b/packages/server/src/db/maps.ts
@@ -124,6 +124,12 @@ export interface UpdateMapInput {
   hoursPerDay?: number;
   workerCount?: number;
   focusFactor?: number;
+  /** Pull-queue claim cap (int ≥ 0; 0 = hold). */
+  maxActiveClaims?: number;
+  /** Pull-queue AND-filter: `version:<id>` / `type:bug`. Empty = open. */
+  dispatchGate?: string[];
+  /** Pull-queue ranking keys (bugs|priority|size|age). Empty = default. */
+  dispatchPolicy?: string[];
   githubInstallationId?: string | null;
   githubRepoOwner?: string | null;
   githubRepoName?: string | null;
@@ -149,6 +155,9 @@ export async function updateMap(mapId: string, input: UpdateMapInput): Promise<M
   if (input.hoursPerDay !== undefined) updates.hoursPerDay = input.hoursPerDay;
   if (input.workerCount !== undefined) updates.workerCount = input.workerCount;
   if (input.focusFactor !== undefined) updates.focusFactor = clampFocusFactor(input.focusFactor);
+  if (input.maxActiveClaims !== undefined) updates.maxActiveClaims = Math.max(0, Math.floor(input.maxActiveClaims));
+  if (input.dispatchGate !== undefined) updates.dispatchGate = input.dispatchGate;
+  if (input.dispatchPolicy !== undefined) updates.dispatchPolicy = input.dispatchPolicy;
   if (input.githubInstallationId !== undefined) updates.githubInstallationId = input.githubInstallationId;
   if (input.githubRepoOwner !== undefined) updates.githubRepoOwner = input.githubRepoOwner;
   if (input.githubRepoName !== undefined) updates.githubRepoName = input.githubRepoName;

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -886,5 +886,20 @@ export async function runMigrations(): Promise<void> {
     ALTER TABLE release_snapshots ADD COLUMN IF NOT EXISTS remaining_tickets REAL
   `);
 
+  // ── Pull queue: Leidang dispatch knobs ─────────────────────────
+  // max_active_claims: fleet-wide claim cap for get_next_ticket; 0 = hold
+  // (grants nothing) so existing maps stay closed until they opt in.
+  // dispatch_gate: AND-filter (`version:<id>` / `type:bug`), empty = open.
+  // dispatch_policy: ordered ranking keys, empty = default bugs,priority,age.
+  await db.execute(sql`
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS max_active_claims INTEGER NOT NULL DEFAULT 0
+  `);
+  await db.execute(sql`
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS dispatch_gate JSONB NOT NULL DEFAULT '[]'
+  `);
+  await db.execute(sql`
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS dispatch_policy JSONB NOT NULL DEFAULT '[]'
+  `);
+
   console.log('[db] Migrations complete.');
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -138,6 +138,17 @@ export const maps = pgTable('maps', {
   // Discounts the velocity-adjusted completion forecast to absorb meetings /
   // support / firefighting / unplanned work. Default 1 = no leakage.
   focusFactor: real('focus_factor').notNull().default(1),
+
+  // ── Pull queue (Leidang) ────────────────────────────────────────
+  // Fleet-wide cap on concurrently claimed nodes for get_next_ticket.
+  // 0 = hold (grants nothing) — the safe default until a map opts in.
+  maxActiveClaims: integer('max_active_claims').notNull().default(0),
+  // AND-filter fencing the pull queue: `version:<id>` / `type:bug`.
+  // Empty array = no fence.
+  dispatchGate: jsonb('dispatch_gate').notNull().default([]), // string[]
+  // Ordered ranking keys for the gated ready set (bugs|priority|size|age).
+  // Empty array = default ["bugs","priority","age"].
+  dispatchPolicy: jsonb('dispatch_policy').notNull().default([]), // string[]
 });
 
 // ── Nodes ──────────────────────────────────────────────────────────

--- a/packages/server/src/routes/__tests__/pull-next-route.test.ts
+++ b/packages/server/src/routes/__tests__/pull-next-route.test.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /api/maps/:id/pull-next — route wiring for get_next_ticket.
+ *
+ * The decision logic is covered in services/__tests__/pull-queue.test.ts;
+ * this file pins the HTTP adapter: body validation, pass-through of
+ * sessionId/profile, and error translation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const mocks = vi.hoisted(() => ({
+  getNextTicket: vi.fn(),
+}));
+
+vi.mock('../../services/orchestration.js', () => {
+  class OrchestrationNotFoundError extends Error {}
+  class ClaimOwnershipError extends Error {}
+  return {
+    readyNodes: vi.fn(),
+    claimNode: vi.fn(),
+    releaseNode: vi.fn(),
+    conflictScan: vi.fn(),
+    getNextTicket: mocks.getNextTicket,
+    OrchestrationNotFoundError,
+    ClaimOwnershipError,
+  };
+});
+
+import { orchestrationRoutes } from '../orchestration.js';
+import { OrchestrationNotFoundError } from '../../services/orchestration.js';
+
+let app: FastifyInstance;
+
+beforeEach(async () => {
+  mocks.getNextTicket.mockReset();
+  app = Fastify();
+  await app.register(orchestrationRoutes);
+  await app.ready();
+});
+
+describe('POST /api/maps/:id/pull-next', () => {
+  it('400s without a sessionId', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/pull-next',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe('VALIDATION_ERROR');
+    expect(mocks.getNextTicket).not.toHaveBeenCalled();
+  });
+
+  it('forwards mapId, sessionId, and the dormant profile to the service', async () => {
+    const result = {
+      granted: true,
+      active: 1,
+      cap: 12,
+      ticket: { id: 'n1', text: 'Fix it' },
+      skipped: [],
+    };
+    mocks.getNextTicket.mockResolvedValue(result);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/pull-next',
+      payload: { sessionId: 'claudia:worker-3:acct1', profile: 'standard' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(result);
+    expect(mocks.getNextTicket).toHaveBeenCalledWith(
+      'map-1',
+      'claudia:worker-3:acct1',
+      'standard',
+    );
+  });
+
+  it('passes refusals through as 200s (a refusal is a normal answer)', async () => {
+    mocks.getNextTicket.mockResolvedValue({
+      granted: false,
+      reason: 'hold',
+      active: 0,
+      cap: 0,
+      skipped: [],
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-1/pull-next',
+      payload: { sessionId: 'w1' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().reason).toBe('hold');
+  });
+
+  it('404s when the service reports the map missing', async () => {
+    mocks.getNextTicket.mockRejectedValue(new OrchestrationNotFoundError('Map map-x not found'));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/maps/map-x/pull-next',
+      payload: { sessionId: 'w1' },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe('MAP_NOT_FOUND');
+  });
+});

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -17,6 +17,7 @@ import {
   claimNode,
   releaseNode,
   conflictScan,
+  getNextTicket,
   ClaimOwnershipError,
   OrchestrationNotFoundError,
 } from '../services/orchestration.js';
@@ -100,6 +101,30 @@ export async function orchestrationRoutes(app: FastifyInstance): Promise<void> {
 
       try {
         const result = await releaseNode(mapId, nodeId, body.sessionId);
+        return reply.status(200).send(result);
+      } catch (err) {
+        return handleOrchestrationError(err, reply);
+      }
+    },
+  );
+
+  // ── POST /api/maps/:id/pull-next — get_next_ticket ────────────
+  // Atomic pull for the Leidang fleet: cap gate → dispatch gate →
+  // policy sort → empty-brief guard → claim, all serialized per map.
+  app.post<{ Params: { id: string } }>(
+    '/api/maps/:id/pull-next',
+    async (req, reply) => {
+      const mapId = req.params.id;
+      const body = req.body as { sessionId?: string; profile?: string };
+
+      if (!body.sessionId || typeof body.sessionId !== 'string') {
+        return reply.status(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'sessionId is required' },
+        });
+      }
+
+      try {
+        const result = await getNextTicket(mapId, body.sessionId, body.profile);
         return reply.status(200).send(result);
       } catch (err) {
         return handleOrchestrationError(err, reply);

--- a/packages/server/src/services/__tests__/pull-queue.test.ts
+++ b/packages/server/src/services/__tests__/pull-queue.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Leidang pull queue — decision-core tests.
+ *
+ * `selectPullCandidates` is the pure heart of getNextTicket: cap gate →
+ * dispatchGate AND-filter → dispatchPolicy sort → empty-brief guard.
+ * The transactional shell (advisory lock + conditional claim) is thin
+ * and exercised through the route test; everything decision-shaped is
+ * pinned here against real @mindblown/core predicates.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Node as CoreNode, StatusDef } from '@mindblown/core';
+
+// The service module imports the DB substrate at module level; stub the
+// I/O edges but keep @mindblown/core and drizzle-orm real — the pure
+// functions under test lean on real isReady/buildTodoIds semantics.
+vi.mock('../../db/connection.js', () => ({ db: {} }));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+
+import {
+  selectPullCandidates,
+  matchesDispatchGate,
+  sortByDispatchPolicy,
+  hasBrief,
+  DEFAULT_DISPATCH_POLICY,
+} from '../orchestration.js';
+
+const WORKFLOW: StatusDef[] = [
+  { id: 'todo', name: 'Todo', category: 'todo', color: '#9ca3af', position: 0 },
+  { id: 'in_progress', name: 'In Progress', category: 'in_progress', color: '#3b82f6', position: 1 },
+  { id: 'done', name: 'Done', category: 'done', color: '#22c55e', position: 2 },
+];
+
+let seq = 0;
+function makeNode(overrides: Partial<CoreNode> & { id: string }): CoreNode {
+  seq += 1;
+  return {
+    mapId: 'map-1',
+    parentId: 'root',
+    childrenIds: [],
+    text: `Node ${overrides.id}`,
+    description: `Brief for ${overrides.id}`,
+    x: null,
+    y: null,
+    collapsed: false,
+    effortEstimate: null,
+    actualEffort: null,
+    percentComplete: null,
+    status: null,
+    blockedReason: null,
+    assigneeIds: [],
+    priority: null,
+    dueDate: null,
+    startDate: null,
+    tags: [],
+    customFields: {},
+    dependencies: [],
+    versionId: null,
+    cycleId: null,
+    externalLinks: [],
+    autoProgress: 'off',
+    priorityRank: null,
+    completedAt: null,
+    requirementId: null,
+    requirementPriority: null,
+    requirementText: null,
+    phaseId: null,
+    verificationText: null,
+    verificationUrl: null,
+    claimedBySession: null,
+    claimedAt: null,
+    scopes: [],
+    linkedPr: null,
+    createdAt: new Date(2026, 0, 1, 0, 0, seq).toISOString(),
+    updatedAt: new Date(2026, 0, 1, 0, 0, seq).toISOString(),
+    createdBy: 'test',
+    revision: 1,
+    deletedAt: null,
+    ...overrides,
+  } as CoreNode;
+}
+
+const root = makeNode({ id: 'root', parentId: null, description: null });
+
+function select(
+  nodes: CoreNode[],
+  opts: Partial<{ cap: number; gate: string[]; policy: string[] }> = {},
+) {
+  return selectPullCandidates([root, ...nodes], {
+    workflow: WORKFLOW,
+    cap: opts.cap ?? 10,
+    gate: opts.gate ?? [],
+    policy: opts.policy ?? [],
+  });
+}
+
+describe('cap gate', () => {
+  it('cap 0 = hold: grants nothing regardless of ready work', () => {
+    const d = select([makeNode({ id: 'a' })], { cap: 0 });
+    expect(d.reason).toBe('hold');
+    expect(d.ranked).toHaveLength(0);
+  });
+
+  it('refuses with reason cap when active claims reach the cap', () => {
+    const d = select(
+      [
+        makeNode({ id: 'a', claimedBySession: 'w1', claimedAt: new Date().toISOString() }),
+        makeNode({ id: 'b', claimedBySession: 'w2', claimedAt: new Date().toISOString() }),
+        makeNode({ id: 'c' }),
+      ],
+      { cap: 2 },
+    );
+    expect(d.reason).toBe('cap');
+    expect(d.active).toBe(2);
+    expect(d.cap).toBe(2);
+  });
+
+  it('grants below the cap', () => {
+    const d = select(
+      [makeNode({ id: 'a', claimedBySession: 'w1' }), makeNode({ id: 'b' })],
+      { cap: 2 },
+    );
+    expect(d.reason).toBeUndefined();
+    expect(d.ranked.map((n) => n.id)).toEqual(['b']);
+  });
+});
+
+describe('ready-set membership', () => {
+  it('excludes the root, claimed, non-todo, and dep-blocked nodes', () => {
+    const done = makeNode({ id: 'dep-done', status: 'done' });
+    const open = makeNode({ id: 'dep-open', status: 'in_progress' });
+    const d = select([
+      done,
+      open,
+      makeNode({ id: 'claimed', claimedBySession: 'w9' }),
+      makeNode({ id: 'in-flight', status: 'in_progress' }),
+      makeNode({
+        id: 'blocked',
+        dependencies: [{ targetNodeId: 'dep-open', type: 'FS', lag: 0 }],
+      }),
+      makeNode({
+        id: 'unblocked',
+        dependencies: [{ targetNodeId: 'dep-done', type: 'FS', lag: 0 }],
+      }),
+      makeNode({ id: 'plain' }),
+    ]);
+    expect(d.ranked.map((n) => n.id).sort()).toEqual(['plain', 'unblocked']);
+  });
+});
+
+describe('dispatchGate', () => {
+  it('version: matches own and ancestor-inherited versionIds', () => {
+    const epic = makeNode({ id: 'epic', versionId: 'v1' });
+    const inherited = makeNode({ id: 'inherited', parentId: 'epic' });
+    const explicit = makeNode({ id: 'explicit', versionId: 'v1' });
+    const other = makeNode({ id: 'other', versionId: 'v2' });
+    const unversioned = makeNode({ id: 'loose' });
+    const d = select([epic, inherited, explicit, other, unversioned], {
+      gate: ['version:v1'],
+    });
+    expect(d.ranked.map((n) => n.id).sort()).toEqual(['epic', 'explicit', 'inherited']);
+  });
+
+  it('type:bug + version:<id> AND together', () => {
+    const d = select(
+      [
+        makeNode({ id: 'v1-bug', versionId: 'v1', tags: ['bug'] }),
+        makeNode({ id: 'v1-feature', versionId: 'v1' }),
+        makeNode({ id: 'v2-bug', versionId: 'v2', tags: ['bug'] }),
+      ],
+      { gate: ['version:v1', 'type:bug'] },
+    );
+    expect(d.ranked.map((n) => n.id)).toEqual(['v1-bug']);
+  });
+
+  it('empty gate is no fence; unknown entries fail closed', () => {
+    const nodes = [makeNode({ id: 'a' })];
+    expect(select(nodes, { gate: [] }).ranked).toHaveLength(1);
+    expect(select(nodes, { gate: ['sprint:s1'] }).ranked).toHaveLength(0);
+  });
+
+  it('matchesDispatchGate exposes the same semantics directly', () => {
+    const bug = makeNode({ id: 'bug', tags: ['Bug'] }); // case-insensitive
+    const nodeMap = new Map([[bug.id, bug]]);
+    expect(matchesDispatchGate(bug, ['type:bug'], nodeMap)).toBe(true);
+    expect(matchesDispatchGate(bug, ['version:v1'], nodeMap)).toBe(false);
+  });
+});
+
+describe('dispatchPolicy', () => {
+  it('default policy is bugs → priority → age', () => {
+    const oldFeature = makeNode({ id: 'old-feature', createdAt: '2026-01-01T00:00:00Z' });
+    const p0Feature = makeNode({ id: 'p0-feature', priority: 'P0', createdAt: '2026-02-01T00:00:00Z' });
+    const bug = makeNode({ id: 'bug', tags: ['bug'], createdAt: '2026-03-01T00:00:00Z' });
+    const d = select([oldFeature, p0Feature, bug]);
+    expect(d.ranked.map((n) => n.id)).toEqual(['bug', 'p0-feature', 'old-feature']);
+    expect(DEFAULT_DISPATCH_POLICY).toEqual(['bugs', 'priority', 'age']);
+  });
+
+  it('priority key: priorityRank beats the P0–P3 enum, nulls last', () => {
+    const sorted = sortByDispatchPolicy(
+      [
+        makeNode({ id: 'p1', priority: 'P1' }),
+        makeNode({ id: 'ranked-9', priorityRank: 9, priority: 'P3' }),
+        makeNode({ id: 'ranked-2', priorityRank: 2 }),
+        makeNode({ id: 'none' }),
+      ],
+      ['priority'],
+    );
+    expect(sorted.map((n) => n.id)).toEqual(['ranked-2', 'ranked-9', 'p1', 'none']);
+  });
+
+  it('size key: smallest estimate first, unestimated last', () => {
+    const sorted = sortByDispatchPolicy(
+      [
+        makeNode({ id: 'big', effortEstimate: 8 }),
+        makeNode({ id: 'unsized' }),
+        makeNode({ id: 'small', effortEstimate: 0.5 }),
+      ],
+      ['size'],
+    );
+    expect(sorted.map((n) => n.id)).toEqual(['small', 'big', 'unsized']);
+  });
+
+  it('a custom policy order overrides the default', () => {
+    const bug = makeNode({ id: 'bug', tags: ['bug'], createdAt: '2026-03-01T00:00:00Z' });
+    const older = makeNode({ id: 'older', createdAt: '2026-01-01T00:00:00Z' });
+    const d = select([bug, older], { policy: ['age'] });
+    expect(d.ranked.map((n) => n.id)).toEqual(['older', 'bug']);
+  });
+});
+
+describe('empty-brief guard', () => {
+  it('splits brief-less ready nodes into skipped', () => {
+    const briefed = makeNode({ id: 'briefed' });
+    const bare = makeNode({ id: 'bare', description: null });
+    const linked = makeNode({
+      id: 'linked',
+      description: null,
+      externalLinks: [
+        {
+          provider: 'github',
+          externalId: 'o/r#1',
+          url: 'https://github.com/o/r/issues/1',
+          syncEnabled: true,
+          lastSyncedAt: null,
+          state: 'open',
+        },
+      ],
+    });
+    const d = select([briefed, bare, linked]);
+    expect(d.ranked.map((n) => n.id).sort()).toEqual(['briefed', 'linked']);
+    expect(d.skipped.map((n) => n.id)).toEqual(['bare']);
+  });
+
+  it('hasBrief treats whitespace-only ProseMirror docs as empty', () => {
+    const emptyDoc = makeNode({
+      id: 'x',
+      description: { type: 'doc', content: [{ type: 'paragraph', content: [] }] } as unknown as CoreNode['description'],
+    });
+    expect(hasBrief(emptyDoc)).toBe(false);
+    expect(hasBrief(makeNode({ id: 'y', description: 'real text' }))).toBe(true);
+  });
+});

--- a/packages/server/src/services/orchestration.ts
+++ b/packages/server/src/services/orchestration.ts
@@ -12,7 +12,7 @@
  * (HTTP status codes for the routes, propagated to the LLM for the chat).
  */
 
-import { eq, and } from 'drizzle-orm';
+import { eq, and, isNull, sql } from 'drizzle-orm';
 import { db } from '../db/connection.js';
 import { nodes, maps } from '../db/schema.js';
 import { dbNodeToCore } from '../db/helpers.js';
@@ -25,6 +25,7 @@ import {
   buildIsDonePredicate,
   buildInProgressIds,
   buildTodoIds,
+  proseMirrorToPlainText,
 } from '@mindblown/core';
 import type { Node as CoreNode, StatusDef, NodeMap } from '@mindblown/core';
 import type {
@@ -32,6 +33,8 @@ import type {
   ClaimNodeResult,
   ReleaseNodeResult,
   ConflictScanResult,
+  GetNextTicketResult,
+  TicketBrief,
 } from '@mindblown/tool-kit';
 
 // ── Errors ──────────────────────────────────────────────────────
@@ -96,17 +99,12 @@ export async function readyNodes(
     ? ready.filter((n) => scopeOverlap(n.scopes, scopeFilter).length > 0)
     : ready;
 
-  // Group by parent → sort each group by resolved sibling order → flatten.
-  const byParent = new Map<string | null, CoreNode[]>();
-  for (const n of filtered) {
-    const key = n.parentId;
-    if (!byParent.has(key)) byParent.set(key, []);
-    byParent.get(key)!.push(n);
-  }
-  const sorted: CoreNode[] = [];
-  for (const [, siblings] of byParent) {
-    sorted.push(...resolvedSiblingOrder(siblings));
-  }
+  // Global priorityRank ASC NULLS LAST → priority (P0–P3) → createdAt ASC,
+  // exactly what the ready_nodes tool description promises. (Used to group
+  // by parent and only order within sibling groups, which made the overall
+  // list order depend on Map-iteration order of the parents — doc/impl
+  // drift fixed alongside the Leidang pull queue.)
+  const sorted = resolvedSiblingOrder(filtered);
 
   const page = sorted.slice(0, limit);
   return {
@@ -244,6 +242,308 @@ export async function releaseNode(
     node: { id: updatedNode.id, text: updatedNode.text },
     released: true,
   };
+}
+
+// ── getNextTicket (Leidang pull queue) ──────────────────────────
+
+export const DEFAULT_DISPATCH_POLICY = ['bugs', 'priority', 'age'];
+
+/** Tag auto-applied to ready nodes the pull queue refuses to hand out. */
+export const NEEDS_BRIEF_TAG = 'needs-brief';
+
+/**
+ * Effective version of a node: its own versionId, or the nearest
+ * ancestor's (explicit-assignment-wins walk — same semantics as the
+ * search_nodes versionId filter and the lint engine).
+ */
+function effectiveVersionId(node: CoreNode, nodeMap: NodeMap): string | null {
+  const seen = new Set<string>();
+  let cur: CoreNode | undefined = node;
+  while (cur) {
+    if (cur.versionId != null) return cur.versionId;
+    if (cur.parentId === null || seen.has(cur.parentId)) return null;
+    seen.add(cur.parentId);
+    cur = nodeMap.get(cur.parentId);
+  }
+  return null;
+}
+
+/** Bug detection for gate/policy purposes: node carries the "bug" tag
+ *  (node.tags mirrors GitHub labels, so a GH `bug` label counts). */
+function isBugNode(node: CoreNode): boolean {
+  return node.tags.some((t) => t.toLowerCase() === 'bug');
+}
+
+/**
+ * AND-filter over the map's dispatchGate. Vocabulary is deliberately
+ * tiny: `version:<versionId>` and `type:bug`. Empty gate = no fence.
+ * Unknown entries match NOTHING (fail-closed): a typo in the gate
+ * empties the queue loudly instead of silently opening the fence.
+ */
+export function matchesDispatchGate(
+  node: CoreNode,
+  gate: string[],
+  nodeMap: NodeMap,
+): boolean {
+  return gate.every((entry) => {
+    if (entry === 'type:bug') return isBugNode(node);
+    if (entry.startsWith('version:')) {
+      return effectiveVersionId(node, nodeMap) === entry.slice('version:'.length);
+    }
+    return false;
+  });
+}
+
+const PRIORITY_ORDER: Record<string, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
+
+/**
+ * Sort the gated ready set by the map's dispatchPolicy — an ordered list
+ * of sort keys, compared left to right: `bugs` (bug-tagged first),
+ * `priority` (priorityRank ASC NULLS LAST, then P0–P3), `size` (effort
+ * estimate ascending, nulls last), `age` (oldest createdAt first).
+ * Ties after all keys fall back to createdAt, then id (stable output).
+ */
+export function sortByDispatchPolicy(candidates: CoreNode[], policy: string[]): CoreNode[] {
+  const compareBy = (key: string, a: CoreNode, b: CoreNode): number => {
+    switch (key) {
+      case 'bugs':
+        return Number(isBugNode(b)) - Number(isBugNode(a));
+      case 'priority': {
+        const ra = a.priorityRank;
+        const rb = b.priorityRank;
+        if (ra !== null || rb !== null) {
+          if (ra === null) return 1;
+          if (rb === null) return -1;
+          if (ra !== rb) return ra - rb;
+        }
+        const pa = a.priority !== null ? (PRIORITY_ORDER[a.priority] ?? 4) : 4;
+        const pb = b.priority !== null ? (PRIORITY_ORDER[b.priority] ?? 4) : 4;
+        return pa - pb;
+      }
+      case 'size': {
+        const ea = a.effortEstimate;
+        const eb = b.effortEstimate;
+        if (ea === null && eb === null) return 0;
+        if (ea === null) return 1;
+        if (eb === null) return -1;
+        return ea - eb;
+      }
+      case 'age':
+        return a.createdAt.localeCompare(b.createdAt);
+      default:
+        return 0; // unknown keys are inert — validated at the tool layer
+    }
+  };
+  return [...candidates].sort((a, b) => {
+    for (const key of policy) {
+      const cmp = compareBy(key, a, b);
+      if (cmp !== 0) return cmp;
+    }
+    const byAge = a.createdAt.localeCompare(b.createdAt);
+    if (byAge !== 0) return byAge;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/**
+ * Empty-brief guard: a ticket is dispatchable only if the worker gets a
+ * self-contained brief — a non-empty description, or a linked GitHub
+ * issue it can read (inbound sync copies issue bodies into the
+ * description, so a linked node normally carries the text locally too).
+ */
+export function hasBrief(node: CoreNode): boolean {
+  if (proseMirrorToPlainText(node.description).trim() !== '') return true;
+  return node.externalLinks.some((l) => l.provider === 'github');
+}
+
+interface PullDecision {
+  active: number;
+  cap: number;
+  reason?: 'hold' | 'cap';
+  /** Ranked, gated, dispatchable candidates in claim-attempt order. */
+  ranked: CoreNode[];
+  /** Ready-but-empty-brief nodes to tag `needs-brief` and report. */
+  skipped: CoreNode[];
+}
+
+/**
+ * Pure decision core of getNextTicket: cap gate → dispatch gate →
+ * policy sort → empty-brief guard. No I/O; the transactional shell
+ * applies the claim. Exported for direct unit testing.
+ */
+export function selectPullCandidates(
+  allNodes: CoreNode[],
+  opts: { workflow: StatusDef[]; cap: number; gate: string[]; policy: string[] },
+): PullDecision {
+  const active = allNodes.filter((n) => n.claimedBySession !== null).length;
+  const cap = Math.max(0, Math.floor(opts.cap));
+  if (cap === 0) return { active, cap, reason: 'hold', ranked: [], skipped: [] };
+  if (active >= cap) return { active, cap, reason: 'cap', ranked: [], skipped: [] };
+
+  const isDone = buildIsDonePredicate(opts.workflow);
+  const todoIds = buildTodoIds(opts.workflow);
+  const nodeMap: NodeMap = new Map(allNodes.map((n) => [n.id, n]));
+
+  const ready = allNodes.filter(
+    (n) =>
+      n.parentId !== null && // the root is not a ticket
+      (n.status === null || todoIds.has(n.status)) &&
+      n.claimedBySession === null &&
+      isReady(n, nodeMap, isDone),
+  );
+  const gated = ready.filter((n) => matchesDispatchGate(n, opts.gate, nodeMap));
+  const policy = opts.policy.length > 0 ? opts.policy : DEFAULT_DISPATCH_POLICY;
+  const rankedAll = sortByDispatchPolicy(gated, policy);
+
+  return {
+    active,
+    cap,
+    ranked: rankedAll.filter(hasBrief),
+    skipped: rankedAll.filter((n) => !hasBrief(n)),
+  };
+}
+
+/**
+ * Atomic pull: hand the calling session the next ticket per the map's
+ * cap / gate / policy, claiming it in the same transaction.
+ *
+ * The whole read-decide-claim sequence is serialized per map with
+ * `pg_advisory_xact_lock(hashtext(mapId))` — traffic is a few pulls per
+ * minute, so the lock is free and structurally kills every
+ * count-then-claim race between concurrent pulls. `claim_node` bypasses
+ * this lock (row-level FOR UPDATE only), so the claim itself is still a
+ * conditional UPDATE … WHERE claimed_by_session IS NULL: unlike
+ * claim_node's deliberate transfer semantics (orchestrator reclaims),
+ * the pull path NEVER steals a claim — if a candidate got claimed in
+ * between, we move on to the next one.
+ *
+ * `profile` is reserved-but-dormant in v1: accepted, ignored.
+ */
+export async function getNextTicket(
+  mapId: string,
+  sessionId: string,
+  _profile?: string,
+): Promise<GetNextTicketResult> {
+  const now = new Date();
+
+  const { result, taggedNodes, winnerNode } = await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${mapId}))`);
+
+    const [mapRow] = await tx.select().from(maps).where(eq(maps.id, mapId));
+    if (!mapRow) throw new OrchestrationNotFoundError(`Map ${mapId} not found`);
+
+    const allRows = await tx
+      .select()
+      .from(nodes)
+      .where(and(eq(nodes.mapId, mapId), notDeleted));
+    const allNodes = allRows.map((r) => dbNodeToCore(r as unknown as Record<string, unknown>));
+    const nodeMap: NodeMap = new Map(allNodes.map((n) => [n.id, n]));
+
+    const decision = selectPullCandidates(allNodes, {
+      workflow: ((mapRow.statusWorkflow as StatusDef[]) ?? []),
+      cap: (mapRow.maxActiveClaims as number) ?? 0,
+      gate: ((mapRow.dispatchGate as string[]) ?? []),
+      policy: ((mapRow.dispatchPolicy as string[]) ?? []),
+    });
+
+    // Tag empty-brief nodes `needs-brief` so the queue starves loudly.
+    // Only write when the tag is new — repeat pulls stay read-only.
+    const tagged: CoreNode[] = [];
+    for (const n of decision.skipped) {
+      if (n.tags.includes(NEEDS_BRIEF_TAG)) continue;
+      const [row] = await tx
+        .update(nodes)
+        .set({ tags: [...n.tags, NEEDS_BRIEF_TAG], updatedAt: now })
+        .where(and(eq(nodes.id, n.id), notDeleted))
+        .returning();
+      if (row) tagged.push(dbNodeToCore(row as unknown as Record<string, unknown>));
+    }
+
+    const skipped = decision.skipped.map((n) => ({
+      id: n.id,
+      text: n.text,
+      reason: 'needs-brief' as const,
+    }));
+
+    if (decision.reason !== undefined) {
+      return {
+        result: {
+          granted: false as const,
+          reason: decision.reason,
+          active: decision.active,
+          cap: decision.cap,
+          skipped,
+        },
+        taggedNodes: tagged,
+        winnerNode: null,
+      };
+    }
+
+    for (const candidate of decision.ranked) {
+      const [row] = await tx
+        .update(nodes)
+        .set({ claimedBySession: sessionId, claimedAt: now, updatedAt: now })
+        .where(and(eq(nodes.id, candidate.id), notDeleted, isNull(nodes.claimedBySession)))
+        .returning();
+      if (!row) continue; // claimed out from under us via claim_node — next
+
+      const winner = dbNodeToCore(row as unknown as Record<string, unknown>);
+      const ticket: TicketBrief = {
+        id: winner.id,
+        mapId,
+        text: winner.text,
+        description: proseMirrorToPlainText(winner.description),
+        priority: winner.priority,
+        priorityRank: winner.priorityRank,
+        tags: winner.tags,
+        scopes: winner.scopes,
+        versionId: effectiveVersionId(winner, nodeMap),
+        effortEstimate: winner.effortEstimate,
+        githubLinks: winner.externalLinks
+          .filter((l) => l.provider === 'github')
+          .map((l) => ({ externalId: l.externalId, url: l.url })),
+        claimedAt: winner.claimedAt,
+      };
+      return {
+        result: {
+          granted: true as const,
+          active: decision.active + 1,
+          cap: decision.cap,
+          ticket,
+          skipped,
+        },
+        taggedNodes: tagged,
+        winnerNode: winner,
+      };
+    }
+
+    return {
+      result: {
+        granted: false as const,
+        reason: 'empty' as const,
+        active: decision.active,
+        cap: decision.cap,
+        skipped,
+      },
+      taggedNodes: tagged,
+      winnerNode: null,
+    };
+  });
+
+  // Broadcasts after commit, mirroring claimNode.
+  for (const n of taggedNodes) {
+    broadcast(mapId, { type: 'node:updated', nodeId: n.id, fields: ['tags'], node: n });
+  }
+  if (winnerNode) {
+    broadcast(mapId, {
+      type: 'node:updated',
+      nodeId: winnerNode.id,
+      fields: ['claimedBySession', 'claimedAt'],
+      node: winnerNode,
+    });
+  }
+
+  return result;
 }
 
 // ── conflictScan ────────────────────────────────────────────────

--- a/packages/server/src/sync/mapContext.ts
+++ b/packages/server/src/sync/mapContext.ts
@@ -90,43 +90,11 @@ export function _clearMapContextCacheForTests(): void {
 
 // ── ProseMirror description → plain text ──────────────────────────
 
-/**
- * Map node descriptions are stored as ProseMirror JSON (rich text), but
- * the triage prompt only needs plain text. Walk the doc and concatenate
- * every leaf `text` node, joining paragraphs with a single newline so
- * Claude sees something readable without HTML/JSON noise.
- *
- * Strings pass through unchanged so we tolerate legacy nodes whose
- * description was saved as a raw string before the ProseMirror migration.
- * Returns empty string for null/undefined/unknown shapes.
- */
-export function proseMirrorToPlainText(description: unknown): string {
-  if (description == null) return '';
-  if (typeof description === 'string') return description;
-  if (typeof description !== 'object') return '';
-
-  const lines: string[] = [];
-  const walk = (node: unknown): void => {
-    if (!node || typeof node !== 'object') return;
-    const obj = node as { type?: string; text?: unknown; content?: unknown };
-    if (obj.type === 'text' && typeof obj.text === 'string') {
-      lines.push(obj.text);
-      return;
-    }
-    if (Array.isArray(obj.content)) {
-      const before = lines.length;
-      for (const child of obj.content) walk(child);
-      // Treat block-level nodes as paragraph breaks. We don't try to
-      // recreate exact formatting; the triage prompt only needs the gist.
-      const isBlock = obj.type !== undefined && obj.type !== 'text' && obj.type !== 'doc';
-      if (isBlock && lines.length > before) {
-        lines.push('\n');
-      }
-    }
-  };
-  walk(description);
-  return lines.join('').replace(/\n{3,}/g, '\n\n').trim();
-}
+// Moved to @mindblown/core (richtext.ts) so packages/integrations can
+// render issue bodies with the same walk. Re-exported here for the
+// existing server-side import sites.
+import { proseMirrorToPlainText } from '@mindblown/core';
+export { proseMirrorToPlainText };
 
 // ── Builder ───────────────────────────────────────────────────────
 

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -177,6 +177,52 @@ export interface DuplicateLinkGroup {
   }>;
 }
 
+// ── Pull queue: get_next_ticket (Leidang) ──────────────────────────
+
+/**
+ * Self-contained work brief handed to a pulling session. The receiving
+ * worker has a fresh context and no memory — everything it needs to
+ * start must be in here (or one hop away via the GitHub links).
+ */
+export interface TicketBrief {
+  id: string;
+  mapId: string;
+  text: string;
+  /** Description rendered to plain text (ProseMirror walked). */
+  description: string;
+  priority: string | null;
+  priorityRank: number | null;
+  tags: string[];
+  scopes: string[];
+  /** Effective version (own or ancestor-inherited). */
+  versionId: string | null;
+  effortEstimate: number | null;
+  githubLinks: Array<{ externalId: string; url: string }>;
+  claimedAt: string | null;
+}
+
+export interface SkippedTicket {
+  id: string;
+  text: string;
+  reason: 'needs-brief';
+}
+
+export interface GetNextTicketResult {
+  granted: boolean;
+  /**
+   * Set when granted is false: `hold` = cap is 0 (fleet hold), `cap` =
+   * active claims have reached the cap, `empty` = nothing dispatchable
+   * inside the gate.
+   */
+  reason?: 'hold' | 'cap' | 'empty';
+  /** Currently claimed node count (incl. the fresh claim when granted). */
+  active: number;
+  cap: number;
+  ticket?: TicketBrief;
+  /** Ready nodes refused for having no brief (auto-tagged needs-brief). */
+  skipped: SkippedTicket[];
+}
+
 export interface ConflictScanResult {
   /** null in map-wide mode (no candidate given). */
   candidateId: string | null;
@@ -204,6 +250,9 @@ export interface ToolBackend {
       hoursPerDay?: number;
       workerCount?: number;
       focusFactor?: number;
+      maxActiveClaims?: number;
+      dispatchGate?: string[];
+      dispatchPolicy?: string[];
       autoImportNewIssues?: boolean;
       phases?: PhaseDef[];
     },
@@ -276,6 +325,7 @@ export interface ToolBackend {
     opts?: { limit?: number; scopeFilter?: string[] },
   ): Promise<ReadyNodesResult>;
   claimNode(mapId: string, nodeId: string, sessionId: string): Promise<ClaimNodeResult>;
+  getNextTicket(mapId: string, sessionId: string, profile?: string): Promise<GetNextTicketResult>;
   releaseNode(mapId: string, nodeId: string, sessionId: string): Promise<ReleaseNodeResult>;
   conflictScan(mapId: string, candidateNodeId?: string): Promise<ConflictScanResult>;
 }

--- a/packages/tool-kit/src/index.ts
+++ b/packages/tool-kit/src/index.ts
@@ -12,6 +12,10 @@ export type {
   ReleaseNodeResult,
   ConflictEntry,
   ConflictScanResult,
+  // Pull queue (Leidang)
+  TicketBrief,
+  SkippedTicket,
+  GetNextTicketResult,
 } from './backend.js';
 export type { ToolSpec } from './spec.js';
 export { defineTool } from './spec.js';

--- a/packages/tool-kit/src/tools/__tests__/get-next-ticket.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/get-next-ticket.test.ts
@@ -1,0 +1,99 @@
+/**
+ * get_next_ticket — MCP surface tests (Leidang pull queue).
+ *
+ * Pins the zod schema (sessionId required, profile optional/dormant)
+ * and the handler's rendering of grants, refusals, and needs-brief
+ * skips, so pull-fleet workers see the full self-contained brief.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { getNextTicketTool } from '../orchestration.js';
+import type { ToolBackend, GetNextTicketResult } from '../../backend.js';
+
+function makeBackend(result: GetNextTicketResult): {
+  backend: ToolBackend;
+  calls: Array<{ mapId: string; sessionId: string; profile?: string }>;
+} {
+  const calls: Array<{ mapId: string; sessionId: string; profile?: string }> = [];
+  const backend = {
+    getNextTicket: async (mapId: string, sessionId: string, profile?: string) => {
+      calls.push({ mapId, sessionId, profile });
+      return result;
+    },
+  } as unknown as ToolBackend;
+  return { backend, calls };
+}
+
+describe('get_next_ticket schema', () => {
+  const schema = z.object(getNextTicketTool.schema);
+
+  it('requires mapId and sessionId; profile is optional', () => {
+    expect(() => schema.parse({ mapId: 'm1' })).toThrow();
+    expect(schema.parse({ mapId: 'm1', sessionId: 'w1' }).profile).toBeUndefined();
+    expect(schema.parse({ mapId: 'm1', sessionId: 'w1', profile: 'heavy' }).profile).toBe('heavy');
+  });
+});
+
+describe('get_next_ticket handler', () => {
+  it('renders the full brief on a grant and forwards all args', async () => {
+    const { backend, calls } = makeBackend({
+      granted: true,
+      active: 3,
+      cap: 12,
+      ticket: {
+        id: 'n1',
+        mapId: 'm1',
+        text: 'Fix the flaky retry',
+        description: 'Steps:\n1. reproduce\n2. fix',
+        priority: 'P1',
+        priorityRank: 4,
+        tags: ['bug'],
+        scopes: ['packages/server'],
+        versionId: 'v-mvp',
+        effortEstimate: 2,
+        githubLinks: [{ externalId: 'o/r#7', url: 'https://github.com/o/r/issues/7' }],
+        claimedAt: '2026-07-25T10:00:00Z',
+      },
+      skipped: [],
+    });
+    const out = await getNextTicketTool.handler(backend, {
+      mapId: 'm1',
+      sessionId: 'claudia:worker-1:acct1',
+      profile: 'standard',
+    } as never);
+    expect(calls).toEqual([
+      { mapId: 'm1', sessionId: 'claudia:worker-1:acct1', profile: 'standard' },
+    ]);
+    expect(out).toContain('n1');
+    expect(out).toContain('Fix the flaky retry');
+    expect(out).toContain('Steps:');
+    expect(out).toContain('o/r#7');
+    expect(out).toContain('3/12');
+  });
+
+  it('explains hold / cap / empty refusals', async () => {
+    const hold = makeBackend({ granted: false, reason: 'hold', active: 0, cap: 0, skipped: [] });
+    expect(await getNextTicketTool.handler(hold.backend, { mapId: 'm1', sessionId: 'w1' } as never)).toContain('hold');
+
+    const cap = makeBackend({ granted: false, reason: 'cap', active: 12, cap: 12, skipped: [] });
+    expect(await getNextTicketTool.handler(cap.backend, { mapId: 'm1', sessionId: 'w1' } as never)).toContain('12/12');
+
+    const empty = makeBackend({ granted: false, reason: 'empty', active: 1, cap: 12, skipped: [] });
+    expect(await getNextTicketTool.handler(empty.backend, { mapId: 'm1', sessionId: 'w1' } as never)).toContain('No ticket granted');
+  });
+
+  it('lists needs-brief skips so the queue starves loudly', async () => {
+    const { backend } = makeBackend({
+      granted: false,
+      reason: 'empty',
+      active: 0,
+      cap: 12,
+      skipped: [{ id: 'n9', text: 'mystery node', reason: 'needs-brief' }],
+    });
+    const out = await getNextTicketTool.handler(backend, { mapId: 'm1', sessionId: 'w1' } as never);
+    expect(out).toContain('needs-brief');
+    expect(out).toContain('n9');
+    expect(out).toContain('mystery node');
+  });
+});

--- a/packages/tool-kit/src/tools/__tests__/map.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/map.test.ts
@@ -57,6 +57,43 @@ describe('update_map tool — focusFactor', () => {
   });
 });
 
+// Leidang pull-queue knobs — update_map is the orchestrator's one-write
+// control surface for the get_next_ticket queue (cap, fence, ranking).
+describe('update_map tool — dispatch knobs', () => {
+  const schema = z.object(updateMapTool.schema);
+
+  it('accepts the three knobs and forwards them', async () => {
+    const parsed = schema.parse({
+      mapId: 'm1',
+      maxActiveClaims: 12,
+      dispatchGate: ['version:v-mvp', 'type:bug'],
+      dispatchPolicy: ['bugs', 'size', 'priority', 'age'],
+    });
+    expect(parsed.maxActiveClaims).toBe(12);
+
+    const recorder = makeRecordingBackend();
+    await updateMapTool.handler(recorder.backend, {
+      mapId: 'm1',
+      maxActiveClaims: 0,
+      dispatchGate: [],
+      dispatchPolicy: [],
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({
+      maxActiveClaims: 0,
+      dispatchGate: [],
+      dispatchPolicy: [],
+    });
+  });
+
+  it('rejects negative/fractional caps, off-vocabulary gates, unknown policy keys', () => {
+    expect(() => schema.parse({ mapId: 'm1', maxActiveClaims: -1 })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', maxActiveClaims: 2.5 })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', dispatchGate: ['sprint:s1'] })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', dispatchGate: ['version:'] })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', dispatchPolicy: ['chaos'] })).toThrow();
+  });
+});
+
 // Phase column — update_map is the write surface for the map's PhaseDef
 // list (add / rename / reorder in REPLACE mode). The handler normalizes:
 // missing ids are generated, missing positions default to the array index.

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -86,6 +86,7 @@ function makeRecordingBackend(): {
     listNotInMindBlown: async () => { throw new Error('not implemented'); },
     // Orchestration substrate (#111)
     readyNodes: async () => { throw new Error('not implemented'); },
+    getNextTicket: async () => { throw new Error('not implemented'); },
     claimNode: async () => { throw new Error('not implemented'); },
     releaseNode: async () => { throw new Error('not implemented'); },
     conflictScan: async () => { throw new Error('not implemented'); },

--- a/packages/tool-kit/src/tools/__tests__/triage.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/triage.test.ts
@@ -128,6 +128,7 @@ function makeRecorder(): Recorder {
     },
     // Orchestration substrate (#111)
     readyNodes: async () => { throw new Error('not used'); },
+    getNextTicket: async () => { throw new Error('not used'); },
     claimNode: async () => { throw new Error('not used'); },
     releaseNode: async () => { throw new Error('not used'); },
     conflictScan: async () => { throw new Error('not used'); },

--- a/packages/tool-kit/src/tools/map.ts
+++ b/packages/tool-kit/src/tools/map.ts
@@ -67,7 +67,7 @@ export const createMapTool = defineTool({
 export const updateMapTool = defineTool({
   name: 'update_map',
   description:
-    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, focus factor, phases, or GitHub auto-import setting. phases is the map's project-phase definition list ({id, name, position} — statusWorkflow idiom); pass the COMPLETE new array to add, rename, or reorder phases. Keep existing ids stable when renaming/reordering — nodes reference phases by id (node.phaseId), so a changed id orphans them. Omit id on a NEW entry and one is generated. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). focusFactor (0.05–1.0, default 1) is the fraction of calendar time that actually reaches planned-ticket work — set it below 1 to stretch the velocity-adjusted completion forecast for meetings/support/firefighting/unplanned work (e.g. 0.5 = half of each day reaches planned work, so forecasts take twice as long). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. Pass nullable fields as null to clear.",
+    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, focus factor, phases, or GitHub auto-import setting. phases is the map's project-phase definition list ({id, name, position} — statusWorkflow idiom); pass the COMPLETE new array to add, rename, or reorder phases. Keep existing ids stable when renaming/reordering — nodes reference phases by id (node.phaseId), so a changed id orphans them. Omit id on a NEW entry and one is generated. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). focusFactor (0.05–1.0, default 1) is the fraction of calendar time that actually reaches planned-ticket work — set it below 1 to stretch the velocity-adjusted completion forecast for meetings/support/firefighting/unplanned work (e.g. 0.5 = half of each day reaches planned work, so forecasts take twice as long). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. maxActiveClaims / dispatchGate / dispatchPolicy configure the get_next_ticket pull queue: maxActiveClaims caps concurrently claimed nodes fleet-wide (0 = hold, grants nothing — the default); dispatchGate is an AND-filter fencing what the queue hands out (entries \"version:<versionId>\" or \"type:bug\"; empty = no fence; a ticket outside the gate is invisible, not deprioritized); dispatchPolicy is the ordered ranking of the gated ready set (keys bugs/priority/size/age; empty = default [\"bugs\",\"priority\",\"age\"]). Pass nullable fields as null to clear.",
   schema: {
     mapId: z.string().describe('The map ID'),
     name: z.string().optional().describe('New map name'),
@@ -95,6 +95,20 @@ export const updateMapTool = defineTool({
       .max(1)
       .optional()
       .describe('Fraction of calendar time reaching planned-ticket work (0.05–1.0, default 1). Below 1 stretches the velocity-adjusted completion forecast to absorb meetings/support/unplanned work (0.5 = half of each day reaches planned work).'),
+    maxActiveClaims: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Fleet-wide cap on concurrently claimed nodes for the get_next_ticket pull queue. 0 = hold: the queue grants nothing and in-flight work drains naturally (default 0).'),
+    dispatchGate: z
+      .array(z.string().regex(/^(version:.+|type:bug)$/, 'gate entries must be "version:<versionId>" or "type:bug"'))
+      .optional()
+      .describe('Pull-queue AND-filter (REPLACE mode — the full new array). Entries: "version:<versionId>" (effective version, ancestor-inherited) and "type:bug" (node tagged "bug"). Empty array = no fence. Tickets outside the gate are invisible to get_next_ticket.'),
+    dispatchPolicy: z
+      .array(z.enum(['bugs', 'priority', 'size', 'age']))
+      .optional()
+      .describe('Pull-queue ranking keys in order (REPLACE mode): bugs = bug-tagged first, priority = priorityRank then P0–P3, size = smallest estimate first (nulls last), age = oldest first. Empty array = default ["bugs","priority","age"].'),
     autoImportNewIssues: z
       .boolean()
       .optional()
@@ -124,7 +138,7 @@ export const updateMapTool = defineTool({
         'Project phase definitions (REPLACE mode — the full new array). Send the complete list to add, rename, or reorder; keep ids of existing phases stable so node.phaseId references stay valid.',
       ),
   },
-  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, focusFactor, autoImportNewIssues, phases }) => {
+  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, focusFactor, maxActiveClaims, dispatchGate, dispatchPolicy, autoImportNewIssues, phases }) => {
     const fields: {
       name?: string;
       description?: string | null;
@@ -133,6 +147,9 @@ export const updateMapTool = defineTool({
       hoursPerDay?: number;
       workerCount?: number;
       focusFactor?: number;
+      maxActiveClaims?: number;
+      dispatchGate?: string[];
+      dispatchPolicy?: string[];
       autoImportNewIssues?: boolean;
       phases?: Array<{ id: string; name: string; position: number; color?: string; targetDate?: string | null }>;
     } = {};
@@ -143,6 +160,9 @@ export const updateMapTool = defineTool({
     if (hoursPerDay !== undefined) fields.hoursPerDay = hoursPerDay;
     if (workerCount !== undefined) fields.workerCount = workerCount;
     if (focusFactor !== undefined) fields.focusFactor = focusFactor;
+    if (maxActiveClaims !== undefined) fields.maxActiveClaims = maxActiveClaims;
+    if (dispatchGate !== undefined) fields.dispatchGate = dispatchGate;
+    if (dispatchPolicy !== undefined) fields.dispatchPolicy = dispatchPolicy;
     if (autoImportNewIssues !== undefined) fields.autoImportNewIssues = autoImportNewIssues;
     if (phases !== undefined) {
       // Normalize: generate ids for new entries, default position to the

--- a/packages/tool-kit/src/tools/orchestration.ts
+++ b/packages/tool-kit/src/tools/orchestration.ts
@@ -1,11 +1,12 @@
 /**
  * Orchestration substrate MCP tools (#111).
  *
- * Implements the 4 new tools that turn MindBlown into a work-queue +
+ * Implements the tools that turn MindBlown into a work-queue +
  * soft-conflict detector for parallel Claude coding sessions:
  *
  *   ready_nodes     — list nodes ready to be claimed + dispatched
- *   claim_node      — claim a node for a session
+ *   get_next_ticket — atomic pull: pick + claim the next ticket (Leidang)
+ *   claim_node      — claim a node for a session (orchestrator/manual)
  *   release_node    — release a claim (rejects if caller doesn't own it)
  *   conflict_scan   — detect in-flight nodes that share scopes with a candidate
  */
@@ -64,6 +65,80 @@ export const readyNodesTool = defineTool({
   },
 });
 
+export const getNextTicketTool = defineTool({
+  name: 'get_next_ticket',
+  description: [
+    'Pull the next ticket from a map\'s work queue — the one call a worker needs.',
+    'Atomically picks the best ready node per the map\'s dispatch settings and',
+    'claims it for your session, all serialized per map (no pull races).',
+    '',
+    'Selection pipeline (configured via update_map):',
+    '  1. Cap gate: if the map\'s active claims >= maxActiveClaims, the pull is',
+    '     refused with reason "cap" (reason "hold" when the cap is 0 — the fleet hold).',
+    '  2. dispatchGate AND-filter fences the ready set ("version:<id>", "type:bug";',
+    '     empty = no fence). Tickets outside the gate are invisible, not deprioritized.',
+    '  3. dispatchPolicy orders what\'s left (default ["bugs","priority","age"]).',
+    '  4. Empty-brief guard: ready nodes with no description and no linked GitHub',
+    '     issue are refused, auto-tagged "needs-brief", and listed in skipped[].',
+    '',
+    'On success you get the full self-contained brief: title, plain-text',
+    'description, priority, scopes, tags, effective version, GitHub links.',
+    'Finish with set_status("done") (auto-releases the claim) or release_node',
+    'to hand the ticket back. Unlike claim_node, a pull NEVER steals an',
+    'existing claim.',
+    '',
+    'reason values when granted=false: "hold" (cap 0), "cap" (at capacity),',
+    '"empty" (nothing dispatchable inside the gate — if skipped[] is non-empty,',
+    'the queue has work that needs briefs written first).',
+  ].join('\n'),
+  schema: {
+    mapId: z.string().describe('The map ID to pull from'),
+    sessionId: z
+      .string()
+      .describe('Session identifier of the pulling worker (e.g. "claudia:worker-3:acct1"). Opaque to MindBlown; used as the claim owner.'),
+    profile: z
+      .string()
+      .optional()
+      .describe('Worker profile label (e.g. "standard", "heavy"). Reserved for future eligibility routing — accepted and ignored in v1.'),
+  },
+  handler: async (backend, { mapId, sessionId, profile }) => {
+    const result = await backend.getNextTicket(mapId, sessionId, profile);
+
+    const lines: string[] = [];
+    if (result.granted && result.ticket) {
+      const t = result.ticket;
+      lines.push(`Ticket granted to session "${sessionId}" (${result.active}/${result.cap} claims active):`);
+      lines.push('');
+      lines.push(`  id: ${t.id}`);
+      lines.push(`  title: ${t.text}`);
+      if (t.priority || t.priorityRank !== null) {
+        lines.push(`  priority: ${t.priority ?? '—'}${t.priorityRank !== null ? ` (rank ${t.priorityRank})` : ''}`);
+      }
+      if (t.effortEstimate !== null) lines.push(`  estimate: ${t.effortEstimate}`);
+      if (t.versionId) lines.push(`  version: ${t.versionId}`);
+      if (t.tags.length > 0) lines.push(`  tags: [${t.tags.join(', ')}]`);
+      if (t.scopes.length > 0) lines.push(`  scopes: [${t.scopes.join(', ')}]`);
+      for (const l of t.githubLinks) lines.push(`  github: ${l.externalId} — ${l.url}`);
+      lines.push('');
+      lines.push(t.description ? `Brief:\n${t.description}` : 'Brief: (no description — read the linked GitHub issue)');
+    } else {
+      const why =
+        result.reason === 'hold'
+          ? 'the map is on hold (maxActiveClaims = 0)'
+          : result.reason === 'cap'
+            ? `the claim cap is reached (${result.active}/${result.cap} active)`
+            : 'no dispatchable ticket inside the dispatch gate';
+      lines.push(`No ticket granted — ${why}.`);
+    }
+    if (result.skipped.length > 0) {
+      lines.push('');
+      lines.push(`Skipped ${result.skipped.length} ready node(s) with no brief (tagged "${'needs-brief'}"):`);
+      for (const s of result.skipped) lines.push(`  - ${s.id} "${s.text}"`);
+    }
+    return lines.join('\n');
+  },
+});
+
 export const claimNodeTool = defineTool({
   name: 'claim_node',
   description: [
@@ -73,6 +148,8 @@ export const claimNodeTool = defineTool({
     'claimed by a different session, the call succeeds but returns a soft warning',
     '(the claim is transferred to the new session — this is intentional: if the',
     'original session crashed, the orchestrator should be able to reclaim).',
+    'Because of these transfer semantics this is a manual/orchestrator tool —',
+    'pull-fleet workers should use get_next_ticket, which never steals claims.',
     '',
     'After claiming, dispatch your coding agent and let it call set_status("done")',
     'when it finishes — that automatically clears the claim.',
@@ -222,6 +299,7 @@ export const conflictScanTool = defineTool({
 
 export const orchestrationTools = [
   readyNodesTool,
+  getNextTicketTool,
   claimNodeTool,
   releaseNodeTool,
   conflictScanTool,


### PR DESCRIPTION
## What

Layer 1 of the **Leidang** pull-fleet design (`claude-fleet/docs/leidang-design.md`) — step 1 of the migration order. Workers **pull** tickets instead of being pushed them; MindBlown owns the queue, the lock, the ranking policy, and the fleet-wide throttle.

### New map columns (full eight-layer DoD pass)

| Column | Meaning |
|---|---|
| `maxActiveClaims` (int, default **0 = hold**) | Fleet-wide cap on concurrent claims. Cap 0 replaces `#PAUSED-BY-DANIEL#` crontab surgery — set it and the fleet drains naturally. |
| `dispatchGate` (jsonb string[]) | AND-filter fencing the pull queue. Vocabulary: `version:<id>` (effective version, ancestor-inherited), `type:bug` (node tagged `bug`). Empty = no fence. **Fail-closed** on unknown entries — a typo empties the queue loudly instead of silently opening the fence. |
| `dispatchPolicy` (jsonb string[]) | Ordered ranking keys `bugs` / `priority` / `size` / `age`. Empty = default `["bugs","priority","age"]`. |

All three writable via `update_map` (zod-validated) → operating-phase switches are one MCP call.

### `POST /api/maps/:id/pull-next` + MCP tool `get_next_ticket(mapId, sessionId, profile?)`

One transaction serialized per map with `pg_advisory_xact_lock(hashtext(mapId))`:

1. **Cap gate** — `hold` (cap 0) / `cap` (at capacity) refusals with `active`/`cap` counts.
2. **Dispatch gate** — AND-filter over the ready set (todo + unclaimed + deps done, root excluded).
3. **Policy sort** — ordered keys, stable tiebreak on age then id.
4. **Empty-brief guard** — ready nodes with no description and no linked GitHub issue are refused, auto-tagged `needs-brief`, and returned in `skipped[]` so the queue starves loudly.
5. **Conditional claim** — `UPDATE … WHERE claimed_by_session IS NULL`: the pull path **never steals** a claim (unlike `claim_node`'s intentional transfer semantics, which stay orchestrator-only — tool description now says so). Raced candidates are skipped, not stolen.

Returns the full self-contained brief: title, plain-text description, priority/rank, tags, scopes, effective version, estimate, GitHub links. `profile` is reserved-but-dormant (accepted, ignored — no policy table).

### Fix-alongs

- **`ready_nodes` doc/impl drift**: the service now sorts globally by `priorityRank ASC NULLS LAST → P0–P3 → createdAt ASC`, exactly what the tool description always promised (it used to only order within sibling groups).
- **`integrations/github.ts` garbage issue bodies**: non-string (ProseMirror) descriptions were `JSON.stringify`-ed into issue bodies in `createGitHubIssue` and `updateGitHubIssue`. Both now render via `proseMirrorToPlainText`, which moved to `@mindblown/core` (server re-exports it) so the integrations package can use it.

## Tests

- `services/__tests__/pull-queue.test.ts` — 14 tests over the pure decision core (cap/hold, ready-set membership, gate AND + inheritance + fail-closed, policy keys incl. size-nulls-last, empty-brief guard) against real core predicates.
- `routes/__tests__/pull-next-route.test.ts` — HTTP adapter wiring (400 validation, arg pass-through, refusal-as-200, 404 translation).
- `tool-kit __tests__/get-next-ticket.test.ts` + `map.test.ts` additions — zod surface + handler rendering + knob round-trip (the CLAUDE.md "invisible to MCP agents" failure mode).
- `core __tests__/richtext.test.ts` — pins the moved walk.

`pnpm turbo typecheck` and `pnpm turbo test` green across all packages (server 661, tool-kit 105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ehja4MDrtqNJ8DkFmrjiR