### PR TITLE
fix(requirements): register back to English, and "Code Progress"

### DIFF
--- a/packages/core/src/__tests__/requirements.test.ts
+++ b/packages/core/src/__tests__/requirements.test.ts
@@ -4,6 +4,7 @@ import {
   requirementStage,
   stageCounts,
   STAGE_LABEL,
+  STAGE_LABEL_DE,
   STAGE_COLOR,
   STAGE_ORDER,
 } from '../requirements.js';
@@ -63,11 +64,19 @@ describe('requirementStage', () => {
 
 describe('stage presentation', () => {
   it('reserves green for the two signed-off stages', () => {
-    // The whole point of renaming "Done" to "Gebaut": if built stayed
+    // The whole point of renaming "Done" to "Built": if built stayed
     // green, a skimming reader would still read it as finished.
     expect(STAGE_COLOR.built.bg).not.toBe(STAGE_COLOR.accepted.bg);
-    expect(STAGE_LABEL.built).toBe('Gebaut');
-    expect(STAGE_LABEL.accepted).toBe('Abgenommen');
+    expect(STAGE_LABEL.built).toBe('Built');
+    expect(STAGE_LABEL.accepted).toBe('Accepted');
+  });
+
+  it('keeps the German document wording in step with the English UI', () => {
+    // The app is English; only the Anforderungsdokument is German. Both
+    // sets live in core so a new stage can't reach one and miss the other.
+    expect(Object.keys(STAGE_LABEL_DE).sort()).toEqual(Object.keys(STAGE_LABEL).sort());
+    expect(STAGE_LABEL_DE.built).toBe('Gebaut');
+    expect(STAGE_LABEL_DE.accepted).toBe('Abgenommen');
   });
 
   it('orders the funnel from most to least complete', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,6 +109,7 @@ export {
   stageCounts,
   BUILT_THRESHOLD,
   STAGE_LABEL,
+  STAGE_LABEL_DE,
   STAGE_ORDER,
   STAGE_COLOR,
 } from './requirements.js';

--- a/packages/core/src/requirements.ts
+++ b/packages/core/src/requirements.ts
@@ -58,13 +58,27 @@ export function requirementStage(
 }
 
 /**
- * German labels — the register, the Word export and the MCP overview all
- * speak to the same (German-speaking) business readers, so the wording
- * lives in one place. "Gebaut" rather than "Umgesetzt"/"Done": at 100 %
- * progress the only thing the system actually knows is that the code
- * landed. "Abgenommen" is reserved for a real verdict.
+ * Labels for the product UI, which is English throughout.
+ *
+ * "Built" rather than "Done": at 100 % progress the only thing the system
+ * actually knows is that the code landed. "Accepted" is reserved for a
+ * real verdict.
  */
 export const STAGE_LABEL: Record<RequirementStage, string> = {
+  open: 'Open',
+  in_progress: 'In Progress',
+  built: 'Built',
+  it_verified: 'IT Verified',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+};
+
+/**
+ * Labels for the Anforderungsdokument (Markdown + Word), which is written
+ * for German-speaking business readers and has always been German. Kept
+ * next to the English set so the two can't drift apart.
+ */
+export const STAGE_LABEL_DE: Record<RequirementStage, string> = {
   open: 'Offen',
   in_progress: 'In Umsetzung',
   built: 'Gebaut',

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -23,11 +23,13 @@ import * as api from './api.js';
 // @mindblown/core because the Word export and the MCP overview have to
 // say exactly the same thing.
 //
-// The word matters: 100 % progress is "Gebaut", not "Done" — the rollup
-// only knows that code merged. Green is reserved for the two stages that
-// required a human verdict.
+// The word matters: 100 % code progress is "Built", not "Done" — the
+// rollup only knows that code merged. Green is reserved for the two
+// stages that required a human verdict. (The German wording lives in
+// core too, but only the Anforderungsdokument uses it — the app is
+// English throughout.)
 
-/** The register speaks German because its readers are the business side. */
+/** Gate names. Same two words in the app and in the German export. */
 const GATE_LABEL: Record<RequirementGate, string> = { it: 'IT', business: 'Business' };
 
 const HEALTH_COLOR: Record<string, string> = {
@@ -378,9 +380,9 @@ export function RequirementsView() {
         if (
           !row.built &&
           !window.confirm(
-            `${row.node.requirementId} steht auf «${STAGE_LABEL[row.stage]}» — trotzdem ${
-              gate === 'it' ? 'als IT-geprüft markieren' : 'abnehmen'
-            }?`,
+            `${row.node.requirementId} is "${STAGE_LABEL[row.stage]}" — ${
+              gate === 'it' ? 'mark it IT-verified' : 'accept it'
+            } anyway?`,
           )
         ) {
           return;
@@ -397,7 +399,7 @@ export function RequirementsView() {
   const rejectRequirement = async (row: ReqRow, gate: RequirementGate) => {
     if (!currentMapId || !user) return;
     const comment = window.prompt(
-      `${row.node.requirementId} zurückweisen (${GATE_LABEL[gate]}) — warum? (Begründung erforderlich)`,
+      `Reject ${row.node.requirementId} at the ${GATE_LABEL[gate]} gate — why? (Reason required)`,
     );
     if (comment == null) return; // cancelled
     if (comment.trim() === '') return;
@@ -458,10 +460,10 @@ export function RequirementsView() {
               {totals.accepted}
             </span>
             <span style={{ fontSize: 11, color: '#64748b' }}>
-              von {allRows.length} abgenommen · {totals.built} gebaut, davon{' '}
-              {totals.built - totals.accepted} ohne Abnahme
+              of {allRows.length} accepted · {totals.built} built, {totals.built - totals.accepted}{' '}
+              of them without sign-off
               {(hideDone || statusFilter || priorityFilter || versionFilterActive) &&
-                ` · ${filteredRows.length} angezeigt (gefiltert)`}
+                ` · showing ${filteredRows.length} (filtered)`}
             </span>
           </div>
           <StageFunnel counts={totals} total={allRows.length} />
@@ -472,8 +474,8 @@ export function RequirementsView() {
             aria-pressed={hideDone}
             title={
               hideDone
-                ? `${totals.built} gebaute Anforderung${totals.built === 1 ? '' : 'en'} ausgeblendet — klicken zum Anzeigen`
-                : 'Gebaute Anforderungen ausblenden (100 % Fortschritt; Zurückgewiesene bleiben sichtbar)'
+                ? `${totals.built} built requirement${totals.built === 1 ? '' : 's'} hidden — click to show`
+                : 'Hide requirements whose code is complete (rejected ones stay visible)'
             }
             style={{
               ...secondaryButtonStyle(false),
@@ -482,7 +484,7 @@ export function RequirementsView() {
                 : {}),
             }}
           >
-            {hideDone ? `Gebaute versteckt (${totals.built})` : 'Gebaute ausblenden'}
+            {hideDone ? `Built hidden (${totals.built})` : 'Hide built'}
           </button>
           <select
             value={statusFilter}
@@ -495,7 +497,7 @@ export function RequirementsView() {
             }}
             style={filterSelectStyle}
           >
-            <option value="">Alle Stufen</option>
+            <option value="">All stages</option>
             {STAGE_ORDER.map((s) => (
               <option key={s} value={s}>
                 {STAGE_LABEL[s]}
@@ -578,12 +580,12 @@ export function RequirementsView() {
             onChange={(e) => setAcceptanceFilter(e.target.value as '' | api.AcceptanceFilter)}
             style={filterSelectStyle}
           >
-            <option value="">Abnahme: alle</option>
-            <option value="it-open">IT-Prüfung offen ({totals.itOpen})</option>
-            <option value="business-open">Abnahme offen ({totals.businessOpen})</option>
-            <option value="none">Ohne Urteil</option>
-            <option value="mine-open">Mein Urteil ausstehend</option>
-            <option value="rejected">Zurückgewiesen</option>
+            <option value="">Acceptance: all</option>
+            <option value="it-open">IT review pending ({totals.itOpen})</option>
+            <option value="business-open">Sign-off pending ({totals.businessOpen})</option>
+            <option value="none">No verdict yet</option>
+            <option value="mine-open">My verdict pending</option>
+            <option value="rejected">Rejected</option>
           </select>
           <button
             onClick={() => setShowCreate((v) => !v)}
@@ -718,7 +720,10 @@ export function RequirementsView() {
                 <th style={thStyle}>Priority</th>
                 <th style={thStyle}>Release</th>
                 <th style={thStyle}>Status</th>
-                <th style={thStyle}>Progress</th>
+                {/* "Code Progress", not "Progress": the number is the share
+                    of merged work, which is exactly what "Built" reports
+                    and exactly what a sign-off does NOT follow from. */}
+                <th style={thStyle}>Code Progress</th>
                 <th style={{ ...thStyle, textAlign: 'right' }}>Remaining</th>
                 <th style={thStyle}>GitHub</th>
                 <th style={thStyle}>Acceptance</th>
@@ -787,7 +792,7 @@ function ChapterGroup({
         <td colSpan={9} style={groupHeaderStyle}>
           {chapterText}
           <span style={{ fontWeight: 400, color: '#64748b', marginLeft: 8 }}>
-            {rows.length} req · {built} gebaut · {accepted} abgenommen
+            {rows.length} req · {built} built · {accepted} accepted
           </span>
         </td>
       </tr>
@@ -982,8 +987,8 @@ function ChapterGroup({
             <span
               title={
                 r.built
-                  ? 'Abgeleitet aus Fortschritt + Abnahme-Urteilen. «Gebaut» heisst: Code fertig, noch niemand hat unterschrieben.'
-                  : 'Abgeleitet aus dem Fortschritts-Rollup — die darunterliegende Arbeit abschliessen, um das zu ändern'
+                  ? 'Derived from code progress + sign-off verdicts. "Built" means the code is complete and nobody has signed off yet.'
+                  : 'Derived from the progress rollup — finish the work underneath to change it'
               }
               style={{
                 padding: '2px 8px',
@@ -1118,7 +1123,7 @@ function ChapterGroup({
             )}
           </td>
 
-          {/* Abnahme — one slot per gate. Two ✓ from the same person would
+          {/* Acceptance — one slot per gate. Two ✓ from the same person would
               be indistinguishable without the gate label above them. */}
           <td style={{ ...tdStyle, ...wrappingCellStyle }} onClick={(e) => e.stopPropagation()}>
             <div style={{ display: 'flex', gap: 10 }}>
@@ -1184,10 +1189,10 @@ function GateSlot({
         <span
           onClick={own ? () => onToggle(row, gate) : undefined}
           title={
-            (stale ? 'Seit dem Urteil geändert! ' : '') +
-            `${a.userName}, ${rejected ? 'zurückgewiesen' : 'erteilt'} ${a.acceptedAt.slice(0, 10)} bei ${Math.round(a.progressAtAcceptance)} %` +
-            (rejected && a.comment ? ` — «${a.comment}»` : '') +
-            (own ? ' — klicken zum Zurückziehen' : '')
+            (stale ? 'Changed since this verdict! ' : '') +
+            `${a.userName}, ${rejected ? 'rejected' : 'signed off'} ${a.acceptedAt.slice(0, 10)} at ${Math.round(a.progressAtAcceptance)}%` +
+            (rejected && a.comment ? ` — "${a.comment}"` : '') +
+            (own ? ' — click to withdraw' : '')
           }
           style={{
             display: 'inline-block',
@@ -1211,8 +1216,8 @@ function GateSlot({
             onClick={() => onToggle(row, gate)}
             title={
               gate === 'it'
-                ? 'IT-Prüfung erteilen — funktioniert wie gebaut'
-                : 'Abnehmen — ist das, was bestellt wurde'
+                ? 'Mark IT-verified — it works as built'
+                : 'Accept — this is what was asked for'
             }
             style={ghostChipStyle('#cbd5e1', '#64748b')}
           >
@@ -1220,7 +1225,7 @@ function GateSlot({
           </button>
           <button
             onClick={() => onReject(row, gate)}
-            title="Zurückweisen — Begründung erforderlich"
+            title="Reject — reason required"
             style={ghostChipStyle('#fca5a5', '#b91c1c')}
           >
             ✗

--- a/packages/mindmap/src/mobile/MobileRequirementsView.tsx
+++ b/packages/mindmap/src/mobile/MobileRequirementsView.tsx
@@ -11,7 +11,7 @@ import type { AcceptanceRow, NodeWithComputed } from '../api.js';
 
 // The stage is never stored — derived from the progress rollup folded
 // with the sign-off verdicts, mirroring the desktop RequirementsView.
-// "Gebaut" ≠ "Abgenommen" here too: same words, same colours, one source
+// "Built" ≠ "Accepted" here too: same words, same colours, one source
 // in @mindblown/core.
 
 // 'todo' is the "hide built" button — everything not yet built in one
@@ -138,8 +138,8 @@ export function MobileRequirementsView({
       {/* Lead with the accepted count — the whole point of the stage split
           is that "gebaut" must not read as the finish line. */}
       <div style={{ padding: '0 12px 8px', fontSize: 12, color: '#64748b' }}>
-        <b style={{ fontSize: 17, color: '#047857' }}>{counts.accepted}</b> von {rows.length}{' '}
-        abgenommen · {counts.built} gebaut
+        <b style={{ fontSize: 17, color: '#047857' }}>{counts.accepted}</b> of {rows.length}{' '}
+        accepted · {counts.built} built
       </div>
       <div className="mb-filter-row">
         {(['all', 'todo', 'accepted', 'it_verified', 'built', 'in_progress', 'open', 'rejected'] as const)
@@ -152,7 +152,7 @@ export function MobileRequirementsView({
               aria-pressed={filter === f}
               onClick={() => setFilter(f)}
             >
-              {f === 'all' ? 'Alle' : f === 'todo' ? 'Offene Arbeit' : STAGE_LABEL[f]}
+              {f === 'all' ? 'All' : f === 'todo' ? 'Open work' : STAGE_LABEL[f]}
               <span className="mb-filter-count">{counts[f]}</span>
             </button>
           ))}

--- a/packages/mindmap/src/mobile/MobileViewer.tsx
+++ b/packages/mindmap/src/mobile/MobileViewer.tsx
@@ -96,7 +96,7 @@ export function MobileViewer({ map }: Props) {
         if (!cancelled) setAcceptances(r.acceptances);
       })
       .catch(() => {
-        // Without verdicts the register degrades to "Gebaut" at 100 % —
+        // Without verdicts the register degrades to "Built" at 100 % —
         // under-claiming, which is the safe direction to fail in.
       });
     api

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -10,7 +10,7 @@ import {
   requirementStage,
   stageCounts,
   BUILT_THRESHOLD,
-  STAGE_LABEL,
+  STAGE_LABEL_DE,
   STAGE_ORDER,
   STAGE_COLOR,
 } from '@mindblown/core';
@@ -142,7 +142,7 @@ const LEGACY_STATUS_DE: Record<string, string> = {
 };
 
 function statusFilterLabel(status: string): string {
-  return LEGACY_STATUS_DE[status] ?? STAGE_LABEL[status as RequirementStage] ?? status;
+  return LEGACY_STATUS_DE[status] ?? STAGE_LABEL_DE[status as RequirementStage] ?? status;
 }
 
 /** Gate prefix in the Abnahme cell — short, because the column is narrow. */
@@ -329,7 +329,7 @@ export function buildRegisterData(
         .map((n) => {
           const p = progressOf(n);
           const stage = stageOf(n);
-          const status = STAGE_LABEL[stage];
+          const status = STAGE_LABEL_DE[stage];
           const effort = computed.get(n.id)?.computedEffort ?? n.effortEstimate ?? 0;
           const abnahme = (accByNode.get(n.id) ?? []).map((a) => {
             const d = a.acceptedAt.slice(5, 10).split('-').reverse().join('.');
@@ -405,7 +405,7 @@ function standLine(data: RegisterData): string {
   const subject = data.total === 1 ? 'dieser Anforderung' : `dieser ${data.total} Anforderungen`;
   const parts = STAGE_ORDER.filter(
     (s) => data.counts[s] > 0 || s === 'accepted',
-  ).map((s) => `${data.counts[s]} ${STAGE_LABEL[s]}`);
+  ).map((s) => `${data.counts[s]} ${STAGE_LABEL_DE[s]}`);
   return `**Stand ${subject}:** ${parts.join(' · ')}`;
 }
 
@@ -461,12 +461,14 @@ const STATUS_FILL: Record<RequirementStage, string> = Object.fromEntries(
 const ZEBRA_FILL = 'f8fafc';
 
 // Column widths as % of table width: ID, Anforderung, Priorität, Release,
-// Status, Fortschritt, Aufwand, Rest, Abnahme. LibreOffice ignores
+// Status, Code-Fortschritt, Aufwand, Rest, Abnahme. LibreOffice ignores
 // percentage widths that only sit on header cells — the table needs an
 // explicit grid (columnWidths, in DXA) and fixed layout, and every cell
-// must carry its column width. Fortschritt is sized so bar + percentage
-// stay on ONE line, Aufwand/Rest so their headers don't wrap.
-const COL_PCT = [7, 33, 6, 8, 10, 12, 6, 6, 12];
+// must carry its column width. Code-Fortschritt is sized so bar +
+// percentage stay on ONE line and the (longer) header doesn't wrap;
+// Aufwand/Rest likewise. The 2 points it gained came from Anforderung,
+// which has the most slack.
+const COL_PCT = [7, 31, 6, 8, 10, 14, 6, 6, 12];
 // Usable A4 LANDSCAPE width with 2 cm (1134 twip) margins.
 const PAGE_MARGIN = 1134;
 const TABLE_DXA = 16838 - 2 * PAGE_MARGIN;
@@ -587,7 +589,7 @@ export async function renderDocx(data: RegisterData): Promise<Buffer> {
         cell('Priorität', { bold: true, fill: 'e2e8f0', width: COL_PCT[2] }),
         cell('Release', { bold: true, fill: 'e2e8f0', width: COL_PCT[3] }),
         cell('Status', { bold: true, fill: 'e2e8f0', width: COL_PCT[4] }),
-        cell('Fortschritt', { bold: true, fill: 'e2e8f0', width: COL_PCT[5] }),
+        cell('Code-Fortschritt', { bold: true, fill: 'e2e8f0', width: COL_PCT[5] }),
         cell('Aufwand', { bold: true, fill: 'e2e8f0', width: COL_PCT[6] }),
         cell('Rest', { bold: true, fill: 'e2e8f0', width: COL_PCT[7] }),
         cell('Abnahme', { bold: true, fill: 'e2e8f0', width: COL_PCT[8] }),


### PR DESCRIPTION
Zwei Korrekturen zu #275.

## Die App ist englisch

#275 hat deutsche Stufen-Labels, Filter, Buttons und Dialoge ins Register und in den mobilen Reqs-Tab geschoben. Falsch: nur das **Anforderungsdokument** (Markdown + Word) richtet sich an deutschsprachige Business-Leser, und das war es immer schon.

- `STAGE_LABEL` ist jetzt englisch: Open · In Progress · **Built** · IT Verified · **Accepted** · Rejected
- `STAGE_LABEL_DE` liegt daneben in `core` und speist ausschliesslich den Export: Offen · In Umsetzung · Gebaut · IT-geprüft · Abgenommen · Zurückgewiesen

Beide Sets im selben Modul, plus ein Test auf Schlüsselgleichheit — sonst erreicht eine neue Stufe irgendwann das eine Set und verfehlt das andere.

Zurückübersetzt: Statusfilter, Abnahme-Filter (inkl. der beiden Queues), „Hide built", Kapitel-Zähler, Stufen-Tooltip, Bestätigungs- und Ablehnungsdialog, die ✓/✗-Tooltips der Gate-Slots, und die Mobile-Kopfzeile samt Filter-Chips.

## „Code Progress" statt „Progress"

Die Zahl ist der Anteil gemergter Arbeit — dasselbe, was **Built** meldet, und genau das, woraus eine Abnahme *nicht* folgt. Eine Spalte namens „Progress" direkt neben der Stufen-Spalte lädt zu der Lesart ein, gegen die die Stufen überhaupt existieren.

- Register: `Code Progress`
- Word-Export: `Code-Fortschritt` — die Spalte bekommt 2 Prozentpunkte Breite von „Anforderung" ab, damit der längere Titel nicht umbricht

## Verifikation

`pnpm turbo typecheck` 11/11 grün · `pnpm turbo test` 1100 Tests grün, Lauf nach der letzten Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hmg59MysVp454euVc4Yx6s