### PR TITLE
Anforderungsdokument: "dieses Projekts" statt "dieser Map"

### DIFF
--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -255,7 +255,7 @@ describe('buildRegisterData — filters (export mirrors the filter bar)', () => 
     expect(md).toContain('Gefilterter Auszug');
     expect(md).toContain('Release: ohne Zuordnung');
     expect(md).toContain(
-      '**Umfang:** 1 der insgesamt 4 Anforderungen dieser Map — gefilterter Auszug (Release: ohne Zuordnung)',
+      '**Umfang:** 1 der insgesamt 4 Anforderungen dieses Projekts — gefilterter Auszug (Release: ohne Zuordnung)',
     );
     expect(md).toContain('**Stand dieser Anforderung:**');
   });
@@ -263,7 +263,7 @@ describe('buildRegisterData — filters (export mirrors the filter bar)', () => 
   it('renders an unfiltered document without the Auszug banner', () => {
     const md = renderMarkdown(buildF({}));
     expect(md).not.toContain('Gefilterter Auszug');
-    expect(md).toContain('**Umfang:** alle 4 Anforderungen dieser Map');
+    expect(md).toContain('**Umfang:** alle 4 Anforderungen dieses Projekts');
     expect(md).toContain(
       '**Stand dieser 4 Anforderungen:** 1 Umgesetzt · 1 Teilweise · 2 Offen',
     );

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -314,8 +314,8 @@ const LEGEND = [
  */
 function scopeLine(data: RegisterData): string {
   return data.filterLabel
-    ? `**Umfang:** ${data.total} der insgesamt ${data.totalAll} Anforderungen dieser Map — gefilterter Auszug (${data.filterLabel})`
-    : `**Umfang:** alle ${data.totalAll} Anforderungen dieser Map`;
+    ? `**Umfang:** ${data.total} der insgesamt ${data.totalAll} Anforderungen dieses Projekts — gefilterter Auszug (${data.filterLabel})`
+    : `**Umfang:** alle ${data.totalAll} Anforderungen dieses Projekts`;
 }
 
 function standLine(data: RegisterData): string {


### PR DESCRIPTION
Folgeänderung zu #270. Die Umfang-Zeile im Anforderungsdokument sprach von der "Map" — Werkzeug-Vokabular in einem Dokument, das an die Fachseite geht.

```
Umfang: 44 der insgesamt 163 Anforderungen dieses Projekts — gefilterter Auszug (Release: nur MVP)
Umfang: alle 163 Anforderungen dieses Projekts
```

Betrifft Markdown- und DOCX-Export (gemeinsame `scopeLine()`). Tests angepasst, `typecheck` + `test` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFjAoSHBhK9eznsHrf4pEQ