### PR TITLE
fix(requirements): distinguish the +N overflow badge from a link

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1116,7 +1116,10 @@ function ChapterGroup({
                   .slice(GH_LINK_CAP)
                   .map((l) => (l.id.includes('#') ? `#${l.id.split('#')[1]}` : l.id))
                   .join(', ')}
-                style={{ color: '#94a3b8', marginLeft: 6, cursor: 'help' }}
+                // Not #94a3b8: that is exactly the inherited-closed link
+                // colour, so the overflow count read as one more link of
+                // the same kind rather than a count of hidden ones.
+                style={{ color: '#475569', marginLeft: 6, cursor: 'help' }}
               >
                 +{r.ghLinks.length - GH_LINK_CAP}
               </span>


### PR DESCRIPTION
Small follow-up to #276, cleaning up an ambiguity that PR introduced.

The GitHub column caps how many links it renders (`GH_LINK_CAP`) and shows `+N` for the remainder. That badge was `#94a3b8` — which is now precisely the colour #276 assigns to an *inherited, closed* link. So on a row with hidden links, `+2` rendered identically to one more chip of that kind, reading as another link rather than a count of concealed ones.

Darkened to `#475569`: outside both the blue (open) and slate (closed) link families, so it reads as metadata. The `—` placeholder for "no links" stays `#cbd5e1` and was never part of the collision.

`pnpm turbo typecheck` clean; 695 server / 93 mindmap tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFjAoSHBhK9eznsHrf4pEQ