### PR TITLE
feat(requirements): "Gebaut" ist nicht "Abgenommen" — Stufen + IT/Business-Gates

### DIFF
--- a/packages/core/src/__tests__/requirements.test.ts
+++ b/packages/core/src/__tests__/requirements.test.ts
@@ -1,5 +1,91 @@
 import { describe, it, expect } from 'vitest';
-import { collectRequirementGhLinks } from '../requirements.js';
+import {
+  collectRequirementGhLinks,
+  requirementStage,
+  stageCounts,
+  STAGE_LABEL,
+  STAGE_COLOR,
+  STAGE_ORDER,
+} from '../requirements.js';
+
+describe('requirementStage', () => {
+  const it_ = { gate: 'it' as const, decision: 'accepted' as const };
+  const biz = { gate: 'business' as const, decision: 'accepted' as const };
+
+  it('derives the progress-only stages when nobody has signed', () => {
+    expect(requirementStage(0)).toBe('open');
+    expect(requirementStage(0.1)).toBe('in_progress');
+    expect(requirementStage(99.4)).toBe('in_progress');
+    // 99.5 is the register's rounding boundary — 99.5 displays as 100 %.
+    expect(requirementStage(99.5)).toBe('built');
+    expect(requirementStage(100)).toBe('built');
+  });
+
+  it('never calls a finished rollup "accepted" on its own', () => {
+    expect(requirementStage(100, [])).toBe('built');
+  });
+
+  it('reports the furthest gate reached', () => {
+    expect(requirementStage(100, [it_])).toBe('it_verified');
+    expect(requirementStage(100, [biz])).toBe('accepted');
+    expect(requirementStage(100, [it_, biz])).toBe('accepted');
+  });
+
+  it('treats a gate-less row as the business sign-off it used to be', () => {
+    // Every pre-split acceptance was a business verdict; the DEFAULT
+    // backfills them, and this keeps in-flight payloads consistent.
+    expect(requirementStage(100, [{ decision: 'accepted' }])).toBe('accepted');
+  });
+
+  it('lets business acceptance stand without an IT verdict', () => {
+    // The gates are independent flags, not a pipeline — the backfill
+    // produces exactly this shape for all 163 existing rows.
+    expect(requirementStage(100, [biz])).toBe('accepted');
+  });
+
+  it('lets a rejection outrank everything, at any progress', () => {
+    const no = { gate: 'business' as const, decision: 'rejected' as const };
+    expect(requirementStage(100, [no])).toBe('rejected');
+    expect(requirementStage(100, [it_, biz, no])).toBe('rejected');
+    expect(requirementStage(0, [no])).toBe('rejected');
+    // An IT rejection counts too, even with the business ✓ standing.
+    expect(
+      requirementStage(100, [{ gate: 'it', decision: 'rejected' }, biz]),
+    ).toBe('rejected');
+  });
+
+  it('can sign off on work that is not finished', () => {
+    // "Good enough, we'll take it" is a real outcome; the UI confirms it
+    // rather than blocking it.
+    expect(requirementStage(40, [biz])).toBe('accepted');
+  });
+});
+
+describe('stage presentation', () => {
+  it('reserves green for the two signed-off stages', () => {
+    // The whole point of renaming "Done" to "Gebaut": if built stayed
+    // green, a skimming reader would still read it as finished.
+    expect(STAGE_COLOR.built.bg).not.toBe(STAGE_COLOR.accepted.bg);
+    expect(STAGE_LABEL.built).toBe('Gebaut');
+    expect(STAGE_LABEL.accepted).toBe('Abgenommen');
+  });
+
+  it('orders the funnel from most to least complete', () => {
+    expect(STAGE_ORDER[0]).toBe('accepted');
+    expect(STAGE_ORDER).toHaveLength(6);
+  });
+
+  it('counts every stage, including the empty ones', () => {
+    expect(stageCounts(['built', 'built', 'open'])).toEqual({
+      open: 1,
+      in_progress: 0,
+      built: 2,
+      it_verified: 0,
+      accepted: 0,
+      rejected: 0,
+    });
+  });
+});
 
 type N = {
   id: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,8 +103,22 @@ export type { CalibrationSample, CalibrationAssessment } from './calibration.js'
 export { proseMirrorToPlainText } from './richtext.js';
 
 // Requirements register helpers
-export { collectRequirementGhLinks } from './requirements.js';
-export type { GhLinkSource, RequirementGhLink } from './requirements.js';
+export {
+  collectRequirementGhLinks,
+  requirementStage,
+  stageCounts,
+  BUILT_THRESHOLD,
+  STAGE_LABEL,
+  STAGE_ORDER,
+  STAGE_COLOR,
+} from './requirements.js';
+export type {
+  GhLinkSource,
+  RequirementGhLink,
+  RequirementGate,
+  RequirementStage,
+  RequirementVerdict,
+} from './requirements.js';
 
 // Velocity & capacity helpers
 export {

--- a/packages/core/src/requirements.ts
+++ b/packages/core/src/requirements.ts
@@ -1,4 +1,119 @@
 /**
+ * Requirement lifecycle stage — derived, never stored.
+ *
+ * Progress alone answers "is the code merged?", which is not the same
+ * question as "did we get what we asked for". The register used to call
+ * 100 % progress "done", and business read that as fulfilled. So the
+ * stage folds two independent inputs together: the progress rollup, and
+ * the sign-off verdicts recorded per gate in `requirement_acceptances`.
+ *
+ * The gates are deliberately NOT a pipeline. Verdicts that predate the
+ * gate split were backfilled to 'business', so a business acceptance
+ * without an IT verdict is a normal state, not a corrupt one — each gate
+ * is an independent flag and the stage reports the furthest one reached.
+ */
+export type RequirementGate = 'it' | 'business';
+
+export type RequirementStage =
+  | 'open'
+  | 'in_progress'
+  | 'built'
+  | 'it_verified'
+  | 'accepted'
+  | 'rejected';
+
+/** The parts of a sign-off row the stage derivation needs. */
+export interface RequirementVerdict {
+  gate?: RequirementGate | null;
+  decision?: 'accepted' | 'rejected' | null;
+}
+
+/** Progress at or above this counts as built (matches the register's rollup rounding). */
+export const BUILT_THRESHOLD = 99.5;
+
+/**
+ * Derive the lifecycle stage from the progress rollup plus the ACTIVE
+ * verdicts on the requirement. Callers pass only active rows (revoked
+ * ones are filtered on the read side), so this is a pure fold.
+ *
+ * A rejection outranks everything: a requirement someone objected to is
+ * not "done" no matter how green the rollup is — that objection is the
+ * single most important thing the row can say.
+ */
+export function requirementStage(
+  progress: number,
+  verdicts: readonly RequirementVerdict[] = [],
+): RequirementStage {
+  if (verdicts.some((v) => v.decision === 'rejected')) return 'rejected';
+  // A verdict row with no gate is a pre-split acceptance: treat it as the
+  // business sign-off it was, so the backfill and the live path agree.
+  const accepted = (gate: RequirementGate) =>
+    verdicts.some(
+      (v) => v.decision !== 'rejected' && (v.gate ?? 'business') === gate,
+    );
+  if (accepted('business')) return 'accepted';
+  if (accepted('it')) return 'it_verified';
+  if (progress >= BUILT_THRESHOLD) return 'built';
+  return progress > 0 ? 'in_progress' : 'open';
+}
+
+/**
+ * German labels — the register, the Word export and the MCP overview all
+ * speak to the same (German-speaking) business readers, so the wording
+ * lives in one place. "Gebaut" rather than "Umgesetzt"/"Done": at 100 %
+ * progress the only thing the system actually knows is that the code
+ * landed. "Abgenommen" is reserved for a real verdict.
+ */
+export const STAGE_LABEL: Record<RequirementStage, string> = {
+  open: 'Offen',
+  in_progress: 'In Umsetzung',
+  built: 'Gebaut',
+  it_verified: 'IT-geprüft',
+  accepted: 'Abgenommen',
+  rejected: 'Zurückgewiesen',
+};
+
+/**
+ * Funnel order, least to most complete. Green is reserved for the last
+ * two — see STAGE_COLOR: if "Gebaut" stayed green, renaming it would
+ * change nothing for anyone skimming the column.
+ */
+export const STAGE_ORDER: RequirementStage[] = [
+  'accepted',
+  'it_verified',
+  'built',
+  'in_progress',
+  'open',
+  'rejected',
+];
+
+/** Chip colours, shared by the register UI and the docx cell shading. */
+export const STAGE_COLOR: Record<RequirementStage, { bg: string; fg: string }> = {
+  open: { bg: '#f1f5f9', fg: '#475569' },
+  in_progress: { bg: '#fef3c7', fg: '#92400e' },
+  built: { bg: '#dbeafe', fg: '#1e40af' },
+  it_verified: { bg: '#ccfbf1', fg: '#0f766e' },
+  accepted: { bg: '#d1fae5', fg: '#065f46' },
+  rejected: { bg: '#fee2e2', fg: '#991b1b' },
+};
+
+/** Count requirements per stage, always returning every key (0 included). */
+export function stageCounts(
+  stages: readonly RequirementStage[],
+): Record<RequirementStage, number> {
+  const counts = {
+    open: 0,
+    in_progress: 0,
+    built: 0,
+    it_verified: 0,
+    accepted: 0,
+    rejected: 0,
+  } as Record<RequirementStage, number>;
+  for (const s of stages) counts[s]++;
+  return counts;
+}
+
+/**
  * GitHub links for a requirement row.
  *
  * A requirement is a business statement; the issues that implement it

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -13,6 +13,7 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { RequirementGate } from '@mindblown/core';
 
 /**
  * Light-weight shape of a Fastify `app.inject(...)` response. We only
@@ -356,6 +357,8 @@ export interface AcceptanceRow {
   nodeRevisionAtAcceptance: number;
   decision: 'accepted' | 'rejected';
   comment: string | null;
+  /** Optional: rows written before the gate split read as 'business'. */
+  gate?: RequirementGate;
 }
 
 export function getAcceptances(mapId: string): Promise<{ acceptances: AcceptanceRow[] }> {
@@ -365,7 +368,11 @@ export function getAcceptances(mapId: string): Promise<{ acceptances: Acceptance
 export function acceptRequirement(
   mapId: string,
   nodeId: string,
-  verdict?: { decision: 'accepted' | 'rejected'; comment?: string },
+  verdict?: {
+    decision?: 'accepted' | 'rejected';
+    comment?: string;
+    gate?: RequirementGate;
+  },
 ): Promise<AcceptanceRow> {
   return request<AcceptanceRow>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
     method: 'POST',
@@ -373,10 +380,17 @@ export function acceptRequirement(
   });
 }
 
-export function revokeAcceptance(mapId: string, nodeId: string): Promise<{ success: boolean }> {
-  return request<{ success: boolean }>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
-    method: 'DELETE',
-  });
+export function revokeAcceptance(
+  mapId: string,
+  nodeId: string,
+  gate?: RequirementGate,
+): Promise<{ success: boolean }> {
+  // Gate rides in the query string — the route rejects a DELETE body.
+  const qs = gate ? `?gate=${gate}` : '';
+  return request<{ success: boolean }>(
+    `/api/maps/${mapId}/nodes/${nodeId}/acceptance${qs}`,
+    { method: 'DELETE' },
+  );
 }
 
 export interface RequirementsExportFilter {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -23,7 +23,8 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { allTools as sharedTools, type ToolSpec } from '@mindblown/tool-kit';
-import { clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes } from '@mindblown/core';
+import { clampFocusFactor, scopedCapacityDays, assessCalibration, assessForecastConfidence, calibrationSamplesFromNodes, requirementStage, stageCounts, BUILT_THRESHOLD, STAGE_ORDER } from '@mindblown/core';
+import type { RequirementStage } from '@mindblown/core';
 import * as api from './api.js';
 import { scopedLeaves } from './scope.js';
 import { descendantVersionIds } from './requirementScope.js';
@@ -476,13 +477,19 @@ server.tool(
 
 server.tool(
   'accept_requirement',
-  "Record the calling user's acceptance (Abnahme) of a requirement — a human sign-off, orthogonal to the derived status. Snapshots current progress + node revision so later changes flag the acceptance as stale. Identify the requirement by requirementId (e.g. MAN-01) or nodeId.",
+  "Record the calling user's sign-off on a requirement — the only thing that moves it past \"built\" in the register. Two independent gates: gate='it' (does it actually work?) and gate='business' (is it what we asked for?). Snapshots current progress + node revision so later changes flag the verdict as stale. One active verdict per user PER GATE — revoke_acceptance first to change one. Identify the requirement by requirementId (e.g. MAN-01) or nodeId.",
   {
     mapId: z.string().describe('The map ID'),
     requirementId: z.string().optional().describe('Requirement ID, e.g. "MAN-01"'),
     nodeId: z.string().optional().describe('Node ID (alternative to requirementId)'),
+    gate: z
+      .enum(['it', 'business'])
+      .optional()
+      .describe(
+        "Which gate to sign: 'it' = verified it works (dev/QA side), 'business' = accepted as delivered (the Abnahme). Defaults to 'business'.",
+      ),
   },
-  async ({ mapId, requirementId, nodeId }) => {
+  async ({ mapId, requirementId, nodeId, gate }) => {
     try {
       let id = nodeId;
       if (!id) {
@@ -492,9 +499,9 @@ server.tool(
         if (!hit) return toolError(`No node with requirementId ${requirementId} in map ${mapId}.`);
         id = hit.id;
       }
-      const a = await api.acceptRequirement(mapId, id);
+      const a = await api.acceptRequirement(mapId, id, { gate });
       return toolResult(
-        `Accepted ${requirementId ?? id} as ${a.userName} at ${a.acceptedAt} (progress ${Math.round(a.progressAtAcceptance)}%, revision ${a.nodeRevisionAtAcceptance}).`,
+        `Accepted ${requirementId ?? id} at the ${a.gate} gate as ${a.userName} at ${a.acceptedAt} (progress ${Math.round(a.progressAtAcceptance)}%, revision ${a.nodeRevisionAtAcceptance}).`,
       );
     } catch (err) {
       return toolError(err);
@@ -504,7 +511,7 @@ server.tool(
 
 server.tool(
   'reject_requirement',
-  "Record the calling user's REJECTION of a requirement with a mandatory comment explaining why — the counterpart to accept_requirement. Shows as ✗ in the register, overview and exports so the objection is visible data. One active verdict per user per requirement: revoke_acceptance first to change an existing verdict. Identify the requirement by requirementId (e.g. MAN-01) or nodeId.",
+  "Record the calling user's REJECTION of a requirement with a mandatory comment explaining why — the counterpart to accept_requirement. A rejection outranks every other stage in the register: the row reads \"rejected\" no matter how complete the rollup says it is. Same two gates as accept_requirement. One active verdict per user per gate: revoke_acceptance first to change an existing one. Identify the requirement by requirementId (e.g. MAN-01) or nodeId.",
   {
     mapId: z.string().describe('The map ID'),
     requirementId: z.string().optional().describe('Requirement ID, e.g. "MAN-01"'),
@@ -513,8 +520,14 @@ server.tool(
       .string()
       .min(1)
       .describe('Why the requirement is rejected — what is wrong or missing (mandatory)'),
+    gate: z
+      .enum(['it', 'business'])
+      .optional()
+      .describe(
+        "Which gate is rejecting: 'it' = does not work as built, 'business' = not what was asked for. Defaults to 'business'.",
+      ),
   },
-  async ({ mapId, requirementId, nodeId, comment }) => {
+  async ({ mapId, requirementId, nodeId, comment, gate }) => {
     try {
       let id = nodeId;
       if (!id) {
@@ -524,9 +537,13 @@ server.tool(
         if (!hit) return toolError(`No node with requirementId ${requirementId} in map ${mapId}.`);
         id = hit.id;
       }
-      const a = await api.acceptRequirement(mapId, id, { decision: 'rejected', comment });
+      const a = await api.acceptRequirement(mapId, id, {
+        decision: 'rejected',
+        comment,
+        gate,
+      });
       return toolResult(
-        `Rejected ${requirementId ?? id} as ${a.userName} at ${a.acceptedAt} (progress ${Math.round(a.progressAtAcceptance)}%, revision ${a.nodeRevisionAtAcceptance}): «${comment}»`,
+        `Rejected ${requirementId ?? id} at the ${a.gate} gate as ${a.userName} at ${a.acceptedAt} (progress ${Math.round(a.progressAtAcceptance)}%, revision ${a.nodeRevisionAtAcceptance}): «${comment}»`,
       );
     } catch (err) {
       return toolError(err);
@@ -536,13 +553,17 @@ server.tool(
 
 server.tool(
   'revoke_acceptance',
-  "Revoke the calling user's active verdict (acceptance OR rejection) on a requirement. History is preserved (append-only); a later re-acceptance/re-rejection is a new sign-off row.",
+  "Revoke the calling user's active verdict (acceptance OR rejection) on ONE gate of a requirement. Gate-scoped: withdrawing the IT verdict leaves the business sign-off standing. History is preserved (append-only); a later re-acceptance/re-rejection is a new sign-off row.",
   {
     mapId: z.string().describe('The map ID'),
     requirementId: z.string().optional().describe('Requirement ID, e.g. "MAN-01"'),
     nodeId: z.string().optional().describe('Node ID (alternative to requirementId)'),
+    gate: z
+      .enum(['it', 'business'])
+      .optional()
+      .describe("Which gate's verdict to withdraw. Defaults to 'business'."),
   },
-  async ({ mapId, requirementId, nodeId }) => {
+  async ({ mapId, requirementId, nodeId, gate }) => {
     try {
       let id = nodeId;
       if (!id) {
@@ -552,8 +573,8 @@ server.tool(
         if (!hit) return toolError(`No node with requirementId ${requirementId} in map ${mapId}.`);
         id = hit.id;
       }
-      await api.revokeAcceptance(mapId, id);
-      return toolResult(`Revoked verdict on ${requirementId ?? id}.`);
+      await api.revokeAcceptance(mapId, id, gate);
+      return toolResult(`Revoked ${gate ?? 'business'} verdict on ${requirementId ?? id}.`);
     } catch (err) {
       return toolError(err);
     }
@@ -604,13 +625,24 @@ server.tool(
 
 server.tool(
   'requirements_overview',
-  'Business-facing requirements register: every node carrying a requirementId, grouped by top-level branch (chapter). Per requirement: MoSCoW priority, derived status (done ≙ Umgesetzt / partial ≙ Teilweise / open ≙ Offen — from progress rollup, never stored), progress %, remaining effort, and linked GitHub issues. Answers "which requirements exist and where do they stand?" without the full get_map dump.',
+  'Business-facing requirements register: every node carrying a requirementId, grouped by parent (chapter). Per requirement: MoSCoW priority, derived lifecycle stage, progress %, remaining effort, linked GitHub issues and the sign-off verdicts. IMPORTANT — "built" is NOT "done": 100% progress only means the code merged. The stage folds the progress rollup together with the per-gate verdicts: open → in_progress → built → it_verified → accepted, and rejected (any active ✗) outranks all of them. Only accept_requirement/reject_requirement can move a requirement past "built"; nothing about the stage is stored.',
   {
     mapId: z.string().describe('The map ID'),
     status: z
-      .enum(['open', 'partial', 'done'])
+      .enum([
+        'open',
+        'in_progress',
+        'built',
+        'it_verified',
+        'accepted',
+        'rejected',
+        'partial',
+        'done',
+      ])
       .optional()
-      .describe('Only requirements in this derived status'),
+      .describe(
+        'Only requirements in this derived stage. "partial"/"done" are the pre-gate progress buckets, still accepted: they filter on progress alone (done = built or beyond).',
+      ),
     requirementPriority: z
       .enum(['must', 'should', 'could'])
       .optional()
@@ -668,8 +700,9 @@ server.tool(
       const progressOf = (n: (typeof requirements)[number]): number =>
         (n.childrenIds?.length ?? 0) > 0 ? n.computedProgress : (n.percentComplete ?? 0);
 
-      const statusOf = (progress: number): 'open' | 'partial' | 'done' =>
-        progress >= 100 ? 'done' : progress > 0 ? 'partial' : 'open';
+      // Stage, not just progress — see requirementStage in @mindblown/core.
+      const stageOf = (nodeId: string, progress: number): RequirementStage =>
+        requirementStage(progress, accByNode.get(nodeId) ?? []);
 
       // Unestimated leaves in a requirement's subtree — flags where the
       // effort/remaining numbers under-count (null leaves carry 0 effort
@@ -696,7 +729,8 @@ server.tool(
           chapter: chapterOf(n.id),
           chapterOrder: chapterOrderOf(n.id),
           progress,
-          status: statusOf(progress),
+          stage: stageOf(n.id, progress),
+          built: progress >= BUILT_THRESHOLD,
           remaining: n.computedEffort * (1 - progress / 100),
           unestimated: unestimatedLeaves(n.id),
           // Own links first, then any on the work below — progress and effort
@@ -720,10 +754,11 @@ server.tool(
         };
       });
 
-      const totalByStatus = { done: 0, partial: 0, open: 0 };
-      for (const r of rows) totalByStatus[r.status]++;
+      const totals = stageCounts(rows.map((r) => r.stage));
 
-      if (status) rows = rows.filter((r) => r.status === status);
+      if (status === 'done') rows = rows.filter((r) => r.built);
+      else if (status === 'partial') rows = rows.filter((r) => r.progress > 0 && !r.built);
+      else if (status) rows = rows.filter((r) => r.stage === status);
       if (requirementPriority) {
         rows = rows.filter((r) => r.node.requirementPriority === requirementPriority);
       }
@@ -752,8 +787,17 @@ server.tool(
 
       const lines: string[] = [];
       lines.push(`Requirements register — ${data.map.name}`);
+      // The funnel, not a single "done" count: the gap between built and
+      // accepted is the number this tool exists to make impossible to miss.
       lines.push(
-        `${requirements.length} requirement(s): ${totalByStatus.done} done / ${totalByStatus.partial} partial / ${totalByStatus.open} open`,
+        `${requirements.length} requirement(s): ${STAGE_ORDER.filter(
+          (s) => totals[s] > 0 || s === 'accepted',
+        )
+          .map((s) => `${totals[s]} ${s}`)
+          .join(' / ')}`,
+      );
+      lines.push(
+        '("built" = code merged, nobody signed off yet — only "accepted" means the business side confirmed it)',
       );
       if (status || requirementPriority || versionId) {
         let versionLabel = versionId;
@@ -769,21 +813,31 @@ server.tool(
         lines.push(`Showing ${rows.length} after filter (${filters.join(', ')})`);
       }
 
-      const statusMark = { done: '✓ done', partial: '◐ partial', open: '○ open' } as const;
+      const stageMark: Record<RequirementStage, string> = {
+        accepted: '✓✓ accepted',
+        it_verified: '✓ it_verified',
+        built: '▣ built',
+        in_progress: '◐ in_progress',
+        open: '○ open',
+        rejected: '✗ REJECTED',
+      };
       for (const [chapter, list] of chapters) {
-        const doneCount = list.filter((r) => r.status === 'done').length;
+        const builtCount = list.filter((r) => r.built).length;
+        const acceptedCount = list.filter((r) => r.stage === 'accepted').length;
         lines.push('');
-        lines.push(`## ${chapter} (${list.length} req, ${doneCount} done)`);
+        lines.push(
+          `## ${chapter} (${list.length} req, ${builtCount} built, ${acceptedCount} accepted)`,
+        );
         for (const r of list) {
           const prio = r.node.requirementPriority ? ` [${r.node.requirementPriority}]` : '';
           const parts = [
-            `${r.node.requirementId}${prio} ${statusMark[r.status]} ${r.progress.toFixed(0)}%`,
+            `${r.node.requirementId}${prio} ${stageMark[r.stage]} ${r.progress.toFixed(0)}%`,
             `— ${r.node.text} (id: ${r.node.id})`,
           ];
-          if (r.status !== 'done' && r.remaining > 0) {
+          if (!r.built && r.remaining > 0) {
             parts.push(`· ${r.remaining.toFixed(1)} ${unit} remaining`);
           }
-          if (r.status !== 'done' && r.unestimated > 0) {
+          if (!r.built && r.unestimated > 0) {
             parts.push(`· ⚠ ${r.unestimated} unestimated leaf(s) — effort under-counts`);
           }
           if (r.ghLinks.length > 0) {
@@ -797,7 +851,7 @@ server.tool(
                 r.node.revision !== a.nodeRevisionAtAcceptance;
               const mark = a.decision === 'rejected' ? ' ✗' : '';
               const why = a.decision === 'rejected' && a.comment ? ` («${a.comment}»)` : '';
-              return `${a.userName}${mark}${why}${stale ? ' ⚠stale' : ''}`;
+              return `${a.gate ?? 'business'}/${a.userName}${mark}${why}${stale ? ' ⚠stale' : ''}`;
             });
             parts.push(`· Abnahme: ${fmt.join(', ')}`);
           }

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,29 +1,34 @@
 import { useEffect, useMemo, useState } from 'react';
-import { compareVersions, collectRequirementGhLinks } from '@mindblown/core';
-import type { Node, Version } from '@mindblown/core';
+import {
+  compareVersions,
+  collectRequirementGhLinks,
+  requirementStage,
+  stageCounts,
+  BUILT_THRESHOLD,
+  STAGE_LABEL,
+  STAGE_ORDER,
+  STAGE_COLOR,
+} from '@mindblown/core';
+import type { Node, Version, RequirementGate, RequirementStage } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import { linkColor, linkWeight } from './ghLinkStyle.js';
 import { REQ_VERSION_NONE } from './urlState.js';
 import * as api from './api.js';
 
-// ── Derived requirement status ───────────────────────────────────
+// ── Derived requirement stage ────────────────────────────────────
 //
-// Never stored — always derived from progress rollup so the register
-// can't drift from the plan (the whole point of the feature).
+// Never stored — derived from the progress rollup folded together with
+// the per-gate sign-off verdicts, so the register can't drift from the
+// plan (the whole point of the feature). The labels and colours live in
+// @mindblown/core because the Word export and the MCP overview have to
+// say exactly the same thing.
+//
+// The word matters: 100 % progress is "Gebaut", not "Done" — the rollup
+// only knows that code merged. Green is reserved for the two stages that
+// required a human verdict.
 
-type ReqStatus = 'open' | 'partial' | 'done';
-
-const STATUS_LABEL: Record<ReqStatus, string> = {
-  done: 'Done',
-  partial: 'Partial',
-  open: 'Open',
-};
-
-const STATUS_COLOR: Record<ReqStatus, { bg: string; fg: string }> = {
-  done: { bg: '#d1fae5', fg: '#065f46' },
-  partial: { bg: '#fef3c7', fg: '#92400e' },
-  open: { bg: '#f1f5f9', fg: '#475569' },
-};
+/** The register speaks German because its readers are the business side. */
+const GATE_LABEL: Record<RequirementGate, string> = { it: 'IT', business: 'Business' };
 
 const HEALTH_COLOR: Record<string, string> = {
   on_track: '#10b981',
@@ -43,7 +48,11 @@ interface ReqRow {
   chapterText: string;
   isLeaf: boolean;
   progress: number;
-  status: ReqStatus;
+  stage: RequirementStage;
+  /** Progress alone says the code landed — kept for "hide done" and Rest. */
+  built: boolean;
+  /** Active verdicts on this requirement, split by gate. */
+  verdicts: Record<RequirementGate, api.AcceptanceRow | undefined>;
   remaining: number;
   unestimated: number;
   health: string;
@@ -60,10 +69,6 @@ interface ReqRow {
   descendantVersionIds: string[];
   /** What the register treats as "the" release: own, else a unanimous descendant one. */
   effectiveVersionId: string | null;
-}
-
-function statusOf(progress: number): ReqStatus {
-  return progress >= 100 ? 'done' : progress > 0 ? 'partial' : 'open';
 }
 
 function compareReqIds(a: ReqRow, b: ReqRow): number {
@@ -101,7 +106,7 @@ export function RequirementsView() {
 
   const user = useMindmapStore((s) => s.user);
   const [acceptances, setAcceptances] = useState<api.AcceptanceRow[]>([]);
-  const [acceptanceFilter, setAcceptanceFilter] = useState<'' | 'none' | 'mine-open' | 'rejected'>('');
+  const [acceptanceFilter, setAcceptanceFilter] = useState<'' | api.AcceptanceFilter>('');
   const [exporting, setExporting] = useState(false);
 
   useEffect(() => {
@@ -126,7 +131,7 @@ export function RequirementsView() {
     return m;
   }, [acceptances]);
 
-  const [statusFilter, setStatusFilter] = useState<'' | ReqStatus>('');
+  const [statusFilter, setStatusFilter] = useState<'' | RequirementStage>('');
   const [priorityFilter, setPriorityFilter] = useState<'' | 'must' | 'should' | 'could'>('');
   // Release filter lives in the store (mirrored to ?rv= / ?rvm= by
   // useUrlState) so the selection survives a copied link.
@@ -186,13 +191,22 @@ export function RequirementsView() {
         // requirements sit directly under their Bereich node, so the parent
         // IS the chapter; this also matches ListView's group-by-parent.
         const chapter = node.parentId ? nodes[node.parentId] : null;
+        // One active verdict per gate is a DB invariant, so first-wins is
+        // exact rather than a heuristic.
+        const accs = accByNode.get(node.id) ?? [];
+        const verdicts = {
+          it: accs.find((a) => a.gate === 'it'),
+          business: accs.find((a) => (a.gate ?? 'business') === 'business'),
+        };
         return {
           node,
           chapterId: chapter?.id ?? null,
           chapterText: chapter?.text ?? '(root)',
           isLeaf,
           progress,
-          status: statusOf(progress),
+          stage: requirementStage(progress, accs),
+          built: progress >= BUILT_THRESHOLD,
+          verdicts,
           remaining: (cv?.computedEffort ?? 0) * (1 - progress / 100),
           unestimated: countUnestimatedLeaves(node.id),
           health: cv?.healthSignal ?? 'on_track',
@@ -210,12 +224,19 @@ export function RequirementsView() {
             (descendantVersionIds.length === 1 ? descendantVersionIds[0] : null),
         };
       });
-  }, [nodes, computed]);
+  }, [nodes, computed, accByNode]);
 
   const totals = useMemo(() => {
-    const t = { done: 0, partial: 0, open: 0 };
-    for (const r of allRows) t[r.status]++;
-    return t;
+    const counts = stageCounts(allRows.map((r) => r.stage));
+    return {
+      ...counts,
+      built: allRows.filter((r) => r.built).length,
+      // The two review queues. Not derivable from the stage counts: a
+      // business-accepted requirement can still be missing its IT verdict
+      // (every pre-split row was backfilled as business).
+      itOpen: allRows.filter((r) => r.built && !r.verdicts.it).length,
+      businessOpen: allRows.filter((r) => r.built && !r.verdicts.business).length,
+    };
   }, [allRows]);
 
   // Slider position derived from the selected version id; an id that no
@@ -234,8 +255,10 @@ export function RequirementsView() {
   const filteredRows = useMemo(
     () =>
       allRows.filter((r) => {
-        if (hideDone && r.status === 'done') return false;
-        if (statusFilter && r.status !== statusFilter) return false;
+        // A rejected requirement is never hidden — it is the row that most
+        // needs to stay visible, however green the rollup looks.
+        if (hideDone && r.built && r.stage !== 'rejected') return false;
+        if (statusFilter && r.stage !== statusFilter) return false;
         if (priorityFilter && r.node.requirementPriority !== priorityFilter) return false;
         if (showUnscheduledOnly) {
           // "No release" means nothing below it is scheduled either.
@@ -269,6 +292,12 @@ export function RequirementsView() {
           }
           if (acceptanceFilter === 'rejected' && !accs.some((a) => a.decision === 'rejected')) {
             return false;
+          }
+          // Review queues: only what is far enough along to actually judge.
+          if (acceptanceFilter === 'it-open' || acceptanceFilter === 'business-open') {
+            if (!r.built) return false;
+            const gate: RequirementGate = acceptanceFilter === 'it-open' ? 'it' : 'business';
+            if (accs.some((a) => (a.gate ?? 'business') === gate)) return false;
           }
         }
         return true;
@@ -334,21 +363,29 @@ export function RequirementsView() {
       : [];
   }, [allRows, nodes, rootNodeId, dfsOrder]);
 
-  const toggleAcceptance = async (row: ReqRow) => {
+  const toggleAcceptance = async (row: ReqRow, gate: RequirementGate) => {
     if (!currentMapId || !user) return;
-    const mine = (accByNode.get(row.node.id) ?? []).find((a) => a.userId === user.id);
+    const mine = (accByNode.get(row.node.id) ?? []).find(
+      (a) => a.userId === user.id && (a.gate ?? 'business') === gate,
+    );
     try {
       if (mine) {
-        await api.revokeAcceptance(currentMapId, row.node.id);
+        await api.revokeAcceptance(currentMapId, row.node.id, gate);
         setAcceptances((prev) => prev.filter((a) => a.id !== mine.id));
       } else {
+        // Signing off on something that isn't built yet is legitimate
+        // ("good enough, we'll take it") but should never be a slip.
         if (
-          row.status !== 'done' &&
-          !window.confirm(`Status is ${STATUS_LABEL[row.status]} — accept anyway?`)
+          !row.built &&
+          !window.confirm(
+            `${row.node.requirementId} steht auf «${STAGE_LABEL[row.stage]}» — trotzdem ${
+              gate === 'it' ? 'als IT-geprüft markieren' : 'abnehmen'
+            }?`,
+          )
         ) {
           return;
         }
-        const created = await api.acceptRequirement(currentMapId, row.node.id);
+        const created = await api.acceptRequirement(currentMapId, row.node.id, { gate });
         setAcceptances((prev) => [...prev, created]);
       }
     } catch {
@@ -357,10 +394,10 @@ export function RequirementsView() {
     }
   };
 
-  const rejectRequirement = async (row: ReqRow) => {
+  const rejectRequirement = async (row: ReqRow, gate: RequirementGate) => {
     if (!currentMapId || !user) return;
     const comment = window.prompt(
-      `Reject ${row.node.requirementId} — why? (Reason required)`,
+      `${row.node.requirementId} zurückweisen (${GATE_LABEL[gate]}) — warum? (Begründung erforderlich)`,
     );
     if (comment == null) return; // cancelled
     if (comment.trim() === '') return;
@@ -368,6 +405,7 @@ export function RequirementsView() {
       const created = await api.acceptRequirement(currentMapId, row.node.id, {
         decision: 'rejected',
         comment: comment.trim(),
+        gate,
       });
       setAcceptances((prev) => [...prev, created]);
     } catch {
@@ -412,12 +450,21 @@ export function RequirementsView() {
       <div style={headerStyle}>
         <div>
           <h2 style={{ margin: 0, fontSize: 16, color: '#1e293b' }}>Requirements</h2>
-          <div style={{ fontSize: 11, color: '#64748b', marginTop: 2 }}>
-            {allRows.length} requirement{allRows.length === 1 ? '' : 's'} · {totals.done} done ·{' '}
-            {totals.partial} partial · {totals.open} open
-            {(hideDone || statusFilter || priorityFilter || versionFilterActive) &&
-              ` · showing ${filteredRows.length} (filtered)`}
+          {/* The headline number is the ACCEPTED one. Leading with "116
+              done" was the whole problem: that count only ever meant code
+              had merged, and business read it as delivered. */}
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 7, marginTop: 3 }}>
+            <span style={{ fontSize: 20, fontWeight: 700, color: '#047857', lineHeight: 1 }}>
+              {totals.accepted}
+            </span>
+            <span style={{ fontSize: 11, color: '#64748b' }}>
+              von {allRows.length} abgenommen · {totals.built} gebaut, davon{' '}
+              {totals.built - totals.accepted} ohne Abnahme
+              {(hideDone || statusFilter || priorityFilter || versionFilterActive) &&
+                ` · ${filteredRows.length} angezeigt (gefiltert)`}
+            </span>
           </div>
+          <StageFunnel counts={totals} total={allRows.length} />
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <button
@@ -425,8 +472,8 @@ export function RequirementsView() {
             aria-pressed={hideDone}
             title={
               hideDone
-                ? `${totals.done} done requirement${totals.done === 1 ? '' : 's'} hidden — click to show`
-                : 'Hide requirements that are 100% complete'
+                ? `${totals.built} gebaute Anforderung${totals.built === 1 ? '' : 'en'} ausgeblendet — klicken zum Anzeigen`
+                : 'Gebaute Anforderungen ausblenden (100 % Fortschritt; Zurückgewiesene bleiben sichtbar)'
             }
             style={{
               ...secondaryButtonStyle(false),
@@ -435,22 +482,25 @@ export function RequirementsView() {
                 : {}),
             }}
           >
-            {hideDone ? `Done hidden (${totals.done})` : 'Hide done'}
+            {hideDone ? `Gebaute versteckt (${totals.built})` : 'Gebaute ausblenden'}
           </button>
           <select
             value={statusFilter}
             onChange={(e) => {
-              const v = e.target.value as '' | ReqStatus;
+              const v = e.target.value as '' | RequirementStage;
               setStatusFilter(v);
-              // Asking for Done while hiding Done would show an empty table.
-              if (v === 'done') setHideDone(false);
+              // Asking for a built-or-beyond stage while hiding those would
+              // show an empty table.
+              if (v === 'built' || v === 'it_verified' || v === 'accepted') setHideDone(false);
             }}
             style={filterSelectStyle}
           >
-            <option value="">All statuses</option>
-            <option value="open">Open</option>
-            <option value="partial">Partial</option>
-            <option value="done">Done</option>
+            <option value="">Alle Stufen</option>
+            {STAGE_ORDER.map((s) => (
+              <option key={s} value={s}>
+                {STAGE_LABEL[s]}
+              </option>
+            ))}
           </select>
           <select
             value={priorityFilter}
@@ -525,15 +575,15 @@ export function RequirementsView() {
           </div>
           <select
             value={acceptanceFilter}
-            onChange={(e) =>
-              setAcceptanceFilter(e.target.value as '' | 'none' | 'mine-open' | 'rejected')
-            }
+            onChange={(e) => setAcceptanceFilter(e.target.value as '' | api.AcceptanceFilter)}
             style={filterSelectStyle}
           >
-            <option value="">Acceptance: all</option>
-            <option value="none">Not accepted</option>
-            <option value="mine-open">My acceptance pending</option>
-            <option value="rejected">Rejected</option>
+            <option value="">Abnahme: alle</option>
+            <option value="it-open">IT-Prüfung offen ({totals.itOpen})</option>
+            <option value="business-open">Abnahme offen ({totals.businessOpen})</option>
+            <option value="none">Ohne Urteil</option>
+            <option value="mine-open">Mein Urteil ausstehend</option>
+            <option value="rejected">Zurückgewiesen</option>
           </select>
           <button
             onClick={() => setShowCreate((v) => !v)}
@@ -687,7 +737,6 @@ export function RequirementsView() {
                   setEditingCell={setEditingCell}
                   updateNode={updateNode}
                   jumpToNode={jumpToNode}
-                  accByNode={accByNode}
                   currentUserId={user?.id ?? null}
                   toggleAcceptance={toggleAcceptance}
                   rejectRequirement={rejectRequirement}
@@ -713,7 +762,6 @@ function ChapterGroup({
   setEditingCell,
   updateNode,
   jumpToNode,
-  accByNode,
   currentUserId,
   toggleAcceptance,
   rejectRequirement,
@@ -727,19 +775,19 @@ function ChapterGroup({
   setEditingCell: (cell: { nodeId: string; field: string } | null) => void;
   updateNode: (id: string, updates: Partial<Node>) => void;
   jumpToNode: (node: Node) => void;
-  accByNode: Map<string, api.AcceptanceRow[]>;
   currentUserId: string | null;
-  toggleAcceptance: (row: ReqRow) => void;
-  rejectRequirement: (row: ReqRow) => void;
+  toggleAcceptance: (row: ReqRow, gate: RequirementGate) => void;
+  rejectRequirement: (row: ReqRow, gate: RequirementGate) => void;
 }) {
-  const done = rows.filter((r) => r.status === 'done').length;
+  const built = rows.filter((r) => r.built).length;
+  const accepted = rows.filter((r) => r.stage === 'accepted').length;
   return (
     <>
       <tr>
         <td colSpan={9} style={groupHeaderStyle}>
           {chapterText}
           <span style={{ fontWeight: 400, color: '#64748b', marginLeft: 8 }}>
-            {rows.length} req · {done} done
+            {rows.length} req · {built} gebaut · {accepted} abgenommen
           </span>
         </td>
       </tr>
@@ -929,20 +977,25 @@ function ChapterGroup({
             </select>
           </td>
 
-          {/* Derived status — read-only by design */}
+          {/* Derived stage — read-only by design */}
           <td style={tdStyle}>
             <span
-              title="Derived from progress rollup — complete the underlying work to change it"
+              title={
+                r.built
+                  ? 'Abgeleitet aus Fortschritt + Abnahme-Urteilen. «Gebaut» heisst: Code fertig, noch niemand hat unterschrieben.'
+                  : 'Abgeleitet aus dem Fortschritts-Rollup — die darunterliegende Arbeit abschliessen, um das zu ändern'
+              }
               style={{
                 padding: '2px 8px',
                 borderRadius: 10,
                 fontSize: 11,
                 fontWeight: 600,
-                background: STATUS_COLOR[r.status].bg,
-                color: STATUS_COLOR[r.status].fg,
+                whiteSpace: 'nowrap',
+                background: STAGE_COLOR[r.stage].bg,
+                color: STAGE_COLOR[r.stage].fg,
               }}
             >
-              {STATUS_LABEL[r.status]}
+              {STAGE_LABEL[r.stage]}
             </span>
           </td>
 
@@ -985,12 +1038,12 @@ function ChapterGroup({
 
           {/* Remaining effort + unestimated warning */}
           <td style={{ ...tdStyle, ...numericCellStyle }}>
-            {r.status === 'done' ? (
+            {r.built ? (
               <span style={{ color: '#94a3b8' }}>—</span>
             ) : (
               `${r.remaining.toFixed(1)} ${effortUnit}`
             )}
-            {r.status !== 'done' && r.unestimated > 0 && (
+            {!r.built && r.unestimated > 0 && (
               <span
                 title={`${r.unestimated} unestimated leaf/leaves under this requirement — remaining under-counts`}
                 style={{ color: '#d97706', marginLeft: 6, cursor: 'help' }}
@@ -1065,80 +1118,21 @@ function ChapterGroup({
             )}
           </td>
 
-          {/* Acceptance — per-user sign-off chips; own chip toggles */}
+          {/* Abnahme — one slot per gate. Two ✓ from the same person would
+              be indistinguishable without the gate label above them. */}
           <td style={{ ...tdStyle, ...wrappingCellStyle }} onClick={(e) => e.stopPropagation()}>
-            {(accByNode.get(r.node.id) ?? []).map((a) => {
-              const stale =
-                Math.abs(r.progress - a.progressAtAcceptance) > 1 ||
-                r.node.revision !== a.nodeRevisionAtAcceptance;
-              const own = a.userId === currentUserId;
-              const rejected = a.decision === 'rejected';
-              const mark = rejected ? '✗' : '✓';
-              const label = `${a.userName.split(' ')[0]} ${mark} ${a.acceptedAt.slice(5, 10).split('-').reverse().join('.')}.`;
-              return (
-                <span
-                  key={a.id}
-                  onClick={own ? () => toggleAcceptance(r) : undefined}
-                  title={
-                    (stale ? 'Changed since sign-off! ' : '') +
-                    `${a.userName}, ${rejected ? 'rejected' : 'accepted'} ${a.acceptedAt.slice(0, 10)} at ${Math.round(a.progressAtAcceptance)}%` +
-                    (rejected && a.comment ? ` — "${a.comment}"` : '') +
-                    (own ? ' — click to withdraw' : '')
-                  }
-                  style={{
-                    display: 'inline-block',
-                    padding: '2px 8px',
-                    marginRight: 4,
-                    marginBottom: 2,
-                    borderRadius: 10,
-                    fontSize: 11,
-                    fontWeight: 600,
-                    cursor: own ? 'pointer' : 'default',
-                    background: rejected ? '#fee2e2' : stale ? '#fef3c7' : '#d1fae5',
-                    color: rejected ? '#991b1b' : stale ? '#92400e' : '#065f46',
-                  }}
-                >
-                  {stale ? '⚠ ' : ''}
-                  {label}
-                </span>
-              );
-            })}
-            {currentUserId &&
-              !(accByNode.get(r.node.id) ?? []).some((a) => a.userId === currentUserId) && (
-                <>
-                  <button
-                    onClick={() => toggleAcceptance(r)}
-                    title="Accept requirement (personal sign-off, status stays derived)"
-                    style={{
-                      padding: '2px 8px',
-                      borderRadius: 10,
-                      fontSize: 11,
-                      border: '1px dashed #cbd5e1',
-                      background: 'transparent',
-                      color: '#64748b',
-                      cursor: 'pointer',
-                    }}
-                  >
-                    ✓ Accept
-                  </button>
-                  <button
-                    onClick={() => rejectRequirement(r)}
-                    title="Reject requirement — reason required"
-                    style={{
-                      padding: '2px 8px',
-                      marginLeft: 4,
-                      borderRadius: 10,
-                      fontSize: 11,
-                      border: '1px dashed #fca5a5',
-                      background: 'transparent',
-                      color: '#b91c1c',
-                      cursor: 'pointer',
-                    }}
-                  >
-                    ✗
-                  </button>
-                </>
-              )}
+            <div style={{ display: 'flex', gap: 10 }}>
+              {(['it', 'business'] as const).map((gate) => (
+                <GateSlot
+                  key={gate}
+                  gate={gate}
+                  row={r}
+                  currentUserId={currentUserId}
+                  onToggle={toggleAcceptance}
+                  onReject={rejectRequirement}
+                />
+              ))}
+            </div>
           </td>
         </tr>
       ))}
@@ -1147,6 +1141,171 @@ function ChapterGroup({
 }
 
 // ── Small pieces ─────────────────────────────────────────────────
+
+/**
+ * One gate's verdict slot. Either the standing verdict (own chip clicks
+ * to withdraw) or the ✓/✗ pair to record one.
+ */
+function GateSlot({
+  gate,
+  row,
+  currentUserId,
+  onToggle,
+  onReject,
+}: {
+  gate: RequirementGate;
+  row: ReqRow;
+  currentUserId: string | null;
+  onToggle: (row: ReqRow, gate: RequirementGate) => void;
+  onReject: (row: ReqRow, gate: RequirementGate) => void;
+}) {
+  const a = row.verdicts[gate];
+  const own = a != null && a.userId === currentUserId;
+  const stale =
+    a != null &&
+    (Math.abs(row.progress - a.progressAtAcceptance) > 1 ||
+      row.node.revision !== a.nodeRevisionAtAcceptance);
+  const rejected = a?.decision === 'rejected';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 70 }}>
+      <span
+        style={{
+          fontSize: 9,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: '#94a3b8',
+          fontWeight: 700,
+        }}
+      >
+        {GATE_LABEL[gate]}
+      </span>
+      {a ? (
+        <span
+          onClick={own ? () => onToggle(row, gate) : undefined}
+          title={
+            (stale ? 'Seit dem Urteil geändert! ' : '') +
+            `${a.userName}, ${rejected ? 'zurückgewiesen' : 'erteilt'} ${a.acceptedAt.slice(0, 10)} bei ${Math.round(a.progressAtAcceptance)} %` +
+            (rejected && a.comment ? ` — «${a.comment}»` : '') +
+            (own ? ' — klicken zum Zurückziehen' : '')
+          }
+          style={{
+            display: 'inline-block',
+            padding: '2px 8px',
+            borderRadius: 10,
+            fontSize: 11,
+            fontWeight: 600,
+            whiteSpace: 'nowrap',
+            cursor: own ? 'pointer' : 'default',
+            background: rejected ? '#fee2e2' : stale ? '#fef3c7' : '#d1fae5',
+            color: rejected ? '#991b1b' : stale ? '#92400e' : '#065f46',
+          }}
+        >
+          {stale ? '⚠ ' : ''}
+          {a.userName.split(' ')[0]} {rejected ? '✗' : '✓'}{' '}
+          {a.acceptedAt.slice(5, 10).split('-').reverse().join('.')}.
+        </span>
+      ) : currentUserId ? (
+        <span style={{ display: 'flex', gap: 3 }}>
+          <button
+            onClick={() => onToggle(row, gate)}
+            title={
+              gate === 'it'
+                ? 'IT-Prüfung erteilen — funktioniert wie gebaut'
+                : 'Abnehmen — ist das, was bestellt wurde'
+            }
+            style={ghostChipStyle('#cbd5e1', '#64748b')}
+          >
+            ✓
+          </button>
+          <button
+            onClick={() => onReject(row, gate)}
+            title="Zurückweisen — Begründung erforderlich"
+            style={ghostChipStyle('#fca5a5', '#b91c1c')}
+          >
+            ✗
+          </button>
+        </span>
+      ) : (
+        <span style={{ color: '#cbd5e1', fontSize: 11 }}>—</span>
+      )}
+    </div>
+  );
+}
+
+function ghostChipStyle(borderColor: string, color: string): React.CSSProperties {
+  return {
+    padding: '2px 7px',
+    borderRadius: 10,
+    fontSize: 11,
+    border: `1px dashed ${borderColor}`,
+    background: 'transparent',
+    color,
+    cursor: 'pointer',
+  };
+}
+
+/**
+ * The funnel bar under the header. Its job is to make the gap between
+ * "gebaut" and "abgenommen" impossible to skip past — a single green
+ * percentage never showed it.
+ */
+function StageFunnel({
+  counts,
+  total,
+}: {
+  counts: Record<RequirementStage, number>;
+  total: number;
+}) {
+  if (total === 0) return null;
+  const segments = STAGE_ORDER.filter((s) => counts[s] > 0);
+  return (
+    <div style={{ marginTop: 6, maxWidth: 460 }}>
+      <div
+        style={{
+          display: 'flex',
+          height: 8,
+          borderRadius: 4,
+          overflow: 'hidden',
+          background: '#f1f5f9',
+        }}
+      >
+        {segments.map((s) => (
+          <div
+            key={s}
+            title={`${counts[s]} ${STAGE_LABEL[s]}`}
+            style={{ width: `${(counts[s] / total) * 100}%`, background: STAGE_COLOR[s].fg }}
+          />
+        ))}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '2px 12px',
+          marginTop: 5,
+          fontSize: 10,
+          color: '#64748b',
+        }}
+      >
+        {STAGE_ORDER.filter((s) => counts[s] > 0 || s === 'accepted').map((s) => (
+          <span key={s} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <i
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: 2,
+                background: STAGE_COLOR[s].fg,
+                display: 'inline-block',
+              }}
+            />
+            {STAGE_LABEL[s]} <b style={{ color: '#334155' }}>{counts[s]}</b>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function ProgressBar({ percent, editable }: { percent: number; editable: boolean }) {
   const clamped = Math.min(100, Math.max(0, Math.round(percent)));

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -5,6 +5,8 @@ import type {
   Version,
   ScheduledNode,
   CriticalPathResult,
+  RequirementGate,
+  RequirementStage,
 } from '@mindblown/core';
 
 const BASE_URL: string = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
@@ -590,14 +592,22 @@ export function updateMap(id: string, fields: Record<string, unknown>): Promise<
  * export route so the document matches what's on screen.
  */
 export interface RequirementsExportFilter {
-  status?: 'open' | 'partial' | 'done';
+  status?: RequirementStage;
   priority?: 'must' | 'should' | 'could';
   /** Version id, or 'none' for "no release assigned". */
   release?: string;
   releaseMode?: 'cumulative' | 'exact';
   hideDone?: boolean;
-  acceptance?: 'none' | 'mine-open' | 'rejected';
+  acceptance?: AcceptanceFilter;
 }
+
+/** Mirrors the server's RegisterFilter['acceptance']. */
+export type AcceptanceFilter =
+  | 'none'
+  | 'mine-open'
+  | 'rejected'
+  | 'it-open'
+  | 'business-open';
 
 function requirementsExportQuery(format: string, filter: RequirementsExportFilter): string {
   const params = new URLSearchParams({ format });
@@ -646,6 +656,8 @@ export interface AcceptanceRow {
   nodeRevisionAtAcceptance: number;
   decision: 'accepted' | 'rejected';
   comment: string | null;
+  /** Optional: rows written before the gate split read as 'business'. */
+  gate?: RequirementGate;
 }
 
 export function fetchAcceptances(mapId: string): Promise<{ acceptances: AcceptanceRow[] }> {
@@ -655,7 +667,11 @@ export function fetchAcceptances(mapId: string): Promise<{ acceptances: Acceptan
 export function acceptRequirement(
   mapId: string,
   nodeId: string,
-  verdict?: { decision: 'accepted' | 'rejected'; comment?: string },
+  verdict?: {
+    decision?: 'accepted' | 'rejected';
+    comment?: string;
+    gate?: RequirementGate;
+  },
 ): Promise<AcceptanceRow> {
   return request<AcceptanceRow>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, {
     method: 'POST',
@@ -663,8 +679,16 @@ export function acceptRequirement(
   });
 }
 
-export function revokeAcceptance(mapId: string, nodeId: string): Promise<void> {
-  return request<void>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance`, { method: 'DELETE' });
+export function revokeAcceptance(
+  mapId: string,
+  nodeId: string,
+  gate?: RequirementGate,
+): Promise<void> {
+  // Gate as a query param: the route rejects a DELETE body.
+  const qs = gate ? `?gate=${gate}` : '';
+  return request<void>(`/api/maps/${mapId}/nodes/${nodeId}/acceptance${qs}`, {
+    method: 'DELETE',
+  });
 }
 
 // ── Nodes ────────────────────────────────────────────────────────

--- a/packages/mindmap/src/mobile/MobileRequirementsView.tsx
+++ b/packages/mindmap/src/mobile/MobileRequirementsView.tsx
@@ -1,26 +1,22 @@
 import { useMemo, useState } from 'react';
-import type { MindMap, Version } from '@mindblown/core';
-import type { NodeWithComputed } from '../api.js';
+import {
+  requirementStage,
+  stageCounts,
+  BUILT_THRESHOLD,
+  STAGE_LABEL,
+  STAGE_COLOR,
+} from '@mindblown/core';
+import type { MindMap, Version, RequirementStage } from '@mindblown/core';
+import type { AcceptanceRow, NodeWithComputed } from '../api.js';
 
-// Requirement status is never stored — always derived from the progress
-// rollup, mirroring the desktop RequirementsView.
+// The stage is never stored — derived from the progress rollup folded
+// with the sign-off verdicts, mirroring the desktop RequirementsView.
+// "Gebaut" ≠ "Abgenommen" here too: same words, same colours, one source
+// in @mindblown/core.
 
-type ReqStatus = 'open' | 'partial' | 'done';
-// 'todo' is the "hide done" button — open + partial in one tap, which is
-// what you want on a phone far more often than any single status.
-type Filter = 'all' | 'todo' | ReqStatus;
-
-const STATUS_LABEL: Record<ReqStatus, string> = {
-  done: 'Done',
-  partial: 'Partial',
-  open: 'Open',
-};
-
-const STATUS_COLOR: Record<ReqStatus, { bg: string; fg: string }> = {
-  done: { bg: '#d1fae5', fg: '#065f46' },
-  partial: { bg: '#fef3c7', fg: '#92400e' },
-  open: { bg: '#f1f5f9', fg: '#475569' },
-};
+// 'todo' is the "hide built" button — everything not yet built in one
+// tap, which is what you want on a phone more often than any single stage.
+type Filter = 'all' | 'todo' | RequirementStage;
 
 const PRIORITY_LABEL: Record<string, string> = {
   must: 'Must',
@@ -32,12 +28,15 @@ interface Props {
   nodes: NodeWithComputed[];
   map: MindMap;
   versions: Version[];
+  acceptances: AcceptanceRow[];
   onSelect: (nodeId: string) => void;
 }
 
 interface ReqRow {
   node: NodeWithComputed;
-  status: ReqStatus;
+  stage: RequirementStage;
+  /** Progress alone — drives the "todo" filter and the % suffix. */
+  built: boolean;
   chapterText: string;
   /** Release label; null when neither the requirement nor its subtree is scheduled. */
   releaseLabel: string | null;
@@ -45,16 +44,24 @@ interface ReqRow {
   releaseInherited: boolean;
 }
 
-function statusOf(progress: number): ReqStatus {
-  return progress >= 100 ? 'done' : progress > 0 ? 'partial' : 'open';
-}
-
-export function MobileRequirementsView({ nodes, map, versions, onSelect }: Props) {
+export function MobileRequirementsView({
+  nodes,
+  map,
+  versions,
+  acceptances,
+  onSelect,
+}: Props) {
   const [filter, setFilter] = useState<Filter>('all');
 
   const rows = useMemo<ReqRow[]>(() => {
     const byId = new Map(nodes.map((n) => [n.id, n]));
     const versionName = new Map(versions.map((v) => [v.id, v.name]));
+    const accByNode = new Map<string, AcceptanceRow[]>();
+    for (const a of acceptances) {
+      const list = accByNode.get(a.nodeId) ?? [];
+      list.push(a);
+      accByNode.set(a.nodeId, list);
+    }
 
     // Requirements are usually tagged only on the work below them, so an
     // untagged one falls back to what its subtree carries (desktop parity).
@@ -75,9 +82,11 @@ export function MobileRequirementsView({ nodes, map, versions, onSelect }: Props
       .map((n) => {
         const parent = n.parentId ? byId.get(n.parentId) : undefined;
         const below = n.versionId ? [] : descendantVersions(n.id);
+        const progress = n.computedProgress ?? 0;
         return {
           node: n,
-          status: statusOf(n.computedProgress ?? 0),
+          stage: requirementStage(progress, accByNode.get(n.id) ?? []),
+          built: progress >= BUILT_THRESHOLD,
           chapterText: parent && parent.id !== map.rootNodeId ? parent.text : '',
           releaseLabel: n.versionId
             ? (versionName.get(n.versionId) ?? '?')
@@ -94,23 +103,24 @@ export function MobileRequirementsView({ nodes, map, versions, onSelect }: Props
           numeric: true,
         }),
       );
-  }, [nodes, map.rootNodeId, versions]);
+  }, [nodes, map.rootNodeId, versions, acceptances]);
 
-  const counts = useMemo(() => {
-    const c = { all: rows.length, todo: 0, open: 0, partial: 0, done: 0 };
-    for (const r of rows) {
-      c[r.status] += 1;
-      if (r.status !== 'done') c.todo += 1;
-    }
-    return c;
-  }, [rows]);
+  const counts = useMemo(
+    () => ({
+      ...stageCounts(rows.map((r) => r.stage)),
+      all: rows.length,
+      todo: rows.filter((r) => !r.built).length,
+      built: rows.filter((r) => r.built).length,
+    }),
+    [rows],
+  );
 
   const filtered =
     filter === 'all'
       ? rows
       : filter === 'todo'
-        ? rows.filter((r) => r.status !== 'done')
-        : rows.filter((r) => r.status === filter);
+        ? rows.filter((r) => !r.built)
+        : rows.filter((r) => r.stage === filter);
 
   if (rows.length === 0) {
     return (
@@ -125,18 +135,27 @@ export function MobileRequirementsView({ nodes, map, versions, onSelect }: Props
 
   return (
     <div className="mb-body" style={{ paddingTop: 8 }}>
+      {/* Lead with the accepted count — the whole point of the stage split
+          is that "gebaut" must not read as the finish line. */}
+      <div style={{ padding: '0 12px 8px', fontSize: 12, color: '#64748b' }}>
+        <b style={{ fontSize: 17, color: '#047857' }}>{counts.accepted}</b> von {rows.length}{' '}
+        abgenommen · {counts.built} gebaut
+      </div>
       <div className="mb-filter-row">
-        {(['all', 'todo', 'open', 'partial', 'done'] as const).map((f) => (
-          <button
-            key={f}
-            className="mb-filter-chip"
-            aria-pressed={filter === f}
-            onClick={() => setFilter(f)}
-          >
-            {f === 'all' ? 'All' : f === 'todo' ? 'Hide done' : STATUS_LABEL[f]}
-            <span className="mb-filter-count">{counts[f]}</span>
-          </button>
-        ))}
+        {(['all', 'todo', 'accepted', 'it_verified', 'built', 'in_progress', 'open', 'rejected'] as const)
+          // Rejected is a chip only when there is something to show.
+          .filter((f) => f !== 'rejected' || counts.rejected > 0)
+          .map((f) => (
+            <button
+              key={f}
+              className="mb-filter-chip"
+              aria-pressed={filter === f}
+              onClick={() => setFilter(f)}
+            >
+              {f === 'all' ? 'Alle' : f === 'todo' ? 'Offene Arbeit' : STAGE_LABEL[f]}
+              <span className="mb-filter-count">{counts[f]}</span>
+            </button>
+          ))}
       </div>
 
       {filtered.length === 0 && (
@@ -145,8 +164,8 @@ export function MobileRequirementsView({ nodes, map, versions, onSelect }: Props
         </div>
       )}
 
-      {filtered.map(({ node, status, chapterText, releaseLabel, releaseInherited }) => {
-        const sc = STATUS_COLOR[status];
+      {filtered.map(({ node, stage, chapterText, releaseLabel, releaseInherited }) => {
+        const sc = STAGE_COLOR[stage];
         const pct = Math.round(node.computedProgress ?? 0);
         return (
           <button key={node.id} className="mb-req-card" onClick={() => onSelect(node.id)}>
@@ -156,8 +175,8 @@ export function MobileRequirementsView({ nodes, map, versions, onSelect }: Props
                 className="mb-status-pill"
                 style={{ background: sc.bg, color: sc.fg, borderColor: sc.bg }}
               >
-                {STATUS_LABEL[status]}
-                {status === 'partial' ? ` · ${pct}%` : ''}
+                {STAGE_LABEL[stage]}
+                {stage === 'in_progress' ? ` · ${pct}%` : ''}
               </span>
               {node.requirementPriority && (
                 <span className="mb-req-priority">

--- a/packages/mindmap/src/mobile/MobileViewer.tsx
+++ b/packages/mindmap/src/mobile/MobileViewer.tsx
@@ -72,12 +72,16 @@ export function MobileViewer({ map }: Props) {
   // don't change under an editing session — fetched once per map, not with
   // the debounced node reload.
   const [versions, setVersions] = useState<Version[]>([]);
+  // Sign-off verdicts, for the Requirements tab's derived stage. Same
+  // deal as versions: one small fetch per map, not per node reload.
+  const [acceptances, setAcceptances] = useState<api.AcceptanceRow[]>([]);
 
   useEffect(() => {
     let cancelled = false;
     setDetail(null);
     setError(null);
     setVersions([]);
+    setAcceptances([]);
     api
       .fetchVersions(map.id)
       .then((v) => {
@@ -85,6 +89,15 @@ export function MobileViewer({ map }: Props) {
       })
       .catch(() => {
         // Release chips just stay empty — not worth failing the map load over.
+      });
+    api
+      .fetchAcceptances(map.id)
+      .then((r) => {
+        if (!cancelled) setAcceptances(r.acceptances);
+      })
+      .catch(() => {
+        // Without verdicts the register degrades to "Gebaut" at 100 % —
+        // under-claiming, which is the safe direction to fail in.
       });
     api
       .fetchMap(map.id, { omit: OMIT_FIELDS })
@@ -253,6 +266,7 @@ export function MobileViewer({ map }: Props) {
               nodes={nodes}
               map={detail.map}
               versions={versions}
+              acceptances={acceptances}
               onSelect={setSelectedId}
             />
           )}

--- a/packages/server/src/db/acceptances.ts
+++ b/packages/server/src/db/acceptances.ts
@@ -1,4 +1,5 @@
 import { and, eq, isNull } from 'drizzle-orm';
+import type { RequirementGate } from '@mindblown/core';
 import { db } from './connection.js';
 import { requirementAcceptances, users } from './schema.js';
 
@@ -27,6 +28,8 @@ export interface Acceptance {
   decision: AcceptanceDecision;
   /** Reviewer comment — always present on rejections (route-enforced). */
   comment: string | null;
+  /** Which gate this verdict answers. Pre-split rows read as 'business'. */
+  gate: RequirementGate;
 }
 
 function toIso(v: unknown): string {
@@ -47,6 +50,7 @@ export async function listActiveAcceptances(mapId: string): Promise<Acceptance[]
       nodeRevisionAtAcceptance: requirementAcceptances.nodeRevisionAtAcceptance,
       decision: requirementAcceptances.decision,
       comment: requirementAcceptances.comment,
+      gate: requirementAcceptances.gate,
     })
     .from(requirementAcceptances)
     .innerJoin(users, eq(users.id, requirementAcceptances.userId))
@@ -55,16 +59,17 @@ export async function listActiveAcceptances(mapId: string): Promise<Acceptance[]
     ...r,
     acceptedAt: toIso(r.acceptedAt),
     decision: (r.decision as AcceptanceDecision) ?? 'accepted',
+    gate: (r.gate as RequirementGate) ?? 'business',
   }));
 }
 
 /**
- * Record a verdict (accept or reject) on a requirement node. Snapshots
- * the derived progress and node revision the reviewer saw. Returns the
- * new row, or null when this user already has an ACTIVE verdict on the
- * node (idempotent — the 23505 on the partial unique index is mapped to
- * null so a double click never errors). Switching verdict = revoke the
- * old row first, then record the new one.
+ * Record a verdict (accept or reject) on a requirement node for one gate.
+ * Snapshots the derived progress and node revision the reviewer saw.
+ * Returns the new row, or null when this user already has an ACTIVE
+ * verdict on the node FOR THAT GATE (idempotent — the 23505 on the
+ * partial unique index is mapped to null so a double click never errors).
+ * Switching verdict = revoke the old row first, then record the new one.
  */
 export async function accept(
   mapId: string,
@@ -74,11 +79,21 @@ export async function accept(
   nodeRevisionAtAcceptance: number,
   decision: AcceptanceDecision = 'accepted',
   comment: string | null = null,
+  gate: RequirementGate = 'business',
 ): Promise<Acceptance | null> {
   try {
     const [row] = await db
       .insert(requirementAcceptances)
-      .values({ mapId, nodeId, userId, progressAtAcceptance, nodeRevisionAtAcceptance, decision, comment })
+      .values({
+        mapId,
+        nodeId,
+        userId,
+        progressAtAcceptance,
+        nodeRevisionAtAcceptance,
+        decision,
+        comment,
+        gate,
+      })
       .returning();
     const [u] = await db.select({ name: users.name }).from(users).where(eq(users.id, userId));
     return {
@@ -92,10 +107,17 @@ export async function accept(
       nodeRevisionAtAcceptance: row.nodeRevisionAtAcceptance,
       decision: (row.decision as AcceptanceDecision) ?? 'accepted',
       comment: row.comment ?? null,
+      gate: (row.gate as RequirementGate) ?? 'business',
     };
   } catch (err) {
     const e = err as { code?: string; constraint?: string };
-    if (e?.code === '23505' && e?.constraint === 'requirement_acceptances_active_unique') {
+    // Both names: the pre-gate index and the widened one. A rolling deploy
+    // can hit either between migration and restart.
+    if (
+      e?.code === '23505' &&
+      (e?.constraint === 'requirement_acceptances_active_gate_unique' ||
+        e?.constraint === 'requirement_acceptances_active_unique')
+    ) {
       return null;
     }
     throw err;
@@ -103,10 +125,16 @@ export async function accept(
 }
 
 /**
- * Revoke the caller's active acceptance on a node. Returns true when a
- * row was revoked, false when there was none (idempotent).
+ * Revoke the caller's active verdict on a node for one gate. Returns true
+ * when a row was revoked, false when there was none (idempotent).
+ * Gate-scoped on purpose: withdrawing the IT verdict must not silently
+ * take the business sign-off with it.
  */
-export async function revoke(nodeId: string, userId: string): Promise<boolean> {
+export async function revoke(
+  nodeId: string,
+  userId: string,
+  gate: RequirementGate = 'business',
+): Promise<boolean> {
   const rows = await db
     .update(requirementAcceptances)
     .set({ revokedAt: new Date() })
@@ -114,6 +142,7 @@ export async function revoke(nodeId: string, userId: string): Promise<boolean> {
       and(
         eq(requirementAcceptances.nodeId, nodeId),
         eq(requirementAcceptances.userId, userId),
+        eq(requirementAcceptances.gate, gate),
         isNull(requirementAcceptances.revokedAt),
       ),
     )

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -840,6 +840,27 @@ export async function runMigrations(): Promise<void> {
   await db.execute(sql`
     ALTER TABLE requirement_acceptances ADD COLUMN IF NOT EXISTS comment TEXT
   `);
+  // gate: 'it' | 'business' — which question the verdict answers. Every
+  // pre-split row was a business sign-off (that was the only kind), so the
+  // DEFAULT backfills them correctly with no data migration.
+  await db.execute(sql`
+    ALTER TABLE requirement_acceptances
+      ADD COLUMN IF NOT EXISTS gate TEXT NOT NULL DEFAULT 'business'
+  `);
+  // Widen the active-verdict invariant to (node, user, gate): one live
+  // verdict per gate, so the same person can sign IT and Business
+  // separately. Create the wider index BEFORE dropping the narrower one —
+  // the other order leaves a window on every API restart where concurrent
+  // accepts are unprotected. The old index is stricter, so both coexist
+  // happily for the moment in between.
+  await db.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS requirement_acceptances_active_gate_unique
+      ON requirement_acceptances (node_id, user_id, gate)
+      WHERE revoked_at IS NULL
+  `);
+  await db.execute(sql`
+    DROP INDEX IF EXISTS requirement_acceptances_active_unique
+  `);
 
   // ── Phase column (nodes.phase_id + maps.phases) ────────────────
   // maps.phases: PhaseDef[] jsonb — {id, name, position, color?,

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -513,6 +513,11 @@ export const requirementAcceptances = pgTable('requirement_acceptances', {
   decision: text('decision').notNull().default('accepted'),
   // Reviewer comment — mandatory for 'rejected' (enforced in the route).
   comment: text('comment'),
+  // Which gate this verdict answers: 'it' (does it work?) or 'business'
+  // (is it what we asked for?). Default 'business' so pre-split rows keep
+  // meaning what they meant. The active-unique index spans the gate, so a
+  // user holds at most one live verdict PER GATE per node.
+  gate: text('gate').notNull().default('business'),
 });
 
 // ── Lint dismissals (plan-health panel, docs/plan-linter.md) ───────

--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -76,7 +76,7 @@ describe('buildRegisterData — Abnahme verdicts', () => {
 
   it('renders an acceptance as ✓ without comment', () => {
     const data = build(nodes, [{ ...baseAcc, nodeId: 'r1', decision: 'accepted' }]);
-    expect(data.chapters[0].rows[0].abnahme).toEqual(['T. Muster ✓ 17.07.']);
+    expect(data.chapters[0].rows[0].abnahme).toEqual(['Business: T. Muster ✓ 17.07.']);
   });
 
   it('renders a rejection as ✗ with the truncated comment', () => {
@@ -84,7 +84,7 @@ describe('buildRegisterData — Abnahme verdicts', () => {
       { ...baseAcc, nodeId: 'r1', decision: 'rejected', comment: 'Rollen-Dropdown speichert nicht' },
     ]);
     expect(data.chapters[0].rows[0].abnahme).toEqual([
-      'T. Muster ✗ 17.07. («Rollen-Dropdown speichert nicht»)',
+      'Business: T. Muster ✗ 17.07. («Rollen-Dropdown speichert nicht»)',
     ]);
   });
 
@@ -105,7 +105,7 @@ describe('buildRegisterData — Abnahme verdicts', () => {
       { ...baseAcc, nodeId: 'r1', decision: 'rejected', comment: 'kaputt' },
     ]);
     const md = renderMarkdown(data);
-    expect(md).toContain('T. Muster ✗ 17.07. («kaputt»)');
+    expect(md).toContain('Business: T. Muster ✗ 17.07. («kaputt»)');
   });
 });
 
@@ -157,11 +157,11 @@ describe('buildRegisterData — status detail', () => {
     buildRegisterData(map, req(p), new Map(), []).chapters[0].rows[0].statusDetail;
 
   it('appends the derived percentage to partial rows', () => {
-    expect(detail(42)).toBe('Teilweise · 42 %');
+    expect(detail(42)).toBe('In Umsetzung · 42 %');
   });
 
-  it('leaves Umgesetzt and Offen without a percentage', () => {
-    expect(detail(100)).toBe('Umgesetzt');
+  it('leaves Gebaut and Offen without a percentage', () => {
+    expect(detail(100)).toBe('Gebaut');
     expect(detail(null)).toBe('Offen');
   });
 });
@@ -234,11 +234,63 @@ describe('buildRegisterData — filters (export mirrors the filter bar)', () => 
     expect(ids({ acceptance: 'mine-open', currentUserId: 'u1' })).toEqual(['MAN-02', 'MAN-03', 'MAN-04']);
   });
 
+  it('the review queues only list what is far enough along to judge', () => {
+    // MAN-01 is built and carries a (backfilled) business verdict but no
+    // IT one, so it is exactly the IT queue. MAN-03/04 sit at 0 % and must
+    // not show up in either queue — they would bury the real work.
+    expect(ids({ acceptance: 'it-open' })).toEqual(['MAN-01']);
+    expect(ids({ acceptance: 'business-open' })).toEqual([]);
+  });
+
+  it('status accepts a stage, and still honours the pre-split buckets', () => {
+    expect(ids({ status: 'accepted' })).toEqual(['MAN-01']);
+    expect(ids({ status: 'rejected' })).toEqual(['MAN-02']);
+    // 'done'/'partial' are progress-only, which is what they always meant:
+    // MAN-01 is accepted but still counts as done, MAN-02 is rejected at 50 %.
+    expect(ids({ status: 'done' })).toEqual(['MAN-01']);
+    expect(ids({ status: 'partial' })).toEqual(['MAN-02']);
+  });
+
+  it('hideDone keeps rejections on screen', () => {
+    // A ✗ at 100 % is the row that most needs looking at; hiding it with
+    // the rest of the built work is how an objection gets lost.
+    const rejectedAt100 = [
+      ...nodes.slice(0, 3),
+      makeNode({
+        id: 'r2',
+        parentId: 'ch',
+        requirementId: 'MAN-02',
+        requirementPriority: 'must',
+        percentComplete: 100,
+        versionId: 'v2',
+      }),
+      ...nodes.slice(4),
+    ];
+    const data = buildRegisterData(map, rejectedAt100, new Map(), acceptances, versions, {
+      hideDone: true,
+    });
+    expect(data.chapters.flatMap((c) => c.rows.map((r) => r.id))).toContain('MAN-02');
+  });
+
+  it('labels each verdict with its gate', () => {
+    // Two ✓ from the same person are otherwise indistinguishable.
+    const data = buildRegisterData(map, nodes, new Map(), [
+      { ...baseAcc, nodeId: 'r1', userId: 'u1', decision: 'accepted' as const, gate: 'it' as const, nodeRevisionAtAcceptance: 0 },
+      { ...baseAcc, nodeId: 'r1', userId: 'u1', decision: 'accepted' as const, gate: 'business' as const, nodeRevisionAtAcceptance: 0 },
+    ], versions, {});
+    const row = data.chapters[0].rows.find((r) => r.id === 'MAN-01')!;
+    expect(row.abnahme).toEqual([
+      'IT: T. Muster ✓ 17.07.',
+      'Business: T. Muster ✓ 17.07.',
+    ]);
+    expect(row.stage).toBe('accepted');
+  });
+
   it('counts reflect the filtered set, totalAll the whole register', () => {
     const data = buildF({ hideDone: true });
     expect(data.total).toBe(3);
     expect(data.totalAll).toBe(4);
-    expect(data.counts).toEqual({ Umgesetzt: 0, Teilweise: 1, Offen: 2 });
+    expect(data.counts).toMatchObject({ accepted: 0, rejected: 1, open: 2 });
   });
 
   it('describes the active filter in German', () => {
@@ -246,7 +298,7 @@ describe('buildRegisterData — filters (export mirrors the filter bar)', () => 
     expect(buildF({ release: 'v1', releaseMode: 'exact' }).filterLabel).toBe('Release: nur V1');
     expect(buildF({ release: 'none' }).filterLabel).toBe('Release: ohne Zuordnung');
     expect(buildF({ status: 'open', hideDone: true, priority: 'must' }).filterLabel).toBe(
-      'Status: Offen · ohne Umgesetzte · Priorität: Muss',
+      'Status: Offen · ohne Gebaute · Priorität: Muss',
     );
   });
 
@@ -265,7 +317,7 @@ describe('buildRegisterData — filters (export mirrors the filter bar)', () => 
     expect(md).not.toContain('Gefilterter Auszug');
     expect(md).toContain('**Umfang:** alle 4 Anforderungen dieses Projekts');
     expect(md).toContain(
-      '**Stand dieser 4 Anforderungen:** 1 Umgesetzt · 1 Teilweise · 2 Offen',
+      '**Stand dieser 4 Anforderungen:** 1 Abgenommen · 2 Offen · 1 Zurückgewiesen',
     );
   });
 });

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -5,7 +5,16 @@ import type {
   NodeId,
   Version,
 } from '@mindblown/core';
-import { compareVersions } from '@mindblown/core';
+import {
+  compareVersions,
+  requirementStage,
+  stageCounts,
+  BUILT_THRESHOLD,
+  STAGE_LABEL,
+  STAGE_ORDER,
+  STAGE_COLOR,
+} from '@mindblown/core';
+import type { RequirementGate, RequirementStage } from '@mindblown/core';
 import {
   Document,
   HeadingLevel,
@@ -34,6 +43,8 @@ export interface AcceptanceInfo {
   decision?: 'accepted' | 'rejected';
   /** Reviewer comment; always present on rejections. */
   comment?: string | null;
+  /** Gate answered — optional so pre-split callers/rows read as 'business'. */
+  gate?: RequirementGate;
 }
 
 /**
@@ -57,14 +68,17 @@ export interface RegisterRow {
   prio: string;
   /** Version name, "↳ V2" when inherited from the work below, "—" when unscheduled. */
   release: string;
+  /** Derived lifecycle stage — progress rollup folded with the sign-off verdicts. */
+  stage: RequirementStage;
+  /** Stage label, e.g. "Gebaut". */
   status: string;
-  /** Status with the derived percentage on partial rows, e.g. "Teilweise · 42 %". */
+  /** Stage with the derived percentage while in progress, e.g. "In Umsetzung · 42 %". */
   statusDetail: string;
   /** Derived progress 0–100, rounded — feeds the docx progress bar. */
   progress: number;
   aufwand: string;
   rest: string;
-  /** e.g. "D. Haas ✓ 15.07." — one entry per active acceptance, ⚠-suffixed when stale. */
+  /** e.g. "IT: D. Haas ✓ 15.07." — one entry per active verdict, ⚠-suffixed when stale. */
   abnahme: string[];
 }
 
@@ -76,7 +90,12 @@ export interface RegisterData {
   totalAll: number;
   /** Human-readable description of the active filter, null when unfiltered. */
   filterLabel: string | null;
-  counts: { Umgesetzt: number; Teilweise: number; Offen: number };
+  /**
+   * Requirements per lifecycle stage. Replaces the old
+   * {Umgesetzt, Teilweise, Offen} triple, which could only ever describe
+   * how much code had landed.
+   */
+  counts: Record<RequirementStage, number>;
   chapters: Array<{ name: string; rows: RegisterRow[] }>;
 }
 
@@ -86,20 +105,48 @@ export interface RegisterData {
  * `filteredRows` predicate one for one.
  */
 export interface RegisterFilter {
-  status?: 'open' | 'partial' | 'done';
+  /**
+   * A lifecycle stage, or one of the legacy progress buckets
+   * ('partial' / 'done') that `?status=` links and older MCP calls still
+   * send. Legacy values keep filtering on progress alone.
+   */
+  status?: RequirementStage | 'partial' | 'done';
   priority?: 'must' | 'should' | 'could';
   /** A version id, or 'none' for "no release anywhere in the subtree". */
   release?: string;
   /** cumulative = due by this release or earlier; exact = only this release. */
   releaseMode?: 'cumulative' | 'exact';
   hideDone?: boolean;
-  acceptance?: 'none' | 'mine-open' | 'rejected';
+  acceptance?: AcceptanceFilter;
   /** Needed by acceptance: 'mine-open' — whose verdict counts as "mine". */
   currentUserId?: string | null;
 }
 
+/**
+ * 'it-open' / 'business-open' are the review queues: what is built enough
+ * to judge but still waiting on that gate's verdict.
+ */
+export type AcceptanceFilter =
+  | 'none'
+  | 'mine-open'
+  | 'rejected'
+  | 'it-open'
+  | 'business-open';
+
 const PRIO: Record<string, string> = { must: 'Muss', should: 'Soll', could: 'Kann' };
-const STATUS_DE: Record<string, string> = { open: 'Offen', partial: 'Teilweise', done: 'Umgesetzt' };
+
+/** Legacy progress buckets, still accepted by the status filter. */
+const LEGACY_STATUS_DE: Record<string, string> = {
+  partial: 'Teilweise',
+  done: 'Umgesetzt',
+};
+
+function statusFilterLabel(status: string): string {
+  return LEGACY_STATUS_DE[status] ?? STAGE_LABEL[status as RequirementStage] ?? status;
+}
+
+/** Gate prefix in the Abnahme cell — short, because the column is narrow. */
+const GATE_SHORT: Record<RequirementGate, string> = { it: 'IT', business: 'Business' };
 
 function truncate(s: string, max: number): string {
   return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
@@ -129,9 +176,8 @@ export function buildRegisterData(
     n.childrenIds.length > 0
       ? (computed.get(n.id)?.computedProgress ?? 0)
       : (n.percentComplete ?? 0);
-  const statusEnOf = (p: number): 'open' | 'partial' | 'done' =>
-    p >= 99.5 ? 'done' : p > 0 ? 'partial' : 'open';
-  const statusOf = (p: number): string => STATUS_DE[statusEnOf(p)];
+  const stageOf = (n: CoreNode): RequirementStage =>
+    requirementStage(progressOf(n), accByNode.get(n.id) ?? []);
 
   // A requirement is usually scheduled through its children, not directly —
   // and can be split across releases, so this is a full descendant walk.
@@ -164,9 +210,22 @@ export function buildRegisterData(
   );
 
   const matchesFilter = (n: CoreNode): boolean => {
-    const st = statusEnOf(progressOf(n));
-    if (filter.hideDone && st === 'done') return false;
-    if (filter.status && st !== filter.status) return false;
+    const p = progressOf(n);
+    const stage = stageOf(n);
+    // "Hide done" hides what is finished from the plan's point of view —
+    // built or better. A rejected requirement is never hidden: it is the
+    // one row that most needs to stay on screen.
+    const isBuiltOrBeyond = stage !== 'rejected' && p >= BUILT_THRESHOLD;
+    if (filter.hideDone && isBuiltOrBeyond) return false;
+    if (filter.status) {
+      if (filter.status === 'done') {
+        if (!isBuiltOrBeyond) return false;
+      } else if (filter.status === 'partial') {
+        if (!(p > 0 && p < BUILT_THRESHOLD)) return false;
+      } else if (stage !== filter.status) {
+        return false;
+      }
+    }
     if (filter.priority && n.requirementPriority !== filter.priority) return false;
     if (filter.release === 'none') {
       // "No release" means nothing below it is scheduled either.
@@ -202,6 +261,17 @@ export function buildRegisterData(
       if (filter.acceptance === 'rejected' && !accs.some((a) => a.decision === 'rejected')) {
         return false;
       }
+      // The two review queues: only what is far enough along to judge.
+      // Listing 0 %-progress requirements as "IT-Prüfung offen" would bury
+      // the handful that are actually waiting.
+      if (filter.acceptance === 'it-open') {
+        if (!isBuiltOrBeyond) return false;
+        if (accs.some((a) => (a.gate ?? 'business') === 'it')) return false;
+      }
+      if (filter.acceptance === 'business-open') {
+        if (!isBuiltOrBeyond) return false;
+        if (accs.some((a) => (a.gate ?? 'business') === 'business')) return false;
+      }
     }
     return true;
   };
@@ -217,12 +287,14 @@ export function buildRegisterData(
       `Release: ${filter.releaseMode === 'exact' ? 'nur' : 'bis'} ${versionName.get(filter.release) ?? filter.release}`,
     );
   }
-  if (filter.status) filterParts.push(`Status: ${STATUS_DE[filter.status]}`);
-  if (filter.hideDone) filterParts.push('ohne Umgesetzte');
+  if (filter.status) filterParts.push(`Status: ${statusFilterLabel(filter.status)}`);
+  if (filter.hideDone) filterParts.push('ohne Gebaute');
   if (filter.priority) filterParts.push(`Priorität: ${PRIO[filter.priority]}`);
   if (filter.acceptance === 'none') filterParts.push('Abnahme: ohne Urteil');
   if (filter.acceptance === 'mine-open') filterParts.push('Abnahme: eigenes Urteil ausstehend');
-  if (filter.acceptance === 'rejected') filterParts.push('Abnahme: abgelehnt');
+  if (filter.acceptance === 'rejected') filterParts.push('Abnahme: zurückgewiesen');
+  if (filter.acceptance === 'it-open') filterParts.push('IT-Prüfung offen');
+  if (filter.acceptance === 'business-open') filterParts.push('Abnahme offen');
   const filterLabel = filterParts.length > 0 ? filterParts.join(' · ') : null;
 
   // Depth-first order for chapter (= parent) sorting.
@@ -242,8 +314,7 @@ export function buildRegisterData(
     (chapters.get(key) ?? chapters.set(key, []).get(key)!).push(n);
   }
 
-  const counts = { Umgesetzt: 0, Teilweise: 0, Offen: 0 };
-  for (const n of requirements) counts[statusOf(progressOf(n)) as keyof typeof counts]++;
+  const counts = stageCounts(requirements.map(stageOf));
 
   const orderedChapters = [...chapters.entries()]
     .sort((a, b) => (dfs.get(a[0]) ?? Infinity) - (dfs.get(b[0]) ?? Infinity))
@@ -257,29 +328,35 @@ export function buildRegisterData(
         )
         .map((n) => {
           const p = progressOf(n);
-          const status = statusOf(p);
+          const stage = stageOf(n);
+          const status = STAGE_LABEL[stage];
           const effort = computed.get(n.id)?.computedEffort ?? n.effortEstimate ?? 0;
           const abnahme = (accByNode.get(n.id) ?? []).map((a) => {
             const d = a.acceptedAt.slice(5, 10).split('-').reverse().join('.');
             const stale = acceptanceIsStale(a, p, n.revision) ? ' ⚠' : '';
+            // Prefix the gate: two ✓ from the same person on the same row
+            // are otherwise indistinguishable.
+            const who = `${GATE_SHORT[a.gate ?? 'business']}: ${a.userName}`;
             if (a.decision === 'rejected') {
               const why = a.comment ? ` («${truncate(a.comment, 60)}»)` : '';
-              return `${a.userName} ✗ ${d}.${why}${stale}`;
+              return `${who} ✗ ${d}.${why}${stale}`;
             }
-            return `${a.userName} ✓ ${d}.${stale}`;
+            return `${who} ✓ ${d}.${stale}`;
           });
           return {
             id: n.requirementId ?? '',
             text: (n.requirementText ?? n.text).replace(/\n/g, ' '),
             prio: PRIO[n.requirementPriority ?? ''] ?? '—',
             release: releaseOf(n),
+            stage,
             status,
-            // "Teilweise" alone reads the same at 5 % and 95 % — the number
-            // is the whole point of a derived status.
-            statusDetail: status === 'Teilweise' ? `${status} · ${Math.round(p)} %` : status,
+            // "In Umsetzung" alone reads the same at 5 % and 95 % — the
+            // number is the whole point of a derived status. Past the
+            // build line the percentage says nothing the stage doesn't.
+            statusDetail: stage === 'in_progress' ? `${status} · ${Math.round(p)} %` : status,
             progress: Math.round(p),
             aufwand: sizeOf(effort),
-            rest: status === 'Umgesetzt' ? '—' : sizeOf(effort * (1 - p / 100)),
+            rest: p >= BUILT_THRESHOLD ? '—' : sizeOf(effort * (1 - p / 100)),
             abnahme,
           };
         }),
@@ -301,9 +378,10 @@ export function buildRegisterData(
 const LEGEND = [
   '**Priorität:** Muss — Kernfunktion (MVP) · Soll — wichtig, nicht MVP-blockierend · Kann — wünschenswert',
   '**Release:** geplante Version · **↳** = aus den darunterliegenden Arbeitspaketen abgeleitet · «—» noch keiner Version zugeordnet',
-  '**Status:** Umgesetzt · Teilweise (mit Fortschritt) · Offen (abgeleitet: 100 % / >0 % / 0 % Fortschritt)',
-  '**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» bei Umgesetzt): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen',
-  '**Abnahme:** ✓ abgenommen · ✗ abgelehnt (mit Begründung) · ⚠ seit dem Urteil geändert',
+  '**Status:** Offen · In Umsetzung (mit Fortschritt) · **Gebaut** (Code fertig, noch niemand hat es geprüft) · **IT-geprüft** (Abnahme durch die Fachseite steht aus) · **Abgenommen** (Fachseite hat unterschrieben) · **Zurückgewiesen** (mit Begründung)',
+  '**Gebaut ist nicht abgenommen.** Offen/In Umsetzung/Gebaut leiten sich aus dem Projektfortschritt ab; IT-geprüft, Abgenommen und Zurückgewiesen entstehen ausschliesslich aus einem namentlichen Urteil.',
+  '**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» ab Gebaut): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen',
+  '**Abnahme:** zwei Stufen — **IT** (funktioniert es?) und **Business** (ist es das, was wir bestellt haben?) · ✓ erteilt · ✗ zurückgewiesen (mit Begründung) · ⚠ seit dem Urteil geändert',
 ];
 
 /**
@@ -318,9 +396,17 @@ function scopeLine(data: RegisterData): string {
     : `**Umfang:** alle ${data.totalAll} Anforderungen dieses Projekts`;
 }
 
+/**
+ * The funnel, not a single "done" number. Stages with a count of 0 are
+ * dropped so the line stays readable — except the first: "0 Abgenommen"
+ * is precisely the fact a reader must not be able to miss.
+ */
 function standLine(data: RegisterData): string {
   const subject = data.total === 1 ? 'dieser Anforderung' : `dieser ${data.total} Anforderungen`;
-  return `**Stand ${subject}:** ${data.counts.Umgesetzt} Umgesetzt · ${data.counts.Teilweise} Teilweise · ${data.counts.Offen} Offen`;
+  const parts = STAGE_ORDER.filter(
+    (s) => data.counts[s] > 0 || s === 'accepted',
+  ).map((s) => `${data.counts[s]} ${STAGE_LABEL[s]}`);
+  return `**Stand ${subject}:** ${parts.join(' · ')}`;
 }
 
 export function renderMarkdown(data: RegisterData): string {
@@ -362,11 +448,14 @@ export function renderMarkdown(data: RegisterData): string {
 
 // ── DOCX renderer ─────────────────────────────────────────────────
 
-const STATUS_FILL: Record<string, string> = {
-  Umgesetzt: 'd1fae5',
-  Teilweise: 'fef3c7',
-  Offen: 'f1f5f9',
-};
+/**
+ * Cell shading per stage, from the shared palette. Green belongs to the
+ * two signed-off stages only — leaving "Gebaut" green would have made the
+ * rename cosmetic, since a skimming reader goes by the colour.
+ */
+const STATUS_FILL: Record<RequirementStage, string> = Object.fromEntries(
+  STAGE_ORDER.map((s) => [s, STAGE_COLOR[s].bg.replace('#', '')]),
+) as Record<RequirementStage, string>;
 
 /** Subtle alternate-row fill, mirroring the register UI's hover tone. */
 const ZEBRA_FILL = 'f8fafc';
@@ -472,7 +561,8 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
   );
 
   data.chapters.forEach((ch, i) => {
-    const doneInChapter = ch.rows.filter((r) => r.status === 'Umgesetzt').length;
+    const builtInChapter = ch.rows.filter((r) => r.progress >= BUILT_THRESHOLD).length;
+    const acceptedInChapter = ch.rows.filter((r) => r.stage === 'accepted').length;
     children.push(
       new Paragraph({
         heading: HeadingLevel.HEADING_1,
@@ -481,7 +571,7 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
           new TextRun(`${i + 1}. ${ch.name}`),
           // Same at-a-glance counts as the register UI's group header rows.
           new TextRun({
-            text: `   ${ch.rows.length} Anforderung${ch.rows.length === 1 ? '' : 'en'} · ${doneInChapter} umgesetzt`,
+            text: `   ${ch.rows.length} Anforderung${ch.rows.length === 1 ? '' : 'en'} · ${builtInChapter} gebaut · ${acceptedInChapter} abgenommen`,
             bold: false,
             size: 18,
             color: '64748b',
@@ -512,7 +602,7 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
           cell(r.text, { width: COL_PCT[1], fill: zebra }),
           cell(r.prio, { width: COL_PCT[2], fill: zebra, bold: r.prio === 'Muss' }),
           cell(r.release, { width: COL_PCT[3], fill: zebra }),
-          cell(r.statusDetail, { fill: STATUS_FILL[r.status], width: COL_PCT[4] }),
+          cell(r.statusDetail, { fill: STATUS_FILL[r.stage], width: COL_PCT[4] }),
           cell(bar.text, { width: COL_PCT[5], fill: zebra, color: bar.color }),
           cell(r.aufwand, { width: COL_PCT[6], fill: zebra }),
           cell(r.rest, { width: COL_PCT[7], fill: zebra }),

--- a/packages/server/src/lint/engine.ts
+++ b/packages/server/src/lint/engine.ts
@@ -76,6 +76,8 @@ export interface AcceptanceInfo {
   acceptedAt: string;
   progressAtAcceptance: number;
   nodeRevisionAtAcceptance: number;
+  /** Which gate went stale. Absent on pre-split rows, which were business. */
+  gate?: 'it' | 'business';
 }
 
 export interface LintOptions {
@@ -416,7 +418,9 @@ export function computePlanLint(opts: LintOptions): LintReport | { error: string
       .map(({ a, node }) =>
         finding(
           node,
-          `accepted by ${a.userName} on ${a.acceptedAt.slice(0, 10)} at ${a.progressAtAcceptance.toFixed(0)}% (rev ${a.nodeRevisionAtAcceptance}) — now ${progressOf(node).toFixed(0)}% (rev ${node.revision})`,
+          // Name the gate: with two verdicts per node, "re-review with the
+          // acceptor" is only actionable if you know which one went stale.
+          `${a.gate ?? 'business'} gate signed by ${a.userName} on ${a.acceptedAt.slice(0, 10)} at ${a.progressAtAcceptance.toFixed(0)}% (rev ${a.nodeRevisionAtAcceptance}) — now ${progressOf(node).toFixed(0)}% (rev ${node.revision})`,
         ),
       ),
     skipped: opts.acceptances == null ? 'acceptance data unavailable' : undefined,

--- a/packages/server/src/routes/acceptances.ts
+++ b/packages/server/src/routes/acceptances.ts
@@ -40,7 +40,7 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
           error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
         });
       }
-      const body = (req.body ?? {}) as { decision?: string; comment?: string };
+      const body = (req.body ?? {}) as { decision?: string; comment?: string; gate?: string };
       const decision = body.decision ?? 'accepted';
       if (decision !== 'accepted' && decision !== 'rejected') {
         return reply.status(400).send({
@@ -48,6 +48,14 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
             code: 'INVALID_DECISION',
             message: "decision must be 'accepted' or 'rejected'",
           },
+        });
+      }
+      // Default 'business': a body-less POST is the #218 acceptance, which
+      // was always the business sign-off.
+      const gate = body.gate ?? 'business';
+      if (gate !== 'it' && gate !== 'business') {
+        return reply.status(400).send({
+          error: { code: 'INVALID_GATE', message: "gate must be 'it' or 'business'" },
         });
       }
       const comment = typeof body.comment === 'string' ? body.comment.trim() : '';
@@ -98,13 +106,13 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
         node.revision,
         decision,
         comment.length > 0 ? comment : null,
+        gate,
       );
       if (!acceptance) {
         return reply.status(409).send({
           error: {
             code: 'ALREADY_ACCEPTED',
-            message:
-              'You already have an active verdict on this requirement — revoke it first to change it',
+            message: `You already have an active ${gate} verdict on this requirement — revoke it first to change it`,
           },
         });
       }
@@ -115,7 +123,9 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
   );
 
   // ── DELETE /api/maps/:id/nodes/:nodeId/acceptance — revoke own ─
-  app.delete<{ Params: { id: string; nodeId: string } }>(
+  // Gate travels as a query param, not a body: a DELETE with a JSON body
+  // is the shape Fastify 400s on when the header and body disagree.
+  app.delete<{ Params: { id: string; nodeId: string }; Querystring: { gate?: string } }>(
     '/api/maps/:id/nodes/:nodeId/acceptance',
     async (req, reply) => {
       const userId = req.userId;
@@ -124,16 +134,25 @@ export async function acceptanceRoutes(app: FastifyInstance): Promise<void> {
           error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
         });
       }
+      const gate = req.query.gate ?? 'business';
+      if (gate !== 'it' && gate !== 'business') {
+        return reply.status(400).send({
+          error: { code: 'INVALID_GATE', message: "gate must be 'it' or 'business'" },
+        });
+      }
       const perm = await permDb.getPermission(req.params.id, userId);
       if (!permDb.hasPermission(perm, 'view')) {
         return reply.status(403).send({
           error: { code: 'FORBIDDEN', message: 'You do not have access to this map' },
         });
       }
-      const revoked = await acceptanceDb.revoke(req.params.nodeId, userId);
+      const revoked = await acceptanceDb.revoke(req.params.nodeId, userId, gate);
       if (!revoked) {
         return reply.status(404).send({
-          error: { code: 'NO_ACTIVE_ACCEPTANCE', message: 'No active acceptance to revoke' },
+          error: {
+            code: 'NO_ACTIVE_ACCEPTANCE',
+            message: `No active ${gate} verdict to revoke`,
+          },
         });
       }
       broadcast(req.params.id, { type: 'acceptance:changed', nodeId: req.params.nodeId });

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -25,6 +25,29 @@ import { workspaces, users, releaseSnapshots } from '../db/schema.js';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? 'mindblown-dev-secret-change-in-production';
 
+/**
+ * Accepted `?status=` values on the requirements export: the six lifecycle
+ * stages, plus the two pre-split progress buckets that older links send.
+ */
+const STATUS_FILTER_VALUES = [
+  'open',
+  'in_progress',
+  'built',
+  'it_verified',
+  'accepted',
+  'rejected',
+  'partial',
+  'done',
+] as const;
+
+const ACCEPTANCE_FILTER_VALUES = [
+  'none',
+  'mine-open',
+  'rejected',
+  'it-open',
+  'business-open',
+] as const;
+
 interface MapProjection {
   totalScope: number;
   totalDone: number;
@@ -247,7 +270,12 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
   //
   // Filter params mirror the Requirements view's filter bar so the export
   // matches what's on screen: ?status=, ?priority=, ?release=<versionId|none>,
-  // ?releaseMode=cumulative|exact, ?hideDone=1, ?acceptance=none|mine-open|rejected.
+  // ?releaseMode=cumulative|exact, ?hideDone=1, ?acceptance=…
+  //
+  // ?status= takes a lifecycle stage (open, in_progress, built, it_verified,
+  // accepted, rejected). 'partial' and 'done' stay accepted so links and
+  // bookmarks from before the stage split keep working — they filter on
+  // progress alone, which is what they always meant.
   app.get<{
     Params: { id: string };
     Querystring: {
@@ -289,10 +317,10 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           ? (value as T)
           : undefined;
       for (const [key, allowed] of [
-        ['status', ['open', 'partial', 'done']],
+        ['status', STATUS_FILTER_VALUES],
         ['priority', ['must', 'should', 'could']],
         ['releaseMode', ['cumulative', 'exact']],
-        ['acceptance', ['none', 'mine-open', 'rejected']],
+        ['acceptance', ACCEPTANCE_FILTER_VALUES],
       ] as const) {
         const value = q[key];
         if (value !== undefined && !(allowed as readonly string[]).includes(value)) {
@@ -316,12 +344,12 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const register = buildRegisterData(data.map, data.nodes, computed, acceptances, versions, {
-        status: oneOf(q.status, ['open', 'partial', 'done']),
+        status: oneOf(q.status, STATUS_FILTER_VALUES),
         priority: oneOf(q.priority, ['must', 'should', 'could']),
         release: q.release,
         releaseMode: oneOf(q.releaseMode, ['cumulative', 'exact']),
         hideDone: q.hideDone === '1' || q.hideDone === 'true',
-        acceptance: oneOf(q.acceptance, ['none', 'mine-open', 'rejected']),
+        acceptance: oneOf(q.acceptance, ACCEPTANCE_FILTER_VALUES),
         currentUserId: req.userId ?? null,
       });
       const format = q.format ?? 'md';


### PR DESCRIPTION
## Problem

Das Register leitete den Status allein aus dem Fortschritts-Rollup ab und nannte 100 % **"Done"**. Auf der echten Roadmap-Map las die Kopfzeile damit `163 requirements · 116 done` — und die Fachseite liest das als Erfüllungsgrad. Gemergter Code heisst aber nicht, dass jemand bekommen hat, was er bestellt hat. Das Wort widerspricht sogar der eigenen Definition of Done in `CLAUDE.md` ("a real user can exercise it").

Die Abnahme aus #218/#230 existierte, lag aber als Spalte am rechten Rand und zählte in keiner Summe mit.

## Was sich ändert

**Eine abgeleitete Stufe statt eines Fortschritts-Labels.** `requirementStage()` in `@mindblown/core` faltet den Rollup mit den Urteilen zusammen:

| Stufe | entsteht aus |
|---|---|
| Offen / In Umsetzung / **Gebaut** | Fortschritt (0 / >0 / ≥99,5 %) |
| **IT-geprüft** | ein `gate='it'`-Urteil |
| **Abgenommen** | ein `gate='business'`-Urteil |
| **Zurückgewiesen** | irgendein aktives ✗ — schlägt alles andere |

Weiterhin nichts gespeichert. Labels und Farben liegen einmal in `core`, damit Register, Word-Export und MCP wortgleich sind.

**`requirement_acceptances.gate`** ('it' | 'business') — zwei unabhängige Urteile pro Anforderung. Die Gates sind bewusst *keine* Pipeline: alle bestehenden Zeilen werden per `DEFAULT` auf `business` gebackfillt (das waren sie), also ist "business-abgenommen ohne IT-Urteil" ein normaler Zustand.

**Grün ist ab jetzt für Abgenommen/IT-geprüft reserviert**, Gebaut wird blau. Ohne den Farbwechsel wäre die Umbenennung kosmetisch — beim Überfliegen liest man das Farbfeld, nicht das Wort. Gilt auch für die Zellhinterlegung im Word-Export.

**Der Funnel ersetzt die "done"-Zahl** in Kopfzeile, Kapitelzählern und der Stand-Zeile des Dokuments. Die grosse Zahl ist die abgenommene.

## Migrations-Detail

Der Aktiv-Index wächst von `(node_id, user_id)` auf `(node_id, user_id, gate)`. Die neue Variante wird angelegt **bevor** die alte fällt — die andere Reihenfolge lässt bei jedem API-Restart ein Fenster offen, in dem gleichzeitige Accepts unbewacht sind. Der Fehler-Mapper akzeptiert beide Indexnamen, damit ein rollender Deploy nichts umbringt.

## Oberflächen (alle in diesem PR)

Register · Mobile-Reqs-Tab (lädt jetzt Urteile mit) · REST (`gate` im POST-Body, als Query-Param im DELETE) · Markdown- und Word-Export · MCP: `accept_requirement` / `reject_requirement` / `revoke_acceptance` bekommen `gate`, `requirements_overview` zeigt Stufen + Funnel · `plan_lint` benennt das stale gewordene Gate.

Zwei neue Filter-Queues: **IT-Prüfung offen** und **Abnahme offen** — bewusst nur für Gebautes, sonst verstopfen 0 %-Anforderungen die Warteschlange. **"Gebaute ausblenden"** lässt Zurückgewiesene stehen.

## Rückwärtskompatibilität

`?status=done|partial` (Links, Bookmarks, ältere MCP-Aufrufe) filtern weiter rein auf Fortschritt. Ein body-loser POST auf `/acceptance` bleibt die Business-Abnahme.

## Was das am Tag 1 tut

Die Zahl auf der Seite fällt von *116 gebaut* auf *0 abgenommen*, bis jemand unterschreibt. Das ist beabsichtigt und der ehrliche Stand — kein Backfill von Urteilen, die niemand gefällt hat.

## Verifikation

`pnpm turbo typecheck` 11/11 grün · `pnpm turbo test` 1095 Tests grün. Neu abgedeckt: Stufen-Ableitung inkl. Rejection-Vorrang und gate-loser Alt-Zeilen (core), Gate-Präfix in der Abnahme-Spalte, die beiden Review-Queues, Stage- vs. Legacy-Status-Filter und dass `hideDone` Zurückgewiesene stehen lässt (server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hmg59MysVp454euVc4Yx6s