### PR TITLE
Gantt: hide-done rolls up + "Requirements only" mode; clearer requirements-export header

### DIFF
--- a/packages/mindmap/src/GanttView.tsx
+++ b/packages/mindmap/src/GanttView.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import { collectScopeMatches, hasActiveScopeFilter } from './scopeFilter.js';
+import { collectDoneNodeIds, collectRequirementKeepIds } from './viewScope.js';
 import { fetchSchedule, updateMap as updateMapApi } from './api.js';
 
 // ── Schedule response shape (from GET /api/maps/:id/schedule) ────
@@ -29,6 +30,7 @@ const MAX_TASK_LIST_WIDTH = 1200;
 // Bumped whenever the default changes so users with cached widths
 // pick up the new default on next load.
 const TASK_WIDTH_STORAGE_KEY = 'mindblown_gantt_task_width_v3';
+const REQ_ONLY_STORAGE_KEY = 'mindblown_gantt_req_only';
 const ROW_HEIGHT = 36;
 const HEADER_HEIGHT = 48;
 const HEALTH_COLORS: Record<string, string> = {
@@ -283,6 +285,18 @@ export function GanttView() {
   const [workersInput, setWorkersInput] = useState<number>(1);
   const [savingWorkers, setSavingWorkers] = useState(false);
   const [showBehindOnly, setShowBehindOnly] = useState(false);
+  // Requirements-only mode: the chart collapses to the requirement register
+  // (nodes carrying a requirementId) instead of every task in the tree.
+  // Persisted like hideDone — it is a way of reading the plan, not a
+  // one-off lookup.
+  const [showReqOnly, setShowReqOnly] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(REQ_ONLY_STORAGE_KEY) === '1';
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(REQ_ONLY_STORAGE_KEY, showReqOnly ? '1' : '0');
+  }, [showReqOnly]);
   // Hide done items from the Gantt — persisted per-user in localStorage so
   // the choice survives page refresh and tab switches.
   const [hideDone, setHideDone] = useState<boolean>(() => {
@@ -419,6 +433,29 @@ export function GanttView() {
   // if a parent is tagged V1, its untagged children inherit V1. A subtree
   // is shown only if the current node matches the active filter (shared
   // walk in scopeFilter.ts, same semantics as getVisibleNodes).
+  // Done-ness for the hide-done filter: status category OR 100%, rolled up
+  // through parents (see collectDoneNodeIds).
+  const doneSet = useMemo(() => {
+    if (!rootNodeId || !hideDone) return new Set<string>();
+    return collectDoneNodeIds(
+      (id) => nodes[id],
+      rootNodeId,
+      currentMap?.statusWorkflow ?? [],
+    );
+  }, [nodes, rootNodeId, hideDone, currentMap?.statusWorkflow]);
+
+  // How many requirements the map carries at all — gates the toggle so it
+  // isn't a dead button on maps that never adopted the register.
+  const requirementCount = useMemo(
+    () => Object.values(nodes).filter((n) => n.requirementId != null).length,
+    [nodes],
+  );
+  // The stored preference is per-user, not per-map. On a map without
+  // requirements it would filter the chart down to nothing while the
+  // toggle sits disabled — so it only takes effect where it can mean
+  // something.
+  const reqOnlyActive = showReqOnly && requirementCount > 0;
+
   const rows = useMemo(() => {
     if (!rootNodeId || !nodes[rootNodeId]) return [];
 
@@ -453,26 +490,55 @@ export function GanttView() {
       }
     }
 
+    // "Requirements only" — requirement nodes + their connecting ancestors,
+    // so the chart reads as one bar per REQ-ID (see collectRequirementKeepIds).
+    const reqKeep = reqOnlyActive ? collectRequirementKeepIds(nodes) : new Set<string>();
+
+    // Does this node produce a row of its own? (Collapse state aside — that
+    // is the walk's business.) hideDone is handled separately because it
+    // prunes the whole subtree rather than skipping one level.
+    const emitsRow = (nodeId: string): boolean => {
+      if (scopeFilterActive && !inScope.has(nodeId)) return false;
+      if (showBehindOnly && !behindKeep.has(nodeId)) return false;
+      if (reqOnlyActive && !reqKeep.has(nodeId)) return false;
+      return true;
+    };
+
+    // A row only earns an expand chevron when something below it actually
+    // survives the filters. Without this, "Requirements only" leaves every
+    // requirement with a chevron that expands into nothing (its children
+    // are all filtered out).
+    const hasVisibleDescendant = new Set<string>();
+    const scan = (nodeId: string): boolean => {
+      const node = nodes[nodeId];
+      if (!node) return false;
+      if (hideDone && doneSet.has(nodeId)) return false;
+      let below = false;
+      for (const cid of node.childrenIds) {
+        if (scan(cid)) below = true;
+      }
+      if (below) hasVisibleDescendant.add(nodeId);
+      return below || emitsRow(nodeId);
+    };
+    scan(rootNodeId);
+
     const result: FlatRow[] = [];
     const walk = (nodeId: string, depth: number) => {
       const node = nodes[nodeId];
       if (!node) return;
-      if (scopeFilterActive && !inScope.has(nodeId)) {
-        // Skip this node but still descend — a tagged leaf can live under
-        // an untagged parent.
-        for (const cid of node.childrenIds) walk(cid, depth);
-        return;
-      }
-      if (showBehindOnly && !behindKeep.has(nodeId)) {
-        for (const cid of node.childrenIds) walk(cid, depth);
-        return;
-      }
       // Hide done items — both done leaves AND parents whose subtree is
-      // entirely done (percentComplete >= 100 propagates via rollup).
-      if (hideDone && (node.percentComplete ?? 0) >= 100) {
+      // entirely done. Never test node.percentComplete here: it is null on
+      // parents and untouched on leaves closed via status.
+      if (hideDone && doneSet.has(nodeId)) {
         return;
       }
-      const hasChildren = node.childrenIds.length > 0;
+      if (!emitsRow(nodeId)) {
+        // Skip this node but still descend — a tagged leaf can live under
+        // an untagged parent, a requirement under a plain chapter.
+        for (const cid of node.childrenIds) walk(cid, depth);
+        return;
+      }
+      const hasChildren = hasVisibleDescendant.has(nodeId);
       const isExpanded = !collapsedSet.has(nodeId);
       result.push({
         node,
@@ -487,6 +553,7 @@ export function GanttView() {
     walk(rootNodeId, 0);
     return result;
   }, [
+    reqOnlyActive,
     nodes,
     rootNodeId,
     collapsedSet,
@@ -495,6 +562,7 @@ export function GanttView() {
     activePhaseFilter,
     showBehindOnly,
     hideDone,
+    doneSet,
     computed,
   ]);
 
@@ -1090,6 +1158,34 @@ export function GanttView() {
           </span>
         )}
 
+        {/* Requirements-only toggle */}
+        <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
+        <button
+          onClick={() => requirementCount > 0 && setShowReqOnly((v) => !v)}
+          disabled={requirementCount === 0}
+          aria-pressed={reqOnlyActive}
+          title={
+            requirementCount === 0
+              ? 'This map has no requirements yet — give a node a requirement ID to use this'
+              : reqOnlyActive
+                ? `Showing the ${requirementCount} requirement${requirementCount === 1 ? '' : 's'} only. Click to show every task again.`
+                : `Collapse the chart to the ${requirementCount} requirement${requirementCount === 1 ? '' : 's'} — one bar per REQ-ID, spanning its whole subtree.`
+          }
+          style={{
+            padding: '3px 10px',
+            borderRadius: 4,
+            border: '1px solid #c7d2fe',
+            fontSize: 11,
+            fontWeight: 600,
+            fontFamily: 'inherit',
+            cursor: requirementCount === 0 ? 'not-allowed' : 'pointer',
+            background: reqOnlyActive ? '#4f46e5' : '#fff',
+            color: reqOnlyActive ? '#fff' : requirementCount === 0 ? '#cbd5e1' : '#4338ca',
+          }}
+        >
+          {reqOnlyActive ? `Requirements ✓ (${requirementCount})` : 'Requirements only'}
+        </button>
+
         {/* Hide done toggle */}
         <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
         <button
@@ -1214,6 +1310,15 @@ export function GanttView() {
               overflowX: 'hidden',
             }}
           >
+            {rows.length === 0 && (
+              <div style={{ padding: '16px 12px', fontSize: 11, color: '#94a3b8', lineHeight: 1.5 }}>
+                {reqOnlyActive && hideDone
+                  ? 'Every requirement is done. Turn off "Hide done" to see them.'
+                  : reqOnlyActive
+                    ? 'No requirement matches the active filters.'
+                    : 'Nothing matches the active filters.'}
+              </div>
+            )}
             <div style={{ height: totalHeight, position: 'relative' }}>
               {dropIndicatorY != null && (
                 <div
@@ -1338,6 +1443,24 @@ export function GanttView() {
                         <div style={{ width: 16, flexShrink: 0 }} />
                       )}
 
+                      {row.node.requirementId && (
+                        <span
+                          title={`Requirement ${row.node.requirementId}`}
+                          style={{
+                            flexShrink: 0,
+                            marginRight: 6,
+                            padding: '1px 5px',
+                            borderRadius: 3,
+                            background: '#eef2ff',
+                            color: '#4338ca',
+                            fontSize: 10,
+                            fontWeight: 700,
+                            fontVariantNumeric: 'tabular-nums',
+                          }}
+                        >
+                          {row.node.requirementId}
+                        </span>
+                      )}
                       <span
                         style={{
                           overflow: 'hidden',

--- a/packages/mindmap/src/__tests__/viewScope.test.ts
+++ b/packages/mindmap/src/__tests__/viewScope.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { computeTree } from '@mindblown/core';
 import type { Node } from '@mindblown/core';
-import { selectHillBranches, computeWorkloads } from '../viewScope.js';
+import {
+  selectHillBranches,
+  computeWorkloads,
+  collectDoneNodeIds,
+  collectRequirementKeepIds,
+} from '../viewScope.js';
 
 // The store module reads localStorage at import time (auth-token bootstrap);
 // shim it for the node test environment BEFORE the dynamic import below.
@@ -160,6 +165,129 @@ const workflow = [
 
 const workloadsNow = () =>
   computeWorkloads(useMindmapStore.getState().getVisibleNodes(SCOPE_ONLY), workflow);
+
+describe('collectDoneNodeIds — the Gantt "hide done" oracle', () => {
+  const lookupFrom = (nodes: Record<string, Node>) => (id: string) => nodes[id];
+
+  it('marks a leaf done via percentComplete AND via a done status', () => {
+    const nodes: Record<string, Node> = {
+      root: makeNode('root', null, { childrenIds: ['byPct', 'byStatus', 'open'] }),
+      byPct: makeNode('byPct', 'root', { percentComplete: 100 }),
+      // Closed via set_status only — percentComplete stays null, which is
+      // exactly what the old `percentComplete >= 100` test missed.
+      byStatus: makeNode('byStatus', 'root', { status: 'done' }),
+      open: makeNode('open', 'root', { percentComplete: 40 }),
+    };
+    const done = collectDoneNodeIds(lookupFrom(nodes), 'root', workflow);
+    expect(done.has('byPct')).toBe(true);
+    expect(done.has('byStatus')).toBe(true);
+    expect(done.has('open')).toBe(false);
+    expect(done.has('root')).toBe(false);
+  });
+
+  it('rolls up: a parent whose children are all done is done, even with percentComplete null', () => {
+    const nodes: Record<string, Node> = {
+      root: makeNode('root', null, { childrenIds: ['epic'] }),
+      epic: makeNode('epic', 'root', { childrenIds: ['c1', 'c2'] }),
+      c1: makeNode('c1', 'epic', { percentComplete: 100 }),
+      c2: makeNode('c2', 'epic', { status: 'done' }),
+    };
+    const done = collectDoneNodeIds(lookupFrom(nodes), 'root', workflow);
+    expect([...done].sort()).toEqual(['c1', 'c2', 'epic', 'root']);
+  });
+
+  it('a single open child keeps the parent visible but still hides its done siblings', () => {
+    const nodes: Record<string, Node> = {
+      root: makeNode('root', null, { childrenIds: ['epic'] }),
+      epic: makeNode('epic', 'root', { childrenIds: ['c1', 'c2'] }),
+      c1: makeNode('c1', 'epic', { percentComplete: 100 }),
+      c2: makeNode('c2', 'epic', { percentComplete: 10 }),
+    };
+    const done = collectDoneNodeIds(lookupFrom(nodes), 'root', workflow);
+    expect([...done]).toEqual(['c1']);
+  });
+
+  it('falls back to the name heuristic when the status is not in the workflow', () => {
+    const nodes: Record<string, Node> = {
+      root: makeNode('root', null, { childrenIds: ['a'] }),
+      a: makeNode('a', 'root', { status: 'Closed' }),
+    };
+    expect(collectDoneNodeIds(lookupFrom(nodes), 'root', []).has('a')).toBe(true);
+  });
+
+  it('survives a cyclic parent/child link without recursing forever', () => {
+    const nodes: Record<string, Node> = {
+      root: makeNode('root', null, { childrenIds: ['a'] }),
+      a: makeNode('a', 'root', { childrenIds: ['root'] }),
+    };
+    expect(() => collectDoneNodeIds(lookupFrom(nodes), 'root', workflow)).not.toThrow();
+  });
+});
+
+describe('collectRequirementKeepIds — the Gantt "requirements only" rows', () => {
+  /**
+   * Doc-shaped map:
+   *   root
+   *   ├─ kapitel3            (chapter, no REQ-ID)
+   *   │   ├─ MAN-01          requirement, decomposed into work
+   *   │   │   ├─ w1          plain task
+   *   │   │   └─ w2          plain task
+   *   │   └─ MAN-02          requirement, still a leaf
+   *   └─ infra               no requirement anywhere below
+   *       └─ i1
+   */
+  const docMap = (): Record<string, Node> => ({
+    root: makeNode('root', null, { childrenIds: ['kapitel3', 'infra'] }),
+    kapitel3: makeNode('kapitel3', 'root', { childrenIds: ['man01', 'man02'] }),
+    man01: makeNode('man01', 'kapitel3', {
+      childrenIds: ['w1', 'w2'],
+      requirementId: 'MAN-01',
+    }),
+    w1: makeNode('w1', 'man01'),
+    w2: makeNode('w2', 'man01'),
+    man02: makeNode('man02', 'kapitel3', { requirementId: 'MAN-02' }),
+    infra: makeNode('infra', 'root', { childrenIds: ['i1'] }),
+    i1: makeNode('i1', 'infra'),
+  });
+
+  it('keeps requirements plus their connecting ancestors, and nothing else', () => {
+    expect([...collectRequirementKeepIds(docMap())].sort()).toEqual([
+      'kapitel3',
+      'man01',
+      'man02',
+      'root',
+    ]);
+  });
+
+  it('drops the work a requirement decomposes into — it belongs to the rolled-up bar', () => {
+    const keep = collectRequirementKeepIds(docMap());
+    expect(keep.has('w1')).toBe(false);
+    expect(keep.has('w2')).toBe(false);
+  });
+
+  it('drops whole branches that carry no requirement', () => {
+    const keep = collectRequirementKeepIds(docMap());
+    expect(keep.has('infra')).toBe(false);
+    expect(keep.has('i1')).toBe(false);
+  });
+
+  it('keeps a requirement nested under another requirement', () => {
+    const nodes = docMap();
+    nodes.w1 = makeNode('w1', 'man01', { requirementId: 'MAN-01.1' });
+    const keep = collectRequirementKeepIds(nodes);
+    expect(keep.has('w1')).toBe(true);
+    expect(keep.has('man01')).toBe(true);
+    expect(keep.has('w2')).toBe(false);
+  });
+
+  it('returns an empty set on a map that never adopted the register', () => {
+    const nodes = docMap();
+    delete (nodes.man01 as { requirementId?: string | null }).requirementId;
+    nodes.man01 = makeNode('man01', 'kapitel3', { childrenIds: ['w1', 'w2'] });
+    nodes.man02 = makeNode('man02', 'kapitel3');
+    expect(collectRequirementKeepIds(nodes).size).toBe(0);
+  });
+});
 
 describe('scope-only getVisibleNodes as the data basis for HillChart/WorkloadView', () => {
   beforeEach(() => setStoreState());

--- a/packages/mindmap/src/mobile/MobileGanttView.tsx
+++ b/packages/mindmap/src/mobile/MobileGanttView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { MindMap, StatusDef } from '@mindblown/core';
 import * as api from '../api.js';
 import type { NodeWithComputed, ScheduleResponse } from '../api.js';
+import { collectDoneNodeIds } from '../viewScope.js';
 
 interface Props {
   nodes: NodeWithComputed[];
@@ -150,14 +151,22 @@ export function MobileGanttView({ nodes, map, onSelect }: Props) {
     const critical = new Set(schedule.criticalPath.path);
     const treeOrder = flattenTreeIds(nodes, map.rootNodeId);
 
+    // Done-ness is status-category OR 100%, rolled up through parents —
+    // node.percentComplete alone is null on parents and stale on leaves
+    // closed via status.
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    const doneIds = hideDone
+      ? collectDoneNodeIds((id) => byId.get(id), map.rootNodeId, map.statusWorkflow)
+      : new Set<string>();
+
     const dated: { node: NodeWithComputed; start: Date; end: Date }[] = [];
     for (const id of treeOrder) {
       const d = dateById.get(id);
       if (!d) continue;
-      const node = nodes.find((n) => n.id === id);
+      const node = byId.get(id);
       if (!node) continue;
       if (d.end <= d.start) continue;
-      if (hideDone && (node.percentComplete ?? 0) >= 100) continue;
+      if (hideDone && doneIds.has(id)) continue;
       dated.push({ node, start: d.start, end: d.end });
     }
 

--- a/packages/mindmap/src/viewScope.ts
+++ b/packages/mindmap/src/viewScope.ts
@@ -181,6 +181,79 @@ export function statusCategory(
 }
 
 /**
+ * Every node in the tree that counts as "done" for a hide-done filter.
+ *
+ * A leaf is done when its status sits in a `done` workflow category OR its
+ * `percentComplete` reached 100 — the same either/or the server uses when it
+ * stamps `completedAt` (see `updateNode` in server/src/db/nodes.ts). A parent
+ * is done when every one of its children is, because a parent holds no
+ * progress of its own — the rollup does.
+ *
+ * Both Gantt views used to test `node.percentComplete >= 100` alone, which
+ * missed two whole classes of finished work: leaves closed by status (their
+ * raw `percentComplete` is never touched) and every parent above them (a
+ * parent's raw `percentComplete` is null — the 100 lives in the rollup).
+ *
+ * @param lookup - resolves a node id; views hold either a Record or an array.
+ */
+export function collectDoneNodeIds(
+  lookup: (id: string) => Node | undefined,
+  rootId: string,
+  statusWorkflow: StatusWorkflowStep[],
+): Set<string> {
+  const done = new Set<string>();
+  const seen = new Set<string>();
+  const visit = (id: string): boolean => {
+    if (seen.has(id)) return done.has(id); // cycle guard on malformed trees
+    seen.add(id);
+    const node = lookup(id);
+    if (!node) return false;
+    let isDone: boolean;
+    if (node.childrenIds.length === 0) {
+      isDone =
+        (node.percentComplete ?? 0) >= 100 ||
+        statusCategory(node, statusWorkflow) === 'done';
+    } else {
+      // Descend into every child regardless of the running verdict — a
+      // done child under a not-done parent still has to land in the set.
+      let all = true;
+      for (const cid of node.childrenIds) {
+        if (!visit(cid)) all = false;
+      }
+      isDone = all;
+    }
+    if (isDone) done.add(id);
+    return isDone;
+  };
+  visit(rootId);
+  return done;
+}
+
+/**
+ * The rows a "requirements only" chart keeps: every node carrying a
+ * `requirementId`, plus the ancestors that connect them to the root.
+ *
+ * The ancestors stay so the chapters still group the rows and the
+ * indentation keeps meaning — a flat list of REQ-IDs loses which Bereich
+ * each one belongs to. Everything a requirement decomposes into is left
+ * out on purpose: that work is already inside the requirement's rolled-up
+ * bar, which is what makes the chart one row per REQ-ID.
+ */
+export function collectRequirementKeepIds(nodes: Record<string, Node>): Set<string> {
+  const keep = new Set<string>();
+  for (const n of Object.values(nodes)) {
+    if (n.requirementId == null) continue;
+    let cur: string | null | undefined = n.id;
+    // Stops at the first already-kept ancestor — its own chain is in already.
+    while (cur && !keep.has(cur)) {
+      keep.add(cur);
+      cur = nodes[cur]?.parentId;
+    }
+  }
+  return keep;
+}
+
+/**
  * Who a leaf's effort should count against, strongest signal first.
  *
  * `assigneeIds` is the field the model intends for this, but nothing

--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -250,17 +250,23 @@ describe('buildRegisterData — filters (export mirrors the filter bar)', () => 
     );
   });
 
-  it('marks the rendered Markdown as a filtered Auszug with X von Y', () => {
+  it('marks the rendered Markdown as a filtered Auszug and separates scope from Stand', () => {
     const md = renderMarkdown(buildF({ release: 'none' }));
     expect(md).toContain('Gefilterter Auszug');
     expect(md).toContain('Release: ohne Zuordnung');
-    expect(md).toContain('**Stand:** 1 von 4 Anforderungen');
+    expect(md).toContain(
+      '**Umfang:** 1 der insgesamt 4 Anforderungen dieser Map — gefilterter Auszug (Release: ohne Zuordnung)',
+    );
+    expect(md).toContain('**Stand dieser Anforderung:**');
   });
 
   it('renders an unfiltered document without the Auszug banner', () => {
     const md = renderMarkdown(buildF({}));
     expect(md).not.toContain('Gefilterter Auszug');
-    expect(md).toContain('**Stand:** 4 Anforderungen');
+    expect(md).toContain('**Umfang:** alle 4 Anforderungen dieser Map');
+    expect(md).toContain(
+      '**Stand dieser 4 Anforderungen:** 1 Umgesetzt · 1 Teilweise · 2 Offen',
+    );
   });
 });
 

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -306,6 +306,23 @@ const LEGEND = [
   '**Abnahme:** ✓ abgenommen · ✗ abgelehnt (mit Begründung) · ⚠ seit dem Urteil geändert',
 ];
 
+/**
+ * The header used to read "Stand: 44 von 163 Anforderungen — 12 Umgesetzt …",
+ * which readers took as "44 of 163 done". Scope (how much of the register this
+ * document covers) and Stand (how far that scope is along) are two different
+ * numbers, so they get two lines. Markers are stripped for the docx renderer.
+ */
+function scopeLine(data: RegisterData): string {
+  return data.filterLabel
+    ? `**Umfang:** ${data.total} der insgesamt ${data.totalAll} Anforderungen dieser Map — gefilterter Auszug (${data.filterLabel})`
+    : `**Umfang:** alle ${data.totalAll} Anforderungen dieser Map`;
+}
+
+function standLine(data: RegisterData): string {
+  const subject = data.total === 1 ? 'dieser Anforderung' : `dieser ${data.total} Anforderungen`;
+  return `**Stand ${subject}:** ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`;
+}
+
 export function renderMarkdown(data: RegisterData): string {
   const L: string[] = [];
   L.push(`# ${data.title}`);
@@ -322,9 +339,9 @@ export function renderMarkdown(data: RegisterData): string {
     L.push(line);
   }
   L.push('');
-  L.push(
-    `**Stand:** ${data.total}${data.filterLabel ? ` von ${data.totalAll}` : ''} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
-  );
+  L.push(scopeLine(data));
+  L.push('');
+  L.push(standLine(data));
   L.push('');
   L.push('---');
   data.chapters.forEach((ch, i) => {
@@ -441,13 +458,15 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
   }
   children.push(
     new Paragraph({
-      spacing: { before: 160, after: 240 },
+      spacing: { before: 160 },
       children: [
-        new TextRun({
-          text: `Stand: ${data.total}${data.filterLabel ? ` von ${data.totalAll}` : ''} Anforderungen — ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`,
-          bold: true,
-          size: 20,
-        }),
+        new TextRun({ text: scopeLine(data).replace(/\*\*/g, ''), bold: true, size: 20 }),
+      ],
+    }),
+    new Paragraph({
+      spacing: { before: 60, after: 240 },
+      children: [
+        new TextRun({ text: standLine(data).replace(/\*\*/g, ''), bold: true, size: 20 }),
       ],
     }),
   );


### PR DESCRIPTION
## The bug

Gantt "hide done" tested `node.percentComplete >= 100` — a raw field that is `null` on every parent and never touched when a leaf is closed via status. So two whole classes of finished work stayed on the chart: leaves closed with `set_status('done')`, and every parent above them.

`collectDoneNodeIds()` replaces that test with the rolled-up definition the server already uses when it stamps `completedAt`: a **leaf** is done when its status sits in a `done` workflow category **or** it hit 100%; a **parent** is done when all its children are.

Both Gantt surfaces carried the identical bug — desktop `GanttView` and `mobile/MobileGanttView` — and both now share the oracle.

## Requirements only

New toggle in the Gantt toolbar. The chart collapses to the nodes carrying a `requirementId` plus the chapters connecting them to the root, so it reads as **one bar per REQ-ID**, spanning that requirement's whole subtree. Everything the requirement decomposes into is already inside that rolled-up bar.

- Rows show the REQ-ID as a badge.
- The preference persists per user, but only takes effect on maps that have requirements — otherwise it would filter the chart to nothing behind a disabled button.
- Composes with hide-done, behind-only, and the version/sprint/phase filters.
- Expand chevrons now track whether anything below actually survives the filters, so they no longer expand into nothing.
- Empty state added — the Gantt could not be empty before this.

## Requirements export header

`**Stand:** 44 von 163 Anforderungen — 12 Umgesetzt · 20 Teilweise · 12 Offen` read as "44 of 163 done". Scope and progress are different numbers, so the header is now two lines:

```
**Umfang:** 44 der insgesamt 163 Anforderungen dieser Map — gefilterter Auszug (Release: nur MVP)

**Stand dieser 44 Anforderungen:** 12 Umgesetzt · 20 Teilweise · 12 Offen
```

The Stand line names its own denominator, and the active filter is repeated where the count is — the "Gefilterter Auszug" banner sits five legend lines further up. Unfiltered reads `**Umfang:** alle 163 Anforderungen dieser Map`. Markdown and DOCX renderers now share `scopeLine()`/`standLine()` instead of each carrying a copy of the template string.

## Verification

`pnpm turbo typecheck` and `pnpm turbo test` clean (89 tests). 10 new unit tests over both helpers: status-only done, rollup, mixed siblings, unknown-status fallback, cycle guard; requirement + ancestor keep, decomposed work dropped, requirement-free branches dropped, nested requirements, register-free map.

No new `Node` field, so no DB/REST/MCP layers are involved — this is view-side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWNwN5UEL9UKP2MavMC5MM