### PR TITLE
feat(requirements): Abnahme-Karte in der Requirements-View + verificationVideoUrl

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -45,6 +45,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     phaseId: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -43,6 +43,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     phaseId: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -46,6 +46,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     phaseId: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -272,6 +272,15 @@ export interface Node {
    */
   verificationUrl: string | null;
 
+  /**
+   * Link to a short demo video showing the requirement in action (e.g. a
+   * screen recording). Rendered as a "watch video" button on the review
+   * surface next to `verificationUrl`. Optional companion to the written
+   * Prüfanleitung — a non-technical reviewer who can't follow the steps
+   * can watch instead. Like the other two, NOT in the GitHub SYNC_FIELDS.
+   */
+  verificationVideoUrl: string | null;
+
   // ── Auto-progress (parent-epic rollup) ────────────────────
   /**
    * When set to `'children'`, the server auto-computes percentComplete on this

--- a/packages/mcp/src/__tests__/requirementScope.test.ts
+++ b/packages/mcp/src/__tests__/requirementScope.test.ts
@@ -41,6 +41,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     phaseId: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     claimedBySession: null,
     claimedAt: null,
     computedEffort: 0,

--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -40,6 +40,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     phaseId: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     claimedBySession: null,
     claimedAt: null,
     computedEffort: 0,

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -143,6 +143,7 @@ export interface NodeWithComputed {
   phaseId: string | null;
   verificationText: string | null;
   verificationUrl: string | null;
+  verificationVideoUrl: string | null;
   // Orchestration substrate (#111) — surfaced for slot accounting (#153).
   claimedBySession: string | null;
   claimedAt: string | null;

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -205,6 +205,7 @@ function PropertyPanelInner({
   const [requirementId, setRequirementId] = useState(node.requirementId ?? '');
   const [verificationText, setVerificationText] = useState(node.verificationText ?? '');
   const [verificationUrl, setVerificationUrl] = useState(node.verificationUrl ?? '');
+  const [verificationVideoUrl, setVerificationVideoUrl] = useState(node.verificationVideoUrl ?? '');
 
   // Sync local state when node changes externally
   useEffect(() => { setTitle(node.text); }, [node.text]);
@@ -218,6 +219,7 @@ function PropertyPanelInner({
   useEffect(() => { setRequirementId(node.requirementId ?? ''); }, [node.requirementId]);
   useEffect(() => { setVerificationText(node.verificationText ?? ''); }, [node.verificationText]);
   useEffect(() => { setVerificationUrl(node.verificationUrl ?? ''); }, [node.verificationUrl]);
+  useEffect(() => { setVerificationVideoUrl(node.verificationVideoUrl ?? ''); }, [node.verificationVideoUrl]);
 
   const allNodes = useMindmapStore((s) => s.nodes);
   const predecessorTitles = (computedValues?.blockedBy?.predecessorIds ?? [])
@@ -496,6 +498,22 @@ function PropertyPanelInner({
                 onKeyDown={(e) => e.stopPropagation()}
                 style={inputStyle}
                 placeholder="https://staging… (wo wird geprüft?)"
+              />
+            </Field>
+            <Field label="Video-Link">
+              <input
+                value={verificationVideoUrl}
+                onChange={(e) => setVerificationVideoUrl(e.target.value)}
+                onBlur={() => {
+                  const trimmed = verificationVideoUrl.trim();
+                  const persisted = node.verificationVideoUrl ?? '';
+                  if (trimmed !== persisted) {
+                    directUpdate(nodeId, { verificationVideoUrl: trimmed || null });
+                  }
+                }}
+                onKeyDown={(e) => e.stopPropagation()}
+                style={inputStyle}
+                placeholder="https://… (kurzes Demo-Video)"
               />
             </Field>
           </>

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useMemo, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   compareVersions,
@@ -14,6 +14,7 @@ import {
 import type { Node, Version, RequirementGate, RequirementStage } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import { linkColor, linkWeight } from './ghLinkStyle.js';
+import { isHttpUrl, verificationOf, type Verification } from './verification.js';
 import { REQ_VERSION_NONE } from './urlState.js';
 import * as api from './api.js';
 
@@ -75,32 +76,22 @@ interface ReqRow {
   effectiveVersionId: string | null;
 }
 
-/**
- * The three review-surface fields a non-technical reviewer needs before
- * pressing ✓ or ✗: how to check it, where to check it, and the demo video.
- * Whitespace-only counts as unset — the property panel writes `null` on
- * clear, but older rows can still carry a stray space.
- */
-interface Verification {
-  text: string | null;
-  url: string | null;
-  videoUrl: string | null;
-}
-
-/** null when the requirement carries none of the three — the row then looks exactly as before. */
-function verificationOf(node: Node): Verification | null {
-  const text = node.verificationText?.trim() || null;
-  const url = node.verificationUrl?.trim() || null;
-  const videoUrl = node.verificationVideoUrl?.trim() || null;
-  if (text == null && url == null && videoUrl == null) return null;
-  return { text, url, videoUrl };
-}
-
 function compareReqIds(a: ReqRow, b: ReqRow): number {
   return (a.node.requirementId ?? '').localeCompare(b.node.requirementId ?? '', undefined, {
     numeric: true,
   });
 }
+
+/**
+ * Width of the requirements table, in columns — the `<colgroup>` and
+ * `<thead>` below must list exactly this many.
+ *
+ * Every full-width row (the chapter header, the Abnahme card) spans it. A
+ * mismatch after someone adds a column doesn't crash, it just renders a
+ * card one column short, so the number lives in one place rather than
+ * being repeated at each `colSpan`.
+ */
+const REQ_COLUMN_COUNT = 9;
 
 // ── Component ────────────────────────────────────────────────────
 
@@ -736,7 +727,10 @@ export function RequirementsView() {
             {/* Fixed layout + colgroup: without it the browser sizes columns
                 from their widest cell, so changing the release filter (which
                 changes which selects/chips/links are on screen) reshuffles
-                every column width. */}
+                every column width.
+
+                Adding or removing a <col> here means bumping
+                REQ_COLUMN_COUNT above and adding the matching <th>. */}
             <colgroup>
               <col style={{ width: 100 }} />
               <col /> {/* Requirement — absorbs the remaining width */}
@@ -831,7 +825,7 @@ function ChapterGroup({
   return (
     <>
       <tr>
-        <td colSpan={9} style={groupHeaderStyle}>
+        <td colSpan={REQ_COLUMN_COUNT} style={groupHeaderStyle}>
           {chapterText}
           <span style={{ fontWeight: 400, color: '#64748b', marginLeft: 8 }}>
             {rows.length} req · {built} built · {accepted} accepted
@@ -1212,7 +1206,7 @@ function ChapterGroup({
           // acceptance column: a numbered Anleitung needs the full width, and
           // a tall cell would otherwise stretch every sibling cell in the row.
           <tr style={{ background: stripeFor(i) }} onClick={(e) => e.stopPropagation()}>
-            <td colSpan={9} style={verificationRowStyle}>
+            <td colSpan={REQ_COLUMN_COUNT} style={verificationRowStyle}>
               <VerificationPanel v={verification} />
             </td>
           </tr>
@@ -1231,6 +1225,13 @@ function ChapterGroup({
  * field is unset (no empty placeholder boxes, no `href="#"`).
  */
 function VerificationPanel({ v }: { v: Verification }) {
+  // Both URLs come from free-text columns with no server-side validation,
+  // and this card is the first place in the product that renders them as an
+  // href. A URL that isn't http(s) gets no button at all — linking it to
+  // "#" would look live and do nothing, and rendering it as-is would hand a
+  // `javascript:` payload a click target on the acceptance surface.
+  const appUrl = isHttpUrl(v.url) ? v.url : null;
+  const videoUrl = isHttpUrl(v.videoUrl) ? v.videoUrl : null;
   return (
     <div style={verificationPanelStyle}>
       <div
@@ -1247,15 +1248,15 @@ function VerificationPanel({ v }: { v: Verification }) {
         </span>
         {/* Kept on the header line so they stay reachable without scrolling
             past a long Anleitung. */}
-        {(v.url != null || v.videoUrl != null) && (
+        {(appUrl != null || videoUrl != null) && (
           <span style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-            {v.url != null && (
-              <a href={v.url} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
+            {appUrl != null && (
+              <a href={appUrl} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
                 In der Anwendung öffnen ↗
               </a>
             )}
-            {v.videoUrl != null && (
-              <a href={v.videoUrl} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
+            {videoUrl != null && (
+              <a href={videoUrl} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
                 ▶ Video ansehen
               </a>
             )}
@@ -1268,12 +1269,35 @@ function VerificationPanel({ v }: { v: Verification }) {
         // skips the steps. Capped in height so one essay-length Anleitung
         // can't push the links and the rest of the register off-screen.
         <div className="mb-verification-md" style={verificationMarkdownStyle}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{v.text}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={verificationMarkdownComponents}>
+            {v.text}
+          </ReactMarkdown>
         </div>
       )}
     </div>
   );
 }
+
+/**
+ * Links inside the Prüfanleitung open in a new tab, like the two buttons on
+ * the card's header line.
+ *
+ * react-markdown emits a bare `<a href>` with no target, so without this a
+ * reviewer who clicks a link in step 3 navigates the application away and
+ * loses every open card and filter on the way back. GFM autolinks make that
+ * likely: a naked `https://…` typed into an Anleitung becomes a link
+ * whether the author meant it to or not.
+ *
+ * No isHttpUrl() guard here — react-markdown already runs every href
+ * through defaultUrlTransform, which rewrites `javascript:` and `data:` to
+ * an empty href. The header-line buttons need the guard because nothing
+ * sanitizes those.
+ *
+ * `node` is react-markdown's hast node; it must not reach the DOM.
+ */
+const verificationMarkdownComponents: Components = {
+  a: ({ node: _node, ...props }) => <a {...props} target="_blank" rel="noreferrer" />,
+};
 
 // ── Small pieces ─────────────────────────────────────────────────
 

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import {
   compareVersions,
   collectRequirementGhLinks,
@@ -73,6 +75,27 @@ interface ReqRow {
   effectiveVersionId: string | null;
 }
 
+/**
+ * The three review-surface fields a non-technical reviewer needs before
+ * pressing ✓ or ✗: how to check it, where to check it, and the demo video.
+ * Whitespace-only counts as unset — the property panel writes `null` on
+ * clear, but older rows can still carry a stray space.
+ */
+interface Verification {
+  text: string | null;
+  url: string | null;
+  videoUrl: string | null;
+}
+
+/** null when the requirement carries none of the three — the row then looks exactly as before. */
+function verificationOf(node: Node): Verification | null {
+  const text = node.verificationText?.trim() || null;
+  const url = node.verificationUrl?.trim() || null;
+  const videoUrl = node.verificationVideoUrl?.trim() || null;
+  if (text == null && url == null && videoUrl == null) return null;
+  return { text, url, videoUrl };
+}
+
 function compareReqIds(a: ReqRow, b: ReqRow): number {
   return (a.node.requirementId ?? '').localeCompare(b.node.requirementId ?? '', undefined, {
     numeric: true,
@@ -110,6 +133,18 @@ export function RequirementsView() {
   const [acceptances, setAcceptances] = useState<api.AcceptanceRow[]>([]);
   const [acceptanceFilter, setAcceptanceFilter] = useState<'' | api.AcceptanceFilter>('');
   const [exporting, setExporting] = useState(false);
+
+  // Which rows have their Prüfanleitung panel unfolded. A set, not a single
+  // id: a reviewer working down a chapter compares two requirements against
+  // each other, and collapsing the previous one out from under him loses his
+  // place. Collapsed by default so a register of 60 rows stays scannable.
+  const [openVerification, setOpenVerification] = useState<Set<string>>(() => new Set());
+  const toggleVerification = (nodeId: string) =>
+    setOpenVerification((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(nodeId)) next.add(nodeId);
+      return next;
+    });
 
   useEffect(() => {
     if (!currentMapId) return;
@@ -745,12 +780,15 @@ export function RequirementsView() {
                   currentUserId={user?.id ?? null}
                   toggleAcceptance={toggleAcceptance}
                   rejectRequirement={rejectRequirement}
+                  openVerification={openVerification}
+                  toggleVerification={toggleVerification}
                 />
               ))}
             </tbody>
           </table>
         </div>
       )}
+      <style>{verificationMarkdownCss}</style>
     </div>
   );
 }
@@ -770,6 +808,8 @@ function ChapterGroup({
   currentUserId,
   toggleAcceptance,
   rejectRequirement,
+  openVerification,
+  toggleVerification,
 }: {
   chapterText: string;
   rows: ReqRow[];
@@ -783,6 +823,8 @@ function ChapterGroup({
   currentUserId: string | null;
   toggleAcceptance: (row: ReqRow, gate: RequirementGate) => void;
   rejectRequirement: (row: ReqRow, gate: RequirementGate) => void;
+  openVerification: Set<string>;
+  toggleVerification: (nodeId: string) => void;
 }) {
   const built = rows.filter((r) => r.built).length;
   const accepted = rows.filter((r) => r.stage === 'accepted').length;
@@ -796,9 +838,12 @@ function ChapterGroup({
           </span>
         </td>
       </tr>
-      {rows.map((r, i) => (
+      {rows.map((r, i) => {
+        const verification = verificationOf(r.node);
+        const verificationOpen = verification != null && openVerification.has(r.node.id);
+        return (
+        <Fragment key={r.node.id}>
         <tr
-          key={r.node.id}
           onClick={() => jumpToNode(r.node)}
           onMouseEnter={(e) => (e.currentTarget.style.background = '#eff6ff')}
           onMouseLeave={(e) => (e.currentTarget.style.background = stripeFor(i))}
@@ -1141,10 +1186,92 @@ function ChapterGroup({
                 />
               ))}
             </div>
+            {/* The reviewer pressing ✓/✗ is the one who needs to know how to
+                check it — so the handle sits in this cell, not in a column of
+                its own. Rows without any of the three fields get nothing, so
+                a register that was never annotated looks unchanged. */}
+            {verification && (
+              <button
+                onClick={() => toggleVerification(r.node.id)}
+                aria-expanded={verificationOpen}
+                title={
+                  verificationOpen
+                    ? 'Prüfanleitung einklappen'
+                    : 'Prüfanleitung, Prüf-Link und Video einblenden'
+                }
+                style={verificationToggleStyle(verificationOpen)}
+              >
+                {verificationOpen ? '▾' : '▸'}{' '}
+                {verification.text != null ? 'Prüfanleitung' : 'Prüfen'}
+              </button>
+            )}
           </td>
         </tr>
-      ))}
+        {verificationOpen && (
+          // Own row spanning the table rather than a box inside the 180px
+          // acceptance column: a numbered Anleitung needs the full width, and
+          // a tall cell would otherwise stretch every sibling cell in the row.
+          <tr style={{ background: stripeFor(i) }} onClick={(e) => e.stopPropagation()}>
+            <td colSpan={9} style={verificationRowStyle}>
+              <VerificationPanel v={verification} />
+            </td>
+          </tr>
+        )}
+        </Fragment>
+        );
+      })}
     </>
+  );
+}
+
+/**
+ * The Abnahme card: what a non-technical reviewer needs in front of him
+ * before he presses ✓ or ✗ — the written steps, the deep link into the
+ * running application, and the demo video. Each part is omitted when its
+ * field is unset (no empty placeholder boxes, no `href="#"`).
+ */
+function VerificationPanel({ v }: { v: Verification }) {
+  return (
+    <div style={verificationPanelStyle}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 8,
+        }}
+      >
+        <span style={verificationLabelStyle}>
+          {v.text != null ? 'Prüfanleitung' : 'Prüfen'}
+        </span>
+        {/* Kept on the header line so they stay reachable without scrolling
+            past a long Anleitung. */}
+        {(v.url != null || v.videoUrl != null) && (
+          <span style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {v.url != null && (
+              <a href={v.url} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
+                In der Anwendung öffnen ↗
+              </a>
+            )}
+            {v.videoUrl != null && (
+              <a href={v.videoUrl} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
+                ▶ Video ansehen
+              </a>
+            )}
+          </span>
+        )}
+      </div>
+      {v.text != null && (
+        // Markdown, not raw text: the field is written as "1. … 2. …" and a
+        // reviewer reading literal asterisks and digits is a reviewer who
+        // skips the steps. Capped in height so one essay-length Anleitung
+        // can't push the links and the rest of the register off-screen.
+        <div className="mb-verification-md" style={verificationMarkdownStyle}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{v.text}</ReactMarkdown>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -1473,6 +1600,110 @@ const groupHeaderStyle: React.CSSProperties = {
 
 /** Alternating row background — striping survives hover via onMouseLeave. */
 const stripeFor = (i: number) => (i % 2 === 1 ? '#fbfcfe' : '#ffffff');
+
+// ── Abnahme card (Prüfanleitung / Prüf-Link / Video) ─────────────
+
+/** Ghost chip, same family as the ✓/✗ pair it sits under. */
+function verificationToggleStyle(open: boolean): React.CSSProperties {
+  return {
+    marginTop: 6,
+    padding: '2px 7px',
+    borderRadius: 10,
+    fontSize: 11,
+    fontFamily: 'inherit',
+    border: `1px ${open ? 'solid' : 'dashed'} ${open ? '#a5b4fc' : '#cbd5e1'}`,
+    background: open ? '#eef2ff' : 'transparent',
+    color: open ? '#3730a3' : '#64748b',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+  };
+}
+
+const verificationRowStyle: React.CSSProperties = {
+  padding: '0 16px 12px',
+  // The <td> the panel hangs under is the last cell of the row above it;
+  // the row border would otherwise cut between the two.
+  borderBottom: '1px solid #f1f5f9',
+};
+
+const verificationPanelStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  padding: '10px 14px',
+  borderRadius: 8,
+  // Indigo, matching the chapter header — this belongs to the register
+  // chrome, not to the requirement's own status colours.
+  background: '#f5f7ff',
+  borderLeft: '3px solid #a5b4fc',
+};
+
+const verificationLabelStyle: React.CSSProperties = {
+  fontSize: 9,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: '#6366f1',
+  fontWeight: 700,
+};
+
+const verificationLinkStyle: React.CSSProperties = {
+  padding: '4px 10px',
+  borderRadius: 6,
+  fontSize: 11.5,
+  fontWeight: 600,
+  border: '1px solid #c7d2fe',
+  background: '#ffffff',
+  color: '#4338ca',
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+};
+
+const verificationMarkdownStyle: React.CSSProperties = {
+  fontSize: 12.5,
+  lineHeight: 1.55,
+  color: '#334155',
+  maxWidth: 860,
+  maxHeight: 320,
+  overflowY: 'auto',
+};
+
+/**
+ * index.html applies `* { margin: 0; padding: 0 }`, which strips the
+ * indent an <ol> needs to show its numbers — the whole point of rendering
+ * the Prüfanleitung as markdown. Scoped to this panel, same approach as
+ * HelpOverlay's `.help-markdown`.
+ */
+const verificationMarkdownCss = `
+  .mb-verification-md > :first-child { margin-top: 0; }
+  .mb-verification-md > :last-child { margin-bottom: 0; }
+  .mb-verification-md p { margin: 0 0 8px; }
+  .mb-verification-md ol { margin: 0 0 8px; padding-left: 22px; list-style: decimal outside; }
+  .mb-verification-md ul { margin: 0 0 8px; padding-left: 22px; list-style: disc outside; }
+  .mb-verification-md li { margin-bottom: 3px; }
+  .mb-verification-md h1, .mb-verification-md h2, .mb-verification-md h3 {
+    font-size: 13px; font-weight: 700; margin: 12px 0 6px; color: #0f172a;
+  }
+  .mb-verification-md a { color: #4f46e5; }
+  .mb-verification-md strong { font-weight: 700; color: #0f172a; }
+  .mb-verification-md code {
+    font-family: Menlo, Monaco, monospace; font-size: 11.5px;
+    background: #e8ecf7; padding: 1px 4px; border-radius: 3px;
+  }
+  .mb-verification-md pre {
+    background: #0f172a; color: #e2e8f0; padding: 10px 12px;
+    border-radius: 6px; overflow-x: auto; margin: 0 0 8px;
+  }
+  .mb-verification-md pre code { background: none; padding: 0; color: inherit; }
+  .mb-verification-md blockquote {
+    border-left: 3px solid #c7d2fe; margin: 0 0 8px;
+    padding: 2px 10px; color: #475569;
+  }
+  .mb-verification-md table { border-collapse: collapse; font-size: 12px; margin: 0 0 8px; }
+  .mb-verification-md th, .mb-verification-md td {
+    border: 1px solid #e2e8f0; padding: 4px 8px; text-align: left;
+  }
+  .mb-verification-md th { background: #eef2ff; font-weight: 600; }
+`;
 
 const inputStyle: React.CSSProperties = {
   boxSizing: 'border-box',

--- a/packages/mindmap/src/__tests__/verification.test.ts
+++ b/packages/mindmap/src/__tests__/verification.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@mindblown/core';
+import { isHttpUrl, verificationOf } from '../verification.js';
+
+/**
+ * `verificationOf` decides whether a requirement row grows an Abnahme card
+ * at all. The promise the feature makes is "none of the three fields set →
+ * no handle, no card, the register looks exactly as it did before" — a row
+ * that sprouts an empty card is the visible regression, and a stray space
+ * left behind by an older write is the way it happens.
+ */
+
+/** Only the three fields matter here; the rest of Node never gets read. */
+function node(v: Partial<Node>): Node {
+  return { verificationText: null, verificationUrl: null, verificationVideoUrl: null, ...v } as Node;
+}
+
+describe('verificationOf', () => {
+  it('returns null when none of the three fields is set', () => {
+    expect(verificationOf(node({}))).toBeNull();
+  });
+
+  it('treats whitespace-only fields as unset', () => {
+    // The property panel writes null on clear, but rows written before that
+    // can still carry ' ' — which is truthy and would render an empty card.
+    expect(verificationOf(node({ verificationText: '   ' }))).toBeNull();
+    expect(verificationOf(node({ verificationUrl: '\t' }))).toBeNull();
+    expect(verificationOf(node({ verificationVideoUrl: '\n ' }))).toBeNull();
+    expect(
+      verificationOf(
+        node({ verificationText: ' ', verificationUrl: ' ', verificationVideoUrl: ' ' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns a card as soon as any single field is set', () => {
+    // Each of the three on its own is enough — a requirement with only a
+    // video and no written steps still needs the handle.
+    expect(verificationOf(node({ verificationText: '1. Einloggen' }))).toEqual({
+      text: '1. Einloggen',
+      url: null,
+      videoUrl: null,
+    });
+    expect(verificationOf(node({ verificationUrl: 'https://staging.example.com/x' }))).toEqual({
+      text: null,
+      url: 'https://staging.example.com/x',
+      videoUrl: null,
+    });
+    expect(verificationOf(node({ verificationVideoUrl: 'https://v.example.com/a.mp4' }))).toEqual({
+      text: null,
+      url: null,
+      videoUrl: 'https://v.example.com/a.mp4',
+    });
+  });
+
+  it('trims the values it returns', () => {
+    // A trailing newline in the URL would otherwise end up inside the href.
+    expect(
+      verificationOf(
+        node({
+          verificationText: '  1. Einloggen\n2. Mandat öffnen  ',
+          verificationUrl: ' https://staging.example.com/x \n',
+          verificationVideoUrl: '\thttps://v.example.com/a.mp4 ',
+        }),
+      ),
+    ).toEqual({
+      text: '1. Einloggen\n2. Mandat öffnen',
+      url: 'https://staging.example.com/x',
+      videoUrl: 'https://v.example.com/a.mp4',
+    });
+  });
+});
+
+/**
+ * Both URL fields are free-text columns with no server-side validation, and
+ * the Abnahme card is the first surface that renders them as an `href`.
+ */
+describe('isHttpUrl', () => {
+  it('accepts absolute http and https URLs', () => {
+    expect(isHttpUrl('https://staging.example.com/mandates/42')).toBe(true);
+    expect(isHttpUrl('http://localhost:5173/?req=MAN-14')).toBe(true);
+    expect(isHttpUrl('HTTPS://staging.example.com/x')).toBe(true);
+  });
+
+  it('rejects script-bearing schemes', () => {
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isHttpUrl('vbscript:msgbox(1)')).toBe(false);
+    expect(isHttpUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  it('rejects a scheme obfuscated with control characters', () => {
+    // The reason this uses the URL parser and not startsWith(): browsers
+    // strip tabs and newlines out of the scheme, so this navigates.
+    expect(isHttpUrl('java\nscript:alert(1)')).toBe(false);
+    expect(isHttpUrl('java\tscript:alert(1)')).toBe(false);
+    expect(isHttpUrl(' javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects anything that is not an absolute URL', () => {
+    // Nothing resolves a relative href usefully here — the card links out of
+    // the application, not within it.
+    expect(isHttpUrl('staging.example.com/x')).toBe(false);
+    expect(isHttpUrl('/mandates/42')).toBe(false);
+    expect(isHttpUrl('//staging.example.com/x')).toBe(false);
+    expect(isHttpUrl('')).toBe(false);
+    expect(isHttpUrl(null)).toBe(false);
+    expect(isHttpUrl(undefined)).toBe(false);
+  });
+});

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -966,6 +966,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       phaseId: null,
       verificationText: null,
       verificationUrl: null,
+      verificationVideoUrl: null,
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/mindmap/src/verification.ts
+++ b/packages/mindmap/src/verification.ts
@@ -1,0 +1,55 @@
+/**
+ * The Abnahme card's data rules: which of the three review-surface fields
+ * are set, and which URLs are safe to render as a link.
+ *
+ * Kept out of RequirementsView.tsx so it can be unit-tested without
+ * dragging in the zustand store, which the component module creates at
+ * import time — same reason ghLinkStyle.ts lives on its own.
+ */
+
+import type { Node } from '@mindblown/core';
+
+/**
+ * The three review-surface fields a non-technical reviewer needs before
+ * pressing ✓ or ✗: how to check it, where to check it, and the demo video.
+ * Whitespace-only counts as unset — the property panel writes `null` on
+ * clear, but older rows can still carry a stray space.
+ */
+export interface Verification {
+  text: string | null;
+  url: string | null;
+  videoUrl: string | null;
+}
+
+/** null when the requirement carries none of the three — the row then looks exactly as before. */
+export function verificationOf(node: Node): Verification | null {
+  const text = node.verificationText?.trim() || null;
+  const url = node.verificationUrl?.trim() || null;
+  const videoUrl = node.verificationVideoUrl?.trim() || null;
+  if (text == null && url == null && videoUrl == null) return null;
+  return { text, url, videoUrl };
+}
+
+/**
+ * True only for absolute `http:`/`https:` URLs.
+ *
+ * `verificationUrl` / `verificationVideoUrl` are free-text columns with no
+ * server-side validation, and the Abnahme card is the first place in the
+ * product that renders them as an `href`. Anything else — `javascript:`,
+ * `data:`, `vbscript:`, a bare relative path — is refused, and the caller
+ * drops the button rather than emitting a dead or dangerous link.
+ *
+ * Parsed with the URL constructor rather than a prefix check on purpose:
+ * the parser strips the tabs and newlines that make `java\nscript:alert(1)`
+ * work in a browser but slip past a naive `startsWith('javascript:')`.
+ */
+export function isHttpUrl(url: string | null | undefined): boolean {
+  if (url == null) return false;
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    // Not an absolute URL at all (relative path, empty, malformed).
+    return false;
+  }
+}

--- a/packages/server/src/db/__tests__/trackedFields.test.ts
+++ b/packages/server/src/db/__tests__/trackedFields.test.ts
@@ -1,0 +1,130 @@
+/**
+ * What the change log actually records for a node update.
+ *
+ * The list of tracked fields is a plain Set, so a field can only be
+ * "audited" or "invisible" — there is no partial state and no error when a
+ * field is missing, which is why the omission of the Abnahme fields went
+ * unnoticed. These cases assert on the emitted events rather than on the
+ * Set's membership: the point is that an edit to the Prüfanleitung leaves a
+ * row behind, not that a string appears in a list.
+ *
+ * Why it matters for the Abnahme surface specifically: the verdicts are
+ * append-only, but the text a reviewer signed off against was not. Without
+ * these events the register can say who accepted a requirement and cannot
+ * say what the requirement told him to check at the time.
+ *
+ * DB layer is stubbed — this file is about the diff, not about Postgres
+ * (see the note in vitest.config.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type LoggedRow = { fieldName: string; oldValue: unknown; newValue: unknown };
+
+const valuesMock = vi.fn(async (_row: LoggedRow) => undefined);
+const insertMock = vi.fn((_table: unknown) => ({ values: valuesMock }));
+
+vi.mock('../connection.js', () => ({
+  db: { insert: (table: unknown) => insertMock(table) },
+  pool: {},
+}));
+
+import { recordFieldChanges, TRACKED_FIELDS } from '../events.js';
+
+const MAP_ID = 'mmmm-mmmm';
+const NODE_ID = 'nnnn-nnnn';
+const USER_ID = 'uuuu-uuuu';
+
+const ANLEITUNG = '1. Als Treuhänder einloggen\n2. Mandat öffnen';
+
+/** The field/old/new triples the log would have written. */
+function loggedFields(): LoggedRow[] {
+  return valuesMock.mock.calls.map(([row]) => ({
+    fieldName: row.fieldName,
+    oldValue: row.oldValue,
+    newValue: row.newValue,
+  }));
+}
+
+beforeEach(() => {
+  valuesMock.mockClear();
+  insertMock.mockClear();
+});
+
+describe('recordFieldChanges — Abnahme fields', () => {
+  it('records an event when the Prüfanleitung text is rewritten', async () => {
+    await recordFieldChanges(
+      MAP_ID,
+      NODE_ID,
+      USER_ID,
+      { verificationText: ANLEITUNG },
+      { verificationText: ANLEITUNG + '\n3. Badge prüfen' },
+    );
+
+    // Both values, not just the field name: reconstructing what was signed
+    // off needs the text that was replaced, not the fact that it changed.
+    expect(loggedFields()).toEqual([
+      {
+        fieldName: 'verificationText',
+        oldValue: ANLEITUNG,
+        newValue: ANLEITUNG + '\n3. Badge prüfen',
+      },
+    ]);
+  });
+
+  it('records an event when either verification URL is repointed', async () => {
+    await recordFieldChanges(
+      MAP_ID,
+      NODE_ID,
+      USER_ID,
+      { verificationUrl: 'https://staging.example.com/a', verificationVideoUrl: null },
+      {
+        verificationUrl: 'https://staging.example.com/b',
+        verificationVideoUrl: 'https://v.example.com/x.mp4',
+      },
+    );
+
+    const byField = new Map(loggedFields().map((e) => [e.fieldName, e]));
+    expect([...byField.keys()].sort()).toEqual(['verificationUrl', 'verificationVideoUrl']);
+    expect(byField.get('verificationUrl')).toEqual({
+      fieldName: 'verificationUrl',
+      oldValue: 'https://staging.example.com/a',
+      newValue: 'https://staging.example.com/b',
+    });
+    expect(byField.get('verificationVideoUrl')?.oldValue).toBeNull();
+  });
+
+  it('records the first write, when the field goes from unset to set', async () => {
+    // Annotating a requirement that never had a Prüfanleitung is the common
+    // case; null → text must not be mistaken for "nothing changed".
+    await recordFieldChanges(
+      MAP_ID,
+      NODE_ID,
+      USER_ID,
+      { verificationText: null },
+      { verificationText: ANLEITUNG },
+    );
+    expect(loggedFields()).toEqual([
+      { fieldName: 'verificationText', oldValue: null, newValue: ANLEITUNG },
+    ]);
+  });
+
+  it('stays silent when the Abnahme fields are untouched', async () => {
+    await recordFieldChanges(
+      MAP_ID,
+      NODE_ID,
+      USER_ID,
+      { text: 'before', verificationText: ANLEITUNG },
+      { text: 'after', verificationText: ANLEITUNG },
+    );
+    expect(loggedFields().map((e) => e.fieldName)).toEqual(['text']);
+  });
+
+  it('keeps all three fields on the tracked list', () => {
+    // Belt to the braces above: a future edit to the Set can't quietly drop
+    // one of the three while the other two keep the suite green.
+    for (const f of ['verificationText', 'verificationUrl', 'verificationVideoUrl'] as const) {
+      expect(TRACKED_FIELDS.has(f)).toBe(true);
+    }
+  });
+});

--- a/packages/server/src/db/events.ts
+++ b/packages/server/src/db/events.ts
@@ -39,6 +39,15 @@ export const TRACKED_FIELDS = new Set<keyof CoreNode>([
   'cycleId',
   'assigneeIds',
   'phaseId',
+  // The Abnahme surface. The Prüfanleitung is the text a customer's
+  // signature refers to at a sign-off, and the two URLs are where he was
+  // told to look — so an edit after the fact has to leave a trace. The
+  // verdicts themselves are already append-only; without these three the
+  // register can say who accepted what, but not what "what" said at the
+  // time. Not noise either: they're written once and then rarely touched.
+  'verificationText',
+  'verificationUrl',
+  'verificationVideoUrl',
 ]);
 
 function valuesDiffer(a: unknown, b: unknown): boolean {

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -45,6 +45,8 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     phaseId: (get('phaseId', 'phase_id') as string) ?? null,
     verificationText: (get('verificationText', 'verification_text') as string) ?? null,
     verificationUrl: (get('verificationUrl', 'verification_url') as string) ?? null,
+    verificationVideoUrl:
+      (get('verificationVideoUrl', 'verification_video_url') as string) ?? null,
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -796,12 +796,17 @@ export async function runMigrations(): Promise<void> {
   `);
   // verification_text: how to verify (Prüfanleitung, markdown) rendered on
   // the review surface. verification_url: deep link (e.g. staging URL).
-  // Both business prose like requirement_text — never GitHub-synced.
+  // verification_video_url: short demo recording for reviewers who would
+  // rather watch than read. All three business prose like requirement_text
+  // — never GitHub-synced.
   await db.execute(sql`
     ALTER TABLE nodes ADD COLUMN IF NOT EXISTS verification_text TEXT
   `);
   await db.execute(sql`
     ALTER TABLE nodes ADD COLUMN IF NOT EXISTS verification_url TEXT
+  `);
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS verification_video_url TEXT
   `);
 
   // ── Requirement acceptances (Abnahme) ──────────────────────────

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -245,6 +245,7 @@ export interface CreateNodeInput {
   phaseId?: string | null;
   verificationText?: string | null;
   verificationUrl?: string | null;
+  verificationVideoUrl?: string | null;
   assigneeIds?: string[];
 }
 
@@ -296,6 +297,7 @@ export async function createNode(
       phaseId: input.phaseId ?? null,
       verificationText: input.verificationText ?? null,
       verificationUrl: input.verificationUrl ?? null,
+      verificationVideoUrl: input.verificationVideoUrl ?? null,
       assigneeIds: input.assigneeIds ?? [],
       tags: [],
       customFields: {},
@@ -391,6 +393,7 @@ export interface UpdateNodeInput {
   phaseId?: string | null;
   verificationText?: string | null;
   verificationUrl?: string | null;
+  verificationVideoUrl?: string | null;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -512,6 +515,8 @@ export async function updateNode(
   if (input.phaseId !== undefined) updates.phaseId = input.phaseId;
   if (input.verificationText !== undefined) updates.verificationText = input.verificationText;
   if (input.verificationUrl !== undefined) updates.verificationUrl = input.verificationUrl;
+  if (input.verificationVideoUrl !== undefined)
+    updates.verificationVideoUrl = input.verificationVideoUrl;
   // Orchestration substrate (#111)
   if (input.claimedBySession !== undefined) updates.claimedBySession = input.claimedBySession;
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -221,10 +221,11 @@ export const nodes = pgTable('nodes', {
   requirementPriority: text('requirement_priority'),
   // Business phrasing for register/doc export; NOT GitHub-synced.
   requirementText: text('requirement_text'),
-  // How to verify (Prüfanleitung, markdown) + deep link for the review
-  // surface. Like requirement_text, NOT GitHub-synced.
+  // How to verify (Prüfanleitung, markdown) + deep link + demo video for
+  // the review surface. Like requirement_text, NOT GitHub-synced.
   verificationText: text('verification_text'),
   verificationUrl: text('verification_url'),
+  verificationVideoUrl: text('verification_video_url'),
 
   // ── Phase ─────────────────────────────────────────────────────
   // References a PhaseDef.id from maps.phases (statusWorkflow idiom,

--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -39,6 +39,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     requirementText: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     claimedBySession: null,
     claimedAt: null,
     revision: 0,

--- a/packages/server/src/lint/__tests__/engine.test.ts
+++ b/packages/server/src/lint/__tests__/engine.test.ts
@@ -40,6 +40,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     phaseId: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     claimedBySession: null,
     claimedAt: null,
     revision: 0,

--- a/packages/server/src/routes/__tests__/verification-fields-route.test.ts
+++ b/packages/server/src/routes/__tests__/verification-fields-route.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Route tests for the verification fields on the node write surface.
+ *
+ * `verificationText` / `verificationUrl` / `verificationVideoUrl` are what
+ * the Requirements view puts in front of a non-technical reviewer before he
+ * presses ✓ or ✗ (the Abnahme card). They are plain nullable TEXT columns —
+ * no validation, no GitHub sync — so the only thing that can break is the
+ * wiring, and the wiring is exactly what silently drops a field.
+ *
+ * `verificationVideoUrl` is the newest of the three; these cases pin it to
+ * the same behaviour as its two siblings on both write routes, including
+ * the null-clears-it path (an omitted field and an explicit null mean
+ * different things to db/nodes.ts `updateNode`).
+ *
+ * Mock pattern mirrors phase-node-routes.test.ts — stub the DB layer +
+ * side-effect modules, exercise route wiring without Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const createNodeMock = vi.fn();
+const updateNodeMock = vi.fn();
+const getNodeMock = vi.fn(async () => null);
+
+vi.mock('../../db/nodes.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/nodes.js')>();
+  return {
+    ...actual,
+    createNode: (...args: unknown[]) => createNodeMock(...args),
+    updateNode: (...args: unknown[]) => updateNodeMock(...args),
+    getNode: (...args: unknown[]) => getNodeMock(),
+  };
+});
+
+vi.mock('../../db/maps.js', () => ({ updateMap: vi.fn() }));
+vi.mock('../../db/events.js', () => ({
+  recordEvent: vi.fn(async () => {}),
+  recordFieldChanges: vi.fn(async () => {}),
+}));
+vi.mock('../../ws.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../../ai/embeddings.js', () => ({ scheduleEmbedNode: vi.fn() }));
+vi.mock('@mindblown/integrations', () => ({
+  updateGitHubIssue: vi.fn(),
+  getGitHubIssue: vi.fn(),
+}));
+vi.mock('../integrations.js', () => ({
+  getGitHubContextForMap: vi.fn(async () => null),
+}));
+
+import { nodeRoutes } from '../nodes.js';
+
+// ── Test harness ──────────────────────────────────────────────────
+
+const MAP_ID = 'mmmm-mmmm-mmmm-mmmm';
+const NODE_ID = 'nnnn-nnnn-nnnn-nnnn';
+
+const ANLEITUNG = '1. Als Treuhänder einloggen\n2. Mandat öffnen\n\n**Erwartet:** Badge sichtbar';
+const PRUEF_URL = 'https://staging.example.com/mandates/42';
+const VIDEO_URL = 'https://videos.example.com/abnahme/man-14.mp4';
+
+/** Minimal CoreNode-shaped stub the routes can broadcast/sync safely. */
+function stubNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: NODE_ID,
+    mapId: MAP_ID,
+    parentId: 'pppp-pppp',
+    childrenIds: [],
+    text: 'stub node',
+    externalLinks: [],
+    verificationText: null,
+    verificationUrl: null,
+    verificationVideoUrl: null,
+    ...overrides,
+  };
+}
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    req.userId = 'uuuu-uuuu-uuuu-uuuu';
+  });
+  await app.register(nodeRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  createNodeMock.mockReset();
+  updateNodeMock.mockReset();
+  getNodeMock.mockReset();
+  getNodeMock.mockResolvedValue(null as never);
+});
+
+// ── Cases ─────────────────────────────────────────────────────────
+
+describe('PUT /api/maps/:id/nodes/:nodeId — verification fields round-trip', () => {
+  it('forwards all three verification fields and returns them on the node', async () => {
+    updateNodeMock.mockResolvedValueOnce(
+      stubNode({
+        verificationText: ANLEITUNG,
+        verificationUrl: PRUEF_URL,
+        verificationVideoUrl: VIDEO_URL,
+      }),
+    );
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: {
+        verificationText: ANLEITUNG,
+        verificationUrl: PRUEF_URL,
+        verificationVideoUrl: VIDEO_URL,
+      },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock).toHaveBeenCalledOnce();
+    expect(updateNodeMock.mock.calls[0][0]).toBe(NODE_ID);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({
+      verificationText: ANLEITUNG,
+      verificationUrl: PRUEF_URL,
+      verificationVideoUrl: VIDEO_URL,
+    });
+    expect(res.json().verificationVideoUrl).toBe(VIDEO_URL);
+    expect(res.json().verificationUrl).toBe(PRUEF_URL);
+    expect(res.json().verificationText).toBe(ANLEITUNG);
+  });
+
+  it('forwards verificationVideoUrl on its own — no sibling field required', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ verificationVideoUrl: VIDEO_URL }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { verificationVideoUrl: VIDEO_URL },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ verificationVideoUrl: VIDEO_URL });
+    expect(res.json().verificationVideoUrl).toBe(VIDEO_URL);
+  });
+
+  it('forwards verificationVideoUrl: null (clear) — null survives as a value, not an omission', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ verificationVideoUrl: null }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { verificationVideoUrl: null },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ verificationVideoUrl: null });
+    expect(res.json().verificationVideoUrl).toBeNull();
+  });
+
+  it('leaves verificationVideoUrl untouched when the update is about something else', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ text: 'renamed' }));
+    const app = await buildApp();
+    await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { text: 'renamed' },
+    });
+    await app.close();
+
+    expect('verificationVideoUrl' in (updateNodeMock.mock.calls[0][1] as object)).toBe(false);
+  });
+});
+
+describe('POST /api/maps/:id/nodes — verification fields on create', () => {
+  it('forwards all three verification fields to createNode', async () => {
+    createNodeMock.mockResolvedValueOnce(
+      stubNode({
+        text: 'Neue Anforderung',
+        verificationText: ANLEITUNG,
+        verificationUrl: PRUEF_URL,
+        verificationVideoUrl: VIDEO_URL,
+      }),
+    );
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/maps/${MAP_ID}/nodes`,
+      payload: {
+        parentId: 'pppp-pppp',
+        text: 'Neue Anforderung',
+        verificationText: ANLEITUNG,
+        verificationUrl: PRUEF_URL,
+        verificationVideoUrl: VIDEO_URL,
+      },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(201);
+    expect(createNodeMock).toHaveBeenCalledOnce();
+    expect(createNodeMock.mock.calls[0][0]).toMatchObject({
+      mapId: MAP_ID,
+      parentId: 'pppp-pppp',
+      text: 'Neue Anforderung',
+      verificationText: ANLEITUNG,
+      verificationUrl: PRUEF_URL,
+      verificationVideoUrl: VIDEO_URL,
+    });
+    expect(res.json().verificationVideoUrl).toBe(VIDEO_URL);
+  });
+});

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -556,6 +556,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           phaseId: null,
           verificationText: null,
           verificationUrl: null,
+          verificationVideoUrl: null,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -175,6 +175,7 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       phaseId?: string | null;
       verificationText?: string | null;
       verificationUrl?: string | null;
+      verificationVideoUrl?: string | null;
       assigneeIds?: string[];
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`

--- a/packages/server/src/services/__tests__/pull-queue.test.ts
+++ b/packages/server/src/services/__tests__/pull-queue.test.ts
@@ -69,6 +69,7 @@ function makeNode(overrides: Partial<CoreNode> & { id: string }): CoreNode {
     phaseId: null,
     verificationText: null,
     verificationUrl: null,
+    verificationVideoUrl: null,
     claimedBySession: null,
     claimedAt: null,
     scopes: [],

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -877,11 +877,62 @@ describe('requirement fields', () => {
       nodeId: 'n1',
       verificationText: '1. Einloggen\n2. Mandat öffnen\n\n**Erwartet:** Badge sichtbar',
       verificationUrl: 'https://staging.example.com/mandates',
+      verificationVideoUrl: 'https://videos.example.com/man-14.mp4',
     } as never);
     expect(recorder.lastUpdate?.fields).toMatchObject({
       verificationText: '1. Einloggen\n2. Mandat öffnen\n\n**Erwartet:** Badge sichtbar',
       verificationUrl: 'https://staging.example.com/mandates',
+      verificationVideoUrl: 'https://videos.example.com/man-14.mp4',
     });
+  });
+
+  // The MCP setter is how the Prüfanleitung, the deep link and the demo
+  // video actually get onto a requirement — an agent-written register with
+  // no way to set the video field leaves the review surface half-empty.
+  //
+  // Asserted against the zod shape, not just the handler: the handler
+  // spreads `...fields` through verbatim, so it forwards a field that the
+  // schema never declared — and the schema is the entire MCP surface an
+  // agent sees. A handler-only test passes with layer 6 missing.
+  it('declares verificationVideoUrl on the update_node schema', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      nodeId: 'n1',
+      verificationText: '1. Einloggen\n2. Prüfen',
+      verificationUrl: 'https://staging.example.com/mandates',
+      verificationVideoUrl: 'https://videos.example.com/man-14.mp4',
+    });
+    expect(parsed.verificationText).toBe('1. Einloggen\n2. Prüfen');
+    expect(parsed.verificationUrl).toBe('https://staging.example.com/mandates');
+    expect(parsed.verificationVideoUrl).toBe('https://videos.example.com/man-14.mp4');
+  });
+
+  it('declares verificationVideoUrl on the create_node schema', () => {
+    const schema = z.object(createNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'Neue Anforderung',
+      verificationVideoUrl: 'https://videos.example.com/admin-demo.mp4',
+    });
+    expect(parsed.verificationVideoUrl).toBe('https://videos.example.com/admin-demo.mp4');
+  });
+
+  it('accepts null on verificationVideoUrl to clear it', () => {
+    const schema = z.object(updateNodeTool.schema);
+    expect(schema.parse({ mapId: 'm1', nodeId: 'n1', verificationVideoUrl: null })
+      .verificationVideoUrl).toBeNull();
+  });
+
+  it('clears verificationVideoUrl when explicitly set to null', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      verificationVideoUrl: null,
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({ verificationVideoUrl: null });
   });
 
   it('forwards verification fields on create', async () => {
@@ -892,10 +943,12 @@ describe('requirement fields', () => {
       text: 'Neue Anforderung',
       verificationText: 'Prüfen im Admin-Panel',
       verificationUrl: 'https://staging.example.com/admin',
+      verificationVideoUrl: 'https://videos.example.com/admin-demo.mp4',
     } as never);
     expect(recorder.lastCreate?.fields).toMatchObject({
       verificationText: 'Prüfen im Admin-Panel',
       verificationUrl: 'https://staging.example.com/admin',
+      verificationVideoUrl: 'https://videos.example.com/admin-demo.mp4',
     });
   });
 
@@ -910,6 +963,7 @@ describe('requirement fields', () => {
     expect('requirementPriority' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
     expect('verificationText' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
     expect('verificationUrl' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
+    expect('verificationVideoUrl' in (recorder.lastUpdate?.fields ?? {})).toBe(false);
   });
 });
 

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -68,6 +68,11 @@ export const createNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('Deep link to where the requirement is verified (e.g. a staging URL). Rendered as an "open" button on the review surface.'),
+    verificationVideoUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Link to a short demo video showing this requirement in action. Rendered as a "watch video" button on the review surface next to the verification link.'),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -176,6 +181,11 @@ export const updateNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('Deep link to where the requirement is verified (e.g. a staging URL). null clears it.'),
+    verificationVideoUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Link to a short demo video showing this requirement in action, shown as a "watch video" button on the review surface. null clears it.'),
     // Orchestration substrate (#111)
     scopes: z
       .array(z.string())


### PR DESCRIPTION
## Warum

Am **6. August** nimmt die erste Treuhandgesellschaft die MVP-Anforderungen fachlich ab. Der Prüfer ist kein Techniker: er soll pro Anforderung eine Prüfanleitung lesen, sich in die laufende Anwendung klicken, optional ein kurzes Demo-Video schauen und dann annehmen oder zurückweisen.

`verificationText` und `verificationUrl` gab es auf dem Node schon — aber nur im PropertyPanel editierbar. **Auf der Review-Oberfläche selbst kamen sie gar nicht vor**: `verification` war in `RequirementsView.tsx` kein einziges Mal zu finden. Die Felder waren damit für genau den Menschen unsichtbar, für den sie geschrieben wurden.

## Teil 1 — neues Feld `verificationVideoUrl`

Ein Demo-Video-Link pro Anforderung, gespiegelt an `verificationUrl` über alle acht Layer der CLAUDE.md-Tabelle:

| # | Layer | Datei |
|---|---|---|
| 1 | Typ | `packages/core/src/types.ts` |
| 2 | Drizzle-Spalte | `packages/server/src/db/schema.ts` |
| 3 | Migration (idempotent, läuft beim API-Start) | `packages/server/src/db/migrate.ts` |
| 4 | Mapping | `db/helpers.ts` (`dbNodeToCore`), `db/nodes.ts` (create + update) |
| 5 | REST | `routes/nodes.ts` (Create-Body), `routes/maps.ts` (Node-Stub) |
| 6 | **MCP-Setter** | `packages/tool-kit/src/tools/node.ts` — Zod auf `create_node` **und** `update_node` |
| 7 | Frontend-Store | `packages/mindmap/src/store.ts`, `packages/mcp/src/api.ts` |
| 8 | Tests | Server-Route, tool-kit-Schema + -Handler, Node-Stubs in core/mcp/server |

Layer 6 ist ausdrücklich **kein Follow-up**: ohne den MCP-Setter lässt sich das Feld gar nicht befüllen, und die Karte bliebe leer.

## Teil 2 — die Abnahme-Karte in `RequirementsView.tsx`

Ein aufklappbarer Bereich pro Zeile. Der Griff sitzt in der Acceptance-Zelle direkt unter dem ✓/✗-Paar — der Mensch, der abnimmt, ist der Mensch, der wissen muss wie man prüft. Aufgeklappt:

- **Prüfanleitung** als gerendertes Markdown (`react-markdown` + `remark-gfm`, beide schon Dependencies von `@mindblown/mindmap`) — nummerierte Schritte als `<ol>`, kein Rohtext.
- **„In der Anwendung öffnen ↗"** → `verificationUrl`, `target="_blank"`.
- **„▶ Video ansehen"** → `verificationVideoUrl`, dito.

Designentscheidungen:

- **Eigene Tabellenzeile** (`colSpan={9}`) statt einer Box in der 180px-Acceptance-Spalte: eine Anleitung braucht die volle Breite, und eine hohe Zelle würde sonst jede Nachbarzelle der Zeile mitziehen. Die Markdown-Fläche ist auf 320px Höhe gedeckelt und scrollt intern, damit eine Aufsatz-lange Anleitung nicht das Register wegschiebt.
- **Die zwei Buttons stehen auf der Kopfzeile** der Karte, nicht darunter — so bleiben sie erreichbar, ohne an einer langen Anleitung vorbeizuscrollen.
- **Leere Felder werden weggelassen**, nicht auf `#` verlinkt. Eine Anforderung ohne alle drei Felder bekommt **gar keinen Griff** und sieht damit exakt aus wie bisher — keine leeren Platzhalterkästen.
- Mehrere Zeilen dürfen gleichzeitig offen sein (`Set<nodeId>`): wer eine Anforderung mit der darüber vergleicht, verliert sonst seine Stelle.
- Das globale `* { padding: 0 }` in `index.html` nimmt einer `<ol>` den Einzug, den sie für ihre Nummern braucht → scoped CSS (`.mb-verification-md`), gleiche Machart wie `HelpOverlay`s `.help-markdown`.
- Keine neue Design-Sprache: Ghost-Chip wie das ✓/✗-Paar, Indigo wie der Kapitel-Header.

## Verifikation

`pnpm turbo typecheck build test lint` — **19/19 Tasks grün**, 700 Server-Tests.

**Neue Tests** (jeder einzeln mutations-verifiziert — Feld aus der Route bzw. aus dem Zod-Schema entfernt und bestätigt, dass genau diese Tests rot werden):

- `packages/server/src/routes/__tests__/verification-fields-route.test.ts` (neu, 5 Cases): alle drei Felder über `POST`/`PUT`, `verificationVideoUrl` allein, `null` als Clear-Wert vs. Auslassung.
- `packages/tool-kit/.../node.test.ts`: **Assertions gegen die Zod-Shape**, nicht nur gegen den Handler. Der Handler spreadet `...fields` durch und hätte ein Feld weitergeleitet, das das Schema nie deklariert hat — ein Handler-only-Test ist mit fehlendem Layer 6 grün. Genau das ist beim Mutationstest aufgefallen.

**Lokale Wegwerf-DB** (`mb_abnahme`, API auf `:3099` — Produktion nicht angefasst): Migration legt `verification_video_url` an; Create-, Update- und `null`-Clear-Pfad round-trippen durch die echten Routen bis in Postgres und zurück (per `psql` gegengeprüft, nicht nur an der API-Antwort).

### Was ich im Browser gesehen habe

Vier Anforderungen angelegt, eine pro Feld-Kombination, und die Requirements-View mit Playwright/Chromium bedient:

| Zeile | Felder | Was auf dem Schirm stand |
|---|---|---|
| MAN-14 | alle drei | Griff „▾ Prüfanleitung"; Karte mit 4 nummerierten Schritten als echte Liste, fett/kursiv/`code` gerendert, **kein** sichtbares `**`; beide Buttons rechts oben |
| MAN-15 | Text + URL | Karte mit 3 Schritten, **nur** „In der Anwendung öffnen" — kein Video-Button, keine Lücke |
| MAN-16 | nur Video | Griff heißt „▾ Prüfen" statt „Prüfanleitung"; Karte enthält nur den Video-Button, keine leere Markdown-Fläche |
| MAN-17 | keins | **kein Griff, keine Karte** — Zeile identisch zu vorher |

Der Akzeptanztest als Persona **Thomas**, einmal komplett durchgelaufen, ohne die Zeile zu verlassen:

```
1. Thomas findet MAN-14 und klickt auf die Prüfanleitung
   → Schritte sichtbar: 4
2. Thomas öffnet den Prüf-Link
   → neuer Tab: https://staging.example.com/mandates/MUSTER-0001
3. Thomas öffnet das Video
   → neuer Tab: https://staging.example.com/videos/man-14-liquidation.mp4
4. Thomas kommt zurück und drückt Annehmen (Business-Gate)
   → Zelle nach dem Klick: "IT | ✓ | ✗ | BUSINESS | Demo ✓ 30.07. | ▾ Prüfanleitung"
   Panel noch offen? true
```

Beide Links öffnen tatsächlich einen neuen Tab (`target="_blank"`, `rel="noreferrer"` — im DOM verifiziert). Nach dem Klick auf ✓ steht MAN-14 auf Status **Accepted**, die Business-Badge zeigt „Demo ✓ 30.07.", und der Funnel oben ist von `0 of 4 accepted` auf `1 of 4 accepted` gesprungen. Die Karte blieb offen.

Screenshots liegen lokal unter `/tmp/shot-0{1..4}-*.png` (kann ich nachreichen).

## Bewusst nicht gemacht

- **Kein `accept_requirement` / `reject_requirement` auf Produktivdaten.** Die einzige Abnahme, die geklickt wurde, ist MAN-14 in der lokalen Wegwerf-DB.
- **Kein abgeleiteter Status angefasst** — Stage und Fortschritt bleiben berechnet.
- **Kein Video-Player eingebaut.** Das Feld ist ein Link, der in einem neuen Tab aufgeht; ein `<video>`-Embed hätte Hosting-, Format- und CSP-Fragen aufgeworfen, die für die Abnahme am 6.8. nichts lösen.
- **Kein DB-Integrationstest für das Update-Mapping in `db/nodes.ts`.** Das Repo hat keinen Postgres-gestützten Test-Harness (alle Server-Tests mocken die DB-Schicht), und `verificationUrl` hat dort auch keinen. Stattdessen habe ich diesen Pfad gegen echtes Postgres von Hand round-getrippt (siehe oben).
- **Die Verifikationsfelder erscheinen nicht im Word-Export** (`requirementsDoc`) — dort waren `verificationText`/`verificationUrl` vorher auch nicht drin. Wenn der Prüfer die Anleitung auf Papier braucht, ist das ein eigenes Ticket.
- Der `validateDOMNesting`-Warning zum `<colgroup>` in der Konsole ist vorbestehend (Whitespace zwischen `<col />` und einem JSX-Kommentar, Zeile ~707) und nicht von diesem PR.
