### PR TITLE
chore(mindmap): Anwenderansicht sachlich benennen — "Prüfanleitungen"

### DIFF
--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -865,7 +865,7 @@ const VIEW_TABS: { id: ActiveView; label: string; enabled: boolean }[] = [
   // Reads the same requirement nodes as the register, for the opposite
   // reader: "how do I check this?" rather than "where does this stand?".
   // Sits next to it so the switch between the two is one click.
-  { id: 'guide', label: 'Anwender', enabled: true },
+  { id: 'guide', label: 'Prüfanleitungen', enabled: true },
   { id: 'list', label: 'List', enabled: true },
   { id: 'calendar', label: 'Calendar', enabled: true },
   { id: 'hill', label: 'Hill Chart', enabled: true },

--- a/packages/mindmap/src/GuideView.tsx
+++ b/packages/mindmap/src/GuideView.tsx
@@ -177,7 +177,7 @@ export function GuideView() {
       <style>{guideCss}</style>
 
       <div style={headerStyle}>
-        <h2 style={{ margin: 0, fontSize: 16, color: INK }}>So prüfst du das</h2>
+        <h2 style={{ margin: 0, fontSize: 16, color: INK }}>Prüfanleitungen</h2>
         <div style={{ fontSize: 11, color: MUTED, marginTop: 3 }}>
           {entries.length} Kriterien · {withGuide} mit Prüfanleitung · {withVideo} mit Video
         </div>


### PR DESCRIPTION
Zwei Beschriftungen, sonst nichts.

- Überschrift **„So prüfst du das" → „Prüfanleitungen"**. Die alte war Entwurfssprache: sie spricht den Leser an, statt zu benennen, was auf der Seite steht — in einer Anwendung, die im Tagesbetrieb einer Treuhandgesellschaft läuft, liest sich das belehrend. Die neue deckt sich mit der Zeile darunter, die ohnehin schon „… mit Prüfanleitung" zählt.
- Reiter **„Anwender" → „Prüfanleitungen"**. Der alte benannte eine Zielgruppe statt eines Inhalts; jeder andere Reiter (Requirements, Releases, Kanban) benennt, was er zeigt.

Keine Logik, keine Struktur, keine Tests berührt.