### PR TITLE
Release composition: what a release holds besides its requirements

### DIFF
--- a/packages/core/src/__tests__/releaseComposition.test.ts
+++ b/packages/core/src/__tests__/releaseComposition.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { computeReleaseComposition } from '../releaseComposition.js';
+import type { CompositionNode } from '../releaseComposition.js';
+
+const V1 = 'ver-1';
+const V2 = 'ver-2';
+
+function node(partial: Partial<CompositionNode> & { id: string }): CompositionNode {
+  return {
+    parentId: null,
+    childrenIds: [],
+    text: partial.id,
+    ...partial,
+  };
+}
+
+const gh = (n: number) => ({
+  provider: 'github',
+  externalId: `acme/repo#${n}`,
+  url: `https://github.com/acme/repo/issues/${n}`,
+});
+
+describe('computeReleaseComposition', () => {
+  it('splits a release into requirement work and the rest', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['req', 'bug'] }),
+      node({ id: 'req', parentId: 'root', requirementId: 'PER-01', childrenIds: ['w1'], text: 'Personen' }),
+      node({ id: 'w1', parentId: 'req', versionId: V1, effortEstimate: 2, percentComplete: 100 }),
+      node({ id: 'bug', parentId: 'root', versionId: V1, effortEstimate: 1, percentComplete: 0, tags: ['type:bug'] }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1);
+
+    expect(c.requirementWork.count).toBe(1);
+    expect(c.otherWork.count).toBe(1);
+    expect(c.coveragePct).toBe(50);
+    expect(c.byRequirement).toHaveLength(1);
+    expect(c.byRequirement[0].requirementId).toBe('PER-01');
+    expect(c.byClassification).toEqual([
+      { label: 'bug', count: 1, openCount: 1, effort: 1 },
+    ]);
+  });
+
+  it('attributes a ticket that shares an issue with a requirement but lives elsewhere', () => {
+    // The case the whole module exists for: the tree is organised by
+    // functional area, so implementation tickets sit far from their
+    // requirement. Only the issue link connects them.
+    const nodes = [
+      node({ id: 'root', childrenIds: ['reqs', 'work'] }),
+      node({ id: 'reqs', parentId: 'root', childrenIds: ['req'] }),
+      node({ id: 'req', parentId: 'reqs', requirementId: 'SPG-06', externalLinks: [gh(1313)] }),
+      node({ id: 'work', parentId: 'root', childrenIds: ['t1'] }),
+      node({ id: 't1', parentId: 'work', versionId: V1, externalLinks: [gh(1313)], effortEstimate: 3 }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1);
+
+    expect(c.coveragePct).toBe(100);
+    expect(c.otherWork.count).toBe(0);
+    expect(c.byRequirement[0].requirementId).toBe('SPG-06');
+  });
+
+  it('follows issue links a requirement inherits from its own children', () => {
+    // collectRequirementGhLinks rolls up descendants' links; a ticket
+    // matching one of those must attribute to the requirement too.
+    const nodes = [
+      node({ id: 'root', childrenIds: ['req', 't1'] }),
+      node({ id: 'req', parentId: 'root', requirementId: 'DOK-08', childrenIds: ['sub'] }),
+      node({ id: 'sub', parentId: 'req', externalLinks: [gh(2936)] }),
+      node({ id: 't1', parentId: 'root', versionId: V1, externalLinks: [gh(2936)] }),
+    ];
+
+    expect(computeReleaseComposition(nodes, V1).coveragePct).toBe(100);
+  });
+
+  it('attributes across releases — a V1 ticket may implement a V2 requirement', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['req', 't1'] }),
+      node({ id: 'req', parentId: 'root', requirementId: 'MAN-11', versionId: V2, externalLinks: [gh(491)] }),
+      node({ id: 't1', parentId: 'root', versionId: V1, externalLinks: [gh(491)] }),
+    ];
+
+    expect(computeReleaseComposition(nodes, V1).coveragePct).toBe(100);
+  });
+
+  it('inherits release membership from the nearest tagged ancestor', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['epic'] }),
+      node({ id: 'epic', parentId: 'root', versionId: V1, childrenIds: ['a', 'b'] }),
+      node({ id: 'a', parentId: 'epic' }),
+      // An explicit tag on the leaf overrides the epic — it was pulled out.
+      node({ id: 'b', parentId: 'epic', versionId: V2 }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1);
+    expect(c.otherWork.count).toBe(1);
+    expect(c.unattributed[0].nodeId).toBe('a');
+  });
+
+  it('counts only leaves — a tagged epic is not its own line item', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['epic'] }),
+      node({ id: 'epic', parentId: 'root', versionId: V1, childrenIds: ['a'], effortEstimate: 99 }),
+      node({ id: 'a', parentId: 'epic', effortEstimate: 2 }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1);
+    expect(c.otherWork.count).toBe(1);
+    expect(c.otherWork.effort).toBe(2);
+  });
+
+  it('reports unestimated leaves instead of counting them as zero-effort work', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['a', 'b'] }),
+      node({ id: 'a', parentId: 'root', versionId: V1, effortEstimate: 4, percentComplete: 50 }),
+      node({ id: 'b', parentId: 'root', versionId: V1, percentComplete: 100 }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1);
+    expect(c.otherWork).toMatchObject({
+      count: 2,
+      openCount: 1,
+      effort: 4,
+      doneEffort: 2,
+      unestimated: 1,
+    });
+  });
+
+  it('buckets work without a type tag as unclassified rather than guessing', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['a', 'b'] }),
+      // Looks exactly like a bug. Carries no tag saying so.
+      node({ id: 'a', parentId: 'root', versionId: V1, text: 'fix(compliance): AIA gate is broken' }),
+      node({ id: 'b', parentId: 'root', versionId: V1, text: 'CI hardening', tags: ['area:backend'] }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1);
+    expect(c.byClassification).toEqual([
+      { label: 'unclassified', count: 2, openCount: 2, effort: 0 },
+    ]);
+  });
+
+  it('honours a custom tag prefix and unclassified label', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['a'] }),
+      node({ id: 'a', parentId: 'root', versionId: V1, tags: ['kind:chore'] }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1, {
+      typeTagPrefix: 'kind:',
+      unclassifiedLabel: 'unbekannt',
+    });
+    expect(c.byClassification[0].label).toBe('chore');
+  });
+
+  it('sorts unattributed work open-first, biggest-first', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['done', 'small', 'big'] }),
+      node({ id: 'done', parentId: 'root', versionId: V1, effortEstimate: 9, percentComplete: 100 }),
+      node({ id: 'small', parentId: 'root', versionId: V1, effortEstimate: 1, percentComplete: 0 }),
+      node({ id: 'big', parentId: 'root', versionId: V1, effortEstimate: 5, percentComplete: 0 }),
+    ];
+
+    expect(computeReleaseComposition(nodes, V1).unattributed.map((u) => u.nodeId)).toEqual([
+      'big',
+      'small',
+      'done',
+    ]);
+  });
+
+  it('returns null coverage for an empty release — no work supports no claim', () => {
+    const nodes = [node({ id: 'root', childrenIds: [] })];
+    const c = computeReleaseComposition(nodes, V1);
+    expect(c.coveragePct).toBeNull();
+    expect(c.requirementWork.count).toBe(0);
+  });
+
+  it('survives a malformed parent chain instead of hanging', () => {
+    const nodes = [
+      node({ id: 'a', parentId: 'b', versionId: V1 }),
+      node({ id: 'b', parentId: 'a' }),
+    ];
+    expect(() => computeReleaseComposition(nodes, V1)).not.toThrow();
+  });
+
+  it('does not double-count an issue claimed by two requirements', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['r1', 'r2', 't1'] }),
+      node({ id: 'r1', parentId: 'root', requirementId: 'A-01', externalLinks: [gh(7)] }),
+      node({ id: 'r2', parentId: 'root', requirementId: 'B-01', externalLinks: [gh(7)] }),
+      node({ id: 't1', parentId: 'root', versionId: V1, externalLinks: [gh(7)], effortEstimate: 2 }),
+    ];
+
+    const c = computeReleaseComposition(nodes, V1);
+    expect(c.requirementWork.count).toBe(1);
+    expect(c.byRequirement).toHaveLength(1);
+    expect(c.byRequirement.reduce((s, r) => s + r.count, 0)).toBe(1);
+  });
+
+  it('ignores non-github external links when joining', () => {
+    const nodes = [
+      node({ id: 'root', childrenIds: ['req', 't1'] }),
+      node({ id: 'req', parentId: 'root', requirementId: 'A-01', externalLinks: [gh(7)] }),
+      node({
+        id: 't1',
+        parentId: 'root',
+        versionId: V1,
+        externalLinks: [{ provider: 'jira', externalId: 'acme/repo#7', url: 'https://jira/7' }],
+      }),
+    ];
+
+    expect(computeReleaseComposition(nodes, V1).coveragePct).toBe(0);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,18 @@ export { proseMirrorToPlainText } from './richtext.js';
 export { collectRequirementGhLinks } from './requirements.js';
 export type { GhLinkSource, RequirementGhLink } from './requirements.js';
 
+// Release composition — requirement work vs. everything else in a release
+export { computeReleaseComposition } from './releaseComposition.js';
+export type {
+  CompositionNode,
+  CompositionBucket,
+  CompositionOptions,
+  RequirementShare,
+  ClassificationShare,
+  UnattributedItem,
+  ReleaseComposition,
+} from './releaseComposition.js';
+
 // Velocity & capacity helpers
 export {
   FOCUS_FACTOR_MIN,

--- a/packages/core/src/releaseComposition.ts
+++ b/packages/core/src/releaseComposition.ts
@@ -1,0 +1,321 @@
+/**
+ * What is actually in a release?
+ *
+ * The requirements register answers "which requirements ship in V1". It
+ * does not answer "what is V1", because a release also carries bugs,
+ * infrastructure, cleanup and features nobody ever wrote a requirement
+ * for. On a real map that second pile is the majority: on the Fulcrum
+ * roadmap, 223 of V1's 293 leaves attribute to no requirement at all.
+ *
+ * A release view built only from requirements therefore reports on a
+ * quarter of the release and looks green while the other three quarters
+ * decide the date. This module computes the whole split.
+ *
+ * ── Attribution ───────────────────────────────────────────────────
+ *
+ * A leaf counts as requirement work when either holds:
+ *
+ *   1. STRUCTURAL — a requirement node sits on its path to the root.
+ *      The work hangs beneath the business statement it implements.
+ *
+ *   2. BY ISSUE LINK — the leaf shares a GitHub issue with a
+ *      requirement, via collectRequirementGhLinks (which already rolls
+ *      up links from a requirement's descendants).
+ *
+ * Rule 2 is the one that matters. The tree is organised by functional
+ * area, so the ticket that implements PER-05 usually lives under
+ * "Compliance, KYC & Regulatory", nowhere near the requirement. Without
+ * the link join, every such ticket reads as unattributed and the
+ * coverage number is noise.
+ *
+ * ── Coverage is counted in TICKETS, not effort ────────────────────
+ *
+ * Effort would be the better unit if the estimates were complete. They
+ * are not: finished work tends to lose its estimate (V1 carries 183
+ * unestimated leaves, nearly all of them done), so an effort-weighted
+ * coverage silently understates whatever already shipped. Ticket counts
+ * are always complete. Effort is reported alongside — with the
+ * unestimated count, so a caller can see how much to trust it.
+ */
+import { collectRequirementGhLinks } from './requirements.js';
+import { effectiveVersionId } from './versions.js';
+
+/** Minimal node shape. Structurally satisfied by the core `Node` type. */
+export interface CompositionNode {
+  id: string;
+  parentId: string | null;
+  childrenIds?: string[] | null;
+  versionId?: string | null;
+  requirementId?: string | null;
+  text: string;
+  tags?: string[] | null;
+  effortEstimate?: number | null;
+  percentComplete?: number | null;
+  externalLinks?: Array<{
+    provider: string;
+    externalId: string;
+    url: string;
+    state?: 'open' | 'closed';
+  }> | null;
+}
+
+export interface CompositionBucket {
+  /** Leaves in this bucket. Always complete — the honest denominator. */
+  count: number;
+  /** Leaves below 100 % complete. */
+  openCount: number;
+  /** Summed leaf estimates. Understates reality by `unestimated` leaves. */
+  effort: number;
+  /** Estimate × progress, summed. */
+  doneEffort: number;
+  /** Leaves carrying no estimate at all. */
+  unestimated: number;
+}
+
+/** One requirement's share of the release. */
+export interface RequirementShare {
+  nodeId: string;
+  /** The register id ("PER-05"), when the requirement carries one. */
+  requirementId: string | null;
+  text: string;
+  count: number;
+  openCount: number;
+  effort: number;
+  doneEffort: number;
+}
+
+/** One class of unattributed work, e.g. everything tagged `type:bug`. */
+export interface ClassificationShare {
+  /** The tag value with its prefix stripped, or the unclassified label. */
+  label: string;
+  count: number;
+  openCount: number;
+  effort: number;
+}
+
+export interface UnattributedItem {
+  nodeId: string;
+  text: string;
+  effort: number | null;
+  /** 0–100; a leaf with no progress set counts as 0. */
+  progress: number;
+  /** First GitHub link, when there is one. */
+  externalId: string | null;
+  url: string | null;
+  label: string;
+}
+
+export interface ReleaseComposition {
+  versionId: string;
+  requirementWork: CompositionBucket;
+  otherWork: CompositionBucket;
+  /**
+   * Share of the release's leaves that attribute to a requirement, 0–100.
+   * Null when the release holds no leaves — no work supports no claim.
+   */
+  coveragePct: number | null;
+  /** Requirements touched by this release, largest share first. */
+  byRequirement: RequirementShare[];
+  /** The rest, grouped by classification tag, largest first. */
+  byClassification: ClassificationShare[];
+  /** Every unattributed leaf, worst-progress first. Callers may cap. */
+  unattributed: UnattributedItem[];
+}
+
+export interface CompositionOptions {
+  /**
+   * Tag prefix that classifies work. GitHub label sync writes issue
+   * labels onto `tags`, so `type:bug` / `type:tech-debt` arrive for free.
+   *
+   * Deliberately NOT a heuristic over the node title. Title regexes
+   * ("fix(", "infra:") look convincing on a demo and quietly mislabel
+   * everything that does not follow the convention of the day — and the
+   * misfiled tickets are exactly the ones this view exists to surface.
+   */
+  typeTagPrefix?: string;
+  /** Bucket for work carrying no classifying tag. */
+  unclassifiedLabel?: string;
+}
+
+const DEFAULT_PREFIX = 'type:';
+const DEFAULT_UNCLASSIFIED = 'unclassified';
+
+function emptyBucket(): CompositionBucket {
+  return { count: 0, openCount: 0, effort: 0, doneEffort: 0, unestimated: 0 };
+}
+
+function isLeaf(n: CompositionNode): boolean {
+  return (n.childrenIds?.length ?? 0) === 0;
+}
+
+/** Nearest requirement on the node's path to the root, itself included. */
+function nearestRequirement<T extends CompositionNode>(
+  nodeId: string,
+  byId: Map<string, T>,
+): T | null {
+  const seen = new Set<string>();
+  let cur: T | undefined = byId.get(nodeId);
+  while (cur) {
+    if (cur.requirementId != null) return cur;
+    const parentId: string | null = cur.parentId;
+    if (parentId == null || seen.has(parentId)) return null;
+    seen.add(parentId);
+    cur = byId.get(parentId);
+  }
+  return null;
+}
+
+function githubLinks(n: CompositionNode) {
+  return (n.externalLinks ?? []).filter((l) => l.provider === 'github');
+}
+
+function classify(n: CompositionNode, prefix: string, fallback: string): string {
+  for (const tag of n.tags ?? []) {
+    if (tag.startsWith(prefix) && tag.length > prefix.length) {
+      return tag.slice(prefix.length);
+    }
+  }
+  return fallback;
+}
+
+function addLeaf(bucket: CompositionBucket, effort: number | null, progress: number): void {
+  bucket.count += 1;
+  if (progress < 100) bucket.openCount += 1;
+  if (effort == null) {
+    bucket.unestimated += 1;
+    return;
+  }
+  bucket.effort += effort;
+  bucket.doneEffort += (effort * progress) / 100;
+}
+
+/** Floating-point noise from repeated addition has no business in a report. */
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function tidy(b: CompositionBucket): CompositionBucket {
+  return { ...b, effort: round(b.effort), doneEffort: round(b.doneEffort) };
+}
+
+export function computeReleaseComposition<T extends CompositionNode>(
+  nodes: Iterable<T>,
+  versionId: string,
+  opts: CompositionOptions = {},
+): ReleaseComposition {
+  const prefix = opts.typeTagPrefix ?? DEFAULT_PREFIX;
+  const unclassified = opts.unclassifiedLabel ?? DEFAULT_UNCLASSIFIED;
+
+  const byId = new Map<string, T>();
+  for (const n of nodes) byId.set(n.id, n);
+  const get = (id: string) => byId.get(id);
+
+  // ── Issue → requirement index ───────────────────────────────────
+  //
+  // Built once over every requirement on the map, not just the ones
+  // already tagged for this release: a leaf sitting in V1 may well
+  // implement a requirement whose own version tag says V2. Attribution
+  // is a statement about the work, not about the release plan.
+  //
+  // First writer wins when two requirements claim the same issue. That
+  // is arbitrary but stable — and a shared issue is a modelling error
+  // worth surfacing elsewhere, not worth double-counting here.
+  const ghToRequirement = new Map<string, T>();
+  for (const n of byId.values()) {
+    if (n.requirementId == null) continue;
+    for (const link of collectRequirementGhLinks(get, n.id)) {
+      if (!ghToRequirement.has(link.externalId)) ghToRequirement.set(link.externalId, n);
+    }
+  }
+
+  const requirementWork = emptyBucket();
+  const otherWork = emptyBucket();
+  const shares = new Map<string, RequirementShare>();
+  const classes = new Map<string, ClassificationShare>();
+  const unattributed: UnattributedItem[] = [];
+
+  for (const node of byId.values()) {
+    if (!isLeaf(node)) continue;
+    if (effectiveVersionId(node.id, byId) !== versionId) continue;
+
+    const effort = node.effortEstimate ?? null;
+    const progress = node.percentComplete ?? 0;
+
+    let requirement = nearestRequirement(node.id, byId);
+    if (requirement == null) {
+      for (const link of githubLinks(node)) {
+        const hit = ghToRequirement.get(link.externalId);
+        if (hit) {
+          requirement = hit;
+          break;
+        }
+      }
+    }
+
+    if (requirement) {
+      addLeaf(requirementWork, effort, progress);
+      let share = shares.get(requirement.id);
+      if (!share) {
+        share = {
+          nodeId: requirement.id,
+          requirementId: requirement.requirementId ?? null,
+          text: requirement.text,
+          count: 0,
+          openCount: 0,
+          effort: 0,
+          doneEffort: 0,
+        };
+        shares.set(requirement.id, share);
+      }
+      share.count += 1;
+      if (progress < 100) share.openCount += 1;
+      if (effort != null) {
+        share.effort += effort;
+        share.doneEffort += (effort * progress) / 100;
+      }
+      continue;
+    }
+
+    addLeaf(otherWork, effort, progress);
+    const label = classify(node, prefix, unclassified);
+    let cls = classes.get(label);
+    if (!cls) {
+      cls = { label, count: 0, openCount: 0, effort: 0 };
+      classes.set(label, cls);
+    }
+    cls.count += 1;
+    if (progress < 100) cls.openCount += 1;
+    if (effort != null) cls.effort += effort;
+
+    const [first] = githubLinks(node);
+    unattributed.push({
+      nodeId: node.id,
+      text: node.text,
+      effort,
+      progress,
+      externalId: first?.externalId ?? null,
+      url: first?.url ?? null,
+      label,
+    });
+  }
+
+  const total = requirementWork.count + otherWork.count;
+
+  return {
+    versionId,
+    requirementWork: tidy(requirementWork),
+    otherWork: tidy(otherWork),
+    coveragePct: total === 0 ? null : Math.round((requirementWork.count / total) * 100),
+    byRequirement: [...shares.values()]
+      .map((s) => ({ ...s, effort: round(s.effort), doneEffort: round(s.doneEffort) }))
+      .sort((a, b) => b.count - a.count || b.effort - a.effort),
+    byClassification: [...classes.values()]
+      .map((c) => ({ ...c, effort: round(c.effort) }))
+      .sort((a, b) => b.count - a.count || b.effort - a.effort),
+    // Open work first, and within it the biggest — the order someone
+    // triaging unattributed work actually wants.
+    unattributed: unattributed.sort(
+      (a, b) => a.progress - b.progress || (b.effort ?? 0) - (a.effort ?? 0),
+    ),
+  };
+}

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -410,6 +410,75 @@ export function getMap(mapId: string): Promise<MapDetail> {
   return request<MapDetail>(`/api/maps/${mapId}`);
 }
 
+// ── Release composition ─────────────────────────────────────────
+//
+// Deliberately a server call rather than a local recomputation: the
+// point of the tool is that an agent and the Releases view quote the
+// same coverage number, and two implementations of one attribution
+// rule drift apart eventually.
+
+export interface CompositionBucket {
+  count: number;
+  openCount: number;
+  effort: number;
+  doneEffort: number;
+  unestimated: number;
+}
+
+export interface ReleaseCompositionRow {
+  versionId: string;
+  versionName: string;
+  versionStatus: string;
+  targetDate: string | null;
+  coveragePct: number | null;
+  requirementWork: CompositionBucket;
+  otherWork: CompositionBucket;
+  byRequirement: Array<{
+    nodeId: string;
+    requirementId: string | null;
+    text: string;
+    count: number;
+    openCount: number;
+    effort: number;
+    doneEffort: number;
+  }>;
+  byClassification: Array<{
+    label: string;
+    count: number;
+    openCount: number;
+    effort: number;
+  }>;
+  unattributed: Array<{
+    nodeId: string;
+    text: string;
+    effort: number | null;
+    progress: number;
+    externalId: string | null;
+    url: string | null;
+    label: string;
+  }>;
+  unattributedTotal: number;
+}
+
+export interface ReleaseCompositionResponse {
+  mapId: string;
+  effortUnit: string;
+  releases: ReleaseCompositionRow[];
+}
+
+export function getReleaseComposition(
+  mapId: string,
+  opts: { versionId?: string; limit?: number } = {},
+): Promise<ReleaseCompositionResponse> {
+  const params = new URLSearchParams();
+  if (opts.versionId) params.set('versionId', opts.versionId);
+  if (opts.limit != null) params.set('limit', String(opts.limit));
+  const q = params.toString();
+  return request<ReleaseCompositionResponse>(
+    `/api/maps/${mapId}/release-composition${q ? `?${q}` : ''}`,
+  );
+}
+
 export function createMap(name: string, description?: string, workspaceId = 'default'): Promise<any> {
   return request('/api/maps', {
     method: 'POST',

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -813,6 +813,110 @@ server.tool(
 );
 
 server.tool(
+  'release_composition',
+  'What a release actually holds: the split between work implementing a requirement and everything else — bugs, infra, cleanup, features nobody specified. requirements_overview answers "which requirements ship in V1"; this answers "what IS V1", usually a much larger set. Attribution is structural (a requirement sits above the task) OR by shared GitHub issue, so a ticket filed under a functional area still counts towards the requirement it implements. Coverage is counted in tasks, not effort — completed work often loses its estimate, and an effort-weighted number would understate whatever already shipped.',
+  {
+    mapId: z.string().describe('The map ID'),
+    versionId: z
+      .string()
+      .optional()
+      .describe('Restrict to one release. Use list_versions to find the id.'),
+    limit: z
+      .number()
+      .optional()
+      .describe('Unattributed tasks listed per release (default 12, max 500).'),
+  },
+  async ({ mapId, versionId, limit }) => {
+    try {
+      const listCap = Math.min(Math.max(limit ?? 12, 0), 500);
+      const data = await api.getReleaseComposition(mapId, { versionId, limit: listCap });
+      const unit = data.effortUnit ?? 'units';
+
+      if (data.releases.length === 0) {
+        return toolResult(
+          `No releases on map ${mapId}. Create one with create_version, then tag nodes with it.`,
+        );
+      }
+
+      const lines: string[] = [`Release composition — map ${mapId}`];
+
+      for (const r of data.releases) {
+        const total = r.requirementWork.count + r.otherWork.count;
+        lines.push('');
+        lines.push(
+          `## ${r.versionName}${r.targetDate ? ` (target ${r.targetDate})` : ''} — ${total} task(s)`,
+        );
+
+        if (total === 0) {
+          lines.push('  nothing scheduled yet — no coverage to report');
+          continue;
+        }
+
+        lines.push(
+          `  Requirement work: ${r.requirementWork.count} task(s), ` +
+            `${r.requirementWork.openCount} open, ${r.requirementWork.effort.toFixed(1)} ${unit}` +
+            (r.requirementWork.unestimated > 0
+              ? ` (⚠ ${r.requirementWork.unestimated} unestimated)`
+              : ''),
+        );
+        lines.push(
+          `  Other work:       ${r.otherWork.count} task(s), ` +
+            `${r.otherWork.openCount} open, ${r.otherWork.effort.toFixed(1)} ${unit}` +
+            (r.otherWork.unestimated > 0 ? ` (⚠ ${r.otherWork.unestimated} unestimated)` : ''),
+        );
+        lines.push(`  Requirement coverage: ${r.coveragePct}% of tasks`);
+
+        if (r.byRequirement.length > 0) {
+          const top = r.byRequirement.slice(0, 10);
+          lines.push(`  Requirements touched (${r.byRequirement.length}):`);
+          for (const q of top) {
+            lines.push(
+              `    ${q.requirementId ?? '—'} ${q.text.slice(0, 70)} · ${q.count} task(s), ${q.openCount} open`,
+            );
+          }
+          if (r.byRequirement.length > top.length) {
+            lines.push(`    … and ${r.byRequirement.length - top.length} more`);
+          }
+        }
+
+        if (r.byClassification.length > 0) {
+          lines.push('  Other work by type tag:');
+          for (const c of r.byClassification) {
+            const note =
+              c.label === 'unclassified'
+                ? ' (no type: label — classification is never guessed from the title)'
+                : '';
+            lines.push(
+              `    ${c.label}: ${c.count} task(s), ${c.openCount} open, ${c.effort.toFixed(1)} ${unit}${note}`,
+            );
+          }
+        }
+
+        if (r.unattributed.length > 0) {
+          lines.push(`  Unattributed, worst first (${r.unattributedTotal} total):`);
+          for (const u of r.unattributed) {
+            const eff = u.effort == null ? 'unest.' : `${u.effort} ${unit}`;
+            lines.push(
+              `    ${u.progress}% · ${eff} · ${u.text.slice(0, 80)}` +
+                `${u.externalId ? ` [${u.externalId}]` : ''} (id: ${u.nodeId})`,
+            );
+          }
+          if (r.unattributedTotal > r.unattributed.length) {
+            lines.push(
+              `    … and ${r.unattributedTotal - r.unattributed.length} more — raise limit to see them`,
+            );
+          }
+        }
+      }
+
+      return toolResult(lines.join('\n'));
+    } catch (err) {
+      return toolError(err);
+    }
+  },
+);
+
+server.tool(
   'completion_forecast',
   'Forecast "when will it be done?" for a node/subtree/version/phase. Reports THREE dates: planned finish (scheduler-based, respects dependencies), velocity-adjusted finish (remaining effort ÷ measured NET rate), and the independent ticket model (open leaves ÷ net ticket completion rate — counts tickets instead of summing estimates, so unestimated work still weighs in). Plus target date (from version/phase or node dueDates) and slip vs target per model. The day and ticket models disagreeing hard means the estimate scale has drifted from ticket granularity. Scope with nodeId (subtree), versionId, or phaseId; omit all to forecast the whole map.',
   {

--- a/packages/mindmap/src/ReleasesView.tsx
+++ b/packages/mindmap/src/ReleasesView.tsx
@@ -1,9 +1,14 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import { compareVersions } from '@mindblown/core';
 import type { Version } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import * as api from './api.js';
-import type { ReleaseForecastResponse, ReleaseForecastRow } from './api.js';
+import type {
+  ReleaseForecastResponse,
+  ReleaseForecastRow,
+  ReleaseCompositionResponse,
+  ReleaseCompositionRow,
+} from './api.js';
 
 // ── Colors ───────────────────────────────────────────────────────
 
@@ -159,6 +164,54 @@ export function ReleasesView() {
   useEffect(() => {
     globalThis.localStorage?.setItem('mb.releases.detail', showDetail ? '1' : '0');
   }, [showDetail]);
+
+  // Composition — what the release holds besides its requirements.
+  // Off by default and fetched only once switched on: the table above
+  // answers "when does it ship", and that question must not get slower
+  // because a second one exists.
+  const [showComposition, setShowComposition] = useState<boolean>(
+    () => globalThis.localStorage?.getItem('mb.releases.composition') === '1',
+  );
+  useEffect(() => {
+    globalThis.localStorage?.setItem('mb.releases.composition', showComposition ? '1' : '0');
+  }, [showComposition]);
+  const [composition, setComposition] = useState<ReleaseCompositionResponse | null>(null);
+  const [compositionLoading, setCompositionLoading] = useState(false);
+  const [compositionError, setCompositionError] = useState<string | null>(null);
+  const [expandedComposition, setExpandedComposition] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!showComposition || !currentMapId) return;
+    let cancelled = false;
+    setCompositionLoading(true);
+    setCompositionError(null);
+    api
+      .fetchReleaseComposition(currentMapId, { limit: 40 })
+      .then((r) => {
+        if (!cancelled) setComposition(r);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setCompositionError(e instanceof Error ? e.message : 'Failed to load composition');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setCompositionLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [showComposition, currentMapId, versions, refreshNonce]);
+
+  const compositionById = useMemo(() => {
+    const m = new Map<string, ReleaseCompositionRow>();
+    for (const r of composition?.releases ?? []) m.set(r.versionId, r);
+    return m;
+  }, [composition]);
+
+  // Release, Status, Target, Projected, Confidence, Buffer/Slip, Scope,
+  // Actions — plus Start, Ticket model and Tasks when Detail is on.
+  const columnCount = 8 + (showDetail ? 3 : 0);
 
   useEffect(() => {
     let cancelled = false;
@@ -347,6 +400,26 @@ export function ReleasesView() {
           >
             {showDetail ? '▾ Detail' : '▸ Detail'}
           </button>
+          <button
+            onClick={() => setShowComposition((v) => !v)}
+            title={
+              showComposition
+                ? 'Hide the requirement / other-work split.'
+                : 'Show what each release holds besides its requirements — bugs, infra, cleanup and features nobody specified.'
+            }
+            style={{
+              padding: '4px 10px',
+              fontSize: 11,
+              fontWeight: 600,
+              color: showComposition ? '#2563eb' : '#64748b',
+              background: showComposition ? '#eff6ff' : '#fff',
+              border: `1px solid ${showComposition ? '#bfdbfe' : '#cbd5e1'}`,
+              borderRadius: 4,
+              cursor: 'pointer',
+            }}
+          >
+            {showComposition ? '▾ Composition' : '▸ Composition'}
+          </button>
           {showDetail && (
           <label
             title={
@@ -473,8 +546,8 @@ export function ReleasesView() {
                 const duration = formatDateRange(row?.effectiveStartDate ?? null, projected);
 
                 return (
+                  <Fragment key={v.id}>
                   <tr
-                    key={v.id}
                     style={{
                       borderBottom: '1px solid #f1f5f9',
                       opacity: isArchived || isReleased ? 0.55 : 1,
@@ -637,6 +710,25 @@ export function ReleasesView() {
                       </div>
                     </td>
                   </tr>
+                  {showComposition && (
+                    <CompositionRow
+                      colSpan={columnCount}
+                      unit={unit}
+                      row={compositionById.get(v.id) ?? null}
+                      loading={compositionLoading}
+                      error={compositionError}
+                      expanded={expandedComposition.has(v.id)}
+                      onToggle={() =>
+                        setExpandedComposition((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(v.id)) next.delete(v.id);
+                          else next.add(v.id);
+                          return next;
+                        })
+                      }
+                    />
+                  )}
+                  </Fragment>
                 );
               })}
             </tbody>
@@ -648,6 +740,328 @@ export function ReleasesView() {
 }
 
 // ── Sub-components ───────────────────────────────────────────────
+
+const REQ_COLOR = '#2563eb';
+const OTHER_COLOR = '#e0871a';
+
+/**
+ * The composition strip under a release row: how much of the release
+ * implements a requirement, and what the rest is.
+ *
+ * The bar is scaled by TICKET COUNT, not effort. Effort would be the
+ * better unit if the estimates were complete; they are not, and a bar
+ * that silently drops every unestimated ticket would understate exactly
+ * the pile this strip exists to show. Effort is printed next to the
+ * counts instead, with its own unestimated warning.
+ */
+function CompositionRow({
+  colSpan,
+  unit,
+  row,
+  loading,
+  error,
+  expanded,
+  onToggle,
+}: {
+  colSpan: number;
+  unit: string;
+  row: ReleaseCompositionRow | null;
+  loading: boolean;
+  error: string | null;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const cell: React.CSSProperties = {
+    padding: '10px 12px 14px',
+    borderBottom: '1px solid #f1f5f9',
+    background: '#fafbfc',
+  };
+
+  if (error) {
+    return (
+      <tr>
+        <td colSpan={colSpan} style={{ ...cell, fontSize: 11, color: '#dc2626' }}>
+          Composition unavailable: {error}
+        </td>
+      </tr>
+    );
+  }
+
+  if (!row) {
+    return (
+      <tr>
+        <td colSpan={colSpan} style={{ ...cell, fontSize: 11, color: '#94a3b8' }}>
+          {loading ? 'Loading composition…' : 'No composition data'}
+        </td>
+      </tr>
+    );
+  }
+
+  const reqCount = row.requirementWork.count;
+  const otherCount = row.otherWork.count;
+  const total = reqCount + otherCount;
+
+  if (total === 0) {
+    return (
+      <tr>
+        <td colSpan={colSpan} style={{ ...cell, fontSize: 11, color: '#94a3b8' }}>
+          Nothing scheduled for this release yet — no coverage to report.
+        </td>
+      </tr>
+    );
+  }
+
+  const reqPct = (reqCount / total) * 100;
+  const reqDonePct = reqCount ? ((reqCount - row.requirementWork.openCount) / reqCount) * 100 : 0;
+  const otherDonePct = otherCount
+    ? ((otherCount - row.otherWork.openCount) / otherCount) * 100
+    : 0;
+  const totalEffort = row.requirementWork.effort + row.otherWork.effort;
+  const unestimated = row.requirementWork.unestimated + row.otherWork.unestimated;
+
+  return (
+    <tr>
+      {/* The strip is a reading surface, not a data grid — past ~1100px
+          the label/number pairs drift so far apart they stop reading as
+          pairs. Cap it and let the rest of the row breathe. */}
+      <td colSpan={colSpan} style={cell}>
+        <div style={{ maxWidth: 1100 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 6 }}>
+          <button
+            onClick={onToggle}
+            style={{
+              padding: 0,
+              border: 'none',
+              background: 'none',
+              cursor: 'pointer',
+              fontSize: 11,
+              fontWeight: 600,
+              color: '#475569',
+            }}
+          >
+            {expanded ? '▾' : '▸'} Composition
+          </button>
+          <span
+            style={{ fontSize: 11, color: '#64748b' }}
+            title="Share of this release's tasks that implement a requirement — either sitting beneath one, or sharing its GitHub issue."
+          >
+            <b style={{ color: row.coveragePct != null && row.coveragePct < 50 ? '#b45309' : '#166534' }}>
+              {row.coveragePct}%
+            </b>{' '}
+            requirement coverage
+          </span>
+          <span style={{ fontSize: 11, color: '#94a3b8' }}>
+            {total} tasks · {totalEffort.toFixed(0)} {unit} estimated
+            {unestimated > 0 && ` · ${unestimated} unestimated`}
+          </span>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            height: 20,
+            borderRadius: 4,
+            overflow: 'hidden',
+            background: '#e2e8f0',
+          }}
+        >
+          <Segment
+            widthPct={reqPct}
+            donePct={reqDonePct}
+            color={REQ_COLOR}
+            label={`Requirements · ${reqCount}`}
+            title={`${reqCount} task(s) implementing a requirement — ${row.requirementWork.openCount} still open, ${row.requirementWork.effort.toFixed(1)} ${unit} estimated.`}
+          />
+          <Segment
+            widthPct={100 - reqPct}
+            donePct={otherDonePct}
+            color={OTHER_COLOR}
+            label={`Other work · ${otherCount}`}
+            title={`${otherCount} task(s) attributing to no requirement — ${row.otherWork.openCount} still open, ${row.otherWork.effort.toFixed(1)} ${unit} estimated.`}
+          />
+        </div>
+
+        {expanded && (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+              gap: 20,
+              marginTop: 14,
+            }}
+          >
+            <div>
+              <ColumnHeading>Requirements in this release</ColumnHeading>
+              {row.byRequirement.length === 0 ? (
+                <Muted>None — every task here attributes to no requirement.</Muted>
+              ) : (
+                row.byRequirement.slice(0, 10).map((r) => (
+                  <div key={r.nodeId} style={{ display: 'flex', gap: 8, fontSize: 11, padding: '2px 0' }}>
+                    <span style={{ fontWeight: 600, color: '#475569', minWidth: 62 }}>
+                      {r.requirementId ?? '—'}
+                    </span>
+                    <span
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        color: '#334155',
+                      }}
+                      title={r.text}
+                    >
+                      {r.text}
+                    </span>
+                    <span style={{ color: '#94a3b8', whiteSpace: 'nowrap' }}>
+                      {r.count} · {r.openCount} open
+                    </span>
+                  </div>
+                ))
+              )}
+              {row.byRequirement.length > 10 && (
+                <Muted>+ {row.byRequirement.length - 10} more requirements</Muted>
+              )}
+            </div>
+
+            <div>
+              <ColumnHeading>Other work — what is it?</ColumnHeading>
+              {row.byClassification.map((c) => (
+                <div key={c.label} style={{ display: 'flex', gap: 8, fontSize: 11, padding: '2px 0' }}>
+                  <span
+                    style={{ flex: 1, color: c.label === 'unclassified' ? '#94a3b8' : '#334155' }}
+                    title={
+                      c.label === 'unclassified'
+                        ? 'No `type:` tag on these tasks. Classification comes from GitHub labels, never from guessing at the title — so untagged work stays honestly unlabelled.'
+                        : undefined
+                    }
+                  >
+                    {c.label}
+                  </span>
+                  <span style={{ color: '#94a3b8', whiteSpace: 'nowrap' }}>
+                    {c.count} · {c.effort.toFixed(1)} {unit} · {c.openCount} open
+                  </span>
+                </div>
+              ))}
+
+              <ColumnHeading style={{ marginTop: 12 }}>
+                Unattributed, worst first
+              </ColumnHeading>
+              {row.unattributed.slice(0, 12).map((u) => (
+                <div key={u.nodeId} style={{ display: 'flex', gap: 6, fontSize: 11, padding: '2px 0' }}>
+                  <span style={{ color: '#94a3b8', minWidth: 30, textAlign: 'right' }}>
+                    {u.progress}%
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      color: '#334155',
+                    }}
+                    title={u.text}
+                  >
+                    {u.text}
+                  </span>
+                  {u.url && (
+                    <a
+                      href={u.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{ color: '#2563eb', textDecoration: 'none', whiteSpace: 'nowrap' }}
+                    >
+                      {u.externalId?.split('#')[1] ? `#${u.externalId.split('#')[1]}` : 'issue'}
+                    </a>
+                  )}
+                </div>
+              ))}
+              {row.unattributedTotal > Math.min(12, row.unattributed.length) && (
+                <Muted>
+                  + {row.unattributedTotal - Math.min(12, row.unattributed.length)} more unattributed
+                </Muted>
+              )}
+            </div>
+          </div>
+        )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+/** One half of the split bar; the saturated part is what is already done. */
+function Segment({
+  widthPct,
+  donePct,
+  color,
+  label,
+  title,
+}: {
+  widthPct: number;
+  donePct: number;
+  color: string;
+  label: string;
+  title: string;
+}) {
+  if (widthPct <= 0) return null;
+  return (
+    <div
+      title={title}
+      style={{ position: 'relative', width: `${widthPct}%`, background: `${color}33`, minWidth: 2 }}
+    >
+      <div
+        style={{ position: 'absolute', inset: 0, right: 'auto', width: `${donePct}%`, background: color }}
+      />
+      {widthPct > 14 && (
+        <div
+          style={{
+            position: 'relative',
+            fontSize: 10,
+            fontWeight: 600,
+            color: '#fff',
+            lineHeight: '20px',
+            padding: '0 6px',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textShadow: '0 1px 2px rgba(0,0,0,.35)',
+          }}
+        >
+          {label}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ColumnHeading({
+  children,
+  style,
+}: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+        color: '#94a3b8',
+        marginBottom: 4,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Muted({ children }: { children: React.ReactNode }) {
+  return <div style={{ fontSize: 11, color: '#94a3b8', padding: '2px 0' }}>{children}</div>;
+}
 
 function VersionForm({
   mode,

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -977,6 +977,81 @@ export function fetchReleaseForecast(
   return request<ReleaseForecastResponse>(`/api/maps/${mapId}/release-forecast${suffix}`);
 }
 
+// ── Release composition ────────────────────────────────────────
+//
+// The forecast says when a release lands. This says what it is made of:
+// the split between work implementing a requirement and everything else.
+
+export interface CompositionBucket {
+  count: number;
+  openCount: number;
+  effort: number;
+  doneEffort: number;
+  unestimated: number;
+}
+
+export interface RequirementShare {
+  nodeId: string;
+  requirementId: string | null;
+  text: string;
+  count: number;
+  openCount: number;
+  effort: number;
+  doneEffort: number;
+}
+
+export interface ClassificationShare {
+  label: string;
+  count: number;
+  openCount: number;
+  effort: number;
+}
+
+export interface UnattributedItem {
+  nodeId: string;
+  text: string;
+  effort: number | null;
+  progress: number;
+  externalId: string | null;
+  url: string | null;
+  label: string;
+}
+
+export interface ReleaseCompositionRow {
+  versionId: string;
+  versionName: string;
+  versionStatus: string;
+  targetDate: string | null;
+  /** Ticket-based share attributing to a requirement; null on an empty release. */
+  coveragePct: number | null;
+  requirementWork: CompositionBucket;
+  otherWork: CompositionBucket;
+  byRequirement: RequirementShare[];
+  byClassification: ClassificationShare[];
+  /** Capped by the `limit` query param — `unattributedTotal` is the truth. */
+  unattributed: UnattributedItem[];
+  unattributedTotal: number;
+}
+
+export interface ReleaseCompositionResponse {
+  mapId: string;
+  effortUnit: string;
+  releases: ReleaseCompositionRow[];
+}
+
+export function fetchReleaseComposition(
+  mapId: string,
+  opts: { versionId?: string; limit?: number } = {},
+): Promise<ReleaseCompositionResponse> {
+  const params = new URLSearchParams();
+  if (opts.versionId) params.set('versionId', opts.versionId);
+  if (opts.limit != null) params.set('limit', String(opts.limit));
+  const query = params.toString();
+  return request<ReleaseCompositionResponse>(
+    `/api/maps/${mapId}/release-composition${query ? `?${query}` : ''}`,
+  );
+}
+
 // ── Calendar subscribe URL ─────────────────────────────────────
 
 export type CalendarIcsView = 'full' | 'milestones' | 'owned';

--- a/packages/server/src/routes/__tests__/release-composition-route.test.ts
+++ b/packages/server/src/routes/__tests__/release-composition-route.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Route tests for GET /api/maps/:id/release-composition — the split
+ * between requirement work and everything else in a release.
+ *
+ * The math is unit-tested in core; what matters here is the wiring the
+ * route owns and core cannot: release ordering, the ?versionId filter,
+ * the unattributed cap (an overview must not ship every leaf of every
+ * release), and the 404s.
+ *
+ * Mock pattern mirrors phase-map-routes.test.ts — stub the DB layer so
+ * we exercise route wiring without Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const getMapMock = vi.fn();
+const listVersionsMock = vi.fn<(...args: unknown[]) => Promise<unknown[]>>(async () => []);
+
+vi.mock('../../db/maps.js', () => ({
+  updateMap: vi.fn(),
+  getMap: (...args: unknown[]) => getMapMock(...args),
+  listMapsForUser: vi.fn(async () => []),
+  createBaseline: vi.fn(),
+  deleteMap: vi.fn(),
+  createMap: vi.fn(),
+}));
+
+vi.mock('../../db/permissions.js', () => ({
+  getPermission: vi.fn(async () => 'edit'),
+  hasPermission: (actual: string | null, required: string) => {
+    if (actual == null) return false;
+    const rank: Record<string, number> = { view: 1, edit: 2, admin: 3 };
+    return (rank[actual] ?? 0) >= (rank[required] ?? 0);
+  },
+}));
+
+vi.mock('../../db/versions.js', () => ({
+  listVersions: (...args: unknown[]) => listVersionsMock(...args),
+}));
+vi.mock('../../db/cycles.js', () => ({}));
+vi.mock('../../db/connection.js', () => ({ db: {} }));
+vi.mock('../../db/schema.js', () => ({ workspaces: {}, users: {}, releaseSnapshots: {} }));
+vi.mock('../../lib/releaseForecast.js', () => ({ computeReleaseForecast: vi.fn() }));
+vi.mock('../../lib/releaseSnapshots.js', () => ({ snapshotReleaseForecastForMap: vi.fn() }));
+vi.mock('../../lib/calendarIcs.js', () => ({
+  buildCalendarIcs: vi.fn(),
+  calendarTokenFor: vi.fn(),
+  verifyCalendarToken: vi.fn(),
+  CALENDAR_VIEWS: [],
+}));
+vi.mock('drizzle-orm', () => ({ and: vi.fn(), eq: vi.fn(), lte: vi.fn(), desc: vi.fn() }));
+
+import { mapRoutes } from '../maps.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+const USER_ID = 'uuuu-uuuu-uuuu-uuuu';
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+const V1 = 'ver-1';
+const V2 = 'ver-2';
+
+const version = (id: string, name: string, targetDate: string | null) => ({
+  id,
+  mapId: MAP_ID,
+  name,
+  status: 'active',
+  targetDate,
+  sortOrder: 0,
+});
+
+function node(partial: Record<string, unknown> & { id: string }) {
+  return {
+    mapId: MAP_ID,
+    parentId: null,
+    childrenIds: [],
+    text: partial.id,
+    tags: [],
+    externalLinks: [],
+    effortEstimate: null,
+    percentComplete: null,
+    versionId: null,
+    requirementId: null,
+    ...partial,
+  };
+}
+
+/** One requirement with a ticket beneath it, plus loose work in each release. */
+function fixtureNodes() {
+  return [
+    node({ id: 'root', childrenIds: ['req', 'loose1', 'loose2', 'loose3', 'v2work'] }),
+    node({ id: 'req', parentId: 'root', requirementId: 'PER-01', childrenIds: ['w1'] }),
+    node({ id: 'w1', parentId: 'req', versionId: V1, effortEstimate: 2, percentComplete: 100 }),
+    node({ id: 'loose1', parentId: 'root', versionId: V1, effortEstimate: 3, tags: ['type:bug'] }),
+    node({ id: 'loose2', parentId: 'root', versionId: V1, effortEstimate: 1 }),
+    node({ id: 'loose3', parentId: 'root', versionId: V1 }),
+    node({ id: 'v2work', parentId: 'root', versionId: V2, effortEstimate: 5 }),
+  ];
+}
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    req.userId = USER_ID;
+    req.authSource = 'jwt';
+  });
+  await app.register(mapRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  getMapMock.mockReset();
+  listVersionsMock.mockReset();
+  getMapMock.mockResolvedValue({
+    map: { id: MAP_ID, effortUnit: 'days' },
+    nodes: fixtureNodes(),
+  });
+  listVersionsMock.mockResolvedValue([
+    version(V2, 'V2', '2026-12-01'),
+    version(V1, 'V1', '2026-09-02'),
+  ]);
+});
+
+// ── Cases ─────────────────────────────────────────────────────────
+
+describe('GET /api/maps/:id/release-composition', () => {
+  it('returns every release, chronologically, with the requirement split', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/release-composition` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // Sorted by target date — V1 ships before V2 even though the DB
+    // handed them back the other way round.
+    expect(body.releases.map((r: { versionName: string }) => r.versionName)).toEqual(['V1', 'V2']);
+
+    const v1 = body.releases[0];
+    expect(v1.requirementWork.count).toBe(1);
+    expect(v1.otherWork.count).toBe(3);
+    expect(v1.coveragePct).toBe(25);
+    expect(v1.byRequirement[0].requirementId).toBe('PER-01');
+    expect(v1.otherWork.unestimated).toBe(1);
+  });
+
+  it('carries the effort unit so the client does not have to guess', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: `/api/maps/${MAP_ID}/release-composition` });
+    await app.close();
+    expect(res.json().effortUnit).toBe('days');
+  });
+
+  it('restricts to one release with ?versionId', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/${MAP_ID}/release-composition?versionId=${V2}`,
+    });
+    await app.close();
+
+    const body = res.json();
+    expect(body.releases).toHaveLength(1);
+    expect(body.releases[0].versionName).toBe('V2');
+  });
+
+  it('caps unattributed items but reports the true total', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/${MAP_ID}/release-composition?limit=1`,
+    });
+    await app.close();
+
+    const v1 = res.json().releases[0];
+    expect(v1.unattributed).toHaveLength(1);
+    // The cap must never masquerade as the answer.
+    expect(v1.unattributedTotal).toBe(3);
+  });
+
+  it('clamps an absurd limit instead of streaming the whole map', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/${MAP_ID}/release-composition?limit=999999`,
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().releases[0].unattributed.length).toBeLessThanOrEqual(500);
+  });
+
+  it('falls back to the default cap when limit is not a number', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/${MAP_ID}/release-composition?limit=banana`,
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().releases[0].unattributed).toHaveLength(3);
+  });
+
+  it('404s on an unknown map', async () => {
+    getMapMock.mockResolvedValueOnce(null);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/${MAP_ID}/release-composition`,
+    });
+    await app.close();
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe('MAP_NOT_FOUND');
+  });
+
+  it('404s on a version that does not belong to the map', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/${MAP_ID}/release-composition?versionId=nope`,
+    });
+    await app.close();
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe('VERSION_NOT_FOUND');
+  });
+
+  it('reports a release with no work as null coverage, not 0 %', async () => {
+    listVersionsMock.mockResolvedValue([version('ver-empty', 'V9', null)]);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/maps/${MAP_ID}/release-composition`,
+    });
+    await app.close();
+    expect(res.json().releases[0].coveragePct).toBeNull();
+  });
+});

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { and, eq, lte, desc } from 'drizzle-orm';
-import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes, effectiveVersionId } from '@mindblown/core';
+import { computeTree, schedule, criticalPath, clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes, effectiveVersionId, computeReleaseComposition, compareVersions } from '@mindblown/core';
 import { buildRegisterData, renderMarkdown, renderDocx } from '../export/requirementsDoc.js';
 import { listActiveAcceptances } from '../db/acceptances.js';
 import type { ScheduleConstraint, NodeId, Node as CoreNode, MindMap } from '@mindblown/core';
@@ -1143,6 +1143,76 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           ? latestSnapshot.createdAt.toISOString()
           : ((latestSnapshot?.createdAt as string | undefined) ?? null),
     });
+  });
+
+  // ── GET /api/maps/:id/release-composition — what is in a release
+  //
+  // The forecast above answers "when does V1 land". This answers "what
+  // is V1 made of": the split between work that implements a
+  // requirement and everything else — bugs, infra, cleanup, features
+  // nobody ever specified. On a real map the second pile is the
+  // majority, so a release view built on requirements alone reports on
+  // a fraction of the release.
+  //
+  // The math lives in core/releaseComposition.ts, shared with the MCP
+  // tool, so an agent and the UI can never quote different coverage.
+  //
+  // ?versionId=  restrict to one release
+  // ?limit=      unattributed items returned per release (default 25)
+  app.get<{
+    Params: { id: string };
+    Querystring: { versionId?: string; limit?: string };
+  }>('/api/maps/:id/release-composition', async (req, reply) => {
+    const data = await mapDb.getMap(req.params.id);
+    if (!data) {
+      return reply.status(404).send({
+        error: { code: 'MAP_NOT_FOUND', message: `Map ${req.params.id} not found` },
+      });
+    }
+
+    const parsedLimit = Number.parseInt(req.query.limit ?? '', 10);
+    const limit = Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 0), 500)
+      : 25;
+
+    const allVersions = await versionDb.listVersions(data.map.id);
+    const wanted = req.query.versionId
+      ? allVersions.filter((v) => v.id === req.query.versionId)
+      : allVersions;
+
+    if (req.query.versionId && wanted.length === 0) {
+      return reply.status(404).send({
+        error: {
+          code: 'VERSION_NOT_FOUND',
+          message: `Version ${req.query.versionId} not found on map ${req.params.id}`,
+        },
+      });
+    }
+
+    const releases = wanted
+      .slice()
+      .sort(compareVersions)
+      .map((version) => {
+        const c = computeReleaseComposition(data.nodes, version.id);
+        return {
+          versionId: version.id,
+          versionName: version.name,
+          versionStatus: version.status,
+          targetDate: version.targetDate ?? null,
+          coveragePct: c.coveragePct,
+          requirementWork: c.requirementWork,
+          otherWork: c.otherWork,
+          byRequirement: c.byRequirement,
+          byClassification: c.byClassification,
+          // Truncated for the overview; the drill-down re-requests one
+          // release with a higher limit rather than shipping every leaf
+          // of every release on first paint.
+          unattributed: c.unattributed.slice(0, limit),
+          unattributedTotal: c.unattributed.length,
+        };
+      });
+
+    return reply.send({ mapId: data.map.id, effortUnit: data.map.effortUnit, releases });
   });
 
   // ── GET /api/maps/:id/forecast-scorecard — grade forecasts vs reality


### PR DESCRIPTION
## Why

`requirements_overview` answers *"which requirements ship in V1"*. Nothing answered *"what **is** V1"* — and on the Fulcrum roadmap that is a very different question:

| Release | Requirement coverage | Tasks |
|---|---|---|
| MVP | 100 % | 54 |
| V1 | **24 %** | 293 |
| V1.5 | 22 % | 221 |
| V1.5 follow-up | 6 % | 686 |
| V2 | 27 % | 477 |

223 of V1's 293 leaves attribute to no requirement at all. A release view built on the register alone reports on a quarter of the release and looks green while the other three quarters decide the date.

## What

- **`core/releaseComposition.ts`** — pure function attributing every leaf of a release to a requirement or to the rest. Attribution is structural (a requirement on the path to the root) **or** by shared GitHub issue via the existing `collectRequirementGhLinks`. The link join is the one that matters: the tree is organised by functional area, so the ticket implementing PER-05 lives nowhere near the requirement.
- **`GET /api/maps/:id/release-composition`** — same shape as `release-forecast`; `?versionId=`, `?limit=`.
- **`ReleasesView`** — a second row per release behind its own toggle, off by default, fetched only when switched on. The forecast table's render path, columns and values are untouched.
- **`release_composition` MCP tool** — calls the endpoint, so an agent and the UI cannot quote different coverage.

## Decisions worth arguing about

**Coverage is counted in tickets, not effort.** Finished work tends to lose its estimate — V1 carries 183 unestimated leaves, nearly all done — so an effort-weighted coverage would understate whatever already shipped. Effort ships alongside, with its unestimated count.

**Classification never guesses from the title.** A regex over `fix(`/`infra:` looks convincing and mislabels everything off the convention of the day, which is exactly the set this view exists to surface. Work without a `type:` label (written by GitHub label sync) reads `unclassified`. On the real roadmap that is 203 of V1's 223 — honest, and itself the finding.

## Verification

- 14 core unit tests, mutation-verified (6 mutations, all killed).
- 9 route tests.
- Full suite green: 1081 tests across all packages.
- End-to-end in a browser against a seeded dev DB: login → Releases → toggle → expand, including a work node attributed purely through a shared GitHub issue. MCP tool driven over stdio against the same server — identical numbers.

## Not in this PR

The writable drill-down (assign an unattributed ticket to a requirement from the list) is its own ticket. Read-only, the view is already usable; writing needs a decision on whether attribution writes a link onto the requirement or moves the node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY3D9CXmkSRaDwDoN7f1tn