### PR TITLE
feat(orchestration): profile-based pull eligibility (#262)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export type {
   CustomFieldDef,
   StatusDef,
   PhaseDef,
+  ProfilePolicy,
   Baseline,
   MindMap,
   User,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -347,6 +347,30 @@ export interface StatusDef {
   position: number; // sort order
 }
 
+/**
+ * Pull-queue profile routing thresholds (#262). Presence of this object
+ * on a map ACTIVATES profile-based eligibility in `get_next_ticket`;
+ * `profilePolicy: null` (the default) keeps the queue profile-blind.
+ *
+ * Class rules built from signals that already exist (no difficulty tag):
+ * - heavy-class ticket: P0 OR effort ≥ `heavyMinHours` — reserved for
+ *   `profile: "heavy"` pullers (first refusal).
+ * - light-eligible ticket: effort ≤ `lightMaxHours` AND priority P2/P3.
+ * - unestimated tickets are eligible to EVERY profile (never starve).
+ * - unknown/absent puller profile = standard (fail open).
+ *
+ * Thresholds are hours; node estimates are normalized from the map's
+ * effortUnit via `hoursPerDay` before comparison. On `points` maps the
+ * effort triggers are inert (points aren't time) — only the P0 heavy
+ * trigger applies.
+ */
+export interface ProfilePolicy {
+  /** Heavy-class floor in hours. Omitted = one day (`hoursPerDay`). */
+  heavyMinHours?: number;
+  /** Light-eligible ceiling in hours. Omitted = 2. */
+  lightMaxHours?: number;
+}
+
 /** A baseline snapshot for plan-vs-actual comparison. */
 export interface Baseline {
   id: string;
@@ -466,6 +490,14 @@ export interface MindMap {
    * an ordered list is the whole policy language.
    */
   dispatchPolicy: string[];
+  /**
+   * Profile routing table for `get_next_ticket(sessionId, profile)`.
+   * null (default) = profile-blind queue — the parameter stays inert
+   * exactly as before #262. See {@link ProfilePolicy} for the rules.
+   * Routing only FILTERS eligibility; dispatchPolicy ranking is
+   * untouched.
+   */
+  profilePolicy: ProfilePolicy | null;
 
   // ── Metadata ──────────────────────────────────────────────
   createdAt: string;

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -156,6 +156,14 @@ export interface NodeWithComputed {
   };
 }
 
+/** Pull-queue profile routing thresholds (mirrors core ProfilePolicy, #262). */
+export interface ProfilePolicy {
+  /** Heavy-class floor in hours. Omitted = one day (the map's hoursPerDay). */
+  heavyMinHours?: number;
+  /** Light-eligible ceiling in hours. Omitted = 2. */
+  lightMaxHours?: number;
+}
+
 /** Project phase definition (mirrors core PhaseDef; statusWorkflow idiom). */
 export interface PhaseDef {
   id: string;
@@ -422,6 +430,7 @@ export function updateMap(
     maxActiveClaims?: number;
     dispatchGate?: string[];
     dispatchPolicy?: string[];
+    profilePolicy?: ProfilePolicy | null;
     autoImportNewIssues?: boolean;
     phases?: PhaseDef[];
   },

--- a/packages/server/src/db/__tests__/mapProfilePolicy.test.ts
+++ b/packages/server/src/db/__tests__/mapProfilePolicy.test.ts
@@ -1,0 +1,38 @@
+/**
+ * dbMapToCore round-trip for the `profile_policy` column (#262).
+ *
+ * The pull queue's backward-compatibility contract hinges on this
+ * mapping: a maps row WITHOUT a stored policy (the live prod state)
+ * must surface as `profilePolicy: null`, which getNextTicket treats
+ * as "profile-blind — ignore the profile parameter entirely". A
+ * stored object must come back intact under both the snake_case
+ * (raw SQL) and camelCase (drizzle) row shapes helpers.ts accepts.
+ */
+import { describe, it, expect } from 'vitest';
+import { dbMapToCore } from '../helpers.js';
+
+const baseRow = {
+  id: 'map-1',
+  workspace_id: 'ws-1',
+  name: 'Test map',
+  root_node_id: 'root-1',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  created_by: 'user-1',
+};
+
+describe('dbMapToCore — profilePolicy', () => {
+  it('absent column (pre-#262 rows) maps to null', () => {
+    expect(dbMapToCore(baseRow).profilePolicy).toBeNull();
+  });
+
+  it('round-trips a stored policy from snake_case and camelCase rows', () => {
+    const policy = { heavyMinHours: 16, lightMaxHours: 4 };
+    expect(dbMapToCore({ ...baseRow, profile_policy: policy }).profilePolicy).toEqual(policy);
+    expect(dbMapToCore({ ...baseRow, profilePolicy: policy }).profilePolicy).toEqual(policy);
+  });
+
+  it('an explicitly NULL column maps to null, not undefined', () => {
+    expect(dbMapToCore({ ...baseRow, profile_policy: null }).profilePolicy).toBeNull();
+  });
+});

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -93,6 +93,7 @@ export function dbMapToCore(row: Record<string, unknown>): MindMap {
     maxActiveClaims: (get('maxActiveClaims', 'max_active_claims') as number) ?? 0,
     dispatchGate: (get('dispatchGate', 'dispatch_gate') as string[]) ?? [],
     dispatchPolicy: (get('dispatchPolicy', 'dispatch_policy') as string[]) ?? [],
+    profilePolicy: (get('profilePolicy', 'profile_policy') as MindMap['profilePolicy']) ?? null,
     createdAt: (get('createdAt', 'created_at') instanceof Date
       ? (get('createdAt', 'created_at') as Date).toISOString()
       : (get('createdAt', 'created_at') as string)),

--- a/packages/server/src/db/maps.ts
+++ b/packages/server/src/db/maps.ts
@@ -3,7 +3,7 @@ import { db } from './connection.js';
 import { maps, mapPermissions, nodes } from './schema.js';
 import { dbMapToCore, dbNodeToCore } from './helpers.js';
 import { notDeleted } from './nodes.js';
-import type { MindMap, Node as CoreNode, StatusDef, PhaseDef, CustomFieldDef, LayoutMode, EffortUnit, Baseline } from '@mindblown/core';
+import type { MindMap, Node as CoreNode, StatusDef, PhaseDef, CustomFieldDef, LayoutMode, EffortUnit, Baseline, ProfilePolicy } from '@mindblown/core';
 import { clampFocusFactor } from '@mindblown/core';
 
 // ── Create ─────────────────────────────────────────────────────────
@@ -130,6 +130,8 @@ export interface UpdateMapInput {
   dispatchGate?: string[];
   /** Pull-queue ranking keys (bugs|priority|size|age). Empty = default. */
   dispatchPolicy?: string[];
+  /** Profile routing table (#262); null clears = profile-blind queue. */
+  profilePolicy?: ProfilePolicy | null;
   githubInstallationId?: string | null;
   githubRepoOwner?: string | null;
   githubRepoName?: string | null;
@@ -158,6 +160,7 @@ export async function updateMap(mapId: string, input: UpdateMapInput): Promise<M
   if (input.maxActiveClaims !== undefined) updates.maxActiveClaims = Math.max(0, Math.floor(input.maxActiveClaims));
   if (input.dispatchGate !== undefined) updates.dispatchGate = input.dispatchGate;
   if (input.dispatchPolicy !== undefined) updates.dispatchPolicy = input.dispatchPolicy;
+  if (input.profilePolicy !== undefined) updates.profilePolicy = input.profilePolicy;
   if (input.githubInstallationId !== undefined) updates.githubInstallationId = input.githubInstallationId;
   if (input.githubRepoOwner !== undefined) updates.githubRepoOwner = input.githubRepoOwner;
   if (input.githubRepoName !== undefined) updates.githubRepoName = input.githubRepoName;

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -901,5 +901,13 @@ export async function runMigrations(): Promise<void> {
     ALTER TABLE maps ADD COLUMN IF NOT EXISTS dispatch_policy JSONB NOT NULL DEFAULT '[]'
   `);
 
+  // ── Pull queue: profile routing table (#262) ───────────────────
+  // profile_policy: {heavyMinHours?, lightMaxHours?}. NULL (the default)
+  // keeps get_next_ticket profile-blind — existing maps, including the
+  // live prod map, see zero behavior change until an operator sets it.
+  await db.execute(sql`
+    ALTER TABLE maps ADD COLUMN IF NOT EXISTS profile_policy JSONB
+  `);
+
   console.log('[db] Migrations complete.');
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -149,6 +149,10 @@ export const maps = pgTable('maps', {
   // Ordered ranking keys for the gated ready set (bugs|priority|size|age).
   // Empty array = default ["bugs","priority","age"].
   dispatchPolicy: jsonb('dispatch_policy').notNull().default([]), // string[]
+  // Profile routing table (#262): {heavyMinHours?, lightMaxHours?}.
+  // NULL = profile-blind queue (the pre-#262 behavior) — deliberately
+  // nullable with no default object so existing maps stay untouched.
+  profilePolicy: jsonb('profile_policy'), // ProfilePolicy | null
 });
 
 // ── Nodes ──────────────────────────────────────────────────────────

--- a/packages/server/src/routes/__tests__/pull-next-route.test.ts
+++ b/packages/server/src/routes/__tests__/pull-next-route.test.ts
@@ -51,7 +51,7 @@ describe('POST /api/maps/:id/pull-next', () => {
     expect(mocks.getNextTicket).not.toHaveBeenCalled();
   });
 
-  it('forwards mapId, sessionId, and the dormant profile to the service', async () => {
+  it('forwards mapId, sessionId, and the profile to the service', async () => {
     const result = {
       granted: true,
       active: 1,

--- a/packages/server/src/routes/orchestration.ts
+++ b/packages/server/src/routes/orchestration.ts
@@ -110,7 +110,8 @@ export async function orchestrationRoutes(app: FastifyInstance): Promise<void> {
 
   // ── POST /api/maps/:id/pull-next — get_next_ticket ────────────
   // Atomic pull for the Leidang fleet: cap gate → dispatch gate →
-  // policy sort → empty-brief guard → claim, all serialized per map.
+  // profile eligibility → policy sort → empty-brief guard → claim,
+  // all serialized per map.
   app.post<{ Params: { id: string } }>(
     '/api/maps/:id/pull-next',
     async (req, reply) => {

--- a/packages/server/src/services/__tests__/pull-queue.test.ts
+++ b/packages/server/src/services/__tests__/pull-queue.test.ts
@@ -22,6 +22,8 @@ import {
   matchesDispatchGate,
   sortByDispatchPolicy,
   hasBrief,
+  isProfileEligible,
+  resolveProfile,
   DEFAULT_DISPATCH_POLICY,
 } from '../orchestration.js';
 
@@ -84,13 +86,25 @@ const root = makeNode({ id: 'root', parentId: null, description: null });
 
 function select(
   nodes: CoreNode[],
-  opts: Partial<{ cap: number; gate: string[]; policy: string[] }> = {},
+  opts: Partial<{
+    cap: number;
+    gate: string[];
+    policy: string[];
+    profilePolicy: import('@mindblown/core').ProfilePolicy | null;
+    profile: string;
+    effortUnit: import('@mindblown/core').EffortUnit;
+    hoursPerDay: number;
+  }> = {},
 ) {
   return selectPullCandidates([root, ...nodes], {
     workflow: WORKFLOW,
     cap: opts.cap ?? 10,
     gate: opts.gate ?? [],
     policy: opts.policy ?? [],
+    profilePolicy: opts.profilePolicy,
+    profile: opts.profile,
+    effortUnit: opts.effortUnit,
+    hoursPerDay: opts.hoursPerDay,
   });
 }
 
@@ -262,3 +276,135 @@ describe('empty-brief guard', () => {
     expect(hasBrief(makeNode({ id: 'y', description: 'real text' }))).toBe(true);
   });
 });
+
+// ── Profile routing (#262) ─────────────────────────────────────────
+//
+// A configured profilePolicy FILTERS the gated ready set by the puller's
+// profile; ranking is untouched. No policy (null/omitted) = the queue
+// stays profile-blind regardless of what profile string arrives.
+
+describe('profilePolicy routing', () => {
+  // Map default: effortUnit days, hoursPerDay 8 → spec thresholds
+  // heavy ≥ 1d (8h), light ≤ 2h.
+  const POLICY = {}; // empty object = active with spec defaults
+
+  it('absent policy = zero behavior change, whatever profile is sent', () => {
+    const heavyTicket = makeNode({ id: 'p0', priority: 'P0' });
+    for (const profile of [undefined, 'standard', 'light', 'heavy', 'gibberish']) {
+      const d = select([heavyTicket], { profilePolicy: null, profile });
+      expect(d.ranked.map((n) => n.id)).toEqual(['p0']);
+    }
+  });
+
+  it('heavy-class ticket (P0) is reserved for heavy pullers', () => {
+    const p0 = makeNode({ id: 'p0', priority: 'P0', effortEstimate: 0.1 });
+    expect(select([p0], { profilePolicy: POLICY, profile: 'standard' }).ranked).toHaveLength(0);
+    expect(select([p0], { profilePolicy: POLICY, profile: 'light' }).ranked).toHaveLength(0);
+    expect(select([p0], { profilePolicy: POLICY, profile: 'heavy' }).ranked.map((n) => n.id)).toEqual(['p0']);
+  });
+
+  it('heavy-class ticket (estimate ≥ 1 day) is reserved for heavy pullers', () => {
+    const big = makeNode({ id: 'big', effortEstimate: 1, priority: 'P2' }); // 1 day = 8h ≥ heavyMin
+    expect(select([big], { profilePolicy: POLICY, profile: 'standard' }).ranked).toHaveLength(0);
+    expect(select([big], { profilePolicy: POLICY, profile: 'heavy' }).ranked.map((n) => n.id)).toEqual(['big']);
+  });
+
+  it('normalizes estimates from the map effortUnit before comparing', () => {
+    // 0.5 days × 8 h/day = 4h → below the 8h heavy floor → standard-class.
+    const halfDay = makeNode({ id: 'half', effortEstimate: 0.5, priority: 'P1' });
+    expect(select([halfDay], { profilePolicy: POLICY, profile: 'standard' }).ranked.map((n) => n.id)).toEqual(['half']);
+    // Same numeric estimate on an hours map: 0.5h → still standard-class…
+    expect(
+      select([halfDay], { profilePolicy: POLICY, profile: 'standard', effortUnit: 'hours' }).ranked,
+    ).toHaveLength(1);
+    // …but 8 on an hours map is 8h → heavy-class.
+    const eightHours = makeNode({ id: 'eight', effortEstimate: 8, priority: 'P1' });
+    expect(
+      select([eightHours], { profilePolicy: POLICY, profile: 'standard', effortUnit: 'hours' }).ranked,
+    ).toHaveLength(0);
+  });
+
+  it('unestimated tickets are granted to every profile — never starve', () => {
+    const bare = makeNode({ id: 'bare' });
+    const bareP0 = makeNode({ id: 'bare-p0', priority: 'P0' });
+    for (const profile of ['heavy', 'standard', 'light', undefined]) {
+      const d = select([bare], { profilePolicy: POLICY, profile });
+      expect(d.ranked.map((n) => n.id)).toEqual(['bare']);
+    }
+    // Unestimated P0: eligible to everyone (unestimated wins over the P0
+    // heavy trigger — reserving it could starve it in a heavy-less fleet).
+    expect(select([bareP0], { profilePolicy: POLICY, profile: 'light' }).ranked).toHaveLength(1);
+  });
+
+  it('light pullers get only small P2/P3 tickets (plus unestimated)', () => {
+    const smallP3 = makeNode({ id: 'small-p3', effortEstimate: 0.25, priority: 'P3' }); // 2h
+    const smallP1 = makeNode({ id: 'small-p1', effortEstimate: 0.25, priority: 'P1' });
+    const smallNoPrio = makeNode({ id: 'small-none', effortEstimate: 0.25 });
+    const mediumP2 = makeNode({ id: 'medium-p2', effortEstimate: 0.5, priority: 'P2' }); // 4h > 2h
+    const d = select([smallP3, smallP1, smallNoPrio, mediumP2], { profilePolicy: POLICY, profile: 'light' });
+    expect(d.ranked.map((n) => n.id)).toEqual(['small-p3']);
+    // The same set is fully available to a standard puller (none are heavy-class).
+    const ds = select([smallP3, smallP1, smallNoPrio, mediumP2], { profilePolicy: POLICY, profile: 'standard' });
+    expect(ds.ranked).toHaveLength(4);
+  });
+
+  it('unknown or absent profile fails open to standard', () => {
+    const p0 = makeNode({ id: 'p0', priority: 'P0', effortEstimate: 0.1 });
+    const normal = makeNode({ id: 'normal', effortEstimate: 0.5, priority: 'P1' });
+    for (const profile of [undefined, 'turbo', '']) {
+      const d = select([p0, normal], { profilePolicy: POLICY, profile });
+      expect(d.ranked.map((n) => n.id)).toEqual(['normal']);
+    }
+    expect(resolveProfile(undefined)).toBe('standard');
+    expect(resolveProfile('turbo')).toBe('standard');
+    expect(resolveProfile('heavy')).toBe('heavy');
+  });
+
+  it('thresholds are configurable, not hardcoded', () => {
+    const big = makeNode({ id: 'big', effortEstimate: 1, priority: 'P2' }); // 8h
+    // Raise the heavy floor to 16h: an 8h ticket is standard-class again.
+    expect(
+      select([big], { profilePolicy: { heavyMinHours: 16 }, profile: 'standard' }).ranked,
+    ).toHaveLength(1);
+    // Raise the light ceiling to 8h: the same ticket becomes light-eligible.
+    expect(
+      select([big], { profilePolicy: { heavyMinHours: 16, lightMaxHours: 8 }, profile: 'light' }).ranked,
+    ).toHaveLength(1);
+  });
+
+  it('filters eligibility only — dispatchPolicy ranking is untouched', () => {
+    const bug = makeNode({ id: 'bug', tags: ['bug'], effortEstimate: 0.5, priority: 'P2', createdAt: '2026-03-01T00:00:00Z' });
+    const older = makeNode({ id: 'older', effortEstimate: 0.5, priority: 'P1', createdAt: '2026-01-01T00:00:00Z' });
+    const heavy = makeNode({ id: 'heavy', priority: 'P0', effortEstimate: 2, createdAt: '2026-02-01T00:00:00Z' });
+    const d = select([older, heavy, bug], { profilePolicy: POLICY, profile: 'standard' });
+    // heavy-class filtered out; survivors keep default bugs→priority→age order.
+    expect(d.ranked.map((n) => n.id)).toEqual(['bug', 'older']);
+  });
+
+  it('points maps: effort triggers are inert, only the P0 trigger applies', () => {
+    const fivePoints = makeNode({ id: 'pts', effortEstimate: 5, priority: 'P3' });
+    const p0Points = makeNode({ id: 'pts-p0', effortEstimate: 5, priority: 'P0' });
+    // Estimated-in-points → standard-class: standard yes, light no.
+    expect(
+      select([fivePoints], { profilePolicy: POLICY, profile: 'standard', effortUnit: 'points' }).ranked,
+    ).toHaveLength(1);
+    expect(
+      select([fivePoints], { profilePolicy: POLICY, profile: 'light', effortUnit: 'points' }).ranked,
+    ).toHaveLength(0);
+    // P0 still routes heavy.
+    expect(
+      select([p0Points], { profilePolicy: POLICY, profile: 'standard', effortUnit: 'points' }).ranked,
+    ).toHaveLength(0);
+    expect(
+      select([p0Points], { profilePolicy: POLICY, profile: 'heavy', effortUnit: 'points' }).ranked,
+    ).toHaveLength(1);
+  });
+
+  it('isProfileEligible exposes the same semantics directly', () => {
+    const big = makeNode({ id: 'big', effortEstimate: 2 }); // 2 days = 16h
+    expect(isProfileEligible(big, 'heavy', {}, 'days', 8)).toBe(true);
+    expect(isProfileEligible(big, 'standard', {}, 'days', 8)).toBe(false);
+    expect(isProfileEligible(makeNode({ id: 'u' }), 'light', {}, 'days', 8)).toBe(true);
+  });
+});
+

--- a/packages/server/src/services/orchestration.ts
+++ b/packages/server/src/services/orchestration.ts
@@ -27,7 +27,7 @@ import {
   buildTodoIds,
   proseMirrorToPlainText,
 } from '@mindblown/core';
-import type { Node as CoreNode, StatusDef, NodeMap } from '@mindblown/core';
+import type { Node as CoreNode, StatusDef, NodeMap, ProfilePolicy, EffortUnit } from '@mindblown/core';
 import type {
   ReadyNodesResult,
   ClaimNodeResult,
@@ -356,6 +356,53 @@ export function hasBrief(node: CoreNode): boolean {
   return node.externalLinks.some((l) => l.provider === 'github');
 }
 
+/** Puller profiles the routing table recognizes. Anything else = standard. */
+export type PullProfile = 'heavy' | 'standard' | 'light';
+
+/** Unknown or absent profile strings fail OPEN to standard (#262). */
+export function resolveProfile(profile: string | undefined): PullProfile {
+  return profile === 'heavy' || profile === 'light' ? profile : 'standard';
+}
+
+/**
+ * Profile eligibility filter (#262). Only consulted when the map carries
+ * a profilePolicy — a null policy never reaches this function, so the
+ * pre-#262 profile-blind behavior is preserved by the caller.
+ *
+ * Estimates are normalized to hours from the map's effortUnit
+ * (`days` × hoursPerDay). On `points` maps the effort triggers are inert
+ * (points aren't time): only the P0 heavy trigger applies.
+ *
+ * - unestimated → eligible to every profile (never starves)
+ * - heavy-class (P0 OR ≥ heavyMinHours) → heavy pullers only
+ * - light pullers → additionally need ≤ lightMaxHours AND P2/P3
+ */
+export function isProfileEligible(
+  node: CoreNode,
+  profile: PullProfile,
+  policy: ProfilePolicy,
+  effortUnit: EffortUnit,
+  hoursPerDay: number,
+): boolean {
+  if (profile === 'heavy') return true; // heavy takes anything
+  if (node.effortEstimate === null) return true; // unestimated routes standard — granted to everyone
+
+  const hours =
+    effortUnit === 'hours'
+      ? node.effortEstimate
+      : effortUnit === 'days'
+        ? node.effortEstimate * hoursPerDay
+        : null; // points: not a time unit
+
+  const heavyMin = policy.heavyMinHours ?? hoursPerDay; // spec default: one day
+  const lightMax = policy.lightMaxHours ?? 2;
+
+  const heavyClass = node.priority === 'P0' || (hours !== null && hours >= heavyMin);
+  if (heavyClass) return false; // first refusal: reserved for heavy pullers
+  if (profile === 'standard') return true;
+  return hours !== null && hours <= lightMax && (node.priority === 'P2' || node.priority === 'P3');
+}
+
 interface PullDecision {
   active: number;
   cap: number;
@@ -368,12 +415,24 @@ interface PullDecision {
 
 /**
  * Pure decision core of getNextTicket: cap gate → dispatch gate →
- * policy sort → empty-brief guard. No I/O; the transactional shell
- * applies the claim. Exported for direct unit testing.
+ * profile eligibility (#262) → policy sort → empty-brief guard. No I/O;
+ * the transactional shell applies the claim. Exported for direct unit
+ * testing.
  */
 export function selectPullCandidates(
   allNodes: CoreNode[],
-  opts: { workflow: StatusDef[]; cap: number; gate: string[]; policy: string[] },
+  opts: {
+    workflow: StatusDef[];
+    cap: number;
+    gate: string[];
+    policy: string[];
+    /** Profile routing (#262) — all four optional; omitted or a null
+     *  profilePolicy keeps the queue profile-blind (pre-#262 behavior). */
+    profilePolicy?: ProfilePolicy | null;
+    profile?: string;
+    effortUnit?: EffortUnit;
+    hoursPerDay?: number;
+  },
 ): PullDecision {
   const active = allNodes.filter((n) => n.claimedBySession !== null).length;
   const cap = Math.max(0, Math.floor(opts.cap));
@@ -392,8 +451,23 @@ export function selectPullCandidates(
       isReady(n, nodeMap, isDone),
   );
   const gated = ready.filter((n) => matchesDispatchGate(n, opts.gate, nodeMap));
+  // Profile routing (#262): a configured policy FILTERS eligibility here;
+  // ranking below is untouched. No policy = no filter = pre-#262 behavior.
+  const profilePolicy = opts.profilePolicy ?? null;
+  const eligible =
+    profilePolicy === null
+      ? gated
+      : gated.filter((n) =>
+          isProfileEligible(
+            n,
+            resolveProfile(opts.profile),
+            profilePolicy,
+            opts.effortUnit ?? 'days',
+            opts.hoursPerDay ?? 8,
+          ),
+        );
   const policy = opts.policy.length > 0 ? opts.policy : DEFAULT_DISPATCH_POLICY;
-  const rankedAll = sortByDispatchPolicy(gated, policy);
+  const rankedAll = sortByDispatchPolicy(eligible, policy);
 
   return {
     active,
@@ -417,12 +491,16 @@ export function selectPullCandidates(
  * the pull path NEVER steals a claim — if a candidate got claimed in
  * between, we move on to the next one.
  *
- * `profile` is reserved-but-dormant in v1: accepted, ignored.
+ * `profile` (#262): when the map carries a `profilePolicy`, the puller's
+ * profile filters which tickets it may be granted (heavy / standard /
+ * light — see `isProfileEligible`). Maps without a policy stay
+ * profile-blind: the parameter is accepted and ignored, exactly the
+ * pre-#262 contract.
  */
 export async function getNextTicket(
   mapId: string,
   sessionId: string,
-  _profile?: string,
+  profile?: string,
 ): Promise<GetNextTicketResult> {
   const now = new Date();
 
@@ -444,6 +522,10 @@ export async function getNextTicket(
       cap: (mapRow.maxActiveClaims as number) ?? 0,
       gate: ((mapRow.dispatchGate as string[]) ?? []),
       policy: ((mapRow.dispatchPolicy as string[]) ?? []),
+      profilePolicy: (mapRow.profilePolicy as ProfilePolicy | null) ?? null,
+      profile,
+      effortUnit: (mapRow.effortUnit as EffortUnit) ?? 'days',
+      hoursPerDay: (mapRow.hoursPerDay as number) ?? 8,
     });
 
     // Tag empty-brief nodes `needs-brief` so the queue starves loudly.

--- a/packages/tool-kit/src/backend.ts
+++ b/packages/tool-kit/src/backend.ts
@@ -8,7 +8,7 @@
  * Adding a new backend method requires adding it to both implementations.
  */
 
-import type { MapDetail, MapSummary, NodeWithComputed, PhaseDef } from './types.js';
+import type { MapDetail, MapSummary, NodeWithComputed, PhaseDef, ProfilePolicy } from './types.js';
 
 // ── Triage shapes (#96 Phase 3) ────────────────────────────────────
 // Mirrors the persisted `triage_decisions` row, plus the per-request
@@ -253,6 +253,7 @@ export interface ToolBackend {
       maxActiveClaims?: number;
       dispatchGate?: string[];
       dispatchPolicy?: string[];
+      profilePolicy?: ProfilePolicy | null;
       autoImportNewIssues?: boolean;
       phases?: PhaseDef[];
     },

--- a/packages/tool-kit/src/tools/__tests__/get-next-ticket.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/get-next-ticket.test.ts
@@ -1,7 +1,7 @@
 /**
  * get_next_ticket — MCP surface tests (Leidang pull queue).
  *
- * Pins the zod schema (sessionId required, profile optional/dormant)
+ * Pins the zod schema (sessionId required, profile optional)
  * and the handler's rendering of grants, refusals, and needs-brief
  * skips, so pull-fleet workers see the full self-contained brief.
  */

--- a/packages/tool-kit/src/tools/__tests__/map.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/map.test.ts
@@ -164,3 +164,42 @@ describe('update_map tool — phases', () => {
     expect('phases' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
   });
 });
+
+// Profile routing table (#262) — update_map is how an operator activates
+// (or clears) profile-based pull eligibility; null must round-trip so the
+// queue can be returned to profile-blind.
+describe('update_map tool — profilePolicy', () => {
+  const schema = z.object(updateMapTool.schema);
+
+  it('accepts a threshold object, a partial one, and null', () => {
+    expect(schema.parse({ mapId: 'm1', profilePolicy: { heavyMinHours: 8, lightMaxHours: 2 } }).profilePolicy)
+      .toEqual({ heavyMinHours: 8, lightMaxHours: 2 });
+    expect(schema.parse({ mapId: 'm1', profilePolicy: {} }).profilePolicy).toEqual({});
+    expect(schema.parse({ mapId: 'm1', profilePolicy: null }).profilePolicy).toBeNull();
+  });
+
+  it('rejects unknown keys and non-positive thresholds', () => {
+    expect(() => schema.parse({ mapId: 'm1', profilePolicy: { heavyMinDays: 1 } })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', profilePolicy: { heavyMinHours: 0 } })).toThrow();
+    expect(() => schema.parse({ mapId: 'm1', profilePolicy: { lightMaxHours: -2 } })).toThrow();
+  });
+
+  it('forwards the object — and an explicit null clear — to the backend', async () => {
+    const recorder = makeRecordingBackend();
+    await updateMapTool.handler(recorder.backend, {
+      mapId: 'm1',
+      profilePolicy: { heavyMinHours: 16 },
+    } as never);
+    expect(recorder.lastUpdate?.fields).toEqual({ profilePolicy: { heavyMinHours: 16 } });
+
+    await updateMapTool.handler(recorder.backend, { mapId: 'm1', profilePolicy: null } as never);
+    expect(recorder.lastUpdate?.fields).toEqual({ profilePolicy: null });
+  });
+
+  it('omitting the field does not touch it (no accidental clears)', async () => {
+    const recorder = makeRecordingBackend();
+    await updateMapTool.handler(recorder.backend, { mapId: 'm1', name: 'renamed' } as never);
+    expect('profilePolicy' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+  });
+});
+

--- a/packages/tool-kit/src/tools/map.ts
+++ b/packages/tool-kit/src/tools/map.ts
@@ -67,7 +67,7 @@ export const createMapTool = defineTool({
 export const updateMapTool = defineTool({
   name: 'update_map',
   description:
-    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, focus factor, phases, or GitHub auto-import setting. phases is the map's project-phase definition list ({id, name, position} — statusWorkflow idiom); pass the COMPLETE new array to add, rename, or reorder phases. Keep existing ids stable when renaming/reordering — nodes reference phases by id (node.phaseId), so a changed id orphans them. Omit id on a NEW entry and one is generated. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). focusFactor (0.05–1.0, default 1) is the fraction of calendar time that actually reaches planned-ticket work — set it below 1 to stretch the velocity-adjusted completion forecast for meetings/support/firefighting/unplanned work (e.g. 0.5 = half of each day reaches planned work, so forecasts take twice as long). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. maxActiveClaims / dispatchGate / dispatchPolicy configure the get_next_ticket pull queue: maxActiveClaims caps concurrently claimed nodes fleet-wide (0 = hold, grants nothing — the default); dispatchGate is an AND-filter fencing what the queue hands out (entries \"version:<versionId>\" or \"type:bug\"; empty = no fence; a ticket outside the gate is invisible, not deprioritized); dispatchPolicy is the ordered ranking of the gated ready set (keys bugs/priority/size/age; empty = default [\"bugs\",\"priority\",\"age\"]). Pass nullable fields as null to clear.",
+    "Update a map's name, description, WIP limit, Gantt scheduling anchors, worker count, focus factor, phases, or GitHub auto-import setting. phases is the map's project-phase definition list ({id, name, position} — statusWorkflow idiom); pass the COMPLETE new array to add, rename, or reorder phases. Keep existing ids stable when renaming/reordering — nodes reference phases by id (node.phaseId), so a changed id orphans them. Omit id on a NEW entry and one is generated. wipLimit is a soft cap on how many nodes may sit in an in_progress status. projectStartDate anchors day 0 of the computed schedule (Gantt view). hoursPerDay sets the hours→days conversion when effortUnit is \"hours\" (default 8). workerCount is the parallel-track count the schedule projects onto (view knob, default 1 = strict serial). focusFactor (0.05–1.0, default 1) is the fraction of calendar time that actually reaches planned-ticket work — set it below 1 to stretch the velocity-adjusted completion forecast for meetings/support/firefighting/unplanned work (e.g. 0.5 = half of each day reaches planned work, so forecasts take twice as long). autoImportNewIssues toggles whether new GitHub issues on the bound repo auto-create nodes under the map's GitHub Inbox. maxActiveClaims / dispatchGate / dispatchPolicy configure the get_next_ticket pull queue: maxActiveClaims caps concurrently claimed nodes fleet-wide (0 = hold, grants nothing — the default); dispatchGate is an AND-filter fencing what the queue hands out (entries \"version:<versionId>\" or \"type:bug\"; empty = no fence; a ticket outside the gate is invisible, not deprioritized); dispatchPolicy is the ordered ranking of the gated ready set (keys bugs/priority/size/age; empty = default [\"bugs\",\"priority\",\"age\"]); profilePolicy activates profile routing for get_next_ticket (heavy = first refusal on P0-or-big tickets, light = only small P2/P3 tickets, standard/unknown = everything else; unestimated tickets go to everyone) — thresholds in hours ({heavyMinHours, lightMaxHours}, defaults: one day / 2h), estimates normalized from the map's effortUnit via hoursPerDay; null (the default) keeps the queue profile-blind. Pass nullable fields as null to clear.",
   schema: {
     mapId: z.string().describe('The map ID'),
     name: z.string().optional().describe('New map name'),
@@ -109,6 +109,15 @@ export const updateMapTool = defineTool({
       .array(z.enum(['bugs', 'priority', 'size', 'age']))
       .optional()
       .describe('Pull-queue ranking keys in order (REPLACE mode): bugs = bug-tagged first, priority = priorityRank then P0–P3, size = smallest estimate first (nulls last), age = oldest first. Empty array = default ["bugs","priority","age"].'),
+    profilePolicy: z
+      .object({
+        heavyMinHours: z.number().positive().optional().describe("Heavy-class floor in hours (estimate at/above = heavy pullers only). Omitted = one day (the map's hoursPerDay)."),
+        lightMaxHours: z.number().positive().optional().describe('Light-eligible ceiling in hours. Omitted = 2.'),
+      })
+      .strict()
+      .nullable()
+      .optional()
+      .describe('Profile routing table for get_next_ticket (#262). Presence ACTIVATES routing: heavy-class tickets (P0 or estimate ≥ heavyMinHours) go only to profile "heavy"; profile "light" gets only tickets ≤ lightMaxHours with priority P2/P3; unestimated tickets and profile "standard"/unknown/absent fail open. Ranking is unchanged — this only filters eligibility. null (the default) = profile-blind queue, the pre-#262 behavior.'),
     autoImportNewIssues: z
       .boolean()
       .optional()
@@ -138,7 +147,7 @@ export const updateMapTool = defineTool({
         'Project phase definitions (REPLACE mode — the full new array). Send the complete list to add, rename, or reorder; keep ids of existing phases stable so node.phaseId references stay valid.',
       ),
   },
-  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, focusFactor, maxActiveClaims, dispatchGate, dispatchPolicy, autoImportNewIssues, phases }) => {
+  handler: async (backend, { mapId, name, description, wipLimit, projectStartDate, hoursPerDay, workerCount, focusFactor, maxActiveClaims, dispatchGate, dispatchPolicy, profilePolicy, autoImportNewIssues, phases }) => {
     const fields: {
       name?: string;
       description?: string | null;
@@ -150,6 +159,7 @@ export const updateMapTool = defineTool({
       maxActiveClaims?: number;
       dispatchGate?: string[];
       dispatchPolicy?: string[];
+      profilePolicy?: { heavyMinHours?: number; lightMaxHours?: number } | null;
       autoImportNewIssues?: boolean;
       phases?: Array<{ id: string; name: string; position: number; color?: string; targetDate?: string | null }>;
     } = {};
@@ -163,6 +173,7 @@ export const updateMapTool = defineTool({
     if (maxActiveClaims !== undefined) fields.maxActiveClaims = maxActiveClaims;
     if (dispatchGate !== undefined) fields.dispatchGate = dispatchGate;
     if (dispatchPolicy !== undefined) fields.dispatchPolicy = dispatchPolicy;
+    if (profilePolicy !== undefined) fields.profilePolicy = profilePolicy;
     if (autoImportNewIssues !== undefined) fields.autoImportNewIssues = autoImportNewIssues;
     if (phases !== undefined) {
       // Normalize: generate ids for new entries, default position to the

--- a/packages/tool-kit/src/tools/orchestration.ts
+++ b/packages/tool-kit/src/tools/orchestration.ts
@@ -99,7 +99,7 @@ export const getNextTicketTool = defineTool({
     profile: z
       .string()
       .optional()
-      .describe('Worker profile label (e.g. "standard", "heavy"). Reserved for future eligibility routing — accepted and ignored in v1.'),
+      .describe('Worker profile: "heavy" | "standard" | "light". On maps with a profilePolicy this filters eligibility — heavy gets first refusal on P0/big tickets, light gets only small P2/P3 tickets, standard (also unknown/absent — fail open) gets everything else; unestimated tickets go to every profile. Maps without a profilePolicy ignore it.'),
   },
   handler: async (backend, { mapId, sessionId, profile }) => {
     const result = await backend.getNextTicket(mapId, sessionId, profile);

--- a/packages/tool-kit/src/types.ts
+++ b/packages/tool-kit/src/types.ts
@@ -61,6 +61,14 @@ export interface NodeWithComputed {
   healthSignal: string;
 }
 
+/** Pull-queue profile routing thresholds (mirrors core ProfilePolicy, #262). */
+export interface ProfilePolicy {
+  /** Heavy-class floor in hours. Omitted = one day (the map's hoursPerDay). */
+  heavyMinHours?: number;
+  /** Light-eligible ceiling in hours. Omitted = 2. */
+  lightMaxHours?: number;
+}
+
 /** Project phase definition (mirrors core PhaseDef; statusWorkflow idiom). */
 export interface PhaseDef {
   id: string;


### PR DESCRIPTION
Activates the dormant `profile` parameter of `get_next_ticket` per #262.

## What

A new map-level `profilePolicy` table (`{heavyMinHours?, lightMaxHours?}`, thresholds in hours, spec defaults 1 day / 2h) routes tickets by estimate + priority — signals that already exist, no new difficulty tag:

| puller profile | eligible tickets |
|---|---|
| `heavy` | everything (first refusal on P0 / big tickets, since nobody else gets them) |
| `standard` (also unknown/absent — fail open) | everything except heavy-class (P0 or estimate ≥ `heavyMinHours`) |
| `light` | only estimate ≤ `lightMaxHours` AND priority P2/P3 |
| — | **unestimated tickets are eligible to every profile** (never starve) |

Estimates are normalized to hours from the map's `effortUnit` via `hoursPerDay` before threshold comparison. On `points` maps the effort triggers are inert (points aren't time) — only the P0 heavy trigger applies.

## Backward compatibility (the whole game)

`maps.profile_policy` is a nullable jsonb column, default `NULL`, and a null policy short-circuits before any eligibility code runs. A map without the config — i.e. the live prod map — behaves byte-for-byte as before, whatever profile string arrives. Routing only **filters** the gated ready set: `dispatchGate` / `dispatchPolicy` ranking semantics and the advisory-lock transaction shape are untouched.

## Layers (per the eight-layer definition of done)

1. `core/types.ts` — `ProfilePolicy` + `MindMap.profilePolicy`
2. `db/schema.ts` — nullable `profile_policy` jsonb
3. `db/migrate.ts` — idempotent `ADD COLUMN IF NOT EXISTS`
4. `db/helpers.ts` + `db/maps.ts` — `dbMapToCore` round-trip + `updateMap` pass-through
5. REST — rides the existing `PUT /api/maps/:id` verbatim-body forward (`UpdateMapInput`)
6. tool-kit — `update_map` zod (strict object, nullable to clear) + `get_next_ticket` profile description; mirrored types in tool-kit + mcp client
7. frontend store — no full-`MindMap` literals exist; typecheck confirms
8. tests — see below

## Tests

- `pull-queue.test.ts`: heavy-only ticket refused to standard/light and granted to heavy; unestimated granted to every profile; unknown/absent profile = standard; days/hours normalization; configurable thresholds; ranking order untouched after filtering; points-map inertness; **absent policy = zero behavior change for every profile string**
- `map.test.ts`: `profilePolicy` schema round-trip incl. explicit-null clear and no-accidental-clear
- `mapProfilePolicy.test.ts`: `dbMapToCore` maps missing/NULL column to `null`, stored objects intact

`pnpm turbo typecheck test`: 16/16 tasks, 1045 tests green.

Companion: claude-fleet#12 (actual-effort write-back) validates the estimate-as-difficulty proxy empirically before anyone trusts it hard.

Closes #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4RvFdhQxP1YjNxhCqwUXz