### PR TITLE
fix(releases): negative slip is buffer, not "ahead"

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1058,17 +1058,23 @@ server.tool(
         lines.push('');
         lines.push(`Target:              ${targetDate} (${targetSource})`);
         const targetDateObj = new Date(targetDate);
+        // A negative slip is BUFFER — unspent room between the projection and
+        // the committed date — not evidence the release is running early.
+        // Name it so, or readers spend it.
+        const slipLine = (label: string, days: number) =>
+          days > 0
+            ? `${label.padEnd(20)} ${days} days late`
+            : days < 0
+              ? `${label.padEnd(20)} ${Math.abs(days)} days buffer`
+              : `${label.padEnd(20)} exactly on target (no buffer)`;
         if (hasSchedulableEffort) {
-          const slipPlanned = daysBetween(plannedFinishDate, targetDateObj);
-          lines.push(`Slip (planned):      ${slipPlanned >= 0 ? '+' : ''}${slipPlanned} days`);
+          lines.push(slipLine('Planned vs target:', daysBetween(plannedFinishDate, targetDateObj)));
         }
         if (remainingEffort > 0) {
-          const slipVel = daysBetween(velocityFinishDate, targetDateObj);
-          lines.push(`Slip (velocity):     ${slipVel >= 0 ? '+' : ''}${slipVel} days`);
+          lines.push(slipLine('Velocity vs target:', daysBetween(velocityFinishDate, targetDateObj)));
         }
         if (ticketFinishDate != null) {
-          const slipTicket = daysBetween(ticketFinishDate, targetDateObj);
-          lines.push(`Slip (ticket model): ${slipTicket >= 0 ? '+' : ''}${slipTicket} days`);
+          lines.push(slipLine('Ticket vs target:', daysBetween(ticketFinishDate, targetDateObj)));
         }
       } else {
         lines.push('');

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -64,10 +64,16 @@ function summariseConfidence(c: ReleaseForecastRow['confidence']): string {
   return 'every open leaf estimated';
 }
 
+/**
+ * Negative slip is BUFFER, not "ahead". "Ahead" claims the release is
+ * running early — a statement about progress. All the number actually says
+ * is that the committed date sits later than the projection, which is room
+ * you deliberately left yourself. Calling it "ahead" invites spending it.
+ */
 function formatSlip(days: number | null): { text: string; color: string } {
   if (days == null) return { text: '—', color: '#94a3b8' };
-  if (days === 0) return { text: 'on target', color: '#f59e0b' };
-  if (days < 0) return { text: `${Math.abs(days)}d ahead`, color: '#10b981' };
+  if (days === 0) return { text: 'no buffer', color: '#f59e0b' };
+  if (days < 0) return { text: `Buffer ${Math.abs(days)}d`, color: '#10b981' };
   return { text: `${days}d late`, color: '#ef4444' };
 }
 
@@ -444,7 +450,7 @@ export function ReleasesView() {
                 {showDetail && (
                   <th style={thStyle} title="The independent second model, as a date: open tasks ÷ net task completion rate. Counts tasks instead of summing estimates, so unestimated work still weighs in. The Confidence column is the verdict this feeds.">Ticket model</th>
                 )}
-                <th style={thStyle} title="Projected (velocity) minus Target. Green = ahead of the committed date, red = late.">Slip</th>
+                <th style={thStyle} title="Target minus Projected (velocity). Green = buffer, the room left between the projection and the date you committed to. Red = the projection has already passed the target. Buffer is not progress — it is unspent room.">Buffer / Slip</th>
                 <th style={{ ...thStyle, width: 220 }}>Scope</th>
                 {showDetail && <th style={{ ...thStyle, textAlign: 'right' }}>Tasks</th>}
                 <th style={{ ...thStyle, width: 92, textAlign: 'right' }}>Actions</th>


### PR DESCRIPTION
## Was war falsch

Die Slip-Spalte zeigte `11d ahead` für MVP. Das liest sich als Aussage über den Fortschritt — das Release läuft früh, alles gut. Die Zahl sagt aber nichts dergleichen. Sie sagt: das zugesagte Datum liegt 11 Tage hinter der Prognose. Das ist absichtlich gelassener Spielraum, kein Vorsprung.

Der Unterschied ist nicht kosmetisch. Wer „ahead" liest, gibt es aus.

## Was jetzt dasteht

Spalte heisst **„Buffer / Slip"**:

| Wert | vorher | jetzt |
|---|---|---|
| negativ | `11d ahead` | **`Buffer 11d`** (grün) |
| 0 | `on target` | **`no buffer`** (orange) |
| positiv | `5d late` | `5d late` (rot) |

Die Null wandert bewusst mit: exakt auf der Prognose zu liegen ist der straffste mögliche Plan, nicht der bequeme.

Gleiche Sprache im MCP `completion_forecast` — Agenten lesen jetzt `11 days buffer` statt eines nackten `-11 days`, das sie selbst deuten müssen.

## Tests

`pnpm turbo typecheck` 11/11 · `pnpm turbo test` 1058/1058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dspaHDCJPqLq4DBsh88Ep