### PR TITLE
feat(mindmap): Prüfanleitung raus aus dem Register, Verknüpfung in beide Richtungen

### DIFF
--- a/packages/mindmap/src/GuideView.tsx
+++ b/packages/mindmap/src/GuideView.tsx
@@ -20,9 +20,9 @@ import {
  * (never inside) the requirements register. The register is a controlling
  * instrument: nine columns, six filters, one row per requirement. Five of
  * those nine columns are noise to a reader whose only question is "how do I
- * verify this myself?", and the Prüfanleitung squeezed into its Abnahme
- * cell was unreadable at that width. So this view drops everything the
- * question doesn't need:
+ * verify this myself?", and the Prüfanleitung briefly squeezed into its
+ * Abnahme cell was unreadable at that width. So this view drops everything
+ * the question doesn't need:
  *
  * - **Left: three facts.** Kürzel, title, one marker. Nothing else.
  * - **Right: the criterion whole.** Steps at full reading width, the clip
@@ -32,8 +32,11 @@ import {
  * job; conflating "I understand how to check this" with "I hereby accept
  * it" is exactly the confusion the two-gate model was built to prevent.
  *
- * RequirementsView.tsx is untouched by this file — same store, same
- * derivation rules (chapter = parent node, REQ-ID order), separate surface.
+ * Same store as RequirementsView.tsx and the same derivation rules (chapter
+ * = parent node, REQ-ID order), but a separate surface. The two are linked
+ * in both directions through `selectedNodeId` alone: the register's marker
+ * sets it and switches here, "Im Register ansehen" does the reverse. No
+ * shared state beyond the selection the URL already carries.
  */
 
 // ── Palette ──────────────────────────────────────────────────────
@@ -161,6 +164,18 @@ export function GuideView() {
     );
   };
 
+  /**
+   * Back to the register, on this criterion — the return leg of the marker
+   * that got the reader here. "How do I check this?" and "where does this
+   * stand?" are two questions about the same row, and answering the second
+   * should not cost a scroll through 168 of them: the register reads the
+   * same `selectedNodeId` and scrolls the row into view.
+   */
+  const showInRegister = (node: Node) => {
+    setActiveView('requirements');
+    selectNode(node.id);
+  };
+
   if (!rootNodeId) {
     return (
       <div style={containerStyle}>
@@ -229,7 +244,11 @@ export function GuideView() {
           {/* ── Detail ────────────────────────────────────────── */}
           <main className="mb-guide-detail" ref={detailRef}>
             {selected ? (
-              <GuideCard entry={selected} onEdit={() => editGuide(selected.node)} />
+              <GuideCard
+                entry={selected}
+                onEdit={() => editGuide(selected.node)}
+                onShowInRegister={() => showInRegister(selected.node)}
+              />
             ) : (
               <Placeholder
                 title="Wähle links ein Kriterium"
@@ -366,7 +385,15 @@ function Marker({ marker }: { marker: ReturnType<typeof guideMarker> }) {
 
 // ── Detail card ──────────────────────────────────────────────────
 
-function GuideCard({ entry, onEdit }: { entry: GuideEntry; onEdit: () => void }) {
+function GuideCard({
+  entry,
+  onEdit,
+  onShowInRegister,
+}: {
+  entry: GuideEntry;
+  onEdit: () => void;
+  onShowInRegister: () => void;
+}) {
   return (
     <div style={cardStyle}>
       <div style={eyebrowStyle}>
@@ -469,17 +496,24 @@ function GuideCard({ entry, onEdit }: { entry: GuideEntry; onEdit: () => void })
         >
           Anleitung bearbeiten
         </button>
+        <button
+          className="mb-guide-btn"
+          onClick={onShowInRegister}
+          title="Zeigt dieses Kriterium im Anforderungsregister — Status, Release, Abnahme"
+          style={quietBtnStyle}
+        >
+          Im Register ansehen
+        </button>
       </div>
     </div>
   );
 }
 
 /**
- * Links inside the Anleitung open in a new tab — same reason the register's
- * Abnahme card sets it: react-markdown emits a bare `<a href>`, and GFM
- * autolinks turn a naked URL typed into an Anleitung into one whether the
- * author meant it or not. Navigating the app away mid-check loses the
- * reader's place.
+ * Links inside the Anleitung open in a new tab: react-markdown emits a bare
+ * `<a href>`, and GFM autolinks turn a naked URL typed into an Anleitung
+ * into one whether the author meant it or not. Navigating the app away
+ * mid-check loses the reader's place.
  *
  * No isHttpUrl() guard: react-markdown's defaultUrlTransform already
  * empties `javascript:` and `data:` hrefs. The two buttons above need the
@@ -763,21 +797,24 @@ const guideCss = `
     list-style: none;
     counter-reset: mbstep;
   }
+  /* The chip is positioned out of flow rather than made a grid column.
+     A grid li turns every child into a grid item — including the inline
+     <strong> and <em> that markdown puts *inside* a sentence, and the bare
+     text around them into anonymous items. A step reading
+     "öffne **Mandate → Übersicht** und prüfe …" then broke into three
+     stacked blocks, the last of them wrapping one word per line in the
+     26px marker column. Out-of-flow keeps the step a paragraph. */
   .mb-guide-md ol > li {
     counter-increment: mbstep;
-    display: grid;
-    grid-template-columns: 26px minmax(0, 1fr);
-    gap: 13px;
-    align-items: start;
+    position: relative;
+    padding-left: 39px;
     margin-bottom: 12px;
   }
-  /* Every child of the step goes in column 2, under the previous one. A
-     step written as two paragraphs ("do X" / "then Y happens") otherwise
-     drops its second paragraph into the 26px marker column, where it wraps
-     one word per line. */
-  .mb-guide-md ol > li > * { grid-column: 2; }
   .mb-guide-md ol > li::before {
     content: counter(mbstep);
+    position: absolute;
+    left: 0;
+    top: 1px;
     font-family: ${MONO};
     font-size: 11px;
     color: ${ACCENT};
@@ -788,15 +825,15 @@ const guideCss = `
     height: 26px;
     display: grid;
     place-items: center;
-    margin-top: 1px;
   }
   /* Nested lists fall back to ordinary markers — chips inside chips read as
-     a second numbering scheme rather than a sub-step. */
+     a second numbering scheme rather than a sub-step. The padding the chip
+     reserved has to go back too, or every sub-step sits 39px in. */
   .mb-guide-md ol ol, .mb-guide-md ul ol {
     padding-left: 20px; list-style: decimal outside; counter-reset: none;
   }
   .mb-guide-md ol ol > li, .mb-guide-md ul ol > li {
-    display: list-item; margin-bottom: 4px;
+    display: list-item; position: static; padding-left: 0; margin-bottom: 4px;
   }
   .mb-guide-md ol ol > li::before, .mb-guide-md ul ol > li::before { content: none; }
   .mb-guide-md ul { margin: 0 0 12px; padding-left: 20px; list-style: disc outside; }

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -1,6 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react';
-import ReactMarkdown, { type Components } from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   compareVersions,
   collectRequirementGhLinks,
@@ -14,7 +12,7 @@ import {
 import type { Node, Version, RequirementGate, RequirementStage } from '@mindblown/core';
 import { useMindmapStore } from './store.js';
 import { linkColor, linkWeight } from './ghLinkStyle.js';
-import { isHttpUrl, verificationOf, type Verification } from './verification.js';
+import { isDocumented } from './verification.js';
 import { REQ_VERSION_NONE } from './urlState.js';
 import * as api from './api.js';
 
@@ -86,10 +84,9 @@ function compareReqIds(a: ReqRow, b: ReqRow): number {
  * Width of the requirements table, in columns — the `<colgroup>` and
  * `<thead>` below must list exactly this many.
  *
- * Every full-width row (the chapter header, the Abnahme card) spans it. A
- * mismatch after someone adds a column doesn't crash, it just renders a
- * card one column short, so the number lives in one place rather than
- * being repeated at each `colSpan`.
+ * The chapter header row spans it. A mismatch after someone adds a column
+ * doesn't crash, it just renders that row one column short, so the number
+ * lives in one place rather than being repeated at each `colSpan`.
  */
 const REQ_COLUMN_COUNT = 9;
 
@@ -103,6 +100,7 @@ export function RequirementsView() {
   const updateNode = useMindmapStore((s) => s.updateNode);
   const addNode = useMindmapStore((s) => s.addNode);
   const selectNode = useMindmapStore((s) => s.selectNode);
+  const selectedNodeId = useMindmapStore((s) => s.selectedNodeId);
   const setFocusNode = useMindmapStore((s) => s.setFocusNode);
   const setActiveView = useMindmapStore((s) => s.setActiveView);
   const effortUnit = useMindmapStore((s) => s.currentMap?.effortUnit ?? 'days');
@@ -124,18 +122,6 @@ export function RequirementsView() {
   const [acceptances, setAcceptances] = useState<api.AcceptanceRow[]>([]);
   const [acceptanceFilter, setAcceptanceFilter] = useState<'' | api.AcceptanceFilter>('');
   const [exporting, setExporting] = useState(false);
-
-  // Which rows have their Prüfanleitung panel unfolded. A set, not a single
-  // id: a reviewer working down a chapter compares two requirements against
-  // each other, and collapsing the previous one out from under him loses his
-  // place. Collapsed by default so a register of 60 rows stays scannable.
-  const [openVerification, setOpenVerification] = useState<Set<string>>(() => new Set());
-  const toggleVerification = (nodeId: string) =>
-    setOpenVerification((prev) => {
-      const next = new Set(prev);
-      if (!next.delete(nodeId)) next.add(nodeId);
-      return next;
-    });
 
   useEffect(() => {
     if (!currentMapId) return;
@@ -450,6 +436,27 @@ export function RequirementsView() {
       node.id,
     );
   };
+
+  /**
+   * Over to the Prüfanleitungen, on this criterion.
+   *
+   * Same two moves as jumpToNode, minus the mindmap's focus/pan: the guide
+   * reads the selection out of the store (and useUrlState mirrors it to
+   * `?node=`), so setting it is all the other view needs to open on the
+   * right row.
+   */
+  const jumpToGuide = (node: Node) => {
+    setActiveView('guide');
+    selectNode(node.id);
+  };
+
+  // A criterion arriving from the guide's "Im Register ansehen" lands
+  // somewhere down a register of 168 rows. Without this the view switches and
+  // apparently nothing happens.
+  const selectedRowRef = useRef<HTMLTableRowElement | null>(null);
+  useEffect(() => {
+    selectedRowRef.current?.scrollIntoView({ block: 'center' });
+  }, [selectedNodeId]);
 
   const submitCreate = () => {
     const { chapterId, requirementId, text, requirementPriority } = createFields;
@@ -771,18 +778,18 @@ export function RequirementsView() {
                   setEditingCell={setEditingCell}
                   updateNode={updateNode}
                   jumpToNode={jumpToNode}
+                  jumpToGuide={jumpToGuide}
                   currentUserId={user?.id ?? null}
                   toggleAcceptance={toggleAcceptance}
                   rejectRequirement={rejectRequirement}
-                  openVerification={openVerification}
-                  toggleVerification={toggleVerification}
+                  selectedNodeId={selectedNodeId}
+                  selectedRowRef={selectedRowRef}
                 />
               ))}
             </tbody>
           </table>
         </div>
       )}
-      <style>{verificationMarkdownCss}</style>
     </div>
   );
 }
@@ -799,11 +806,12 @@ function ChapterGroup({
   setEditingCell,
   updateNode,
   jumpToNode,
+  jumpToGuide,
   currentUserId,
   toggleAcceptance,
   rejectRequirement,
-  openVerification,
-  toggleVerification,
+  selectedNodeId,
+  selectedRowRef,
 }: {
   chapterText: string;
   rows: ReqRow[];
@@ -814,11 +822,12 @@ function ChapterGroup({
   setEditingCell: (cell: { nodeId: string; field: string } | null) => void;
   updateNode: (id: string, updates: Partial<Node>) => void;
   jumpToNode: (node: Node) => void;
+  jumpToGuide: (node: Node) => void;
   currentUserId: string | null;
   toggleAcceptance: (row: ReqRow, gate: RequirementGate) => void;
   rejectRequirement: (row: ReqRow, gate: RequirementGate) => void;
-  openVerification: Set<string>;
-  toggleVerification: (nodeId: string) => void;
+  selectedNodeId: string | null;
+  selectedRowRef: React.MutableRefObject<HTMLTableRowElement | null>;
 }) {
   const built = rows.filter((r) => r.built).length;
   const accepted = rows.filter((r) => r.stage === 'accepted').length;
@@ -833,18 +842,28 @@ function ChapterGroup({
         </td>
       </tr>
       {rows.map((r, i) => {
-        const verification = verificationOf(r.node);
-        const verificationOpen = verification != null && openVerification.has(r.node.id);
+        // Which criteria are documented is the one fact the register cannot
+        // show from its own nine columns, so the marker below carries it.
+        // Today that is 23 of 168 — the other 145 rows stay exactly as they
+        // were, which is why this is a marker and not a navigation icon on
+        // every row.
+        const documented = isDocumented(r.node);
+        const current = r.node.id === selectedNodeId;
+        const rowBackground = current ? '#f5f7ff' : stripeFor(i);
         return (
-        <Fragment key={r.node.id}>
         <tr
+          key={r.node.id}
+          ref={current ? selectedRowRef : undefined}
           onClick={() => jumpToNode(r.node)}
           onMouseEnter={(e) => (e.currentTarget.style.background = '#eff6ff')}
-          onMouseLeave={(e) => (e.currentTarget.style.background = stripeFor(i))}
+          onMouseLeave={(e) => (e.currentTarget.style.background = rowBackground)}
           title="Open in mindmap"
           style={{
-            background: stripeFor(i),
+            background: rowBackground,
             borderBottom: '1px solid #f1f5f9',
+            // Marks where a jump from the Prüfanleitungen landed. Quiet on
+            // purpose: it says "here", it does not claim a status.
+            boxShadow: current ? 'inset 3px 0 0 #a5b4fc' : 'none',
             cursor: 'pointer',
           }}
         >
@@ -875,8 +894,35 @@ function ChapterGroup({
                 style={{ ...inputStyle, width: 90, padding: '2px 6px' }}
               />
             ) : (
-              <span style={{ fontWeight: 600, color: '#334155', cursor: 'text' }}>
-                {r.node.requirementId}
+              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ fontWeight: 600, color: '#334155', cursor: 'text' }}>
+                  {r.node.requirementId}
+                </span>
+                {/* Beside the ID, never on it: the ID itself is the inline
+                    editor's click target, and one click meaning either "edit
+                    this" or "leave the register" would be a coin toss. Its
+                    own button with stopPropagation keeps the two apart. */}
+                {documented && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      jumpToGuide(r.node);
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.color = '#4338ca';
+                      e.currentTarget.style.background = '#eef2ff';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.color = '#a5b4fc';
+                      e.currentTarget.style.background = 'transparent';
+                    }}
+                    title="Prüfanleitung ansehen"
+                    aria-label={`Prüfanleitung zu ${r.node.requirementId} ansehen`}
+                    style={guideMarkerStyle}
+                  >
+                    ≡
+                  </button>
+                )}
               </span>
             )}
           </td>
@@ -1180,124 +1226,13 @@ function ChapterGroup({
                 />
               ))}
             </div>
-            {/* The reviewer pressing ✓/✗ is the one who needs to know how to
-                check it — so the handle sits in this cell, not in a column of
-                its own. Rows without any of the three fields get nothing, so
-                a register that was never annotated looks unchanged. */}
-            {verification && (
-              <button
-                onClick={() => toggleVerification(r.node.id)}
-                aria-expanded={verificationOpen}
-                title={
-                  verificationOpen
-                    ? 'Prüfanleitung einklappen'
-                    : 'Prüfanleitung, Prüf-Link und Video einblenden'
-                }
-                style={verificationToggleStyle(verificationOpen)}
-              >
-                {verificationOpen ? '▾' : '▸'}{' '}
-                {verification.text != null ? 'Prüfanleitung' : 'Prüfen'}
-              </button>
-            )}
           </td>
         </tr>
-        {verificationOpen && (
-          // Own row spanning the table rather than a box inside the 180px
-          // acceptance column: a numbered Anleitung needs the full width, and
-          // a tall cell would otherwise stretch every sibling cell in the row.
-          <tr style={{ background: stripeFor(i) }} onClick={(e) => e.stopPropagation()}>
-            <td colSpan={REQ_COLUMN_COUNT} style={verificationRowStyle}>
-              <VerificationPanel v={verification} />
-            </td>
-          </tr>
-        )}
-        </Fragment>
         );
       })}
     </>
   );
 }
-
-/**
- * The Abnahme card: what a non-technical reviewer needs in front of him
- * before he presses ✓ or ✗ — the written steps, the deep link into the
- * running application, and the demo video. Each part is omitted when its
- * field is unset (no empty placeholder boxes, no `href="#"`).
- */
-function VerificationPanel({ v }: { v: Verification }) {
-  // Both URLs come from free-text columns with no server-side validation,
-  // and this card is the first place in the product that renders them as an
-  // href. A URL that isn't http(s) gets no button at all — linking it to
-  // "#" would look live and do nothing, and rendering it as-is would hand a
-  // `javascript:` payload a click target on the acceptance surface.
-  const appUrl = isHttpUrl(v.url) ? v.url : null;
-  const videoUrl = isHttpUrl(v.videoUrl) ? v.videoUrl : null;
-  return (
-    <div style={verificationPanelStyle}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-          gap: 8,
-        }}
-      >
-        <span style={verificationLabelStyle}>
-          {v.text != null ? 'Prüfanleitung' : 'Prüfen'}
-        </span>
-        {/* Kept on the header line so they stay reachable without scrolling
-            past a long Anleitung. */}
-        {(appUrl != null || videoUrl != null) && (
-          <span style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-            {appUrl != null && (
-              <a href={appUrl} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
-                In der Anwendung öffnen ↗
-              </a>
-            )}
-            {videoUrl != null && (
-              <a href={videoUrl} target="_blank" rel="noreferrer" style={verificationLinkStyle}>
-                ▶ Video ansehen
-              </a>
-            )}
-          </span>
-        )}
-      </div>
-      {v.text != null && (
-        // Markdown, not raw text: the field is written as "1. … 2. …" and a
-        // reviewer reading literal asterisks and digits is a reviewer who
-        // skips the steps. Capped in height so one essay-length Anleitung
-        // can't push the links and the rest of the register off-screen.
-        <div className="mb-verification-md" style={verificationMarkdownStyle}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={verificationMarkdownComponents}>
-            {v.text}
-          </ReactMarkdown>
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * Links inside the Prüfanleitung open in a new tab, like the two buttons on
- * the card's header line.
- *
- * react-markdown emits a bare `<a href>` with no target, so without this a
- * reviewer who clicks a link in step 3 navigates the application away and
- * loses every open card and filter on the way back. GFM autolinks make that
- * likely: a naked `https://…` typed into an Anleitung becomes a link
- * whether the author meant it to or not.
- *
- * No isHttpUrl() guard here — react-markdown already runs every href
- * through defaultUrlTransform, which rewrites `javascript:` and `data:` to
- * an empty href. The header-line buttons need the guard because nothing
- * sanitizes those.
- *
- * `node` is react-markdown's hast node; it must not reach the DOM.
- */
-const verificationMarkdownComponents: Components = {
-  a: ({ node: _node, ...props }) => <a {...props} target="_blank" rel="noreferrer" />,
-};
 
 // ── Small pieces ─────────────────────────────────────────────────
 
@@ -1625,109 +1560,34 @@ const groupHeaderStyle: React.CSSProperties = {
 /** Alternating row background — striping survives hover via onMouseLeave. */
 const stripeFor = (i: number) => (i % 2 === 1 ? '#fbfcfe' : '#ffffff');
 
-// ── Abnahme card (Prüfanleitung / Prüf-Link / Video) ─────────────
-
-/** Ghost chip, same family as the ✓/✗ pair it sits under. */
-function verificationToggleStyle(open: boolean): React.CSSProperties {
-  return {
-    marginTop: 6,
-    padding: '2px 7px',
-    borderRadius: 10,
-    fontSize: 11,
-    fontFamily: 'inherit',
-    border: `1px ${open ? 'solid' : 'dashed'} ${open ? '#a5b4fc' : '#cbd5e1'}`,
-    background: open ? '#eef2ff' : 'transparent',
-    color: open ? '#3730a3' : '#64748b',
-    cursor: 'pointer',
-    whiteSpace: 'nowrap',
-  };
-}
-
-const verificationRowStyle: React.CSSProperties = {
-  padding: '0 16px 12px',
-  // The <td> the panel hangs under is the last cell of the row above it;
-  // the row border would otherwise cut between the two.
-  borderBottom: '1px solid #f1f5f9',
-};
-
-const verificationPanelStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-  padding: '10px 14px',
-  borderRadius: 8,
-  // Indigo, matching the chapter header — this belongs to the register
-  // chrome, not to the requirement's own status colours.
-  background: '#f5f7ff',
-  borderLeft: '3px solid #a5b4fc',
-};
-
-const verificationLabelStyle: React.CSSProperties = {
-  fontSize: 9,
-  letterSpacing: '0.08em',
-  textTransform: 'uppercase',
-  color: '#6366f1',
-  fontWeight: 700,
-};
-
-const verificationLinkStyle: React.CSSProperties = {
-  padding: '4px 10px',
-  borderRadius: 6,
-  fontSize: 11.5,
-  fontWeight: 600,
-  border: '1px solid #c7d2fe',
-  background: '#ffffff',
-  color: '#4338ca',
-  textDecoration: 'none',
-  whiteSpace: 'nowrap',
-};
-
-const verificationMarkdownStyle: React.CSSProperties = {
-  fontSize: 12.5,
-  lineHeight: 1.55,
-  color: '#334155',
-  maxWidth: 860,
-  maxHeight: 320,
-  overflowY: 'auto',
-};
+// ── Link into the Prüfanleitungen ────────────────────────────────
 
 /**
- * index.html applies `* { margin: 0; padding: 0 }`, which strips the
- * indent an <ol> needs to show its numbers — the whole point of rendering
- * the Prüfanleitung as markdown. Scoped to this panel, same approach as
- * HelpOverlay's `.help-markdown`.
+ * The marker beside the requirement ID.
+ *
+ * Deliberately not a navigation icon on all 168 rows: it appears only where
+ * a Prüfanleitung (or a Prüf-Link / clip) actually exists, so its presence
+ * is the information — which criteria are documented — and its click is
+ * only the way to go read them. Muted until hover; a register scanned for
+ * status should not have 23 blue dots pulling the eye.
  */
-const verificationMarkdownCss = `
-  .mb-verification-md > :first-child { margin-top: 0; }
-  .mb-verification-md > :last-child { margin-bottom: 0; }
-  .mb-verification-md p { margin: 0 0 8px; }
-  .mb-verification-md ol { margin: 0 0 8px; padding-left: 22px; list-style: decimal outside; }
-  .mb-verification-md ul { margin: 0 0 8px; padding-left: 22px; list-style: disc outside; }
-  .mb-verification-md li { margin-bottom: 3px; }
-  .mb-verification-md h1, .mb-verification-md h2, .mb-verification-md h3 {
-    font-size: 13px; font-weight: 700; margin: 12px 0 6px; color: #0f172a;
-  }
-  .mb-verification-md a { color: #4f46e5; }
-  .mb-verification-md strong { font-weight: 700; color: #0f172a; }
-  .mb-verification-md code {
-    font-family: Menlo, Monaco, monospace; font-size: 11.5px;
-    background: #e8ecf7; padding: 1px 4px; border-radius: 3px;
-  }
-  .mb-verification-md pre {
-    background: #0f172a; color: #e2e8f0; padding: 10px 12px;
-    border-radius: 6px; overflow-x: auto; margin: 0 0 8px;
-  }
-  .mb-verification-md pre code { background: none; padding: 0; color: inherit; }
-  .mb-verification-md blockquote {
-    border-left: 3px solid #c7d2fe; margin: 0 0 8px;
-    padding: 2px 10px; color: #475569;
-  }
-  .mb-verification-md table { border-collapse: collapse; font-size: 12px; margin: 0 0 8px; }
-  .mb-verification-md th, .mb-verification-md td {
-    border: 1px solid #e2e8f0; padding: 4px 8px; text-align: left;
-  }
-  .mb-verification-md th { background: #eef2ff; font-weight: 600; }
-`;
+const guideMarkerStyle: React.CSSProperties = {
+  flexShrink: 0,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 15,
+  height: 15,
+  padding: 0,
+  border: 'none',
+  borderRadius: 3,
+  background: 'transparent',
+  color: '#a5b4fc',
+  fontFamily: 'inherit',
+  fontSize: 11,
+  lineHeight: 1,
+  cursor: 'pointer',
+};
 
 const inputStyle: React.CSSProperties = {
   boxSizing: 'border-box',

--- a/packages/mindmap/src/__tests__/verification.test.ts
+++ b/packages/mindmap/src/__tests__/verification.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import type { Node } from '@mindblown/core';
-import { isHttpUrl, verificationOf } from '../verification.js';
+import { isDocumented, isHttpUrl, verificationOf } from '../verification.js';
 
 /**
- * `verificationOf` decides whether a requirement row grows an Abnahme card
- * at all. The promise the feature makes is "none of the three fields set →
- * no handle, no card, the register looks exactly as it did before" — a row
- * that sprouts an empty card is the visible regression, and a stray space
- * left behind by an older write is the way it happens.
+ * `verificationOf` decides what the Prüfanleitungen view has to show for a
+ * criterion; `isDocumented` decides whether the register's row carries the
+ * marker that jumps there. The promise is "nothing written → no marker, the
+ * register looks exactly as it did before" — a row that sprouts a marker
+ * over nothing is the visible regression, and a stray space left behind by
+ * an older write is the way it happens.
  */
 
 /** Only the three fields matter here; the rest of Node never gets read. */
@@ -72,8 +73,43 @@ describe('verificationOf', () => {
 });
 
 /**
+ * The register's marker. It is the only thing the register says about the
+ * Prüf-felder, so what it counts as "documented" is the whole contract.
+ */
+describe('isDocumented', () => {
+  it('is false when nothing is written', () => {
+    expect(isDocumented(node({}))).toBe(false);
+    expect(isDocumented(node({ verificationText: '   ' }))).toBe(false);
+  });
+
+  it('is true for a written Anleitung', () => {
+    expect(isDocumented(node({ verificationText: '1. Einloggen' }))).toBe(true);
+  });
+
+  it('is true for a clip alone', () => {
+    // No steps written yet, but a reviewer can still watch how it is done —
+    // the marker has to lead him there.
+    expect(isDocumented(node({ verificationVideoUrl: 'https://v.example.com/a.mp4' }))).toBe(true);
+  });
+
+  it('is false for a Prüf-Link alone', () => {
+    // The deep link answers "where do I click this up", not "how do I check
+    // it", and it is deliberately not surfaced in the register at all: the
+    // reader of the register is asking where something stands, and a link
+    // out of the application is an invitation to leave that view.
+    expect(isDocumented(node({ verificationUrl: 'https://staging.example.com/x' }))).toBe(false);
+    // …but it rides along once there is something to read.
+    expect(
+      isDocumented(
+        node({ verificationText: '1. Einloggen', verificationUrl: 'https://staging.example.com/x' }),
+      ),
+    ).toBe(true);
+  });
+});
+
+/**
  * Both URL fields are free-text columns with no server-side validation, and
- * the Abnahme card is the first surface that renders them as an `href`.
+ * the Prüfanleitung is the only surface that renders them as an `href`.
  */
 describe('isHttpUrl', () => {
   it('accepts absolute http and https URLs', () => {

--- a/packages/mindmap/src/guide.ts
+++ b/packages/mindmap/src/guide.ts
@@ -25,9 +25,9 @@ export const ROOT_CHAPTER_ID = '(root)';
  *
  * `appUrl` / `videoUrl` are pre-validated rather than raw: both come from
  * free-text columns, and a caller that forgets `isHttpUrl` would hand a
- * `javascript:` payload an href — the same trap the Abnahme card guards
- * against. Storing them already-checked means the component cannot get it
- * wrong, and `null` doubles as "don't render this part".
+ * `javascript:` payload an href — which is why `isHttpUrl` runs here and
+ * not in the view. Storing them already-checked means the component cannot
+ * get it wrong, and `null` doubles as "don't render this part".
  */
 export interface GuideEntry {
   node: Node;

--- a/packages/mindmap/src/verification.ts
+++ b/packages/mindmap/src/verification.ts
@@ -1,10 +1,15 @@
 /**
- * The Abnahme card's data rules: which of the three review-surface fields
+ * The Prüf-felder's data rules: which of the three review-surface fields
  * are set, and which URLs are safe to render as a link.
  *
- * Kept out of RequirementsView.tsx so it can be unit-tested without
- * dragging in the zustand store, which the component module creates at
- * import time — same reason ghLinkStyle.ts lives on its own.
+ * Two callers, two questions. `guide.ts` builds the Prüfanleitungen view
+ * out of these; the register uses `verificationOf` only to decide whether a
+ * row carries documentation at all, and so earns the marker that jumps
+ * over there.
+ *
+ * Kept out of the component modules so it can be unit-tested without
+ * dragging in the zustand store, which they create at import time — same
+ * reason ghLinkStyle.ts lives on its own.
  */
 
 import type { Node } from '@mindblown/core';
@@ -21,7 +26,7 @@ export interface Verification {
   videoUrl: string | null;
 }
 
-/** null when the requirement carries none of the three — the row then looks exactly as before. */
+/** null when the requirement carries none of the three — the register row then shows no marker. */
 export function verificationOf(node: Node): Verification | null {
   const text = node.verificationText?.trim() || null;
   const url = node.verificationUrl?.trim() || null;
@@ -31,10 +36,25 @@ export function verificationOf(node: Node): Verification | null {
 }
 
 /**
+ * Whether the criterion carries something that answers *how do I check
+ * this* — the written steps or the clip. Drives the register's marker.
+ *
+ * A bare `verificationUrl` deliberately does not count. It answers "where",
+ * not "how", and it is the one part of the Prüf-felder the register should
+ * not advertise: a link out of the application is an invitation to leave
+ * the view its reader is standing in. It belongs on the Prüfanleitung,
+ * where the reader has already decided to go and check.
+ */
+export function isDocumented(node: Node): boolean {
+  const v = verificationOf(node);
+  return v != null && (v.text != null || v.videoUrl != null);
+}
+
+/**
  * True only for absolute `http:`/`https:` URLs.
  *
  * `verificationUrl` / `verificationVideoUrl` are free-text columns with no
- * server-side validation, and the Abnahme card is the first place in the
+ * server-side validation, and the Prüfanleitung is the only place in the
  * product that renders them as an `href`. Anything else — `javascript:`,
  * `data:`, `vbscript:`, a bare relative path — is refused, and the caller
  * drops the button rather than emitting a dead or dangerous link.


### PR DESCRIPTION
Die Prüfanleitung hat seit #287 ihren eigenen Ort. Die aufklappbare Karte, die #285 in die Abnahme-Zelle des Registers gebaut hatte, war damit Doppelung — an der Stelle, die ohnehin am dichtesten ist.

Das Register beantwortet **„wo steht das?"**, die Prüfanleitung **„wie prüfe ich das?"**. Dieser PR nimmt die zweite Frage aus der ersten Ansicht heraus und verbindet die beiden Flächen stattdessen.

## 1. Karte raus

Entfernt: `openVerification` / `toggleVerification`, die Panel-Zeile mit `colSpan`, der Aufklapp-Griff in der Abnahme-Zelle, `VerificationPanel`, `verificationMarkdownComponents` samt `.mb-verification-md`-CSS-Block und den sechs zugehörigen Style-Konstanten, dazu die dadurch verwaisten Importe (`react-markdown`, `remark-gfm`, `Fragment`, `isHttpUrl`, `type Verification`).

Geblieben, weil weiter gebraucht:
- **`verification.ts`** — `verificationOf` / `isHttpUrl` tragen `GuideView.tsx` und `guide.ts`.
- **`REQ_COLUMN_COUNT`** — die Kapitel-Kopfzeile spannt es noch; nur der Kommentar, der die Karte miterwähnte, ist nachgezogen.

Die Abnahme-Logik (✓/✗, Gates, Filter) ist unangetastet.

## 2. Verknüpfung in beide Richtungen

**Register → Prüfanleitung:** ein kleiner Marker (`≡`) neben der Kennung, der **nur auf dokumentierten Kriterien** erscheint — heute 23 von 168, die übrigen 145 Zeilen sehen aus wie vorher. Er trägt damit Information, die das Register sonst nicht hat; ein Navigations-Symbol auf allen 168 Zeilen wäre reine Dichte gewesen.

Er ist ein **eigener Button mit `stopPropagation`**, nicht die Kennung selbst: die ist der Klick-Ziel des Inline-Editors, und ein Klick darf nicht zweierlei bedeuten. Der Sprung folgt `jumpToNode` und wird — wie die anderen Zeilen-Aktionen — als **Prop** an `ChapterGroup` durchgereicht, statt im Kind auf den Store zu greifen.

**Prüfanleitung → Register:** „Im Register ansehen" neben „Anleitung bearbeiten". Das Register hebt die angesprungene Zeile leise hervor (Tönung + indigo Kante) und scrollt sie in den Blick — ohne das wechselt die Ansicht und scheinbar passiert nichts.

Verbindendes Element ist allein `selectedNodeId`, das `useUrlState` schon nach `?node=` spiegelt: kein zweiter Zustand, beide Sprünge sind teilbar.

**Der Deep-Link ins CRM (`verificationUrl`) kommt nicht ins Register zurück.** Deshalb zählt `isDocumented` einen blossen Prüf-Link auch nicht als „dokumentiert": Schritte und Clip beantworten „wie", der Link nur „wo" — und ein Link aus der Anwendung heraus ist für den Leser des Registers eine Einladung, die Sicht zu verlassen, die er gerade braucht.

## 3. Nebenbefund mitgenommen

In der Prüfanleitung war die Schritt-Liste ein Grid (`ol > li { display: grid }`). Dadurch wurde jedes inline `**fett**` zu einem eigenen Grid-Item und der Text drumherum zu einem anonymen Item in der 26px-Markerspalte — ein Wort pro Zeile. Jeder Schritt mit Auszeichnung im Satz zerfiel so in gestapelte Blöcke. Die Nummernchips liegen jetzt out-of-flow (`position: absolute`), der Schritt bleibt ein Absatz. Fiel beim Browser-Durchgang auf; sagt Bescheid, wenn ihr das lieber separat hättet.

## Im Browser gesehen

Eigene Datenbank (`mindblown_link`), eigener API-Port, sieben Kriterien in zwei Kapiteln: drei mit Anleitung, eines nur mit Video, eines nur mit Prüf-Link, zwei ohne alles.

- **Register ohne Karte:** kein Griff mehr in der Abnahme-Zelle, keine aufgeklappte Zweitzeile, jede Zeile wieder einzeilig. Die Abnahme-Zelle trägt nur noch die beiden Gates.
- **Marker nur auf dokumentierten Kriterien:** MAN-1, MAN-3, ABN-1 (Anleitung) und MAN-4 (nur Video) tragen ihn; MAN-2 (nur Prüf-Link) und die undokumentierten Zeilen bleiben leer.
- **Inline-Edit unversehrt:** Klick auf die Kennung öffnet weiterhin das Eingabefeld und wechselt die Ansicht nicht; Klick auf den Marker wechselt die Ansicht und öffnet den Editor nicht.
- **Sprung hin:** `?view=guide&node=…`, die Prüfanleitung öffnet auf genau dem Kriterium (Kapitel aufgeklappt, Karte rechts).
- **Sprung zurück:** `?view=requirements&node=…`, die Zeile ist getönt und markiert. Wie überall in der App öffnet die Auswahl dabei das Eigenschaften-Panel — dort stehen Prüfanleitung, Prüf-Link und Video, was zur Frage „wo steht das?" passt.

## Gates

- `pnpm build`, `pnpm test` (138 Tests im mindmap-Paket, 5 davon neu), `pnpm lint`, `tsc --noEmit` — alle grün.
- Die vier neuen `isDocumented`-Tests sind mutationsgeprüft: „Prüf-Link zählt mit" und „Video zählt nicht" lassen je genau den Test fallen, der sie festhält.
- **Keine Abhängigkeit angefasst** — `react-markdown` / `remark-gfm` bleiben für `GuideView` und `HelpOverlay` im Bundle. Ein `pnpm install` beim Deploy ist für diesen PR also nicht nötig.
