### PR TITLE
feat(mindmap): Anwenderansicht — "So prüfst du das" neben dem Register

### DIFF
--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -19,6 +19,7 @@ import { HillChart } from './HillChart.js';
 import { WorkloadView } from './WorkloadView.js';
 import { ReleasesView } from './ReleasesView.js';
 import { RequirementsView } from './RequirementsView.js';
+import { GuideView } from './GuideView.js';
 import { ImportExport } from './ImportExport.js';
 import { AuthScreen } from './AuthScreen.js';
 import { ShareDialog } from './ShareDialog.js';
@@ -861,6 +862,10 @@ const VIEW_TABS: { id: ActiveView; label: string; enabled: boolean }[] = [
   { id: 'gantt', label: 'Gantt', enabled: true },
   { id: 'releases', label: 'Releases', enabled: true },
   { id: 'requirements', label: 'Requirements', enabled: true },
+  // Reads the same requirement nodes as the register, for the opposite
+  // reader: "how do I check this?" rather than "where does this stand?".
+  // Sits next to it so the switch between the two is one click.
+  { id: 'guide', label: 'Anwender', enabled: true },
   { id: 'list', label: 'List', enabled: true },
   { id: 'calendar', label: 'Calendar', enabled: true },
   { id: 'hill', label: 'Hill Chart', enabled: true },
@@ -2176,6 +2181,7 @@ export function App() {
           {activeView === 'gantt' && <GanttView />}
           {activeView === 'releases' && <ReleasesView />}
           {activeView === 'requirements' && <RequirementsView />}
+          {activeView === 'guide' && <GuideView />}
           {activeView === 'list' && <ListView />}
           {activeView === 'calendar' && <CalendarView />}
           {activeView === 'hill' && <HillChart />}
@@ -2195,7 +2201,15 @@ export function App() {
             mapId={currentMapId}
             onClose={() => setPlanHealthPanelOpen(false)}
           />
-        ) : (
+        ) : activeView === 'guide' ? null : (
+          /* The Anwenderansicht keeps its own selection in `selectedNodeId`
+             (that is what makes a link to one criterion shareable), and the
+             property panel opens on any selection. Docking a 320px editor
+             of estimates, statuses and blocked-reasons beside a view whose
+             entire premise is "three facts, not nine" would undo it — so
+             that one view suppresses the panel and offers "Anleitung
+             bearbeiten" instead, which jumps to the mindmap where the panel
+             belongs. Every other view is untouched. */
           <PropertyPanel />
         )}
       </div>

--- a/packages/mindmap/src/GuideView.tsx
+++ b/packages/mindmap/src/GuideView.tsx
@@ -1,0 +1,832 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Node } from '@mindblown/core';
+import { useMindmapStore } from './store.js';
+import {
+  buildGuideEntries,
+  filterGuideChapters,
+  groupGuideEntries,
+  guideMarker,
+  initialExpandedChapters,
+  type GuideChapter,
+  type GuideEntry,
+} from './guide.js';
+
+/**
+ * The Anwenderansicht — "So prüfst du das".
+ *
+ * A reading surface for the person who has to *check* a criterion, next to
+ * (never inside) the requirements register. The register is a controlling
+ * instrument: nine columns, six filters, one row per requirement. Five of
+ * those nine columns are noise to a reader whose only question is "how do I
+ * verify this myself?", and the Prüfanleitung squeezed into its Abnahme
+ * cell was unreadable at that width. So this view drops everything the
+ * question doesn't need:
+ *
+ * - **Left: three facts.** Kürzel, title, one marker. Nothing else.
+ * - **Right: the criterion whole.** Steps at full reading width, the clip
+ *   as a real player, two actions.
+ *
+ * It deliberately does NOT load acceptances. Signing off is the register's
+ * job; conflating "I understand how to check this" with "I hereby accept
+ * it" is exactly the confusion the two-gate model was built to prevent.
+ *
+ * RequirementsView.tsx is untouched by this file — same store, same
+ * derivation rules (chapter = parent node, REQ-ID order), separate surface.
+ */
+
+// ── Palette ──────────────────────────────────────────────────────
+//
+// MindBlown has no theme layer: no CSS custom properties, no Tailwind, no
+// `prefers-color-scheme` anywhere in the app. Every view carries its own
+// `React.CSSProperties` constants over the same slate + indigo palette,
+// so that is what this view does too — naming the tones it uses rather
+// than standing up a second, competing token system for one screen.
+
+const PAPER = '#f8fafc';
+const RAISED = '#ffffff';
+const INK = '#1e293b';
+const INK_SOFT = '#334155';
+const MUTED = '#64748b';
+const FAINT = '#94a3b8';
+const HAIRLINE = '#e2e8f0';
+const ACCENT = '#4f46e5';
+const ACCENT_INK = '#3730a3';
+const ACCENT_SOFT = '#eef2ff';
+const ACCENT_LINE = '#c7d2fe';
+
+const MONO = 'Menlo, Monaco, Consolas, monospace';
+
+// ── Component ────────────────────────────────────────────────────
+
+export function GuideView() {
+  const nodes = useMindmapStore((s) => s.nodes);
+  const computed = useMindmapStore((s) => s.computed);
+  const rootNodeId = useMindmapStore((s) => s.rootNodeId);
+  const selectedNodeId = useMindmapStore((s) => s.selectedNodeId);
+  const selectNode = useMindmapStore((s) => s.selectNode);
+  const setFocusNode = useMindmapStore((s) => s.setFocusNode);
+  const setActiveView = useMindmapStore((s) => s.setActiveView);
+
+  const [query, setQuery] = useState('');
+
+  const entries = useMemo(
+    () =>
+      buildGuideEntries(nodes, (node) =>
+        node.childrenIds.length === 0
+          ? (node.percentComplete ?? 0)
+          : (computed.get(node.id)?.computedProgress ?? 0),
+      ),
+    [nodes, computed],
+  );
+
+  // Depth-first index of the tree, so chapters read in map order — the
+  // same ordering rule the register uses.
+  const dfsOrder = useMemo(() => {
+    const order = new Map<string, number>();
+    if (!rootNodeId) return order;
+    let i = 0;
+    const walk = (id: string) => {
+      order.set(id, i++);
+      for (const cid of nodes[id]?.childrenIds ?? []) if (nodes[cid]) walk(cid);
+    };
+    walk(rootNodeId);
+    return order;
+  }, [nodes, rootNodeId]);
+
+  const chapters = useMemo(
+    () => groupGuideEntries(entries, (id) => dfsOrder.get(id) ?? Infinity),
+    [entries, dfsOrder],
+  );
+
+  const visibleChapters = useMemo(
+    () => filterGuideChapters(chapters, query),
+    [chapters, query],
+  );
+
+  // The selection lives in the store's `selectedNodeId`, which useUrlState
+  // already mirrors to `?node=`. That makes a link to one criterion
+  // shareable for free, and it survives a reload — no second parameter, no
+  // second source of truth. A selection pointing at a non-requirement node
+  // (picked in the mindmap) simply resolves to nothing here.
+  const selected = useMemo(
+    () => entries.find((e) => e.node.id === selectedNodeId) ?? null,
+    [entries, selectedNodeId],
+  );
+
+  // Folding state: derived from the map's size until the reader touches it,
+  // then his. Deriving rather than seeding via an effect means arriving on a
+  // deep link opens the right chapter on the first paint, with no flash of
+  // a wrongly-folded rail.
+  const [expandedOverride, setExpandedOverride] = useState<Set<string> | null>(null);
+  const derivedExpanded = useMemo(
+    () => initialExpandedChapters(chapters, selected?.chapterId ?? null),
+    [chapters, selected?.chapterId],
+  );
+  const expanded = expandedOverride ?? derivedExpanded;
+  // While searching every surviving chapter is open: a hit hidden inside a
+  // folded chapter looks exactly like no hit at all.
+  const searching = query.trim() !== '';
+  const isExpanded = (id: string) => searching || expanded.has(id);
+  const toggleChapter = (id: string) =>
+    setExpandedOverride(() => {
+      const next = new Set(expanded);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+
+  // A rail holding 168 rows scrolls far past one screen, so a criterion
+  // reached by link has to be brought into view — otherwise a shared link
+  // lands on a rail that looks like it selected nothing.
+  const selectedRef = useRef<HTMLButtonElement | null>(null);
+  const detailRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' });
+    detailRef.current?.scrollTo({ top: 0 });
+  }, [selectedNodeId]);
+
+  /**
+   * Editing is a jump into the existing property panel, not a second
+   * editor: the three Prüf-felder already have one home, and a copy here
+   * would be a second place for the same value to drift. Same move the
+   * register makes when you click a row.
+   */
+  const editGuide = (node: Node) => {
+    setActiveView('mindmap');
+    selectNode(node.id);
+    setFocusNode(node.parentId && node.parentId !== rootNodeId ? node.parentId : null);
+    (window as unknown as { __mindmapPanToNode?: (id: string) => void }).__mindmapPanToNode?.(
+      node.id,
+    );
+  };
+
+  if (!rootNodeId) {
+    return (
+      <div style={containerStyle}>
+        <Placeholder title="Keine Karte geöffnet" body="Öffne eine Karte, um ihre Kriterien zu sehen." />
+      </div>
+    );
+  }
+
+  const withGuide = entries.filter((e) => e.guideText != null).length;
+  const withVideo = entries.filter((e) => e.videoUrl != null).length;
+
+  return (
+    <div style={containerStyle}>
+      <style>{guideCss}</style>
+
+      <div style={headerStyle}>
+        <h2 style={{ margin: 0, fontSize: 16, color: INK }}>So prüfst du das</h2>
+        <div style={{ fontSize: 11, color: MUTED, marginTop: 3 }}>
+          {entries.length} Kriterien · {withGuide} mit Prüfanleitung · {withVideo} mit Video
+        </div>
+      </div>
+
+      {entries.length === 0 ? (
+        <Placeholder
+          title="Noch keine Kriterien"
+          body="Diese Ansicht zeigt jeden Knoten mit einer Requirement-ID. Vergib eine im Eigenschaften-Panel, dann steht er hier."
+        />
+      ) : (
+        <div className="mb-guide-grid">
+          {/* ── Left rail ─────────────────────────────────────── */}
+          <aside className="mb-guide-rail">
+            <div style={searchWrapStyle}>
+              <input
+                className="mb-guide-search"
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                placeholder="Kriterium oder Kürzel suchen…"
+                aria-label="Kriterium suchen"
+                style={searchStyle}
+              />
+            </div>
+
+            <div style={{ flex: 1, overflowY: 'auto', padding: '0 10px 24px' }}>
+              {visibleChapters.length === 0 ? (
+                <div style={{ padding: '18px 6px', fontSize: 12.5, color: MUTED }}>
+                  Nichts gefunden für „{query.trim()}“.
+                </div>
+              ) : (
+                visibleChapters.map((chapter) => (
+                  <ChapterBlock
+                    key={chapter.id}
+                    chapter={chapter}
+                    open={isExpanded(chapter.id)}
+                    onToggle={() => toggleChapter(chapter.id)}
+                    selectedNodeId={selectedNodeId}
+                    selectedRef={selectedRef}
+                    onSelect={(entry) => selectNode(entry.node.id)}
+                  />
+                ))
+              )}
+            </div>
+          </aside>
+
+          {/* ── Detail ────────────────────────────────────────── */}
+          <main className="mb-guide-detail" ref={detailRef}>
+            {selected ? (
+              <GuideCard entry={selected} onEdit={() => editGuide(selected.node)} />
+            ) : (
+              <Placeholder
+                title="Wähle links ein Kriterium"
+                body={
+                  chapters.length > 1
+                    ? `${chapters.length} Kapitel, ${entries.length} Kriterien. Zu jedem steht hier, wie du es selbst nachprüfst — Schritte und, wo vorhanden, ein kurzer Clip.`
+                    : 'Zu jedem Kriterium steht hier, wie du es selbst nachprüfst.'
+                }
+              />
+            )}
+          </main>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Left rail ────────────────────────────────────────────────────
+
+function ChapterBlock({
+  chapter,
+  open,
+  onToggle,
+  selectedNodeId,
+  selectedRef,
+  onSelect,
+}: {
+  chapter: GuideChapter;
+  open: boolean;
+  onToggle: () => void;
+  selectedNodeId: string | null;
+  selectedRef: React.MutableRefObject<HTMLButtonElement | null>;
+  onSelect: (entry: GuideEntry) => void;
+}) {
+  return (
+    <div style={{ marginBottom: 2 }}>
+      {/* Sticky inside the rail's own scroller: working down a chapter of
+          twelve, the heading you are under is the one fact worth keeping
+          on screen. */}
+      <button
+        className="mb-guide-chapter"
+        onClick={onToggle}
+        aria-expanded={open}
+        style={chapterStyle}
+      >
+        <span style={{ color: FAINT, fontSize: 9, width: 9 }}>{open ? '▼' : '▶'}</span>
+        <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {chapter.text}
+        </span>
+        <span style={{ color: FAINT, fontWeight: 400 }}>{chapter.entries.length}</span>
+      </button>
+      {open &&
+        chapter.entries.map((entry) => {
+          const current = entry.node.id === selectedNodeId;
+          const marker = guideMarker(entry);
+          return (
+            <button
+              key={entry.node.id}
+              ref={current ? selectedRef : undefined}
+              className="mb-guide-item"
+              onClick={() => onSelect(entry)}
+              aria-current={current}
+              title={entry.available ? entry.title : `${entry.title} — noch nicht verfügbar`}
+              style={{
+                ...itemStyle,
+                background: current ? ACCENT_SOFT : 'transparent',
+                boxShadow: current ? `inset 3px 0 0 ${ACCENT}` : 'none',
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 10.5,
+                  color: current ? ACCENT_INK : entry.available ? MUTED : FAINT,
+                }}
+              >
+                {entry.requirementId}
+              </span>
+              <span
+                style={{
+                  fontSize: 12.5,
+                  lineHeight: 1.35,
+                  color: entry.available ? INK_SOFT : FAINT,
+                  display: '-webkit-box',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: 2,
+                  overflow: 'hidden',
+                }}
+              >
+                {entry.title}
+              </span>
+              <Marker marker={marker} />
+            </button>
+          );
+        })}
+    </div>
+  );
+}
+
+/**
+ * One dot per row. Filled = a written Anleitung exists; filled with a
+ * triangle = a clip too; a hollow ring = nothing written yet. The ring is
+ * deliberately quiet — a missing Anleitung is a gap in the documentation,
+ * not a fault in the product.
+ */
+function Marker({ marker }: { marker: ReturnType<typeof guideMarker> }) {
+  const label =
+    marker === 'video'
+      ? 'Prüfanleitung und Video vorhanden'
+      : marker === 'guide'
+        ? 'Prüfanleitung vorhanden'
+        : 'Noch keine Prüfanleitung';
+  if (marker === 'video') {
+    return (
+      <span title={label} aria-label={label} style={{ fontSize: 9, color: ACCENT, lineHeight: 1 }}>
+        ▶
+      </span>
+    );
+  }
+  return (
+    <span
+      title={label}
+      aria-label={label}
+      style={{
+        width: 7,
+        height: 7,
+        borderRadius: '50%',
+        background: marker === 'guide' ? ACCENT : 'transparent',
+        border: marker === 'guide' ? 'none' : `1px solid ${HAIRLINE}`,
+      }}
+    />
+  );
+}
+
+// ── Detail card ──────────────────────────────────────────────────
+
+function GuideCard({ entry, onEdit }: { entry: GuideEntry; onEdit: () => void }) {
+  return (
+    <div style={cardStyle}>
+      <div style={eyebrowStyle}>
+        <span style={{ color: ACCENT }}>{entry.requirementId}</span>
+        <span>{entry.chapterText}</span>
+      </div>
+      <h3 style={titleStyle}>{entry.title}</h3>
+      {entry.lede && <p style={ledeStyle}>{entry.lede}</p>}
+
+      {/* Not built yet: said plainly and once, in grey. That something does
+          not exist yet is a state of the plan, not an error — red here
+          would read as "broken". The Anleitung, if someone wrote one ahead
+          of time, still follows below rather than being swallowed. */}
+      {!entry.available && (
+        <div style={noticeStyle}>
+          <span style={noticeDotStyle} />
+          <div>
+            <b style={{ fontWeight: 600, color: INK_SOFT }}>
+              Diese Funktion ist noch nicht verfügbar.
+            </b>
+            <br />
+            {entry.guideText != null
+              ? 'Die Anleitung unten ist bereits geschrieben — prüfbar wird sie, sobald die Funktion ausgeliefert ist.'
+              : 'Sobald sie da ist, steht hier, wie du sie prüfst.'}
+          </div>
+        </div>
+      )}
+
+      {/* The clip gets a real player, or the block is left out entirely.
+          Today `verificationVideoUrl` is empty on every requirement, so no
+          video is the normal case — an empty 16:9 frame on every criterion
+          would be the loudest element of a view built to be quiet. */}
+      {entry.videoUrl && (
+        <div style={{ marginBottom: 24 }}>
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            src={entry.videoUrl}
+            controls
+            preload="metadata"
+            style={{
+              width: '100%',
+              // Capped rather than card-wide: at full width a 16:9 clip is
+              // ~500px tall and pushes every step below the fold, which
+              // turns a page about *following instructions* into a video
+              // player. Fullscreen is one click away when the detail
+              // matters.
+              maxWidth: 640,
+              display: 'block',
+              borderRadius: 10,
+              border: `1px solid ${HAIRLINE}`,
+              background: '#0f172a',
+            }}
+          />
+        </div>
+      )}
+
+      {entry.guideText != null ? (
+        <>
+          <div style={sectionLabelStyle}>Schritte</div>
+          <div className="mb-guide-md" style={stepsStyle}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={guideMarkdownComponents}>
+              {entry.guideText}
+            </ReactMarkdown>
+          </div>
+        </>
+      ) : (
+        entry.available && (
+          <div style={noticeStyle}>
+            <span style={noticeDotStyle} />
+            <div>
+              <b style={{ fontWeight: 600, color: INK_SOFT }}>
+                Für dieses Kriterium ist noch keine Prüfanleitung hinterlegt.
+              </b>
+              <br />
+              Über „Anleitung bearbeiten“ kannst du sie schreiben.
+            </div>
+          </div>
+        )
+      )}
+
+      <div style={actionsStyle}>
+        {/* No URL, no button — a dead link that looks live is worse than an
+            absent one, and `verificationUrl` is unvalidated free text. */}
+        {entry.appUrl && (
+          <a
+            className="mb-guide-btn"
+            href={entry.appUrl}
+            target="_blank"
+            rel="noreferrer"
+            style={primaryBtnStyle}
+          >
+            In der Anwendung öffnen ↗
+          </a>
+        )}
+        <button
+          className="mb-guide-btn"
+          onClick={onEdit}
+          title="Öffnet das Kriterium in der Mindmap; die Prüf-Felder stehen im Eigenschaften-Panel"
+          style={quietBtnStyle}
+        >
+          Anleitung bearbeiten
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Links inside the Anleitung open in a new tab — same reason the register's
+ * Abnahme card sets it: react-markdown emits a bare `<a href>`, and GFM
+ * autolinks turn a naked URL typed into an Anleitung into one whether the
+ * author meant it or not. Navigating the app away mid-check loses the
+ * reader's place.
+ *
+ * No isHttpUrl() guard: react-markdown's defaultUrlTransform already
+ * empties `javascript:` and `data:` hrefs. The two buttons above need the
+ * guard because nothing sanitises those.
+ */
+const guideMarkdownComponents: Components = {
+  a: ({ node: _node, ...props }) => <a {...props} target="_blank" rel="noreferrer" />,
+};
+
+function Placeholder({ title, body }: { title: string; body: string }) {
+  return (
+    <div style={placeholderStyle}>
+      <div style={{ fontSize: 14, fontWeight: 600, color: INK, marginBottom: 6 }}>{title}</div>
+      <div style={{ fontSize: 13, maxWidth: 44 * 8, lineHeight: 1.6 }}>{body}</div>
+    </div>
+  );
+}
+
+// ── Styles ───────────────────────────────────────────────────────
+
+const containerStyle: React.CSSProperties = {
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  background: PAPER,
+  fontFamily: 'inherit',
+  overflow: 'hidden',
+};
+
+const headerStyle: React.CSSProperties = {
+  padding: '14px 24px',
+  borderBottom: `1px solid ${HAIRLINE}`,
+  background: RAISED,
+  flexShrink: 0,
+};
+
+const searchWrapStyle: React.CSSProperties = {
+  padding: '14px 14px 10px',
+  flexShrink: 0,
+};
+
+const searchStyle: React.CSSProperties = {
+  width: '100%',
+  boxSizing: 'border-box',
+  padding: '7px 11px',
+  fontSize: 13,
+  fontFamily: 'inherit',
+  color: INK,
+  background: RAISED,
+  border: `1px solid ${HAIRLINE}`,
+  borderRadius: 8,
+  outline: 'none',
+};
+
+const chapterStyle: React.CSSProperties = {
+  position: 'sticky',
+  top: 0,
+  zIndex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 7,
+  width: '100%',
+  textAlign: 'left',
+  padding: '7px 8px',
+  marginTop: 8,
+  border: 'none',
+  borderRadius: 6,
+  background: PAPER,
+  color: MUTED,
+  fontFamily: MONO,
+  fontSize: 10.5,
+  fontWeight: 600,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  cursor: 'pointer',
+};
+
+const itemStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'auto 1fr auto',
+  alignItems: 'center',
+  gap: 9,
+  width: '100%',
+  textAlign: 'left',
+  padding: '7px 9px',
+  border: 'none',
+  borderRadius: 6,
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+};
+
+const cardStyle: React.CSSProperties = {
+  // A reading surface, not a dashboard panel: on a wide monitor the card
+  // stops rather than stretching, so the steps keep a book's measure
+  // instead of running the full width of a 27-inch screen.
+  maxWidth: 880,
+  width: '100%',
+  background: RAISED,
+  border: `1px solid ${HAIRLINE}`,
+  borderRadius: 12,
+  boxShadow: '0 1px 2px rgba(15,23,42,.04), 0 8px 24px -16px rgba(15,23,42,.18)',
+  padding: '24px 28px 26px',
+};
+
+const eyebrowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 9,
+  fontFamily: MONO,
+  fontSize: 10,
+  letterSpacing: '0.09em',
+  textTransform: 'uppercase',
+  color: MUTED,
+  marginBottom: 8,
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: '0 0 9px',
+  fontSize: 20,
+  fontWeight: 600,
+  lineHeight: 1.3,
+  color: INK,
+  maxWidth: '34em',
+};
+
+const ledeStyle: React.CSSProperties = {
+  margin: '0 0 20px',
+  fontSize: 13.5,
+  lineHeight: 1.6,
+  color: MUTED,
+  maxWidth: '58ch',
+};
+
+const sectionLabelStyle: React.CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 10,
+  letterSpacing: '0.09em',
+  textTransform: 'uppercase',
+  color: MUTED,
+  marginBottom: 12,
+};
+
+const stepsStyle: React.CSSProperties = {
+  fontSize: 13.5,
+  lineHeight: 1.65,
+  color: INK_SOFT,
+  // Prose, not a data grid: past ~70 characters the eye loses the line it
+  // came from on the way back.
+  maxWidth: '68ch',
+  marginBottom: 24,
+};
+
+const noticeStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 11,
+  alignItems: 'flex-start',
+  padding: '14px 16px',
+  marginBottom: 22,
+  border: `1px dashed ${HAIRLINE}`,
+  borderRadius: 10,
+  fontSize: 13,
+  lineHeight: 1.6,
+  color: MUTED,
+  maxWidth: '62ch',
+};
+
+const noticeDotStyle: React.CSSProperties = {
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  background: FAINT,
+  marginTop: 7,
+  flexShrink: 0,
+};
+
+const actionsStyle: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 10,
+  alignItems: 'center',
+  paddingTop: 18,
+  borderTop: `1px solid ${HAIRLINE}`,
+};
+
+const primaryBtnStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '8px 14px',
+  borderRadius: 8,
+  border: `1px solid ${ACCENT}`,
+  background: ACCENT,
+  color: '#ffffff',
+  fontSize: 13,
+  fontWeight: 500,
+  fontFamily: 'inherit',
+  textDecoration: 'none',
+  cursor: 'pointer',
+};
+
+const quietBtnStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '8px 14px',
+  borderRadius: 8,
+  border: `1px solid ${HAIRLINE}`,
+  background: 'transparent',
+  color: MUTED,
+  fontSize: 13,
+  fontWeight: 500,
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+};
+
+const placeholderStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: 1,
+  minHeight: 220,
+  padding: 40,
+  color: MUTED,
+  textAlign: 'center',
+};
+
+/**
+ * Class-based rules for what inline styles cannot express: the two-column
+ * layout collapsing on a narrow window, hover/focus states, and the
+ * markdown the Anleitung is written in.
+ *
+ * Same approach as the register's `.mb-verification-md` block — index.html
+ * applies a global `* { margin: 0; padding: 0 }`, which strips the indent
+ * an <ol> needs to show its numbers at all.
+ */
+const guideCss = `
+  .mb-guide-grid {
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 296px minmax(0, 1fr);
+  }
+  .mb-guide-rail {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    border-right: 1px solid ${HAIRLINE};
+    background: ${PAPER};
+  }
+  .mb-guide-detail {
+    min-width: 0;
+    overflow-y: auto;
+    padding: 24px 28px 56px;
+    display: flex;
+    flex-direction: column;
+  }
+  /* Under ~880px the two columns would each be too narrow to do their job,
+     so the rail becomes a capped list stacked above the criterion. */
+  @media (max-width: 880px) {
+    .mb-guide-grid { grid-template-columns: 1fr; grid-template-rows: minmax(0, 40vh) minmax(0, 1fr); }
+    .mb-guide-rail { border-right: none; border-bottom: 1px solid ${HAIRLINE}; }
+    .mb-guide-detail { padding: 18px 16px 40px; }
+  }
+
+  .mb-guide-search:focus { border-color: ${ACCENT_LINE}; box-shadow: 0 0 0 3px ${ACCENT_SOFT}; }
+  .mb-guide-chapter:hover { color: ${INK_SOFT}; }
+  .mb-guide-item:hover { background: ${RAISED} !important; }
+  .mb-guide-item:focus-visible,
+  .mb-guide-chapter:focus-visible,
+  .mb-guide-btn:focus-visible { outline: 2px solid ${ACCENT}; outline-offset: -2px; }
+  .mb-guide-btn:hover { filter: brightness(0.97); }
+
+  .mb-guide-md > :first-child { margin-top: 0; }
+  .mb-guide-md > :last-child { margin-bottom: 0; }
+  .mb-guide-md p { margin: 0 0 10px; }
+  /* Numbered steps as counter chips rather than plain digits: the reader is
+     working down a list with his hands on the product, and needs to find
+     his place again after every step. */
+  .mb-guide-md ol {
+    margin: 0 0 14px;
+    padding: 0;
+    list-style: none;
+    counter-reset: mbstep;
+  }
+  .mb-guide-md ol > li {
+    counter-increment: mbstep;
+    display: grid;
+    grid-template-columns: 26px minmax(0, 1fr);
+    gap: 13px;
+    align-items: start;
+    margin-bottom: 12px;
+  }
+  /* Every child of the step goes in column 2, under the previous one. A
+     step written as two paragraphs ("do X" / "then Y happens") otherwise
+     drops its second paragraph into the 26px marker column, where it wraps
+     one word per line. */
+  .mb-guide-md ol > li > * { grid-column: 2; }
+  .mb-guide-md ol > li::before {
+    content: counter(mbstep);
+    font-family: ${MONO};
+    font-size: 11px;
+    color: ${ACCENT};
+    border: 1px solid ${HAIRLINE};
+    background: ${RAISED};
+    border-radius: 6px;
+    width: 26px;
+    height: 26px;
+    display: grid;
+    place-items: center;
+    margin-top: 1px;
+  }
+  /* Nested lists fall back to ordinary markers — chips inside chips read as
+     a second numbering scheme rather than a sub-step. */
+  .mb-guide-md ol ol, .mb-guide-md ul ol {
+    padding-left: 20px; list-style: decimal outside; counter-reset: none;
+  }
+  .mb-guide-md ol ol > li, .mb-guide-md ul ol > li {
+    display: list-item; margin-bottom: 4px;
+  }
+  .mb-guide-md ol ol > li::before, .mb-guide-md ul ol > li::before { content: none; }
+  .mb-guide-md ul { margin: 0 0 12px; padding-left: 20px; list-style: disc outside; }
+  .mb-guide-md ul li { margin-bottom: 5px; }
+  .mb-guide-md h1, .mb-guide-md h2, .mb-guide-md h3 {
+    font-size: 13.5px; font-weight: 700; margin: 18px 0 8px; color: ${INK};
+  }
+  .mb-guide-md strong { font-weight: 600; color: ${INK}; }
+  .mb-guide-md a { color: ${ACCENT}; }
+  .mb-guide-md code {
+    font-family: ${MONO}; font-size: 12px;
+    background: ${ACCENT_SOFT}; padding: 1px 5px; border-radius: 4px;
+  }
+  .mb-guide-md pre {
+    background: #0f172a; color: #e2e8f0; padding: 12px 14px;
+    border-radius: 8px; overflow-x: auto; margin: 0 0 12px; font-size: 12px;
+  }
+  .mb-guide-md pre code { background: none; padding: 0; color: inherit; }
+  .mb-guide-md blockquote {
+    border-left: 3px solid ${ACCENT_LINE}; margin: 0 0 12px;
+    padding: 2px 12px; color: ${MUTED};
+  }
+  .mb-guide-md table { border-collapse: collapse; font-size: 12.5px; margin: 0 0 12px; }
+  .mb-guide-md th, .mb-guide-md td {
+    border: 1px solid ${HAIRLINE}; padding: 5px 9px; text-align: left;
+  }
+  .mb-guide-md th { background: ${ACCENT_SOFT}; font-weight: 600; }
+  .mb-guide-md img { max-width: 100%; height: auto; border-radius: 8px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mb-guide-grid * { transition: none !important; animation: none !important; }
+  }
+`;

--- a/packages/mindmap/src/__tests__/guide.test.ts
+++ b/packages/mindmap/src/__tests__/guide.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@mindblown/core';
+import {
+  EXPAND_ALL_LIMIT,
+  ROOT_CHAPTER_ID,
+  buildGuideEntries,
+  filterGuideChapters,
+  groupGuideEntries,
+  guideMarker,
+  initialExpandedChapters,
+  type GuideEntry,
+} from '../guide.js';
+
+/**
+ * The Anwenderansicht's derivation. Three promises are load-bearing and are
+ * what these tests pin:
+ *
+ * 1. **Unbuilt criteria never disappear.** They dim; they do not vanish. A
+ *    view that silently drops half the register is worse than one that
+ *    admits a gap.
+ * 2. **Unvalidated URLs never become an href.** Both URL fields are
+ *    free-text columns, and this view renders one of them into a `<video
+ *    src>` — a place where a bad value is not merely a dead link.
+ * 3. **The rail stays scannable at 168 criteria.** That is the size the
+ *    view exists for, and the size the mock could not show.
+ */
+
+let seq = 0;
+
+/** Minimal Node; only the fields the derivation reads are meaningful. */
+function node(v: Partial<Node>): Node {
+  return {
+    id: `n${seq++}`,
+    text: 'untitled',
+    parentId: null,
+    childrenIds: [],
+    requirementId: null,
+    requirementText: null,
+    description: null,
+    percentComplete: null,
+    verificationText: null,
+    verificationUrl: null,
+    verificationVideoUrl: null,
+    ...v,
+  } as Node;
+}
+
+function mapOf(...list: Node[]): Record<string, Node> {
+  return Object.fromEntries(list.map((n) => [n.id, n]));
+}
+
+/** Leaves report their own percentComplete; nothing here needs a rollup. */
+const leafProgress = (n: Node) => n.percentComplete ?? 0;
+
+describe('buildGuideEntries', () => {
+  it('takes only nodes carrying a requirementId', () => {
+    const req = node({ requirementId: 'PEN-01', text: 'Aufgaben erstellen' });
+    const plain = node({ text: 'irgendeine Teilaufgabe' });
+    const entries = buildGuideEntries(mapOf(req, plain), leafProgress);
+    expect(entries.map((e) => e.requirementId)).toEqual(['PEN-01']);
+  });
+
+  it('uses the parent node as the chapter, and falls back for a parentless one', () => {
+    const chapter = node({ id: 'c1', text: 'Pendenzen' });
+    const req = node({ requirementId: 'PEN-01', parentId: 'c1' });
+    const orphan = node({ requirementId: 'ZZZ-01' });
+    const byId = new Map(
+      buildGuideEntries(mapOf(chapter, req, orphan), leafProgress).map((e) => [
+        e.requirementId,
+        e,
+      ]),
+    );
+    expect(byId.get('PEN-01')!.chapterId).toBe('c1');
+    expect(byId.get('PEN-01')!.chapterText).toBe('Pendenzen');
+    expect(byId.get('ZZZ-01')!.chapterId).toBe(ROOT_CHAPTER_ID);
+  });
+
+  it('prefers the business phrasing over the node text', () => {
+    // requirementText is what the register shows and what the Word export
+    // prints; the node text can be a GitHub-synced issue title.
+    const [e] = buildGuideEntries(
+      mapOf(
+        node({
+          requirementId: 'MAN-01',
+          text: 'feat(mandates): onboarding wizard',
+          requirementText: 'Ein Mandat über den geführten Onboarding-Prozess eröffnen',
+        }),
+      ),
+      leafProgress,
+    );
+    expect(e.title).toBe('Ein Mandat über den geführten Onboarding-Prozess eröffnen');
+  });
+
+  describe('availability', () => {
+    it('is progress-only, and an unbuilt criterion is still returned', () => {
+      // The promise: not-yet-built dims the row, it never removes it.
+      const entries = buildGuideEntries(
+        mapOf(
+          node({ requirementId: 'A-01', percentComplete: 100 }),
+          node({ requirementId: 'A-02', percentComplete: 40 }),
+          node({ requirementId: 'A-03', percentComplete: null }),
+        ),
+        leafProgress,
+      );
+      expect(entries.map((e) => [e.requirementId, e.available])).toEqual([
+        ['A-01', true],
+        ['A-02', false],
+        ['A-03', false],
+      ]);
+    });
+
+    it('reads the rollup for a parent rather than its own percentComplete', () => {
+      // A requirement with work underneath it is judged by what merged
+      // below, exactly as the register judges "Built".
+      const parent = node({ requirementId: 'P-01', childrenIds: ['x'], percentComplete: 0 });
+      const [e] = buildGuideEntries(mapOf(parent), (n) =>
+        n.childrenIds.length === 0 ? (n.percentComplete ?? 0) : 100,
+      );
+      expect(e.available).toBe(true);
+    });
+  });
+
+  describe('URL handling', () => {
+    it('drops URLs that are not absolute http(s)', () => {
+      // This is the guard that keeps a javascript: payload out of an href —
+      // and, for the video field, out of a <video src>.
+      const [e] = buildGuideEntries(
+        mapOf(
+          node({
+            requirementId: 'X-01',
+            verificationUrl: 'javascript:alert(1)',
+            verificationVideoUrl: '/relative/clip.mp4',
+          }),
+        ),
+        leafProgress,
+      );
+      expect(e.appUrl).toBeNull();
+      expect(e.videoUrl).toBeNull();
+      // The raw values stay reachable for anything that wants to show them
+      // as text; only the render-ready fields are cleared.
+      expect(e.verification?.url).toBe('javascript:alert(1)');
+    });
+
+    it('keeps absolute http(s) URLs', () => {
+      const [e] = buildGuideEntries(
+        mapOf(
+          node({
+            requirementId: 'X-02',
+            verificationUrl: 'https://staging.example.com/mandates',
+            verificationVideoUrl: 'https://v.example.com/clip.mp4',
+          }),
+        ),
+        leafProgress,
+      );
+      expect(e.appUrl).toBe('https://staging.example.com/mandates');
+      expect(e.videoUrl).toBe('https://v.example.com/clip.mp4');
+    });
+  });
+
+  describe('lede', () => {
+    it('renders a ProseMirror description down to its first non-empty line', () => {
+      const description = {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Worum es geht.' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Ein zweiter Absatz.' }] },
+        ],
+      };
+      const [e] = buildGuideEntries(
+        mapOf(node({ requirementId: 'L-01', description: description as never })),
+        leafProgress,
+      );
+      expect(e.lede).toBe('Worum es geht.');
+    });
+
+    it('is null when there is no description', () => {
+      const [e] = buildGuideEntries(mapOf(node({ requirementId: 'L-02' })), leafProgress);
+      expect(e.lede).toBeNull();
+    });
+  });
+});
+
+describe('guideMarker', () => {
+  const entry = (v: Partial<GuideEntry>): GuideEntry =>
+    ({ guideText: null, videoUrl: null, ...v }) as GuideEntry;
+
+  it('reports a video only when the URL survived validation', () => {
+    expect(guideMarker(entry({ videoUrl: 'https://v.example.com/a.mp4' }))).toBe('video');
+    expect(guideMarker(entry({ guideText: '1. Einloggen' }))).toBe('guide');
+    expect(guideMarker(entry({}))).toBe('none');
+  });
+
+  it('reports the video state even when both are present', () => {
+    expect(
+      guideMarker(entry({ guideText: '1. Einloggen', videoUrl: 'https://v.example.com/a.mp4' })),
+    ).toBe('video');
+  });
+});
+
+describe('groupGuideEntries', () => {
+  it('orders chapters by the map, criteria by REQ-ID, numerically', () => {
+    // "MAN-10" must not sort between MAN-1 and MAN-2 — the register sorts
+    // numerically and the two views have to agree.
+    const c1 = node({ id: 'c1', text: 'Pendenzen' });
+    const c2 = node({ id: 'c2', text: 'Mandate' });
+    const entries = buildGuideEntries(
+      mapOf(
+        c1,
+        c2,
+        node({ requirementId: 'MAN-10', parentId: 'c2' }),
+        node({ requirementId: 'MAN-2', parentId: 'c2' }),
+        node({ requirementId: 'PEN-01', parentId: 'c1' }),
+      ),
+      leafProgress,
+    );
+    // Chapter rank says Mandate comes first, even though Pendenzen holds
+    // the alphabetically earlier chapter name.
+    const rank = (id: string) => ({ c2: 0, c1: 1 })[id] ?? Infinity;
+    const grouped = groupGuideEntries(entries, rank);
+    expect(grouped.map((c) => c.text)).toEqual(['Mandate', 'Pendenzen']);
+    expect(grouped[0].entries.map((e) => e.requirementId)).toEqual(['MAN-2', 'MAN-10']);
+  });
+
+  it('sinks a chapter the rank function does not know instead of throwing', () => {
+    const entries = buildGuideEntries(
+      mapOf(node({ id: 'c1', text: 'Known' }), node({ requirementId: 'A-01', parentId: 'c1' })),
+      leafProgress,
+    );
+    expect(() => groupGuideEntries(entries, () => Infinity)).not.toThrow();
+  });
+});
+
+describe('filterGuideChapters', () => {
+  const chapters = () => {
+    const c1 = node({ id: 'c1', text: 'Pendenzen' });
+    const c2 = node({ id: 'c2', text: 'Mandate' });
+    const entries = buildGuideEntries(
+      mapOf(
+        c1,
+        c2,
+        node({ requirementId: 'PEN-01', parentId: 'c1', text: 'Aufgaben erstellen' }),
+        node({ requirementId: 'PEN-02', parentId: 'c1', text: 'Erinnerungen versenden' }),
+        node({ requirementId: 'MAN-01', parentId: 'c2', text: 'Mandat eröffnen' }),
+      ),
+      leafProgress,
+    );
+    return groupGuideEntries(entries, (id) => ({ c1: 0, c2: 1 })[id] ?? Infinity);
+  };
+
+  it('returns everything for an empty or whitespace query', () => {
+    expect(filterGuideChapters(chapters(), '')).toHaveLength(2);
+    expect(filterGuideChapters(chapters(), '   ')).toHaveLength(2);
+  });
+
+  it('matches the Kürzel and the title, case-insensitively', () => {
+    const byId = filterGuideChapters(chapters(), 'pen-02');
+    expect(byId.flatMap((c) => c.entries.map((e) => e.requirementId))).toEqual(['PEN-02']);
+    const byTitle = filterGuideChapters(chapters(), 'ERINNERUNG');
+    expect(byTitle.flatMap((c) => c.entries.map((e) => e.requirementId))).toEqual(['PEN-02']);
+  });
+
+  it('keeps a whole chapter when the chapter name is what matched', () => {
+    // Typing a chapter name is the fastest route to it with 22 of them, and
+    // a chapter answering that with 1 of its 2 rows reads as a broken
+    // filter rather than a narrowed one.
+    const result = filterGuideChapters(chapters(), 'Pendenzen');
+    expect(result).toHaveLength(1);
+    expect(result[0].entries.map((e) => e.requirementId)).toEqual(['PEN-01', 'PEN-02']);
+  });
+
+  it('drops chapters that keep nothing', () => {
+    expect(filterGuideChapters(chapters(), 'zzz')).toEqual([]);
+  });
+});
+
+describe('initialExpandedChapters', () => {
+  /** `count` criteria spread over `chapterCount` chapters. */
+  const build = (chapterCount: number, perChapter: number) => {
+    const nodes: Node[] = [];
+    for (let c = 0; c < chapterCount; c++) {
+      nodes.push(node({ id: `c${c}`, text: `Kapitel ${c}` }));
+      for (let i = 0; i < perChapter; i++) {
+        nodes.push(node({ requirementId: `K${c}-${i}`, parentId: `c${c}` }));
+      }
+    }
+    const entries = buildGuideEntries(mapOf(...nodes), leafProgress);
+    return groupGuideEntries(entries, (id) => Number(id.slice(1)));
+  };
+
+  it('unfolds everything on a small map', () => {
+    const chapters = build(2, 3); // 6 criteria
+    expect(initialExpandedChapters(chapters, null).size).toBe(2);
+  });
+
+  it('unfolds only the selected chapter once the map is large', () => {
+    // The case the view exists for: 22 chapters × ~8 = 176 criteria. All
+    // unfolded, the rail is a wall; folded, it is a table of contents.
+    const chapters = build(22, 8);
+    expect(chapters.reduce((n, c) => n + c.entries.length, 0)).toBeGreaterThan(EXPAND_ALL_LIMIT);
+    expect([...initialExpandedChapters(chapters, 'c7')]).toEqual(['c7']);
+  });
+
+  it('falls back to the first chapter when nothing is selected', () => {
+    expect([...initialExpandedChapters(build(22, 8), null)]).toEqual(['c0']);
+  });
+
+  it('falls back to the first chapter when the selection is stale', () => {
+    // A shared link naming a deleted node must not open a rail with every
+    // chapter folded and no way in.
+    expect([...initialExpandedChapters(build(22, 8), 'gone')]).toEqual(['c0']);
+  });
+
+  it('returns an empty set for a map with no chapters', () => {
+    expect(initialExpandedChapters([], null).size).toBe(0);
+  });
+});

--- a/packages/mindmap/src/__tests__/urlState.test.ts
+++ b/packages/mindmap/src/__tests__/urlState.test.ts
@@ -57,6 +57,26 @@ describe('parseUrlState', () => {
     expect(parseUrlState('?view=nonsense').view).toBeNull();
   });
 
+  it('accepts every view the switcher offers', () => {
+    // A view missing from VIEW_IDS survives neither a reload nor a shared
+    // link: it parses to null and silently resolves back to the mindmap.
+    // Cheap to forget when adding a tab, invisible until someone shares one.
+    for (const view of [
+      'mindmap',
+      'kanban',
+      'gantt',
+      'list',
+      'calendar',
+      'hill',
+      'workload',
+      'releases',
+      'requirements',
+      'guide',
+    ]) {
+      expect(parseUrlState(`?view=${view}`).view).toBe(view === 'mindmap' ? 'mindmap' : view);
+    }
+  });
+
   it('treats blank values as absent', () => {
     expect(parseUrlState('?map=&focus=%20')).toEqual(EMPTY_URL_STATE);
   });

--- a/packages/mindmap/src/guide.ts
+++ b/packages/mindmap/src/guide.ts
@@ -1,0 +1,211 @@
+/**
+ * The Anwenderansicht's data rules: which requirements it shows, how they
+ * group into chapters, what the left rail's marker means, and how a search
+ * query narrows the list.
+ *
+ * Kept out of GuideView.tsx for the same reason verification.ts is kept out
+ * of RequirementsView.tsx — the component module builds the zustand store at
+ * import time, so none of this would be reachable from a unit test.
+ *
+ * The view answers one question per requirement: *how do I check this
+ * myself?* That is a different job from the register's, so the derivation
+ * here is deliberately narrower — no acceptance verdicts, no release
+ * filter, no remaining effort. Only what a reader needs to follow steps.
+ */
+
+import { BUILT_THRESHOLD, proseMirrorToPlainText } from '@mindblown/core';
+import type { Node } from '@mindblown/core';
+import { isHttpUrl, verificationOf, type Verification } from './verification.js';
+
+/** Chapter key for requirements that hang straight off the root. */
+export const ROOT_CHAPTER_ID = '(root)';
+
+/**
+ * One criterion, flattened to exactly what the two panes render.
+ *
+ * `appUrl` / `videoUrl` are pre-validated rather than raw: both come from
+ * free-text columns, and a caller that forgets `isHttpUrl` would hand a
+ * `javascript:` payload an href — the same trap the Abnahme card guards
+ * against. Storing them already-checked means the component cannot get it
+ * wrong, and `null` doubles as "don't render this part".
+ */
+export interface GuideEntry {
+  node: Node;
+  requirementId: string;
+  /** Business phrasing when one is set, else the node's own text. */
+  title: string;
+  chapterId: string;
+  chapterText: string;
+  /** First non-empty line of the description, plain text. null when unset. */
+  lede: string | null;
+  verification: Verification | null;
+  /** The Prüfanleitung markdown, or null when nobody has written one. */
+  guideText: string | null;
+  /** Validated http(s) deep link into the running application. */
+  appUrl: string | null;
+  /** Validated http(s) link to the demo clip. */
+  videoUrl: string | null;
+  /**
+   * Whether the feature exists yet. Progress-only, exactly like the
+   * register's "Built" — deliberately NOT the sign-off stage: a reader
+   * asking "how do I check this?" cares whether the screen is there, not
+   * whether two gatekeepers have countersigned it.
+   */
+  available: boolean;
+}
+
+export interface GuideChapter {
+  id: string;
+  text: string;
+  entries: GuideEntry[];
+}
+
+/**
+ * The one marker the left rail carries per row.
+ *
+ * The mock called it "video vorhanden", and against today's data that
+ * would be a dead column — `verificationVideoUrl` is empty on every
+ * requirement, so all 168 rows would show the same empty ring. Folding the
+ * written Anleitung into the same slot keeps one marker that actually
+ * varies now and still gains a distinct state the day clips land.
+ */
+export type GuideMarker = 'video' | 'guide' | 'none';
+
+export function guideMarker(entry: GuideEntry): GuideMarker {
+  if (entry.videoUrl != null) return 'video';
+  if (entry.guideText != null) return 'guide';
+  return 'none';
+}
+
+/**
+ * Above this many criteria the rail opens with only the selected chapter
+ * unfolded. 22 chapter headers fit on one screen; 168 rows do not, and a
+ * reader who has to scroll past six chapters to find the seventh has lost
+ * the overview the view exists to give. Below it, folding is pure friction
+ * — a five-requirement map should just show its five requirements.
+ */
+export const EXPAND_ALL_LIMIT = 25;
+
+/**
+ * Flatten the store's node map into criteria.
+ *
+ * `progressOf` is injected rather than read from `computed` here so the
+ * rollup rule (leaf → own percentComplete, parent → computed) stays with
+ * the component that owns the store subscription, and so a test can state
+ * a progress value without building a ComputedNodeValues map.
+ */
+export function buildGuideEntries(
+  nodes: Record<string, Node>,
+  progressOf: (node: Node) => number,
+): GuideEntry[] {
+  const entries: GuideEntry[] = [];
+  for (const node of Object.values(nodes)) {
+    if (node.requirementId == null) continue;
+    const chapter = node.parentId ? nodes[node.parentId] : undefined;
+    const verification = verificationOf(node);
+    // The description is ProseMirror JSON (older rows: a raw string). Only
+    // its first non-empty line is used — the field is a free-form note, and
+    // an essay pasted into it must not push the steps below the fold.
+    const lede =
+      proseMirrorToPlainText(node.description)
+        .split('\n')
+        .map((line) => line.trim())
+        .find((line) => line !== '') ?? null;
+    entries.push({
+      node,
+      requirementId: node.requirementId,
+      title: node.requirementText ?? node.text,
+      chapterId: chapter?.id ?? ROOT_CHAPTER_ID,
+      chapterText: chapter?.text ?? ROOT_CHAPTER_ID,
+      lede: lede === '' ? null : lede,
+      verification,
+      guideText: verification?.text ?? null,
+      appUrl: isHttpUrl(verification?.url) ? (verification?.url ?? null) : null,
+      videoUrl: isHttpUrl(verification?.videoUrl) ? (verification?.videoUrl ?? null) : null,
+      available: progressOf(node) >= BUILT_THRESHOLD,
+    });
+  }
+  return entries;
+}
+
+/** REQ-ID order, numeric-aware so MAN-9 sorts before MAN-10. */
+export function compareGuideEntries(a: GuideEntry, b: GuideEntry): number {
+  return a.requirementId.localeCompare(b.requirementId, undefined, { numeric: true });
+}
+
+/**
+ * Group into chapters, chapters in map order and criteria in REQ-ID order
+ * — the same two rules the register uses, so a reader who knows one view's
+ * ordering already knows the other's.
+ *
+ * `chapterRank` is the caller's depth-first index of the node tree; a
+ * chapter it doesn't know sinks to the end rather than throwing.
+ */
+export function groupGuideEntries(
+  entries: GuideEntry[],
+  chapterRank: (chapterId: string) => number,
+): GuideChapter[] {
+  const byChapter = new Map<string, GuideChapter>();
+  for (const entry of [...entries].sort(compareGuideEntries)) {
+    let chapter = byChapter.get(entry.chapterId);
+    if (!chapter) {
+      chapter = { id: entry.chapterId, text: entry.chapterText, entries: [] };
+      byChapter.set(entry.chapterId, chapter);
+    }
+    chapter.entries.push(entry);
+  }
+  return [...byChapter.values()].sort((a, b) => chapterRank(a.id) - chapterRank(b.id));
+}
+
+/** Case-insensitive substring match on REQ-ID, title and chapter name. */
+export function matchesGuideQuery(entry: GuideEntry, needle: string): boolean {
+  const q = needle.trim().toLowerCase();
+  if (q === '') return true;
+  return (
+    entry.requirementId.toLowerCase().includes(q) ||
+    entry.title.toLowerCase().includes(q) ||
+    entry.chapterText.toLowerCase().includes(q)
+  );
+}
+
+/**
+ * Narrow the grouped list to a search query, dropping chapters that keep
+ * nothing.
+ *
+ * Note that a query matching a *chapter name* keeps every criterion under
+ * it — not as a special case here, but because `matchesGuideQuery` scores
+ * each entry against its own chapter name. With 22 chapters, typing a
+ * chapter name is the fastest way to reach one, and a chapter that
+ * answered that with three of its twelve rows would read as a broken
+ * filter rather than a narrowed one.
+ */
+export function filterGuideChapters(chapters: GuideChapter[], query: string): GuideChapter[] {
+  const q = query.trim().toLowerCase();
+  if (q === '') return chapters;
+  const out: GuideChapter[] = [];
+  for (const chapter of chapters) {
+    const entries = chapter.entries.filter((e) => matchesGuideQuery(e, q));
+    if (entries.length > 0) out.push({ ...chapter, entries });
+  }
+  return out;
+}
+
+/**
+ * Which chapters the rail starts with unfolded.
+ *
+ * Small map: everything, because folding would only hide what already fit.
+ * Large map: the selected chapter alone, falling back to the first one, so
+ * the rail opens as a table of contents you can scan in a single glance.
+ */
+export function initialExpandedChapters(
+  chapters: GuideChapter[],
+  selectedChapterId: string | null,
+): Set<string> {
+  const total = chapters.reduce((n, c) => n + c.entries.length, 0);
+  if (total <= EXPAND_ALL_LIMIT) return new Set(chapters.map((c) => c.id));
+  const selected =
+    selectedChapterId != null && chapters.some((c) => c.id === selectedChapterId)
+      ? selectedChapterId
+      : chapters[0]?.id;
+  return selected == null ? new Set() : new Set([selected]);
+}

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -17,7 +17,7 @@ function recomputeValues(nodes: Record<string, Node>): Map<NodeId, ComputedNodeV
 
 // ── Store types ────────────────────────────────────────────────
 
-export type ActiveView = 'mindmap' | 'kanban' | 'gantt' | 'list' | 'calendar' | 'hill' | 'workload' | 'releases' | 'requirements';
+export type ActiveView = 'mindmap' | 'kanban' | 'gantt' | 'list' | 'calendar' | 'hill' | 'workload' | 'releases' | 'requirements' | 'guide';
 
 export interface VisibleNode {
   node: Node;

--- a/packages/mindmap/src/urlState.ts
+++ b/packages/mindmap/src/urlState.ts
@@ -69,6 +69,7 @@ const VIEW_IDS: ReadonlySet<string> = new Set<ActiveView>([
   'workload',
   'releases',
   'requirements',
+  'guide',
 ]);
 
 // ── Shape ──────────────────────────────────────────────────────


### PR DESCRIPTION
Eine eigene Ansicht neben dem Requirements-Register, für den Leser, der wissen will **wie prüfe ich das?** — statt die Prüfanleitung weiter in die Abnahme-Zelle einer Neun-Spalten-Tabelle zu quetschen.

`RequirementsView.tsx` ist **nicht angefasst**. Gleiche Datenquelle, gleiche Ableitungsregeln (Kapitel = Elternknoten, REQ-ID-Reihenfolge), eigene Fläche.

## Was drin ist

| Datei | |
|---|---|
| `guide.ts` | Ableitung: Einträge, Gruppierung, Suche, Klapp-Zustand. Rein, ohne Store. |
| `GuideView.tsx` | Die Ansicht. |
| `__tests__/guide.test.ts` | 22 Tests, alle mutationsverifiziert (11 Mutationen, jede gefangen). |
| `App.tsx`, `store.ts`, `urlState.ts` | Drei Integrationspunkte + ein Sonderfall, siehe unten. |

**Auswahl in der URL:** über den bestehenden `?node=`-Parameter (`selectedNodeId`), kein neuer Parameter. Ein Link auf ein Kriterium ist teilbar und übersteht ein Neuladen — verifiziert.

**Keine Abnahme-Daten.** `fetchAcceptances` / `acceptRequirement` werden nicht aufgerufen; Freigeben bleibt Aufgabe des Registers.

## Was ich im Browser gesehen habe

Lokal gegen eine eigene Postgres-DB, gegen **168 Kriterien in 22 Kapiteln** — nicht gegen die fünf des Entwurfs. (Testdaten generiert; die Fulcrum-Karte wurde nicht angefasst.)

- **Hell, 1440×900** — linke Leiste als Inhaltsverzeichnis mit 22 Kapiteln, das gewählte aufgeklappt. Karte auf 880px begrenzt, Schritte als nummerierte Chips, Blockquote für „Erwartet:", zwei Aktionen unten. Kein horizontales Scrollen.
- **Video** — `<video controls>` spielt echt; ohne `verificationVideoUrl` fehlt der Block ersatzlos (der Normalfall heute).
- **Nicht verfügbar** — grauer Hinweis, kein Rot; Eintrag bleibt in der Liste, nur gedämpft.
- **Gebaut, aber undokumentiert** — eigener ruhiger Hinweis plus „Anleitung bearbeiten".
- **Suche** — „beleg" findet 19 Treffer über 18 Kapitel, alle automatisch aufgeklappt; „kyc" behält das ganze Kapitel.
- **Deep-Link** — `?node=…` auf ein Kriterium in Kapitel 17 klappt das Kapitel auf und scrollt die Leiste hin.
- **`javascript:`-URL** — erzeugt null Anchor-Elemente in der Karte; der Knopf fehlt, statt ins Leere zu zeigen.
- **Schmal (860px)** — die zwei Spalten stapeln, Leiste auf 40vh gedeckelt und eigenständig scrollbar. Unter ~600px übernimmt der bestehende Mobile-Viewer die App komplett (kennt diese Ansicht nicht — separater Faden, nicht Teil dieses PRs).
- **Dunkler Modus** — sieht identisch zu hell aus. **MindBlown hat keinen dunklen Modus**: kein `prefers-color-scheme`, keine CSS-Variablen, kein Theme-Layer, in keiner Datei. Siehe unten.

## Abweichungen vom Entwurf, mit Begründung

1. **Klapp-Kapitel statt flacher Liste.** Der Entwurf trägt 168 Einträge nicht: eine flache Leiste wäre ~6700px hoch und das `position: sticky` des Entwurfs würde bei 22 Kapiteln reissen. Die Leiste scrollt jetzt eigenständig, Kapitel klappen, Kapitel-Überschriften sind innerhalb der Leiste sticky. Bei ≤25 Kriterien ist alles aufgeklappt (Klappen wäre dort nur Reibung), darüber nur das gewählte Kapitel — 22 Überschriften passen auf einen Blick, 168 Zeilen nicht.
2. **Der Punkt heisst „Anleitung vorhanden", nicht „Video vorhanden".** `verificationVideoUrl` ist heute auf **jedem** Kriterium leer — die Spalte des Entwurfs wäre 168× derselbe leere Ring gewesen. Ein Marker, drei Zustände: gefüllt = Anleitung, ▶ = Anleitung + Video, hohler Ring = nichts. Gewinnt den Video-Zustand zurück, sobald Clips landen.
3. **Farben in die bestehende Palette übersetzt, nicht danebengestellt.** MindBlown hat kein Token-System — jede Ansicht trägt eigene `React.CSSProperties`-Konstanten über derselben Slate-/Indigo-Palette. Die Struktur des Entwurfs (paper/raised/ink/muted/hairline/accent) ist 1:1 abbildbar, also ist das Pine-Grün zu `#4f46e5` geworden usw. Ein zweites, wärmeres System für einen Reiter hätte wie ein Fremdkörper gewirkt.
4. **Kein Serif.** Der Entwurf setzt Georgia für die Überschriften. Die App hat genau einen Font-Stack, überall. Eine Serifen-Überschrift einen Klick neben der Requirements-Tabelle liest sich als Render-Fehler, nicht als bewusster Registerwechsel. Hierarchie und Zeilenmass des Entwurfs sind übernommen, die Schriftart nicht.
5. **Kein dunkler Modus.** Der Entwurf bringt eine vollständige dunkle Palette mit. Es gibt nirgends etwas, in das die passen würde, und diese eine Ansicht dunkel zu machen hiesse: eine dunkle Fläche in einer hellen App. Das gehört als eigener Faden über die ganze App gemacht, nicht hier eingeschmuggelt.
6. **Video auf 640px begrenzt.** Über die volle Kartenbreite ist ein 16:9-Clip ~500px hoch und schiebt jeden Schritt unter die Falz — eine Seite übers *Schritte-Befolgen* wird zum Videoplayer. Vollbild ist ein Klick.
7. **Das Eigenschaften-Panel ist in dieser einen Ansicht unterdrückt** (`App.tsx`). Das ist die einzige Änderung ausserhalb der drei genannten Integrationspunkte, und sie ist nicht kosmetisch: das Panel öffnet bei *jeder* Auswahl, und da die Auswahl hier in `selectedNodeId` liegt (damit der Link teilbar ist), stand neben der „drei statt neun"-Fläche ein 320px-Editor für Schätzung, Status und Blocked-Reason. Das hätte den ganzen Zweck aufgehoben. „Anleitung bearbeiten" springt stattdessen in die Mindmap, wo das Panel hingehört — verifiziert. Alle anderen Ansichten sind unberührt.

## Gates

`pnpm turbo typecheck test lint` grün (16 Tasks). Mindmap-Suite 124 Tests, Server 705.

## Nicht drin

Datei-Upload und alles Multipart-Verwandte (Parallel-Session). Diese Ansicht **liest** `verificationVideoUrl` nur.
