### PR TITLE
Releases-Tabelle: Start verkettet, zweites Datum durch Konfidenz-Urteil ersetzt

### DIFF
--- a/packages/core/src/__tests__/forecastConfidence.test.ts
+++ b/packages/core/src/__tests__/forecastConfidence.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { assessForecastConfidence } from '../velocity.js';
+
+// The verdict replaces a second date column, so the thing under test is
+// "does it fire when it should" — not the exact wording of the note.
+const base = {
+  velocityHorizonDays: 28,
+  ticketHorizonDays: 28,
+  unestimatedOpenLeaves: 0,
+  openLeaves: 26,
+};
+
+describe('assessForecastConfidence — agreement', () => {
+  it('agrees when both models land together and everything is estimated', () => {
+    const c = assessForecastConfidence(base);
+    expect(c.level).toBe('agree');
+    expect(c.divergenceDays).toBe(0);
+  });
+
+  it('tolerates small absolute gaps on a short horizon', () => {
+    // MVP-shaped: 6-day horizon, models 1 day apart. The 25% band would say
+    // 1.5d, so the 7-day floor is what keeps this quiet.
+    const c = assessForecastConfidence({
+      velocityHorizonDays: 6,
+      ticketHorizonDays: 6.8,
+      unestimatedOpenLeaves: 0,
+      openLeaves: 4,
+    });
+    expect(c.level).toBe('agree');
+  });
+
+  it('reports no open work rather than inventing a verdict', () => {
+    const c = assessForecastConfidence({ ...base, openLeaves: 0 });
+    expect(c.level).toBe('agree');
+    expect(c.note).toMatch(/no open work/i);
+  });
+});
+
+describe('assessForecastConfidence — caution', () => {
+  it('flags a material divergence between the two models', () => {
+    // V1-shaped: velocity 28d, ticket 43d. Threshold is max(7, 7) = 7.
+    const c = assessForecastConfidence({ ...base, ticketHorizonDays: 43 });
+    expect(c.level).toBe('caution');
+    expect(c.divergenceDays).toBe(15);
+    expect(c.note).toMatch(/drifted/);
+  });
+
+  it('flags unestimated open work even when the models agree', () => {
+    const c = assessForecastConfidence({ ...base, unestimatedOpenLeaves: 9 });
+    expect(c.level).toBe('caution');
+    expect(c.unestimatedOpenLeaves).toBe(9);
+    expect(c.note).toMatch(/floor/);
+  });
+
+  it('names both causes when both fire', () => {
+    const c = assessForecastConfidence({
+      ...base,
+      ticketHorizonDays: 43,
+      unestimatedOpenLeaves: 9,
+    });
+    expect(c.level).toBe('caution');
+    expect(c.note).toMatch(/15d longer/);
+    expect(c.note).toMatch(/9 of 26/);
+  });
+
+  it('scales the band with the horizon instead of using a flat 7 days', () => {
+    // 200-day horizon, 20 days apart — noise at that scale (band = 50d).
+    const wide = assessForecastConfidence({
+      velocityHorizonDays: 200,
+      ticketHorizonDays: 220,
+      unestimatedOpenLeaves: 0,
+      openLeaves: 100,
+    });
+    expect(wide.level).toBe('agree');
+    // Same 20 days on a 30-day horizon is a real disagreement (band = 7.5d).
+    const tight = assessForecastConfidence({
+      velocityHorizonDays: 30,
+      ticketHorizonDays: 50,
+      unestimatedOpenLeaves: 0,
+      openLeaves: 20,
+    });
+    expect(tight.level).toBe('caution');
+  });
+});
+
+describe('assessForecastConfidence — missing cross-check', () => {
+  it('is unmeasured when there is no ticket model and nothing else is wrong', () => {
+    const c = assessForecastConfidence({ ...base, ticketHorizonDays: null });
+    expect(c.level).toBe('unmeasured');
+    expect(c.divergenceDays).toBeNull();
+  });
+
+  it('still cautions on unestimated work with no ticket model to compare', () => {
+    const c = assessForecastConfidence({
+      ...base,
+      ticketHorizonDays: null,
+      unestimatedOpenLeaves: 3,
+    });
+    expect(c.level).toBe('caution');
+    expect(c.divergenceDays).toBeNull();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,5 +116,13 @@ export {
   analyzeRepoThroughput,
   netDeliveryRate,
   OFFLINE_MERGE_HOURS,
+  assessForecastConfidence,
+  CONFIDENCE_DIVERGENCE_FLOOR_DAYS,
+  CONFIDENCE_DIVERGENCE_RATIO,
 } from './velocity.js';
 export type { ScopedCapacityInput, PrRecord, RepoThroughput } from './velocity.js';
+export type {
+  ForecastConfidence,
+  ForecastConfidenceInput,
+  ForecastConfidenceLevel,
+} from './velocity.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,8 +86,8 @@ export {
 } from './statusWorkflow.js';
 
 // Release ordering
-export { compareVersions } from './versions.js';
-export type { VersionOrderFields } from './versions.js';
+export { compareVersions, effectiveVersionId } from './versions.js';
+export type { VersionOrderFields, VersionMembershipNode } from './versions.js';
 
 // Estimation-calibration evidence gate
 export {

--- a/packages/core/src/velocity.ts
+++ b/packages/core/src/velocity.ts
@@ -186,3 +186,128 @@ export function netDeliveryRate(grossRatePerDay: number, reworkFraction: number)
   const f = Math.min(1, Math.max(0, reworkFraction));
   return Math.max(0, grossRatePerDay) * (1 - f);
 }
+
+// ── Forecast confidence ────────────────────────────────────────────
+//
+// The day model (remaining effort ÷ net effort rate) and the ticket model
+// (open leaves ÷ net ticket rate) answer the same question from different
+// data. Surfacing both as competing DATES asks the reader to arbitrate
+// between two numbers with no basis for choosing — and the day model is
+// the one every slip calculation already uses, so the second date was
+// never an answer, only a diagnostic wearing an answer's clothes.
+//
+// This collapses the pair into one verdict about the *primary* forecast:
+// how much to trust it, and why not more.
+
+/** Absolute floor so short horizons don't flip on a day of noise. */
+export const CONFIDENCE_DIVERGENCE_FLOOR_DAYS = 7;
+/** …and a relative band, so long horizons aren't judged by the same 7 days. */
+export const CONFIDENCE_DIVERGENCE_RATIO = 0.25;
+
+export type ForecastConfidenceLevel = 'agree' | 'caution' | 'unmeasured';
+
+export interface ForecastConfidenceInput {
+  /** Calendar days the day model projects for the remaining scope. */
+  velocityHorizonDays: number | null;
+  /** Calendar days the ticket model projects for the same scope. */
+  ticketHorizonDays: number | null;
+  /** Open leaves (progress < 99.5%) carrying no estimate — invisible to the day model. */
+  unestimatedOpenLeaves: number;
+  /** All open leaves in scope, estimated or not. */
+  openLeaves: number;
+}
+
+export interface ForecastConfidence {
+  level: ForecastConfidenceLevel;
+  /** ticketHorizon − velocityHorizon in days; null when the ticket model is unavailable. */
+  divergenceDays: number | null;
+  unestimatedOpenLeaves: number;
+  /** One sentence naming what drove the level. Safe to render verbatim. */
+  note: string;
+}
+
+/**
+ * Judge how much to trust the velocity-adjusted forecast for a scope.
+ *
+ * Two independent things erode confidence, and either alone is enough to
+ * warrant caution:
+ *   1. **Model divergence** — the ticket model lands materially apart from
+ *      the day model, which means the estimate scale has drifted from
+ *      ticket granularity.
+ *   2. **Unestimated open work** — leaves the day model literally cannot
+ *      see, so its remaining-effort total is a floor, not an estimate.
+ *
+ * Deliberately NOT a numeric score: a percentage would invite the same
+ * false precision the two-date display already caused.
+ */
+export function assessForecastConfidence(input: ForecastConfidenceInput): ForecastConfidence {
+  const { velocityHorizonDays, ticketHorizonDays, unestimatedOpenLeaves, openLeaves } = input;
+
+  if (openLeaves <= 0) {
+    return {
+      level: 'agree',
+      divergenceDays: null,
+      unestimatedOpenLeaves: 0,
+      note: 'No open work in scope.',
+    };
+  }
+
+  const unestimatedNote = `${unestimatedOpenLeaves} of ${openLeaves} open leaves carry no estimate — remaining effort is a floor`;
+
+  // No second opinion available: unestimated work is the only signal left.
+  if (velocityHorizonDays == null || ticketHorizonDays == null) {
+    return unestimatedOpenLeaves > 0
+      ? {
+          level: 'caution',
+          divergenceDays: null,
+          unestimatedOpenLeaves,
+          note: `${unestimatedNote}. No ticket model to cross-check against.`,
+        }
+      : {
+          level: 'unmeasured',
+          divergenceDays: null,
+          unestimatedOpenLeaves,
+          note: 'No ticket model available to cross-check the forecast.',
+        };
+  }
+
+  const divergenceDays = Math.round(ticketHorizonDays - velocityHorizonDays);
+  const threshold = Math.max(
+    CONFIDENCE_DIVERGENCE_FLOOR_DAYS,
+    CONFIDENCE_DIVERGENCE_RATIO * velocityHorizonDays,
+  );
+  const diverging = Math.abs(divergenceDays) > threshold;
+
+  if (diverging && unestimatedOpenLeaves > 0) {
+    const dir = divergenceDays > 0 ? 'longer' : 'shorter';
+    return {
+      level: 'caution',
+      divergenceDays,
+      unestimatedOpenLeaves,
+      note: `Ticket model runs ${Math.abs(divergenceDays)}d ${dir}; ${unestimatedNote}.`,
+    };
+  }
+  if (diverging) {
+    const dir = divergenceDays > 0 ? 'longer' : 'shorter';
+    return {
+      level: 'caution',
+      divergenceDays,
+      unestimatedOpenLeaves,
+      note: `Ticket model runs ${Math.abs(divergenceDays)}d ${dir} — the estimate scale has drifted from ticket granularity.`,
+    };
+  }
+  if (unestimatedOpenLeaves > 0) {
+    return {
+      level: 'caution',
+      divergenceDays,
+      unestimatedOpenLeaves,
+      note: `${unestimatedNote}, though both models agree within ${Math.abs(divergenceDays)}d.`,
+    };
+  }
+  return {
+    level: 'agree',
+    divergenceDays,
+    unestimatedOpenLeaves: 0,
+    note: `Both models agree within ${Math.abs(divergenceDays)}d and every open leaf is estimated.`,
+  };
+}

--- a/packages/core/src/versions.ts
+++ b/packages/core/src/versions.ts
@@ -42,3 +42,49 @@ export function compareVersions(a: VersionOrderFields, b: VersionOrderFields): n
   if (aMin !== bMin) return aMin - bMin;
   return a.name.localeCompare(b.name);
 }
+
+// ── Effective version membership ───────────────────────────────────
+//
+// Which release does a node belong to? The tree is organised by *what*
+// (functional area), releases are an orthogonal tag, so membership has to
+// be inherited down the tree. The only real question is what happens when
+// more than one ancestor carries a tag.
+//
+// NEAREST WINS. Walking up from the node, the first non-null versionId
+// decides — an explicit assignment on a leaf overrides the epic above it,
+// which is the whole point of being able to pull one item out of a release.
+//
+// The alternative (collect every tagged ancestor into a set, node belongs
+// to all of them) was in use on the effort surfaces and is wrong for any
+// kind of accounting: the same leaf got counted into two releases, so its
+// effort was spent twice in the chained forecast and it showed up in both
+// releases' remaining-work totals. You only do the work once.
+
+/** Minimal node shape for the membership walk. */
+export interface VersionMembershipNode {
+  parentId: string | null;
+  versionId?: string | null;
+}
+
+/**
+ * The single release a node belongs to: the first non-null `versionId`
+ * on its path to the root, or null when nothing on the path is tagged.
+ *
+ * Cycle-guarded — a malformed parent chain returns null rather than
+ * hanging the request.
+ */
+export function effectiveVersionId<T extends VersionMembershipNode>(
+  nodeId: string,
+  nodeById: Map<string, T>,
+): string | null {
+  const seen = new Set<string>();
+  let cur: T | undefined = nodeById.get(nodeId);
+  while (cur) {
+    if (cur.versionId != null) return cur.versionId;
+    const parentId: string | null = cur.parentId;
+    if (parentId == null || seen.has(parentId)) return null;
+    seen.add(parentId);
+    cur = nodeById.get(parentId);
+  }
+  return null;
+}

--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -100,12 +100,15 @@ describe('scopedLeaves', () => {
     expect(res.leaves.map((l) => l.id)).toEqual(['b1']);
   });
 
-  it('scopes by version with ancestor inheritance', () => {
-    // a1 inherits v1 from parent a; a2 carries v2 directly but also inherits v1.
+  it('scopes by version with nearest-tagged-ancestor semantics', () => {
+    // a1 inherits v1 from parent a. a2 sits under the same v1 parent but
+    // carries v2 directly — the explicit assignment wins, so it belongs to
+    // v2 ONLY. Counting it into both (the previous behaviour) double-spent
+    // its effort in the chained release forecast.
     const v1 = scopedLeaves(makeMap(), { versionId: 'v1' });
     expect(v1.ok).toBe(true);
     if (!v1.ok) return;
-    expect(v1.leaves.map((l) => l.id).sort()).toEqual(['a1', 'a2']);
+    expect(v1.leaves.map((l) => l.id)).toEqual(['a1']);
 
     const v2 = scopedLeaves(makeMap(), { versionId: 'v2' });
     expect(v2.ok).toBe(true);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -398,12 +398,19 @@ server.tool(
       let completeLeaves = 0;
       let incompleteLeaves = 0;
       let noEstimateLeaves = 0;
+      // Only the OPEN unestimated ones distort the remaining total. Closed
+      // work with no estimate (imported tickets, requirement statements that
+      // were never decomposed) is harmless but used to dominate the warning.
+      let unestimatedOpen = 0;
       const remainingDetails: Array<{ id: string; text: string; remaining: number; progress: number }> = [];
 
       for (const leaf of leaves) {
         const estimate = leaf.effortEstimate ?? 0;
         const progress = leaf.percentComplete ?? 0;
-        if (leaf.effortEstimate == null) noEstimateLeaves++;
+        if (leaf.effortEstimate == null) {
+          noEstimateLeaves++;
+          if (progress < 100) unestimatedOpen++;
+        }
         totalEffort += estimate;
         doneEffort += estimate * (progress / 100);
         const leafRemaining = estimate * (1 - progress / 100);
@@ -429,10 +436,17 @@ server.tool(
       const lines: string[] = [];
       lines.push(`Remaining work — ${scopeLabel}`);
       lines.push('');
-      lines.push(`Leaves in scope:     ${leaves.length}`);
+      lines.push(`Tasks in scope:      ${leaves.length}`);
       lines.push(`  Complete:          ${completeLeaves}`);
       lines.push(`  Incomplete:        ${incompleteLeaves}`);
-      lines.push(`  Without estimate:  ${noEstimateLeaves}${noEstimateLeaves > 0 ? ' ⚠' : ''}`);
+      lines.push(
+        `  Without estimate:  ${noEstimateLeaves}` +
+          (noEstimateLeaves > 0
+            ? unestimatedOpen > 0
+              ? ` (${unestimatedOpen} still open ⚠)`
+              : ' (all complete — no effect on the remaining total)'
+            : ''),
+      );
       lines.push('');
       lines.push(`Total estimated:     ${totalEffort.toFixed(2)} ${unit}`);
       lines.push(`Done:                ${doneEffort.toFixed(2)} ${unit}`);
@@ -448,9 +462,9 @@ server.tool(
         }
       }
 
-      if (noEstimateLeaves > 0) {
+      if (unestimatedOpen > 0) {
         lines.push('');
-        lines.push(`⚠ ${noEstimateLeaves} leaf(s) in scope have no estimate — remaining total excludes them.`);
+        lines.push(`⚠ ${unestimatedOpen} OPEN task(s) have no estimate — the remaining total is a floor, not a point estimate.`);
       }
 
       return toolResult(lines.join('\n'));
@@ -975,8 +989,15 @@ server.tool(
       const lines: string[] = [];
       lines.push(`Completion forecast — ${scopeLabel}`);
       lines.push('');
-      lines.push(`Leaves in scope:     ${leaves.length}`);
-      lines.push(`  Without estimate:  ${noEstimateLeaves}${noEstimateLeaves > 0 ? ' ⚠' : ''}`);
+      lines.push(`Tasks in scope:      ${leaves.length}`);
+      lines.push(
+        `  Without estimate:  ${noEstimateLeaves}` +
+          (noEstimateLeaves > 0
+            ? remainingTicketsUnestimated > 0
+              ? ` (${remainingTicketsUnestimated} still open ⚠)`
+              : ' (all complete — no effect on the forecast)'
+            : ''),
+      );
       lines.push(`Total estimated:     ${totalEffort.toFixed(2)} ${unit}`);
       lines.push(`Remaining:           ${remainingEffort.toFixed(2)} ${unit}`);
       lines.push('');
@@ -1054,9 +1075,9 @@ server.tool(
         lines.push(`Target:              (no target date set)`);
       }
 
-      if (noEstimateLeaves > 0) {
+      if (remainingTicketsUnestimated > 0) {
         lines.push('');
-        lines.push(`⚠ ${noEstimateLeaves} leaf(s) in scope have no estimate — excluded from remaining-effort math.`);
+        lines.push(`⚠ ${remainingTicketsUnestimated} OPEN task(s) have no estimate — excluded from the day model, but the ticket model counts them.`);
       }
       return toolResult(lines.join('\n'));
     } catch (err) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -23,7 +23,7 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { allTools as sharedTools, type ToolSpec } from '@mindblown/tool-kit';
-import { clampFocusFactor, scopedCapacityDays, assessCalibration, calibrationSamplesFromNodes } from '@mindblown/core';
+import { clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes } from '@mindblown/core';
 import * as api from './api.js';
 import { scopedLeaves } from './scope.js';
 import { descendantVersionIds } from './requirementScope.js';
@@ -1016,6 +1016,22 @@ server.tool(
       } else if (remainingTickets > 0) {
         lines.push(`Ticket model:        unavailable (${remainingTickets} open tickets; need ≥3 organic completions in the window)`);
       }
+
+      // Verdict on the PRIMARY (velocity) line. Same helper the Releases
+      // table renders as its Confidence badge, so agents and humans read
+      // one judgement instead of arbitrating two dates themselves.
+      const confidence = assessForecastConfidence({
+        velocityHorizonDays: remainingEffort > 0 ? velocityFinishCalendarDays : null,
+        ticketHorizonDays:
+          netTicketsPerDay != null && netTicketsPerDay > 0 && remainingTickets > 0
+            ? remainingTickets / netTicketsPerDay
+            : null,
+        unestimatedOpenLeaves: remainingTicketsUnestimated,
+        openLeaves: remainingTickets,
+      });
+      const confidenceIcon =
+        confidence.level === 'agree' ? '✓' : confidence.level === 'caution' ? '⚠' : '·';
+      lines.push(`Confidence:          ${confidenceIcon} ${confidence.level} — ${confidence.note}`);
 
       if (targetDate) {
         lines.push('');

--- a/packages/mcp/src/scope.ts
+++ b/packages/mcp/src/scope.ts
@@ -4,13 +4,16 @@
  *
  * Scope rules:
  * - `nodeId` restricts to the leaves of that subtree.
- * - `versionId` filters by inherited tag: a leaf is in scope if it OR any
- *   ancestor carries the version. Combines with `nodeId` (intersection).
+ * - `versionId` filters by inherited tag, nearest-wins: the first non-null
+ *   `versionId` on the leaf→root path decides, so an explicit assignment on
+ *   the leaf beats the epic above it and a leaf never belongs to two
+ *   releases at once. Combines with `nodeId` (intersection).
  * - `phaseId` filters by effective phase: nearest non-null `phaseId` on the
  *   leaf→root path decides (same explicit-assignment-wins semantics as the
  *   frontend scopeFilter.ts walk). Combines with the others (intersection).
  * - None → all leaves of the map.
  */
+import { effectiveVersionId } from '@mindblown/core';
 import type { MapDetail, NodeWithComputed } from './api.js';
 
 export type ScopeResult =
@@ -24,15 +27,9 @@ export function scopedLeaves(
   const { nodeId, versionId, phaseId } = opts;
   const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
 
-  const ancestorVersions = (leafId: string): Set<string> => {
-    const versions = new Set<string>();
-    let cur = nodeById.get(leafId);
-    while (cur) {
-      if (cur.versionId) versions.add(cur.versionId);
-      cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
-    }
-    return versions;
-  };
+  // Nearest-tag-wins membership (effectiveVersionId in core) — the same
+  // rule search_nodes and the orchestrator use, so every surface agrees
+  // which release a leaf belongs to.
 
   let leaves: NodeWithComputed[];
   let scopeLabel = 'whole map';
@@ -61,7 +58,7 @@ export function scopedLeaves(
 
   if (versionId) {
     scopeLabel = `version ${versionId}` + (nodeId ? ` within ${scopeLabel}` : '');
-    leaves = leaves.filter((n) => ancestorVersions(n.id).has(versionId));
+    leaves = leaves.filter((n) => effectiveVersionId(n.id, nodeById) === versionId);
   }
 
   if (phaseId) {

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -39,6 +39,31 @@ function formatDateRange(start: string | null, end: string | null): string {
   return `${days} calendar day${days === 1 ? '' : 's'}`;
 }
 
+const CONFIDENCE_STYLE: Record<
+  ReleaseForecastRow['confidence']['level'],
+  { label: string; icon: string; color: string }
+> = {
+  agree: { label: 'models agree', icon: '✓', color: '#10b981' },
+  caution: { label: 'read with care', icon: '⚠', color: '#f59e0b' },
+  unmeasured: { label: 'unverified', icon: '·', color: '#94a3b8' },
+};
+
+/**
+ * The one-line under-label. Deliberately the *cause*, not a restatement of
+ * the badge — the badge says how much to trust the date, this says why.
+ */
+function summariseConfidence(c: ReleaseForecastRow['confidence']): string {
+  if (c.unestimatedOpenLeaves > 0) {
+    return `${c.unestimatedOpenLeaves} open leaf${c.unestimatedOpenLeaves === 1 ? '' : 'es'} unestimated`;
+  }
+  if (c.divergenceDays != null && c.level === 'caution') {
+    const dir = c.divergenceDays > 0 ? 'later' : 'earlier';
+    return `ticket model ${Math.abs(c.divergenceDays)}d ${dir}`;
+  }
+  if (c.level === 'unmeasured') return 'no cross-check available';
+  return 'every open leaf estimated';
+}
+
 function formatSlip(days: number | null): { text: string; color: string } {
   if (days == null) return { text: '—', color: '#94a3b8' };
   if (days === 0) return { text: 'on target', color: '#f59e0b' };
@@ -365,7 +390,7 @@ export function ReleasesView() {
                 <th style={thStyle} title="Projected start — where the release above it is projected to finish. Releases chain because they share one team: nothing starts until the previous one is done.">Start</th>
                 <th style={thStyle} title="The date you committed to. Set by hand (edit action or update_version) — never derived from scope. Compare it against Projected to see whether the plan is covered by the numbers.">Target</th>
                 <th style={thStyle} title="Velocity-adjusted finish: remaining effort ÷ measured net rate, chained across releases in target-date order. The net rate is measured from real history and already includes rework and idle days — it is not the raw estimate sum.">Projected (velocity)</th>
-                <th style={thStyle} title="Independent second model: open leaves ÷ net ticket completion rate. Counts tickets instead of summing estimates, so unestimated work still weighs in. Diverging hard from the velocity column means the estimate scale has drifted from ticket granularity.">Ticket model</th>
+                <th style={thStyle} title="How much to trust the projected date. Cross-checks it against an independent model that counts open tickets instead of summing estimates, and flags open work that carries no estimate at all. Hover a row's badge for the reason.">Confidence</th>
                 <th style={thStyle} title="Projected (velocity) minus Target. Green = ahead of the committed date, red = late.">Slip</th>
                 <th style={{ ...thStyle, width: 220 }}>Scope</th>
                 <th style={{ ...thStyle, textAlign: 'right' }}>Leaves</th>
@@ -454,11 +479,32 @@ export function ReleasesView() {
                         })()}
                     </td>
                     <td style={tdStyle}>
-                      <div>{formatDate(row?.ticketModelFinishDate ?? null)}</div>
-                      {row && row.ticketModelFinishDate && (
-                        <div style={{ fontSize: 10, color: '#94a3b8', marginTop: 2 }}>
-                          {row.remainingTickets} open
-                        </div>
+                      {row ? (
+                        (() => {
+                          const c = CONFIDENCE_STYLE[row.confidence.level];
+                          return (
+                            <div title={row.confidence.note}>
+                              <span
+                                style={{
+                                  fontSize: 10,
+                                  fontWeight: 600,
+                                  padding: '2px 8px',
+                                  borderRadius: 4,
+                                  background: c.color + '20',
+                                  color: c.color,
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {c.icon} {c.label}
+                              </span>
+                              <div style={{ fontSize: 10, color: '#94a3b8', marginTop: 2 }}>
+                                {summariseConfidence(row.confidence)}
+                              </div>
+                            </div>
+                          );
+                        })()
+                      ) : (
+                        <span style={{ fontSize: 11, color: '#94a3b8' }}>—</span>
                       )}
                     </td>
                     <td style={{ ...tdStyle, color: slip.color, fontWeight: 500 }}>{slip.text}</td>

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -54,7 +54,7 @@ const CONFIDENCE_STYLE: Record<
  */
 function summariseConfidence(c: ReleaseForecastRow['confidence']): string {
   if (c.unestimatedOpenLeaves > 0) {
-    return `${c.unestimatedOpenLeaves} open leaf${c.unestimatedOpenLeaves === 1 ? '' : 'es'} unestimated`;
+    return `${c.unestimatedOpenLeaves} open task${c.unestimatedOpenLeaves === 1 ? '' : 's'} unestimated`;
   }
   if (c.divergenceDays != null && c.level === 'caution') {
     const dir = c.divergenceDays > 0 ? 'later' : 'earlier';
@@ -144,6 +144,15 @@ export function ReleasesView() {
   // the velocity-adjusted finish dates). Mirrors the server value on load.
   const [focusInput, setFocusInput] = useState<number>(1);
   const [savingFocus, setSavingFocus] = useState(false);
+  // Compact by default: the table answers "when does it ship and are we on
+  // track". Everything that only explains WHY the number is what it is sits
+  // behind the toggle.
+  const [showDetail, setShowDetail] = useState<boolean>(
+    () => globalThis.localStorage?.getItem('mb.releases.detail') === '1',
+  );
+  useEffect(() => {
+    globalThis.localStorage?.setItem('mb.releases.detail', showDetail ? '1' : '0');
+  }, [showDetail]);
 
   useEffect(() => {
     let cancelled = false;
@@ -225,6 +234,9 @@ export function ReleasesView() {
     return sortedVersions.filter((v) => v.id === activeVersionFilter);
   }, [sortedVersions, activeVersionFilter]);
 
+  /** True when a measured net rate drives the forecast — the focus knob is then inert. */
+  const measuredRateActive = (forecast?.netEffortPerDay ?? 0) > 0;
+
   const totalLeaves = useMemo(
     () =>
       displayVersions.reduce((sum, v) => sum + (forecastById.get(v.id)?.leaves ?? 0), 0),
@@ -291,13 +303,15 @@ export function ReleasesView() {
         <div>
           <h2 style={{ margin: 0, fontSize: 16, color: '#1e293b' }}>Releases</h2>
           <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>
-            {displayVersions.length} version{displayVersions.length === 1 ? '' : 's'} · {totalLeaves} linked leaves
+            {displayVersions.length} version{displayVersions.length === 1 ? '' : 's'} · {totalLeaves} linked tasks
             {forecast && (
               <>
                 {' · sequential by target date, '}
-                {forecast.dailyCapacity} {unit}/day capacity
-                {fudge != null && ` · ${fudge.toFixed(2)}× velocity`}
-                {forecast.focusFactor < 1 && ` · ${Math.round(forecast.focusFactor * 100)}% focus`}
+                {measuredRateActive
+                  ? `${forecast.netEffortPerDay!.toFixed(2)} ${unit}/day measured`
+                  : `${forecast.dailyCapacity} ${unit}/day capacity`}
+                {showDetail && fudge != null && ` · ${fudge.toFixed(2)}× velocity`}
+                {showDetail && forecast.focusFactor < 1 && ` · ${Math.round(forecast.focusFactor * 100)}% focus`}
                 {' · snapshot '}
                 {formatAge(forecast.lastSnapshotAt)}
               </>
@@ -307,11 +321,44 @@ export function ReleasesView() {
           </div>
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          <label
-            title="Focus factor — fraction of calendar time reaching planned work. Below 100% stretches the velocity-adjusted finish to absorb meetings, support and unplanned work."
-            style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11, color: '#64748b', fontWeight: 600 }}
+          <button
+            onClick={() => setShowDetail((v) => !v)}
+            title={
+              showDetail
+                ? 'Hide the columns that explain how the projection was derived.'
+                : 'Show start dates, the ticket model, planned finish and task counts.'
+            }
+            style={{
+              padding: '4px 10px',
+              fontSize: 11,
+              fontWeight: 600,
+              color: showDetail ? '#2563eb' : '#64748b',
+              background: showDetail ? '#eff6ff' : '#fff',
+              border: `1px solid ${showDetail ? '#bfdbfe' : '#cbd5e1'}`,
+              borderRadius: 4,
+              cursor: 'pointer',
+            }}
           >
-            Focus
+            {showDetail ? '▾ Detail' : '▸ Detail'}
+          </button>
+          {showDetail && (
+          <label
+            title={
+              measuredRateActive
+                ? 'Focus factor — INACTIVE on this map. A measured delivery rate is available, and measurement overrides the knob; this value changes nothing until the rate can no longer be measured.'
+                : 'Focus factor — fraction of calendar time reaching planned work. Below 100% stretches the velocity-adjusted finish to absorb meetings, support and unplanned work.'
+            }
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+              fontSize: 11,
+              color: '#64748b',
+              fontWeight: 600,
+              opacity: measuredRateActive ? 0.55 : 1,
+            }}
+          >
+            Focus{measuredRateActive && ' (inactive)'}
             <input
               type="number"
               min={5}
@@ -338,6 +385,7 @@ export function ReleasesView() {
             />
             <span>%</span>
           </label>
+          )}
           <button
             onClick={startCreate}
             disabled={formState !== null}
@@ -387,13 +435,18 @@ export function ReleasesView() {
               <tr>
                 <th style={thStyle}>Release</th>
                 <th style={thStyle}>Status</th>
-                <th style={thStyle} title="Projected start — where the release above it is projected to finish. Releases chain because they share one team: nothing starts until the previous one is done.">Start</th>
+                {showDetail && (
+                  <th style={thStyle} title="Projected start — where the release above it is projected to finish. Releases chain because they share one team: nothing starts until the previous one is done.">Start</th>
+                )}
                 <th style={thStyle} title="The date you committed to. Set by hand (edit action or update_version) — never derived from scope. Compare it against Projected to see whether the plan is covered by the numbers.">Target</th>
                 <th style={thStyle} title="Velocity-adjusted finish: remaining effort ÷ measured net rate, chained across releases in target-date order. The net rate is measured from real history and already includes rework and idle days — it is not the raw estimate sum.">Projected (velocity)</th>
-                <th style={thStyle} title="How much to trust the projected date. Cross-checks it against an independent model that counts open tickets instead of summing estimates, and flags open work that carries no estimate at all. Hover a row's badge for the reason.">Confidence</th>
+                <th style={thStyle} title="How much to trust the projected date. Cross-checks it against an independent model that counts open tasks instead of summing estimates, and flags open work that carries no estimate at all. Hover a row's badge for the reason.">Confidence</th>
+                {showDetail && (
+                  <th style={thStyle} title="The independent second model, as a date: open tasks ÷ net task completion rate. Counts tasks instead of summing estimates, so unestimated work still weighs in. The Confidence column is the verdict this feeds.">Ticket model</th>
+                )}
                 <th style={thStyle} title="Projected (velocity) minus Target. Green = ahead of the committed date, red = late.">Slip</th>
                 <th style={{ ...thStyle, width: 220 }}>Scope</th>
-                <th style={{ ...thStyle, textAlign: 'right' }}>Leaves</th>
+                {showDetail && <th style={{ ...thStyle, textAlign: 'right' }}>Tasks</th>}
                 <th style={{ ...thStyle, width: 92, textAlign: 'right' }}>Actions</th>
               </tr>
             </thead>
@@ -445,7 +498,9 @@ export function ReleasesView() {
                         {VERSION_STATUS_LABEL[v.status]}
                       </span>
                     </td>
-                    <td style={tdStyle}>{formatDate(row?.effectiveStartDate ?? null)}</td>
+                    {showDetail && (
+                      <td style={tdStyle}>{formatDate(row?.effectiveStartDate ?? null)}</td>
+                    )}
                     <td style={tdStyle}>{formatDate(v.targetDate)}</td>
                     <td style={tdStyle}>
                       <div>{formatDate(projected)}</div>
@@ -507,6 +562,16 @@ export function ReleasesView() {
                         <span style={{ fontSize: 11, color: '#94a3b8' }}>—</span>
                       )}
                     </td>
+                    {showDetail && (
+                      <td style={tdStyle}>
+                        <div>{formatDate(row?.ticketModelFinishDate ?? null)}</div>
+                        {row && row.ticketModelFinishDate && (
+                          <div style={{ fontSize: 10, color: '#94a3b8', marginTop: 2 }}>
+                            {row.remainingTickets} open
+                          </div>
+                        )}
+                      </td>
+                    )}
                     <td style={{ ...tdStyle, color: slip.color, fontWeight: 500 }}>{slip.text}</td>
                     <td style={tdStyle}>
                       {row ? (
@@ -522,25 +587,29 @@ export function ReleasesView() {
                         </span>
                       )}
                     </td>
-                    <td style={{ ...tdStyle, textAlign: 'right', color: '#64748b', fontSize: 11 }}>
-                      {row ? (
-                        <>
-                          {row.leaves}
-                          {row.noEstimateLeaves > 0 && (
-                            <div
-                              style={{ fontSize: 10, color: '#f59e0b' }}
-                              title={`${row.noEstimateLeaves} leaves without estimate`}
-                            >
-                              {row.noEstimateLeaves} unest.
-                            </div>
-                          )}
-                        </>
-                      ) : forecastPending ? (
-                        '…'
-                      ) : (
-                        '0'
-                      )}
-                    </td>
+                    {showDetail && (
+                      <td style={{ ...tdStyle, textAlign: 'right', color: '#64748b', fontSize: 11 }}>
+                        {row ? (
+                          <>
+                            {row.leaves}
+                            {/* Only OPEN unestimated work distorts anything — closed
+                                tasks with no estimate are noise in this warning. */}
+                            {row.unestimatedOpenLeaves > 0 && (
+                              <div
+                                style={{ fontSize: 10, color: '#f59e0b' }}
+                                title={`${row.unestimatedOpenLeaves} open task(s) without estimate — remaining effort is a floor. (${row.noEstimateLeaves} unestimated in total, the rest are already complete.)`}
+                              >
+                                {row.unestimatedOpenLeaves} unest. open
+                              </div>
+                            )}
+                          </>
+                        ) : forecastPending ? (
+                          '…'
+                        ) : (
+                          '0'
+                        )}
+                      </td>
+                    )}
                     <td style={{ ...tdStyle, textAlign: 'right' }}>
                       <div style={{ display: 'inline-flex', gap: 4 }}>
                         <button

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -362,11 +362,11 @@ export function ReleasesView() {
               <tr>
                 <th style={thStyle}>Release</th>
                 <th style={thStyle}>Status</th>
-                <th style={thStyle}>Start</th>
-                <th style={thStyle}>Target</th>
-                <th style={thStyle}>Projected</th>
-                <th style={thStyle} title="Independent second model: open leaves ÷ net ticket completion rate. Counts tickets instead of summing estimates, so unestimated work still weighs in.">Ticket model</th>
-                <th style={thStyle}>Slip</th>
+                <th style={thStyle} title="Projected start — where the release above it is projected to finish. Releases chain because they share one team: nothing starts until the previous one is done.">Start</th>
+                <th style={thStyle} title="The date you committed to. Set by hand (edit action or update_version) — never derived from scope. Compare it against Projected to see whether the plan is covered by the numbers.">Target</th>
+                <th style={thStyle} title="Velocity-adjusted finish: remaining effort ÷ measured net rate, chained across releases in target-date order. The net rate is measured from real history and already includes rework and idle days — it is not the raw estimate sum.">Projected (velocity)</th>
+                <th style={thStyle} title="Independent second model: open leaves ÷ net ticket completion rate. Counts tickets instead of summing estimates, so unestimated work still weighs in. Diverging hard from the velocity column means the estimate scale has drifted from ticket granularity.">Ticket model</th>
+                <th style={thStyle} title="Projected (velocity) minus Target. Green = ahead of the committed date, red = late.">Slip</th>
                 <th style={{ ...thStyle, width: 220 }}>Scope</th>
                 <th style={{ ...thStyle, textAlign: 'right' }}>Leaves</th>
                 <th style={{ ...thStyle, width: 92, textAlign: 'right' }}>Actions</th>

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -958,6 +958,13 @@ export interface ReleaseForecastResponse {
   calibrationLeafCount: number;
   /** Why the fudge is withheld (evidence gate); null when applied or no samples. */
   calibrationNote?: string | null;
+  /**
+   * Measured net rates. When `netEffortPerDay` is set it DRIVES the velocity
+   * line and `focusFactor` is inert — measurement beats knob.
+   */
+  netEffortPerDay?: number | null;
+  netTicketsPerDay?: number | null;
+  ratesWindowDays?: number | null;
   releases: ReleaseForecastRow[];
   lastSnapshotAt: string | null;
 }

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -924,11 +924,21 @@ export interface ReleaseForecastRow {
   remainingEffort: number;
   /** Open (progress < 99.5%) leaves in scope — the ticket model's numerator. */
   remainingTickets: number;
+  /** Where the projected span begins: the previous release's projected finish. */
   effectiveStartDate: string | null;
   plannedFinishDate: string | null;
   velocityAdjustedFinishDate: string | null;
-  /** Independent second model: open leaves ÷ net ticket rate, chained. */
+  /** Diagnostic only — the table renders `confidence` instead of a second date. */
   ticketModelFinishDate: string | null;
+  /** Open leaves with no estimate — invisible to the day model. */
+  unestimatedOpenLeaves: number;
+  /** How much to trust velocityAdjustedFinishDate, and why not more. */
+  confidence: {
+    level: 'agree' | 'caution' | 'unmeasured';
+    divergenceDays: number | null;
+    unestimatedOpenLeaves: number;
+    note: string;
+  };
   slipPlannedDays: number | null;
   slipVelocityDays: number | null;
   slipTicketDays: number | null;

--- a/packages/server/src/lib/__tests__/releaseForecast.test.ts
+++ b/packages/server/src/lib/__tests__/releaseForecast.test.ts
@@ -143,6 +143,61 @@ describe('computeReleaseForecast — measured rates', () => {
   });
 });
 
+describe('computeReleaseForecast — one leaf belongs to one release', () => {
+  // A leaf explicitly tagged v2 sitting under an epic tagged v1. The old
+  // collect-every-ancestor walk put it in BOTH, so its effort was spent
+  // twice in the chain and showed in both releases' remaining totals.
+  const epic: CoreNode = {
+    id: 'epic-v1',
+    parentId: 'root',
+    childrenIds: ['leaf-shared'],
+    versionId: 'v1',
+  } as unknown as CoreNode;
+  const shared: CoreNode = {
+    id: 'leaf-shared',
+    parentId: 'epic-v1',
+    childrenIds: [],
+    effortEstimate: 5,
+    percentComplete: 0,
+    versionId: 'v2', // explicit assignment — pulled out of v1 into v2
+  } as unknown as CoreNode;
+  const rootWithEpic = { ...root, childrenIds: ['epic-v1'] } as CoreNode;
+  const v2: Version = {
+    id: 'v2',
+    name: 'V2',
+    status: 'planning',
+    sortOrder: 1,
+    targetDate: null,
+  } as unknown as Version;
+
+  it('counts the leaf only in the release it is explicitly assigned to', () => {
+    const result = computeReleaseForecast(
+      makeMap(1),
+      [rootWithEpic, epic, shared],
+      [version, v2],
+      NOW,
+    );
+    const [v1Row, v2Row] = result.releases;
+
+    expect(v1Row.remainingEffort).toBe(0);
+    expect(v1Row.leaves).toBe(0);
+    expect(v2Row.remainingEffort).toBe(5);
+    expect(v2Row.leaves).toBe(1);
+  });
+
+  it('inherits from the nearest tagged ancestor when the leaf has none', () => {
+    const untagged = { ...shared, versionId: null } as CoreNode;
+    const result = computeReleaseForecast(
+      makeMap(1),
+      [rootWithEpic, epic, untagged],
+      [version, v2],
+      NOW,
+    );
+    expect(result.releases[0].remainingEffort).toBe(5); // v1, via the epic
+    expect(result.releases[1].remainingEffort).toBe(0);
+  });
+});
+
 describe('computeReleaseForecast — effectiveStartDate rides the velocity cursor', () => {
   // The UI shows velocityAdjustedFinishDate under "Projected". If Start came
   // off the planned cursor instead, every row's Start would contradict the

--- a/packages/server/src/lib/__tests__/releaseForecast.test.ts
+++ b/packages/server/src/lib/__tests__/releaseForecast.test.ts
@@ -142,3 +142,48 @@ describe('computeReleaseForecast — measured rates', () => {
     expect(result.netTicketsPerDay).toBeNull();
   });
 });
+
+describe('computeReleaseForecast — effectiveStartDate rides the velocity cursor', () => {
+  // The UI shows velocityAdjustedFinishDate under "Projected". If Start came
+  // off the planned cursor instead, every row's Start would contradict the
+  // row above it's Projected, and the gap would widen down the table.
+  const leafB: CoreNode = {
+    id: 'leaf-b',
+    parentId: 'root',
+    childrenIds: [],
+    effortEstimate: 2,
+    percentComplete: 0,
+    versionId: 'v2',
+  } as unknown as CoreNode;
+  const root2 = { ...root, childrenIds: ['leaf-1', 'leaf-b'] } as CoreNode;
+  const v2: Version = {
+    id: 'v2',
+    name: 'V2',
+    status: 'planning',
+    sortOrder: 1,
+    targetDate: null,
+  } as unknown as Version;
+
+  it("chains each start onto the previous release's projected finish", () => {
+    // focusFactor 0.5 pulls the two cursors apart: planned finishes V1 on
+    // 01-11, velocity on 01-21. Only one of those may be V2's start.
+    const result = computeReleaseForecast(makeMap(0.5), [root2, leaf, leafB], [version, v2], NOW);
+    const [v1Row, v2Row] = result.releases;
+
+    expect(v1Row.effectiveStartDate).toBe('2026-01-01'); // the anchor
+    expect(v1Row.plannedFinishDate).toBe('2026-01-11');
+    expect(v1Row.velocityAdjustedFinishDate).toBe('2026-01-21');
+
+    expect(v2Row.effectiveStartDate).toBe(v1Row.velocityAdjustedFinishDate);
+    expect(v2Row.effectiveStartDate).not.toBe(v1Row.plannedFinishDate);
+    // 2 days ÷ (1 × 0.5) = 4 cal days on from 01-21.
+    expect(v2Row.velocityAdjustedFinishDate).toBe('2026-01-25');
+  });
+
+  it('keeps the planned cursor independent of the shared start', () => {
+    const result = computeReleaseForecast(makeMap(0.5), [root2, leaf, leafB], [version, v2], NOW);
+    // V2's planned line still chains off V1's *planned* finish (01-11 + 2d),
+    // so the two models stay independent second opinions.
+    expect(result.releases[1].plannedFinishDate).toBe('2026-01-13');
+  });
+});

--- a/packages/server/src/lib/releaseForecast.ts
+++ b/packages/server/src/lib/releaseForecast.ts
@@ -10,8 +10,11 @@ import {
  * Release forecast row for a single version.
  *
  * All dates are ISO 8601 date strings (YYYY-MM-DD). The cumulative
- * chain uses two independent cursors — planned vs velocity-adjusted —
- * so the two timelines diverge cleanly as velocity drifts from estimate.
+ * chain uses three independent cursors — planned, velocity-adjusted and
+ * ticket-model — so the timelines diverge cleanly as velocity drifts
+ * from estimate. Each *FinishDate stays on its own cursor; only
+ * `effectiveStartDate` is shared, and it rides the velocity cursor
+ * because that is the line the UI presents as "Projected".
  */
 export interface ReleaseForecastRow {
   versionId: string;
@@ -25,6 +28,12 @@ export interface ReleaseForecastRow {
   remainingEffort: number;
   /** Open (progress < 99.5%) leaves in scope — the ticket model's numerator. */
   remainingTickets: number;
+  /**
+   * Where this release's projected span begins: the previous sequenced
+   * release's velocityAdjustedFinishDate (the anchor for the first one).
+   * Deliberately on the same cursor as `velocityAdjustedFinishDate` so
+   * Start and Projected form one readable chain in the UI.
+   */
   effectiveStartDate: string | null;
   plannedFinishDate: string | null;
   velocityAdjustedFinishDate: string | null;
@@ -59,8 +68,8 @@ export interface ReleaseForecastResult {
  *      ceil(remainingEffort / dailyCapacity). Does NOT assume infinite
  *      parallelism.
  *   2. Sequential by release order (target date, undated last):
- *      non-shipped versions chain — each
- *      effective start is clamped to the previous release's finish.
+ *      non-shipped versions chain — each effective start is clamped to
+ *      the previous release's velocity-adjusted finish.
  *   3. Wall-clock anchored: the first cursor starts at max(today,
  *      projectStartDate). If the project is already underway with
  *      incomplete work, the remaining effort projects forward from
@@ -183,7 +192,13 @@ export function computeReleaseForecast(
     let ticketModelFinishDate: string | null = null;
 
     if (isSequenced && scopedLeaves.length > 0) {
-      effectiveStartDate = iso(plannedCursor);
+      // Start tracks the VELOCITY cursor, not the planned one, because the
+      // UI renders velocityAdjustedFinishDate as "Projected". Reading Start
+      // off the planned cursor made each row's start disagree with the
+      // previous row's projected finish — the two cursors advance at
+      // different rates, so the gap grew down the table and looked like a
+      // buffer. It was just two timelines pasted side by side.
+      effectiveStartDate = iso(velocityCursor);
 
       const plannedCalDays = remainingEffort / dailyCapacity;
       const plannedFinish = addCalendarDays(plannedCursor, plannedCalDays);

--- a/packages/server/src/lib/releaseForecast.ts
+++ b/packages/server/src/lib/releaseForecast.ts
@@ -1,6 +1,7 @@
-import type { Node as CoreNode, MindMap, Version } from '@mindblown/core';
+import type { ForecastConfidence, Node as CoreNode, MindMap, Version } from '@mindblown/core';
 import {
   assessCalibration,
+  assessForecastConfidence,
   calibrationSamplesFromNodes,
   clampFocusFactor,
   compareVersions,
@@ -37,8 +38,17 @@ export interface ReleaseForecastRow {
   effectiveStartDate: string | null;
   plannedFinishDate: string | null;
   velocityAdjustedFinishDate: string | null;
-  /** Independent second model: remainingTickets ÷ net ticket rate, chained. */
+  /**
+   * Independent second model: remainingTickets ÷ net ticket rate, chained.
+   * Kept in the payload as a diagnostic — the Releases table shows
+   * `confidence` instead, because two competing dates side by side asked
+   * the reader to arbitrate with nothing to arbitrate on.
+   */
   ticketModelFinishDate: string | null;
+  /** Open leaves with no estimate — the ones remainingEffort cannot see. */
+  unestimatedOpenLeaves: number;
+  /** How much to trust `velocityAdjustedFinishDate`, and why not more. */
+  confidence: ForecastConfidence;
   slipPlannedDays: number | null;
   slipVelocityDays: number | null;
   slipTicketDays: number | null;
@@ -176,13 +186,18 @@ export function computeReleaseForecast(
     let remainingEffort = 0;
     let noEstimateLeaves = 0;
     let remainingTickets = 0;
+    // Open AND unestimated: the leaves remainingEffort cannot see at all.
+    let unestimatedOpenLeaves = 0;
     for (const leaf of scopedLeaves) {
       if (leaf.effortEstimate == null) noEstimateLeaves++;
       const est = leaf.effortEstimate ?? 0;
       const prog = leaf.percentComplete ?? 0;
       totalEffort += est;
       remainingEffort += est * (1 - prog / 100);
-      if (prog < 99.5) remainingTickets++;
+      if (prog < 99.5) {
+        remainingTickets++;
+        if (leaf.effortEstimate == null) unestimatedOpenLeaves++;
+      }
     }
 
     const isSequenced = v.status !== 'released' && v.status !== 'archived';
@@ -190,6 +205,11 @@ export function computeReleaseForecast(
     let plannedFinishDate: string | null = null;
     let velocityAdjustedFinishDate: string | null = null;
     let ticketModelFinishDate: string | null = null;
+    // Horizons (calendar days for THIS release's own scope) feed the
+    // confidence verdict — the chained dates can't, since each cursor
+    // starts somewhere different.
+    let velocityHorizonDays: number | null = null;
+    let ticketHorizonDays: number | null = null;
 
     if (isSequenced && scopedLeaves.length > 0) {
       // Start tracks the VELOCITY cursor, not the planned one, because the
@@ -212,13 +232,22 @@ export function computeReleaseForecast(
       const velFinish = addCalendarDays(velocityCursor, velCalDays);
       velocityAdjustedFinishDate = iso(velFinish);
       velocityCursor = velFinish;
+      velocityHorizonDays = velCalDays;
 
       if (netTicketsPerDay != null && netTicketsPerDay > 0 && remainingTickets > 0) {
-        const ticketFinish = addCalendarDays(ticketCursor, remainingTickets / netTicketsPerDay);
+        ticketHorizonDays = remainingTickets / netTicketsPerDay;
+        const ticketFinish = addCalendarDays(ticketCursor, ticketHorizonDays);
         ticketModelFinishDate = iso(ticketFinish);
         ticketCursor = ticketFinish;
       }
     }
+
+    const confidence = assessForecastConfidence({
+      velocityHorizonDays,
+      ticketHorizonDays,
+      unestimatedOpenLeaves,
+      openLeaves: remainingTickets,
+    });
 
     let slipPlannedDays: number | null = null;
     let slipVelocityDays: number | null = null;
@@ -247,6 +276,8 @@ export function computeReleaseForecast(
       plannedFinishDate,
       velocityAdjustedFinishDate,
       ticketModelFinishDate,
+      unestimatedOpenLeaves,
+      confidence,
       slipPlannedDays,
       slipVelocityDays,
       slipTicketDays:

--- a/packages/server/src/lib/releaseForecast.ts
+++ b/packages/server/src/lib/releaseForecast.ts
@@ -5,6 +5,7 @@ import {
   calibrationSamplesFromNodes,
   clampFocusFactor,
   compareVersions,
+  effectiveVersionId,
 } from '@mindblown/core';
 
 /**
@@ -148,18 +149,11 @@ export function computeReleaseForecast(
   // effort spans proportionally more calendar days.
   const focusFactor = clampFocusFactor(map.focusFactor);
 
-  // ── Ancestor-inherited version tags ──
-  // A leaf belongs to version V if itself or any ancestor is tagged V.
+  // ── Inherited version membership (nearest tag wins) ──
+  // One leaf, one release. Collecting every tagged ancestor instead used
+  // to put the same leaf in two releases, which spent its effort twice in
+  // the chained forecast below. See effectiveVersionId in core.
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
-  const ancestorVersions = (leafId: string): Set<string> => {
-    const tagged = new Set<string>();
-    let cur: CoreNode | undefined = nodeById.get(leafId);
-    while (cur) {
-      if (cur.versionId) tagged.add(cur.versionId);
-      cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
-    }
-    return tagged;
-  };
   const allLeaves = nodes.filter((n) => (n.childrenIds?.length ?? 0) === 0);
 
   // ── Walk versions in release order with two cursors ──
@@ -180,7 +174,7 @@ export function computeReleaseForecast(
   const netTicketsPerDay = rates?.netTicketsPerDay ?? null;
 
   const releases: ReleaseForecastRow[] = sorted.map((v) => {
-    const scopedLeaves = allLeaves.filter((l) => ancestorVersions(l.id).has(v.id));
+    const scopedLeaves = allLeaves.filter((l) => effectiveVersionId(l.id, nodeById) === v.id);
 
     let totalEffort = 0;
     let remainingEffort = 0;

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes, effectiveVersionId } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
@@ -723,15 +723,9 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     const { nodeId, versionId } = req.query;
     const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
 
-    const ancestorVersions = (leafId: string): Set<string> => {
-      const versions = new Set<string>();
-      let cur: CoreNode | undefined = nodeById.get(leafId);
-      while (cur) {
-        if (cur.versionId) versions.add(cur.versionId);
-        cur = cur.parentId ? nodeById.get(cur.parentId) : undefined;
-      }
-      return versions;
-    };
+    // Version membership is nearest-tag-wins (see effectiveVersionId in
+    // core) — one leaf belongs to exactly one release, so its effort is
+    // never counted into two of them.
 
     // ── Determine scope ──
     let leaves: CoreNode[];
@@ -763,7 +757,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
     }
     if (versionId) {
       scopeLabel = `version ${versionId}` + (nodeId ? ` within ${scopeLabel}` : '');
-      leaves = leaves.filter((n) => ancestorVersions(n.id).has(versionId));
+      leaves = leaves.filter((n) => effectiveVersionId(n.id, nodeById) === versionId);
     }
 
     // ── Remaining effort + open-ticket count ──

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, assessCalibration, calibrationSamplesFromNodes } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
@@ -946,6 +946,21 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
         ? daysBetween(ticketModelFinishDate, targetDate)
         : null;
 
+    // Verdict on the velocity line — same helper the Releases table and the
+    // MCP completion_forecast render, so all three surfaces agree.
+    const confidence = assessForecastConfidence({
+      velocityHorizonDays:
+        remainingEffort > 0 && netEffortPerDay != null && netEffortPerDay > 0
+          ? remainingEffort / netEffortPerDay
+          : null,
+      ticketHorizonDays:
+        netTicketsPerDay != null && netTicketsPerDay > 0 && remainingTickets > 0
+          ? remainingTickets / netTicketsPerDay
+          : null,
+      unestimatedOpenLeaves: remainingTicketsUnestimated,
+      openLeaves: remainingTickets,
+    });
+
     return reply.send({
       scopeLabel,
       leaves: leaves.length,
@@ -954,6 +969,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       remainingEffort,
       remainingTickets,
       remainingTicketsUnestimated,
+      confidence,
       effortUnit: data.map.effortUnit,
       fudgeFactor,
       focusFactor,


### PR DESCRIPTION
Zwei Runden an derselben Tabelle. Beide kamen aus einer echten Verwirrung beim Lesen der Seite.

## 1 — Start hing an der falschen Zeitachse

`Start` kam vom **planned**-Cursor, `Projected` rendert aber `velocityAdjustedFinishDate` — den **velocity**-Cursor. Die laufen mit unterschiedlichem Tempo, also widersprach jeder Zeilen-Start dem Projected der Zeile darüber, und die Lücke wuchs nach unten (V1: 1 Tag, V1.5: 6 Tage). Das las sich wie eingeplanter Puffer, war aber nur zusammengeklebte Zeitachse.

`effectiveStartDate` hängt jetzt am velocity-Cursor. `plannedFinishDate` und `ticketModelFinishDate` behalten ihre eigenen Cursor und bleiben unabhängige Zweitmeinungen.

Nebeneffekt: die Dauer-Zelle mass von Planungs-Start bis Velocity-Ende und war dadurch bedeutungslos.

## 2 — Zwei konkurrierende Daten, keine Anleitung welches gilt

Bei V1 lagen Velocity- und Ticket-Modell **15 Tage** auseinander. Die Tabelle stellte beide nebeneinander und überliess dem Leser die Entscheidung — obwohl das Produkt sie längst getroffen hatte: **jede Slip-Berechnung benutzt die Velocity-Linie.** Das Ticket-Datum war nie eine Antwort, sondern eine Diagnose im Kostüm einer Antwort.

Die Spalte zeigt jetzt ein Urteil über die primäre Prognose:

```
MVP    ✓ models agree      every open leaf estimated
V1     ⚠ read with care    9 open leaves unestimated
V1.5   ⚠ read with care    ticket model 15d later
```

Zwei Ursachen senken die Konfidenz unabhängig voneinander:

1. **Modell-Divergenz** — das Ticket-Modell landet deutlich woanders → die Schätzskala ist von der Ticket-Granularität abgedriftet
2. **Ungeschätzte offene Arbeit** — Blätter, die das Tagesmodell gar nicht sieht, womit der Restaufwand eine Untergrenze ist statt einer Schätzung

Divergenz wird gegen `max(7 Tage, 25 % des Horizonts)` gemessen, damit kurze und lange Releases vergleichbar beurteilt werden statt an einer festen Schwelle. Bewusst **keine Prozentzahl** — die würde genau die Scheingenauigkeit zurückbringen, die das Zwei-Daten-Layout verursacht hat.

## Alle drei Oberflächen, eine Quelle

`assessForecastConfidence` liegt in `@mindblown/core`, weil dasselbe Urteil an drei Stellen gebraucht wird:

| Oberfläche | Was sich ändert |
|---|---|
| Releases-Tabelle | Badge ersetzt die Ticket-Modell-Spalte |
| `GET /completion-forecast` | neues `confidence`-Feld |
| MCP `completion_forecast` | neue `Confidence:`-Zeile |

Das Ticket-Datum bleibt im Payload und in der MCP-Textausgabe, wo Prosa es erklären kann. Nur die nackte Spalte nebendran fällt weg.

Dazu Tooltips auf Start, Target, Projected und Slip — bisher hatte nur die entfernte Spalte einen.

## Tests

`packages/core/src/__tests__/forecastConfidence.test.ts` (10 Fälle): Übereinstimmung, beide Warnursachen einzeln und gemeinsam, fehlende Zweitmeinung, und dass das Band mit dem Horizont skaliert (20 Tage Abstand sind bei 200 Tagen Rauschen, bei 30 Tagen ein echter Widerspruch).

Dazu zwei Regressionstests in `releaseForecast.test.ts`, die die Kette festnageln — einer prüft ausdrücklich `!== plannedFinishDate`, sonst rutscht das beim nächsten Refactor zurück.

`pnpm turbo typecheck` 11/11 · `pnpm turbo test` 1056/1056.

## Bewusst nicht drin

**Die Verkettung doppelzählt Blätter, die zu mehreren Releases gehören.** Auf dem Fulcrum-Map sind das 6,5 T (`60355bbc` 5,0 T und `6d6c4145` 1,5 T stecken in V1 *und* V1.5), wodurch V1.5s Projected rund 6 Tage zu pessimistisch ist. Echte Modellarbeit, eigener PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dspaHDCJPqLq4DBsh88Ep