### PR TITLE
fix(requirements): stop dimming 90% of the GitHub column

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { compareVersions, collectRequirementGhLinks } from '@mindblown/core';
 import type { Node, Version } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
+import { linkColor, linkWeight } from './ghLinkStyle.js';
 import { REQ_VERSION_NONE } from './urlState.js';
 import * as api from './api.js';
 
@@ -1029,8 +1030,19 @@ function ChapterGroup({
                     onClick={(e) => e.stopPropagation()}
                     title={titleParts.length > 0 ? titleParts.join(' — ') : undefined}
                     style={{
-                      color: l.inherited ? '#93c5fd' : '#3b82f6',
-                      opacity: l.state === 'closed' ? 0.5 : 1,
+                      // Two signals, one channel. Colour family = issue
+                      // state, shade within it = own vs inherited.
+                      //
+                      // Opacity used to carry "closed", back when the
+                      // `state` field was almost never written and so
+                      // nothing actually dimmed. Once it was populated
+                      // ~90% of links turned out to be closed, which made
+                      // dimming the default and stacked it with the pale
+                      // inherited blue into a near-invisible tier. Marking
+                      // the majority is backwards — open is the exception
+                      // worth the eye, so it gets the colour and weight.
+                      color: linkColor(l.state, l.inherited),
+                      fontWeight: linkWeight(l.state),
                       textDecoration: 'none',
                       marginLeft: i > 0 ? 6 : 0,
                     }}
@@ -1276,6 +1288,7 @@ const numericCellStyle: React.CSSProperties = {
 
 /** Issue links shown before collapsing the rest into a "+N" hint. */
 const GH_LINK_CAP = 2;
+
 
 const groupHeaderStyle: React.CSSProperties = {
   padding: '10px 16px',

--- a/packages/mindmap/src/__tests__/linkColor.test.ts
+++ b/packages/mindmap/src/__tests__/linkColor.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { linkColor } from '../ghLinkStyle.js';
+
+/**
+ * The GitHub column encodes two things at once: whether the issue is
+ * still open, and whether it's linked on the requirement itself or on
+ * work beneath it.
+ *
+ * These used to be colour and opacity respectively. That broke once the
+ * `state` field was actually populated: ~90% of links turned out to be
+ * closed, so the dimmed branch became the default, and dimming stacked
+ * on the pale inherited blue produced a tier that was effectively
+ * invisible. Both signals now live in colour, at full opacity.
+ */
+describe('linkColor', () => {
+  it('separates open from closed by colour family', () => {
+    // Blue = live work, slate = done. Distinct families, not shades of
+    // one — this is the distinction the reader scans for first.
+    expect(linkColor('open', false)).toBe('#2563eb');
+    expect(linkColor('closed', false)).toBe('#64748b');
+    expect(linkColor('open', false)).not.toBe(linkColor('closed', false));
+  });
+
+  it('separates own from inherited within each family', () => {
+    expect(linkColor('open', true)).toBe('#60a5fa');
+    expect(linkColor('closed', true)).toBe('#94a3b8');
+    expect(linkColor('open', true)).not.toBe(linkColor('open', false));
+    expect(linkColor('closed', true)).not.toBe(linkColor('closed', false));
+  });
+
+  it('never repeats a colour across the four states', () => {
+    const all = [
+      linkColor('open', false),
+      linkColor('open', true),
+      linkColor('closed', false),
+      linkColor('closed', true),
+    ];
+    expect(new Set(all).size).toBe(4);
+  });
+
+  it('treats unknown state as open rather than claiming closed', () => {
+    // A link written before `state` existed, or one the resolver hasn't
+    // reached, must not be rendered as done work — same rule the old
+    // dimming followed.
+    expect(linkColor(undefined, false)).toBe(linkColor('open', false));
+    expect(linkColor(undefined, true)).toBe(linkColor('open', true));
+  });
+});

--- a/packages/mindmap/src/ghLinkStyle.ts
+++ b/packages/mindmap/src/ghLinkStyle.ts
@@ -1,0 +1,40 @@
+/**
+ * Presentation rules for GitHub link chips in the requirements table.
+ *
+ * Kept out of RequirementsView.tsx so it can be unit-tested without
+ * dragging in the zustand store, which the component module creates at
+ * import time.
+ */
+
+/**
+ * Colour for one GitHub link chip.
+ *
+ * Four states over two axes, all at full opacity so every one stays
+ * readable:
+ *
+ *              own          inherited
+ *   open       #2563eb      #60a5fa     ← blue family, the live work
+ *   closed     #64748b      #94a3b8     ← slate family, done
+ *   unknown    treated as open (we don't know it's closed, so don't
+ *              claim it is)
+ *
+ * Blue vs slate reads as open vs closed at a glance; the lighter shade
+ * within each family reads as "this issue hangs off work below the
+ * requirement, not on the requirement itself".
+ *
+ * Opacity used to carry the closed signal, back when the `state` field
+ * was almost never written and so nothing actually dimmed. Once it was
+ * populated, ~90% of links turned out to be closed — dimming became the
+ * default, and stacked with the pale inherited blue it produced a tier
+ * that was effectively invisible. Marking the majority is backwards, so
+ * open now gets the colour and the weight.
+ */
+export function linkColor(state: 'open' | 'closed' | undefined, inherited: boolean): string {
+  if (state === 'closed') return inherited ? '#94a3b8' : '#64748b';
+  return inherited ? '#60a5fa' : '#2563eb';
+}
+
+/** Open issues carry the emphasis; closed ones sit back at normal weight. */
+export function linkWeight(state: 'open' | 'closed' | undefined): number {
+  return state === 'closed' ? 400 : 600;
+}


### PR DESCRIPTION
Follow-up to #273/#274. Fixing the data exposed a design assumption that had never actually been exercised.

## What happened

The GitHub column encodes two signals on two channels — colour for own-vs-inherited, opacity for open-vs-closed:

```ts
color:   l.inherited ? '#93c5fd' : '#3b82f6',
opacity: l.state === 'closed' ? 0.5 : 1,
```

That was written when `state` was almost never populated, so nothing dimmed and only the colour axis was ever visible. With the field now correct, **2,235 of 2,488 links (90%) are closed**. Dimming became the *default*, and it stacked with the already-pale inherited blue:

| | open | closed |
|---|---|---|
| own | `#3b82f6` @ 1.0 | `#3b82f6` @ 0.5 |
| inherited | `#93c5fd` @ 1.0 | `#93c5fd` @ **0.5** → ≈ `#c9e2fe` |

That last tier is barely visible on white — reported from the live page as "some opaque/4 and some opaque/2".

## The fix

Raising the opacity floor would only mask it; the real problem is that emphasis was marking the 90% case. Both signals move into colour, at full opacity:

```
           own        inherited
open       #2563eb    #60a5fa     blue  — still live work
closed     #64748b    #94a3b8     slate — done
```

Colour *family* reads open-vs-closed at a glance; shade within the family reads own-vs-inherited. Open also gets the heavier weight, being the actionable ~10%. All four states stay legible.

Unknown state renders as open — we don't know it's closed, so we don't claim it is. Same rule the old dimming followed.

## Note on placement

`linkColor`/`linkWeight` live in a new `ghLinkStyle.ts` rather than in `RequirementsView.tsx`. That component module constructs a zustand store at import time, so importing it from a test crashes outside a browser env — the helper is only unit-testable as its own module.

4 new tests: families separate open from closed, shades separate own from inherited, no colour repeats across the four states, and unknown is treated as open.

`pnpm turbo typecheck` clean; 690 server / 93 mindmap / 109 tool-kit tests pass.

## Conflict note

`feat/requirement-acceptance-gates` rewrites ~470 lines of `RequirementsView.tsx`, including the block this touches. Whichever lands second will need a trivial resolution: keep `color: linkColor(l.state, l.inherited)` / `fontWeight: linkWeight(l.state)` and the `ghLinkStyle.js` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFjAoSHBhK9eznsHrf4pEQ