### PR TITLE
fix(github): populate externalLinks[].state so closed issues actually dim

### DIFF
--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -614,6 +614,48 @@ export async function updateNode(
   return null;
 }
 
+/**
+ * Refresh the cached open/closed `state` on a single GitHub external link
+ * without touching anything else on the node.
+ *
+ * Deliberately NOT routed through updateNode: that bumps `revision` and
+ * `updatedAt` on every call. `state` is a mirror of GitHub, not user
+ * content, and the catchup repairs it in bulk — a revision bump there
+ * would mark every requirement acceptance on those nodes as stale (the
+ * requirements view compares node.revision against the revision captured
+ * at sign-off) and would churn updatedAt for thousands of untouched
+ * nodes. So this writes the jsonb column alone.
+ *
+ * Returns false when the node is gone or carries no such link.
+ */
+export async function setExternalLinkState(
+  nodeId: string,
+  externalId: string,
+  state: 'open' | 'closed',
+  handle: DbHandle = db,
+): Promise<boolean> {
+  const [row] = await handle
+    .select({ externalLinks: nodes.externalLinks })
+    .from(nodes)
+    .where(and(eq(nodes.id, nodeId), notDeleted));
+  if (!row) return false;
+
+  const links = (row.externalLinks as ExternalLink[]) ?? [];
+  let found = false;
+  const next = links.map((l) => {
+    if (l.provider !== 'github' || l.externalId !== externalId) return l;
+    found = true;
+    return { ...l, state };
+  });
+  if (!found) return false;
+
+  await handle
+    .update(nodes)
+    .set({ externalLinks: next })
+    .where(and(eq(nodes.id, nodeId), notDeleted));
+  return true;
+}
+
 // ── Delete (with descendants) ──────────────────────────────────────
 
 /**

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -91,6 +91,7 @@ async function autoLinkNodeFromTitle(
     url: issue.html_url,
     syncEnabled: true,
     lastSyncedAt: new Date().toISOString(),
+    state: issue.state,
   };
 
   const updated = await nodeDb.updateNode(nodeId, {

--- a/packages/server/src/routes/triage.ts
+++ b/packages/server/src/routes/triage.ts
@@ -991,6 +991,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
           url: buildIssueUrlFromExternalId(externalId),
           syncEnabled: true,
           lastSyncedAt: new Date().toISOString(),
+          state: isClosed ? 'closed' : 'open',
         };
         const updated = await nodeDb.updateNode(
           node.id,
@@ -1609,6 +1610,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
             url: buildIssueUrlFromExternalId(row.externalId),
             syncEnabled: true,
             lastSyncedAt: new Date().toISOString(),
+            state: isClosed ? 'closed' : 'open',
           };
           const updated = await nodeDb.updateNode(
             node.id,
@@ -2346,6 +2348,7 @@ export async function triageRoutes(app: FastifyInstance): Promise<void> {
                 url: buildIssueUrlFromExternalId(row.externalId),
                 syncEnabled: true,
                 lastSyncedAt: new Date().toISOString(),
+                state: isClosed ? 'closed' : 'open',
               };
               const updated = await nodeDb.updateNode(
                 node.id,

--- a/packages/server/src/sync/__tests__/githubCatchup.test.ts
+++ b/packages/server/src/sync/__tests__/githubCatchup.test.ts
@@ -46,12 +46,18 @@ vi.mock('../../db/schema.js', () => ({
   githubRepoSync: {},
 }));
 
+// Rows the mocked `db.select(...)` hands back. Defaults to empty so
+// `discoverTargets` sees zero repos (the original behaviour every test
+// below relied on); the link-state cases push node rows in and clear
+// them again afterwards.
+const dbRows = vi.hoisted(() => ({ current: [] as unknown[] }));
+
 vi.mock('../../db/connection.js', () => ({
   db: {
     select: () => ({
       from: () => ({
-        where: async () => [], // discoverTargets → empty
-        then: (resolve: (v: unknown) => unknown) => Promise.resolve([]).then(resolve),
+        where: async () => dbRows.current, // discoverTargets → empty by default
+        then: (resolve: (v: unknown) => unknown) => Promise.resolve(dbRows.current).then(resolve),
       }),
     }),
     execute: async () => undefined,
@@ -61,6 +67,8 @@ vi.mock('../../db/connection.js', () => ({
 vi.mock('../../db/nodes.js', () => ({
   getNode: vi.fn(),
   updateNode: vi.fn(),
+  setExternalLinkState: vi.fn(),
+  notDeleted: { __pred: true },
 }));
 
 vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
@@ -121,11 +129,14 @@ import {
   pushCatchupHeartbeat,
   isHealthyTick,
   reconcileRepo,
+  computeStateUpdates,
   _resetAuthFailureCountersForTests,
   _getAuthFailureCountForTests,
   type ReconcileResult,
 } from '../githubCatchup.js';
 import { fetchChangedIssues, GitHubApiError } from '@mindblown/integrations';
+import type { ExternalLink } from '@mindblown/core';
+import * as nodeDb from '../../db/nodes.js';
 
 // Re-aliased for readability in tests: this is the mock class from
 // the `vi.mock` factory above, not the real one.
@@ -138,6 +149,7 @@ function makeResult(overrides: Partial<ReconcileResult> = {}): ReconcileResult {
     applied: 0,
     skipped: 0,
     noTransition: 0,
+    mirrorRepaired: 0,
     stateSyncErrored: 0,
     ingested: 0,
     ingestErrored: 0,
@@ -651,5 +663,122 @@ describe('reconcileRepo → 401 auth-failure escalation, token-resolution path (
 
     expect(pushKumaMock).not.toHaveBeenCalled();
     expect(_getAuthFailureCountForTests('o/r')).toBe(0);
+  });
+});
+
+// ── Link `state` mirror ───────────────────────────────────────────
+//
+// The requirements view dims closed issues off `externalLinks[].state`.
+// Before this was fixed, only the webhook close/reopen handler ever
+// wrote that field, so ~91% of prod links carried no `state` at all and
+// rendered as if open. Two halves: transitions carry the mirror, and the
+// catchup repairs links whose node needs no transition.
+
+describe('computeStateUpdates → link state mirror', () => {
+  const link = (over: Partial<ExternalLink> = {}): ExternalLink => ({
+    provider: 'github',
+    externalId: 'o/r#14',
+    url: 'https://github.com/o/r/issues/14',
+    syncEnabled: true,
+    lastSyncedAt: null,
+    ...over,
+  });
+
+  it('stamps state=closed on the link when applying a close transition', () => {
+    const updates = computeStateUpdates(
+      { percentComplete: 40, status: 'in_progress', externalLinks: [link()] },
+      { state: 'closed' },
+      'o/r#14',
+    );
+    expect(updates?.externalLinks?.[0].state).toBe('closed');
+  });
+
+  it('stamps state=open on the link when applying a reopen transition', () => {
+    const updates = computeStateUpdates(
+      {
+        percentComplete: 100,
+        status: 'done',
+        externalLinks: [link({ state: 'closed', previousPercentComplete: 40, previousStatus: 'in_progress' })],
+      },
+      { state: 'open' },
+      'o/r#14',
+    );
+    expect(updates?.externalLinks?.[0].state).toBe('open');
+  });
+
+  it('still returns null for a mirror-only drift, so no revision bump happens', () => {
+    // Node already done, issue already closed — but the link never got a
+    // `state`. Repairing that must not go through updateNode, which would
+    // bump revision and stale every requirement acceptance on the node.
+    expect(
+      computeStateUpdates(
+        { percentComplete: 100, status: 'done', externalLinks: [link()] },
+        { state: 'closed' },
+        'o/r#14',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('reconcileRepo → repairs absent/stale link state', () => {
+  beforeEach(() => {
+    _resetAuthFailureCountersForTests();
+    fetchChangedIssuesMock.mockReset();
+    vi.mocked(nodeDb.getNode).mockReset();
+    vi.mocked(nodeDb.updateNode).mockReset();
+    vi.mocked(nodeDb.setExternalLinkState).mockReset();
+    vi.mocked(nodeDb.setExternalLinkState).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    dbRows.current = [];
+  });
+
+  function issue(number: number, state: 'open' | 'closed') {
+    return { number, state, title: `#${number}`, html_url: `https://github.com/o/r/issues/${number}` };
+  }
+
+  function nodeWithLink(externalId: string, over: Partial<ExternalLink> = {}) {
+    return {
+      id: 'n1',
+      mapId: 'm1',
+      percentComplete: 100,
+      status: 'done',
+      externalLinks: [
+        {
+          provider: 'github',
+          externalId,
+          url: 'https://github.com/o/r/issues/14',
+          syncEnabled: true,
+          lastSyncedAt: null,
+          ...over,
+        },
+      ],
+    };
+  }
+
+  it('backfills state on a done node whose closed issue link has none', async () => {
+    fetchChangedIssuesMock.mockResolvedValue([issue(14, 'closed')] as never);
+    dbRows.current = [nodeWithLink('o/r#14')];
+    vi.mocked(nodeDb.getNode).mockResolvedValue(nodeWithLink('o/r#14') as never);
+
+    const res = await reconcileRepo(makeTarget('o', 'r'));
+
+    expect(nodeDb.setExternalLinkState).toHaveBeenCalledWith('n1', 'o/r#14', 'closed');
+    expect(nodeDb.updateNode).not.toHaveBeenCalled(); // no revision bump
+    expect(res.mirrorRepaired).toBe(1);
+  });
+
+  it('leaves an already-correct mirror alone', async () => {
+    fetchChangedIssuesMock.mockResolvedValue([issue(14, 'closed')] as never);
+    dbRows.current = [nodeWithLink('o/r#14', { state: 'closed' })];
+    vi.mocked(nodeDb.getNode).mockResolvedValue(
+      nodeWithLink('o/r#14', { state: 'closed' }) as never,
+    );
+
+    const res = await reconcileRepo(makeTarget('o', 'r'));
+
+    expect(nodeDb.setExternalLinkState).not.toHaveBeenCalled();
+    expect(res.mirrorRepaired).toBe(0);
   });
 });

--- a/packages/server/src/sync/githubCatchup.ts
+++ b/packages/server/src/sync/githubCatchup.ts
@@ -118,6 +118,13 @@ export interface ReconcileResult {
   skipped: number;         // issues with no linked node
   noTransition: number;    // linked node already in correct state
   /**
+   * Links whose cached open/closed mirror was absent or stale and got
+   * repaired in place (no revision bump). Expect a large number on the
+   * first tick after deploy — most links predate the `state` field — then
+   * near-zero steady state.
+   */
+  mirrorRepaired: number;
+  /**
    * Count of node-update errors hit during the state-sync loop. Surfaced
    * alongside `ingestErrored` so partial failures are observable.
    */
@@ -172,6 +179,12 @@ export interface ReconcileResult {
  * The webhook path snapshots unconditionally because each webhook event
  * is a single transition; we get the same effect by gating on "is the
  * node already in the target state?".
+ *
+ * When a transition *does* fire, the link's own `state` mirror rides
+ * along on the same write. The mirror-only case — node already
+ * consistent but `state` absent or stale — deliberately still returns
+ * null here, because repairing it must not bump the node's revision —
+ * the reconcile loop handles that case via `setExternalLinkState`.
  */
 export function computeStateUpdates(
   node: Pick<Node, 'percentComplete' | 'status' | 'externalLinks'>,
@@ -190,9 +203,15 @@ export function computeStateUpdates(
     (link.previousPercentComplete !== undefined && link.previousPercentComplete !== null) ||
     (link.previousStatus !== undefined && link.previousStatus !== null);
 
+  const ghState: 'open' | 'closed' = isClosedOnGitHub ? 'closed' : 'open';
+
   let nextPct: number | null = node.percentComplete ?? null;
   let nextStatus: string | null = node.status ?? null;
-  const nextLink: ExternalLink = { ...link, lastSyncedAt: new Date().toISOString() };
+  const nextLink: ExternalLink = {
+    ...link,
+    lastSyncedAt: new Date().toISOString(),
+    state: ghState,
+  };
   let stateChanged = false;
 
   if (isClosedOnGitHub && !looksDoneInMB) {
@@ -308,7 +327,7 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
     }
     return {
       repo: repoLabel,
-      fetched: 0, applied: 0, skipped: 0, noTransition: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,
+      fetched: 0, applied: 0, skipped: 0, noTransition: 0, mirrorRepaired: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,
       durationMs: Date.now() - startedAt.getTime(),
       since,
       error: `token: ${err instanceof Error ? err.message : String(err)}`,
@@ -347,7 +366,7 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
     }
     return {
       repo: repoLabel,
-      fetched: 0, applied: 0, skipped: 0, noTransition: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,
+      fetched: 0, applied: 0, skipped: 0, noTransition: 0, mirrorRepaired: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,
       durationMs: Date.now() - startedAt.getTime(),
       since,
       error: `fetch: ${err instanceof Error ? err.message : String(err)}`,
@@ -368,6 +387,7 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
   let applied = 0;
   let skipped = 0;
   let noTransition = 0;
+  let mirrorRepaired = 0;
   let stateSyncErrored = 0;
 
   for (const issue of issues) {
@@ -380,7 +400,22 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
       if (!node) { skipped++; continue; }
 
       const updates = computeStateUpdates(node, issue, externalId);
-      if (!updates) { noTransition++; continue; }
+      if (!updates) {
+        // No progress/status transition, but the link's cached open/closed
+        // mirror may still be absent (most links were created without it)
+        // or stale. Repair it in place — no revision bump, no broadcast,
+        // since nothing the user authored has changed.
+        const link = node.externalLinks.find(
+          (l) => l.provider === 'github' && l.externalId === externalId,
+        );
+        const ghState = issue.state === 'closed' ? 'closed' : 'open';
+        if (link && link.state !== ghState) {
+          await nodeDb.setExternalLinkState(hit.nodeId, externalId, ghState);
+          mirrorRepaired++;
+        }
+        noTransition++;
+        continue;
+      }
 
       const updated = await nodeDb.updateNode(hit.nodeId, updates);
       if (updated) {
@@ -521,6 +556,7 @@ export async function reconcileRepo(target: RepoTarget): Promise<ReconcileResult
     applied,
     skipped,
     noTransition,
+    mirrorRepaired,
     stateSyncErrored,
     ingested: ingestCreated,
     ingestErrored,
@@ -618,7 +654,7 @@ export async function runAllCatchups(): Promise<ReconcileResult[]> {
     } catch (err) {
       results.push({
         repo: `${t.owner}/${t.repo}`,
-        fetched: 0, applied: 0, skipped: 0, noTransition: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,
+        fetched: 0, applied: 0, skipped: 0, noTransition: 0, mirrorRepaired: 0, stateSyncErrored: 0, ingested: 0, ingestErrored: 0,
         durationMs: 0,
         since: null,
         error: err instanceof Error ? err.message : String(err),

--- a/packages/server/src/sync/githubIngest.ts
+++ b/packages/server/src/sync/githubIngest.ts
@@ -977,6 +977,7 @@ async function ensureNodeForIssueViaTriage(
       url: issue.html_url,
       syncEnabled: true,
       lastSyncedAt: new Date().toISOString(),
+      state: issue.state,
     };
     // Same milestone-based version routing as the non-triage path —
     // keeps Jenna's Unversioned bucket from refilling after the LLM
@@ -1254,6 +1255,7 @@ export async function ensureNodeForIssue(
       url: issue.html_url,
       syncEnabled: true,
       lastSyncedAt: new Date().toISOString(),
+      state: issue.state,
     };
     // Route the new node to its milestone-derived version when one
     // resolves on this map, so it doesn't land in the Unversioned


### PR DESCRIPTION
## The bug

The requirements page dims a GitHub link when `externalLinks[].state === 'closed'`. It never did, for almost anything. Prod:

```
(null) | 2260
closed |  228
open   |    4
```

91% of GitHub links carry no `state`, so every closed issue among them renders at full opacity. Dan spotted it on `FulcrumCRM/crm#14` — node `done`/100%, issue closed on GitHub, link `state` absent.

## Cause 1 — six of seven creation sites drop the field

Only `link_github_issue` (`routes/integrations.ts:464`) ever set it. Missing at:

- `sync/githubIngest.ts:975`, `:1252` — the main ingest path, origin of most of those 2260
- `routes/nodes.ts:89` — autolink; had the fetched `issue` in hand
- `routes/triage.ts:989`, `:1607`, `:2344` — all three compute `const isClosed` four lines above the link literal

## Cause 2 — nothing repaired existing links

`computeStateUpdates` never wrote `state`, and returns `null` when the node needs no progress/status transition. That's precisely the "node already done, issue already closed" case, so the field could never be filled in later even though the catchup sees real GitHub state on every tick.

## The revision trap

The obvious fix — have the catchup write the mirror through `updateNode` — is wrong. `updateNode` bumps `revision` unconditionally (`db/nodes.ts:484`), and `RequirementsView` marks an acceptance stale on `node.revision !== a.nodeRevisionAtAcceptance`. Backfilling ~2.3k links that way would have invalidated **every requirement sign-off in the register** to fix a shade of blue, plus churned `updatedAt` on thousands of untouched nodes.

So `computeStateUpdates` keeps its transition-only contract (a real transition carries the mirror along on its own write, which legitimately bumps revision), and the mirror-only case goes through a new `setExternalLinkState` that writes the jsonb column alone — no revision, no `updatedAt`, no broadcast.

## Backfill

Self-healing. The next catchup tick per repo repairs that repo's links, counted as `mirrorRepaired` in `ReconcileResult` — expect a large first number, then ~0 steady state.

## Tests

5 new cases in `githubCatchup.test.ts`: close/reopen transitions stamp the mirror; mirror-only drift still returns `null` from `computeStateUpdates` (the revision guard); `reconcileRepo` backfills an absent mirror via `setExternalLinkState` **without** calling `updateNode`; an already-correct mirror is left alone.

`pnpm turbo typecheck` and `pnpm turbo test` (684 tests) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFjAoSHBhK9eznsHrf4pEQ