### PR TITLE
fix(guide): Standbild für die Prüf-Videos (verificationVideoPosterUrl)

### DIFF
--- a/packages/core/src/__tests__/compute.test.ts
+++ b/packages/core/src/__tests__/compute.test.ts
@@ -47,6 +47,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/dependencies.test.ts
+++ b/packages/core/src/__tests__/dependencies.test.ts
@@ -45,6 +45,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -48,6 +48,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     // Orchestration substrate (#111)
     claimedBySession: null,
     claimedAt: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -316,6 +316,25 @@ export interface Node {
    */
   verificationVideoUrl: string | null;
 
+  /**
+   * Still image shown in the player before the clip is started — the
+   * `poster` attribute of the `<video>` on the review surface.
+   *
+   * Not cosmetic, and not something `preload="metadata"` already covers:
+   * the browser paints frame 0, and frame 0 of a screen recording is the
+   * blank page the recorder was still waiting on. Measured against the two
+   * clips that exist: MAN-01 is blank white for ~1 s, PEN-01 for ~3 s. A
+   * `#t=N` media fragment would paint a later frame, but it also *moves
+   * the playhead*, so pressing play would skip the start of the very
+   * instructions the clip exists to give.
+   *
+   * Meaningless without `verificationVideoUrl` — a poster with no video is
+   * not rendered anywhere, and `verificationOf` does not count it as
+   * documentation on its own. Like the other verification fields, NOT in
+   * the GitHub SYNC_FIELDS.
+   */
+  verificationVideoPosterUrl: string | null;
+
   // ── Auto-progress (parent-epic rollup) ────────────────────
   /**
    * When set to `'children'`, the server auto-computes percentComplete on this

--- a/packages/mcp/src/__tests__/requirementScope.test.ts
+++ b/packages/mcp/src/__tests__/requirementScope.test.ts
@@ -43,6 +43,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     claimedBySession: null,
     claimedAt: null,
     computedEffort: 0,

--- a/packages/mcp/src/__tests__/scope.test.ts
+++ b/packages/mcp/src/__tests__/scope.test.ts
@@ -42,6 +42,7 @@ function makeNode(overrides: Partial<NodeWithComputed> & { id: string }): NodeWi
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     claimedBySession: null,
     claimedAt: null,
     computedEffort: 0,

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -144,6 +144,7 @@ export interface NodeWithComputed {
   verificationText: string | null;
   verificationUrl: string | null;
   verificationVideoUrl: string | null;
+  verificationVideoPosterUrl: string | null;
   /**
    * Files and links hung on the node. Present here — this type is a
    * hand-maintained mirror, so it does not inherit from core — because MCP

--- a/packages/mindmap/src/GuideView.tsx
+++ b/packages/mindmap/src/GuideView.tsx
@@ -429,9 +429,17 @@ function GuideCard({
       {entry.videoUrl && (
         <div style={{ marginBottom: 24 }}>
           {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          {/* `poster` falls back to the recording's own first frame when
+              none is stored — which is what every clip did before the
+              field existed, and why the player looked empty: frame 0 of a
+              screen capture is the blank page the recorder was waiting on.
+              `preload="metadata"` is what paints that fallback frame, so
+              it stays even with a poster set; it is also what fills in the
+              duration under the scrubber. */}
           <video
             src={entry.videoUrl}
             controls
+            poster={entry.posterUrl ?? undefined}
             preload="metadata"
             style={{
               width: '100%',

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -208,6 +208,9 @@ function PropertyPanelInner({
   const [verificationText, setVerificationText] = useState(node.verificationText ?? '');
   const [verificationUrl, setVerificationUrl] = useState(node.verificationUrl ?? '');
   const [verificationVideoUrl, setVerificationVideoUrl] = useState(node.verificationVideoUrl ?? '');
+  const [verificationVideoPosterUrl, setVerificationVideoPosterUrl] = useState(
+    node.verificationVideoPosterUrl ?? '',
+  );
 
   // Sync local state when node changes externally
   useEffect(() => { setTitle(node.text); }, [node.text]);
@@ -222,6 +225,7 @@ function PropertyPanelInner({
   useEffect(() => { setVerificationText(node.verificationText ?? ''); }, [node.verificationText]);
   useEffect(() => { setVerificationUrl(node.verificationUrl ?? ''); }, [node.verificationUrl]);
   useEffect(() => { setVerificationVideoUrl(node.verificationVideoUrl ?? ''); }, [node.verificationVideoUrl]);
+  useEffect(() => { setVerificationVideoPosterUrl(node.verificationVideoPosterUrl ?? ''); }, [node.verificationVideoPosterUrl]);
 
   const applyServerNode = useMindmapStore((s) => s.applyServerNode);
   const allNodes = useMindmapStore((s) => s.nodes);
@@ -530,6 +534,35 @@ function PropertyPanelInner({
                 onUploaded={(media) => {
                   setVerificationVideoUrl(media.url);
                   directUpdate(nodeId, { verificationVideoUrl: media.url });
+                }}
+              />
+            </Field>
+            {/* Its own field rather than something derived from the clip:
+                the browser cannot pick a representative frame, and the
+                one it would show for free — frame 0 — is the blank page
+                the screen recorder was still waiting on. Directly under
+                the video link because it is only read when that is set. */}
+            <Field label="Video-Standbild">
+              <input
+                value={verificationVideoPosterUrl}
+                onChange={(e) => setVerificationVideoPosterUrl(e.target.value)}
+                onBlur={() => {
+                  const trimmed = verificationVideoPosterUrl.trim();
+                  const persisted = node.verificationVideoPosterUrl ?? '';
+                  if (trimmed !== persisted) {
+                    directUpdate(nodeId, { verificationVideoPosterUrl: trimmed || null });
+                  }
+                }}
+                onKeyDown={(e) => e.stopPropagation()}
+                style={inputStyle}
+                placeholder="https://… (Standbild für den Player)"
+              />
+              <MediaUploadButton
+                accept="image/*"
+                label="Standbild hochladen…"
+                onUploaded={(media) => {
+                  setVerificationVideoPosterUrl(media.url);
+                  directUpdate(nodeId, { verificationVideoPosterUrl: media.url });
                 }}
               />
             </Field>

--- a/packages/mindmap/src/__tests__/guide.test.ts
+++ b/packages/mindmap/src/__tests__/guide.test.ts
@@ -41,6 +41,7 @@ function node(v: Partial<Node>): Node {
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     ...v,
   } as Node;
 }
@@ -154,6 +155,54 @@ describe('buildGuideEntries', () => {
       );
       expect(e.appUrl).toBe('https://staging.example.com/mandates');
       expect(e.videoUrl).toBe('https://v.example.com/clip.mp4');
+    });
+
+    it('passes an absolute poster through alongside its clip', () => {
+      const [e] = buildGuideEntries(
+        mapOf(
+          node({
+            requirementId: 'X-03',
+            verificationVideoUrl: 'https://v.example.com/clip.mp4',
+            verificationVideoPosterUrl: 'https://v.example.com/clip.jpg',
+          }),
+        ),
+        leafProgress,
+      );
+      expect(e.posterUrl).toBe('https://v.example.com/clip.jpg');
+    });
+
+    it('drops a poster that is not absolute http(s)', () => {
+      // Same guard as the clip: the column is free text, and the value
+      // lands in a <video poster> attribute.
+      const [e] = buildGuideEntries(
+        mapOf(
+          node({
+            requirementId: 'X-04',
+            verificationVideoUrl: 'https://v.example.com/clip.mp4',
+            verificationVideoPosterUrl: 'javascript:alert(1)',
+          }),
+        ),
+        leafProgress,
+      );
+      expect(e.videoUrl).toBe('https://v.example.com/clip.mp4');
+      expect(e.posterUrl).toBeNull();
+    });
+
+    it('drops a poster with no clip to put it on', () => {
+      // A poster is an attribute of a player, and without a videoUrl the
+      // player is never rendered — so the entry must not carry one either.
+      const [e] = buildGuideEntries(
+        mapOf(
+          node({
+            requirementId: 'X-05',
+            verificationText: '1. Einloggen',
+            verificationVideoPosterUrl: 'https://v.example.com/clip.jpg',
+          }),
+        ),
+        leafProgress,
+      );
+      expect(e.videoUrl).toBeNull();
+      expect(e.posterUrl).toBeNull();
     });
   });
 

--- a/packages/mindmap/src/__tests__/verification.test.ts
+++ b/packages/mindmap/src/__tests__/verification.test.ts
@@ -11,9 +11,15 @@ import { isDocumented, isHttpUrl, verificationOf } from '../verification.js';
  * an older write is the way it happens.
  */
 
-/** Only the three fields matter here; the rest of Node never gets read. */
+/** Only the four fields matter here; the rest of Node never gets read. */
 function node(v: Partial<Node>): Node {
-  return { verificationText: null, verificationUrl: null, verificationVideoUrl: null, ...v } as Node;
+  return {
+    verificationText: null,
+    verificationUrl: null,
+    verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
+    ...v,
+  } as Node;
 }
 
 describe('verificationOf', () => {
@@ -41,16 +47,19 @@ describe('verificationOf', () => {
       text: '1. Einloggen',
       url: null,
       videoUrl: null,
+      videoPosterUrl: null,
     });
     expect(verificationOf(node({ verificationUrl: 'https://staging.example.com/x' }))).toEqual({
       text: null,
       url: 'https://staging.example.com/x',
       videoUrl: null,
+      videoPosterUrl: null,
     });
     expect(verificationOf(node({ verificationVideoUrl: 'https://v.example.com/a.mp4' }))).toEqual({
       text: null,
       url: null,
       videoUrl: 'https://v.example.com/a.mp4',
+      videoPosterUrl: null,
     });
   });
 
@@ -62,13 +71,25 @@ describe('verificationOf', () => {
           verificationText: '  1. Einloggen\n2. Mandat öffnen  ',
           verificationUrl: ' https://staging.example.com/x \n',
           verificationVideoUrl: '\thttps://v.example.com/a.mp4 ',
+          verificationVideoPosterUrl: ' https://v.example.com/a.jpg\n',
         }),
       ),
     ).toEqual({
       text: '1. Einloggen\n2. Mandat öffnen',
       url: 'https://staging.example.com/x',
       videoUrl: 'https://v.example.com/a.mp4',
+      videoPosterUrl: 'https://v.example.com/a.jpg',
     });
+  });
+
+  // The poster is the one field that does NOT make the card exist. A still
+  // with no clip behind it is nothing a reviewer can act on, and counting
+  // it would give the register row a marker promising a video that isn't
+  // there.
+  it('does not make a card out of a poster on its own', () => {
+    expect(
+      verificationOf(node({ verificationVideoPosterUrl: 'https://v.example.com/a.jpg' })),
+    ).toBeNull();
   });
 });
 

--- a/packages/mindmap/src/guide.ts
+++ b/packages/mindmap/src/guide.ts
@@ -46,6 +46,12 @@ export interface GuideEntry {
   /** Validated http(s) link to the demo clip. */
   videoUrl: string | null;
   /**
+   * Validated http(s) still image for the clip's player. null whenever
+   * `videoUrl` is null — a poster with nothing to play is not a thing the
+   * view can render, so it never reaches the component.
+   */
+  posterUrl: string | null;
+  /**
    * Whether the feature exists yet. Progress-only, exactly like the
    * register's "Built" — deliberately NOT the sign-off stage: a reader
    * asking "how do I check this?" cares whether the screen is there, not
@@ -103,6 +109,9 @@ export function buildGuideEntries(
     if (node.requirementId == null) continue;
     const chapter = node.parentId ? nodes[node.parentId] : undefined;
     const verification = verificationOf(node);
+    const videoUrl = isHttpUrl(verification?.videoUrl)
+      ? (verification?.videoUrl ?? null)
+      : null;
     // The description is ProseMirror JSON (older rows: a raw string). Only
     // its first non-empty line is used — the field is a free-form note, and
     // an essay pasted into it must not push the steps below the fold.
@@ -121,7 +130,13 @@ export function buildGuideEntries(
       verification,
       guideText: verification?.text ?? null,
       appUrl: isHttpUrl(verification?.url) ? (verification?.url ?? null) : null,
-      videoUrl: isHttpUrl(verification?.videoUrl) ? (verification?.videoUrl ?? null) : null,
+      videoUrl,
+      // Gated on `videoUrl` and not just on its own validity: the poster is
+      // an attribute of a player that only exists when there is a clip.
+      posterUrl:
+        videoUrl != null && isHttpUrl(verification?.videoPosterUrl)
+          ? (verification?.videoPosterUrl ?? null)
+          : null,
       available: progressOf(node) >= BUILT_THRESHOLD,
     });
   }

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -975,6 +975,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
       verificationText: null,
       verificationUrl: null,
       verificationVideoUrl: null,
+      verificationVideoPosterUrl: null,
       // Orchestration substrate (#111)
       claimedBySession: null,
       claimedAt: null,

--- a/packages/mindmap/src/verification.ts
+++ b/packages/mindmap/src/verification.ts
@@ -24,15 +24,30 @@ export interface Verification {
   text: string | null;
   url: string | null;
   videoUrl: string | null;
+  /**
+   * Still image for the clip's player. A fourth field rather than a fourth
+   * *review surface* — it says nothing about how to check the requirement,
+   * it only decides what the player looks like while it sits there.
+   */
+  videoPosterUrl: string | null;
 }
 
-/** null when the requirement carries none of the three — the register row then shows no marker. */
+/**
+ * null when the requirement carries none of the three — the register row
+ * then shows no marker.
+ *
+ * The poster is deliberately outside that test. It is not something a
+ * reviewer can act on: a still with no clip behind it is nothing, and
+ * counting it would give a row a marker promising a video that isn't
+ * there.
+ */
 export function verificationOf(node: Node): Verification | null {
   const text = node.verificationText?.trim() || null;
   const url = node.verificationUrl?.trim() || null;
   const videoUrl = node.verificationVideoUrl?.trim() || null;
   if (text == null && url == null && videoUrl == null) return null;
-  return { text, url, videoUrl };
+  const videoPosterUrl = node.verificationVideoPosterUrl?.trim() || null;
+  return { text, url, videoUrl, videoPosterUrl };
 }
 
 /**

--- a/packages/server/src/db/__tests__/trackedFields.test.ts
+++ b/packages/server/src/db/__tests__/trackedFields.test.ts
@@ -120,10 +120,15 @@ describe('recordFieldChanges — Abnahme fields', () => {
     expect(loggedFields().map((e) => e.fieldName)).toEqual(['text']);
   });
 
-  it('keeps all three fields on the tracked list', () => {
+  it('keeps all four fields on the tracked list', () => {
     // Belt to the braces above: a future edit to the Set can't quietly drop
-    // one of the three while the other two keep the suite green.
-    for (const f of ['verificationText', 'verificationUrl', 'verificationVideoUrl'] as const) {
+    // one of the four while the others keep the suite green.
+    for (const f of [
+      'verificationText',
+      'verificationUrl',
+      'verificationVideoUrl',
+      'verificationVideoPosterUrl',
+    ] as const) {
       expect(TRACKED_FIELDS.has(f)).toBe(true);
     }
   });

--- a/packages/server/src/db/events.ts
+++ b/packages/server/src/db/events.ts
@@ -48,6 +48,11 @@ export const TRACKED_FIELDS = new Set<keyof CoreNode>([
   'verificationText',
   'verificationUrl',
   'verificationVideoUrl',
+  // The poster is decoration rather than evidence, but it is tracked for
+  // the same reason as its video: it is written once and then rarely
+  // touched, so it costs the history nothing, and a swapped still is the
+  // cheapest way to make a clip look like it shows something it doesn't.
+  'verificationVideoPosterUrl',
 ]);
 
 function valuesDiffer(a: unknown, b: unknown): boolean {

--- a/packages/server/src/db/helpers.ts
+++ b/packages/server/src/db/helpers.ts
@@ -48,6 +48,8 @@ export function dbNodeToCore(row: Record<string, unknown>): CoreNode {
     verificationUrl: (get('verificationUrl', 'verification_url') as string) ?? null,
     verificationVideoUrl:
       (get('verificationVideoUrl', 'verification_video_url') as string) ?? null,
+    verificationVideoPosterUrl:
+      (get('verificationVideoPosterUrl', 'verification_video_poster_url') as string) ?? null,
     // Orchestration substrate (#111)
     claimedBySession: (get('claimedBySession', 'claimed_by_session') as string) ?? null,
     claimedAt: (get('claimedAt', 'claimed_at') instanceof Date

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -841,6 +841,13 @@ async function runDdl(db: ReturnType<typeof drizzle>): Promise<void> {
   await db.execute(sql`
     ALTER TABLE nodes ADD COLUMN IF NOT EXISTS verification_video_url TEXT
   `);
+  // verification_video_poster_url: still frame the player shows before the
+  // clip is started. Nullable with no backfill on purpose — the two rows
+  // that carry a video today keep working without one (they just show the
+  // recording's own first frame, which is what they do now).
+  await db.execute(sql`
+    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS verification_video_poster_url TEXT
+  `);
 
   // attachments: files and links a person hung on the node. Deliberately
   // not external_links — the GitHub sync owns that column and rewrites it,

--- a/packages/server/src/db/nodes.ts
+++ b/packages/server/src/db/nodes.ts
@@ -247,6 +247,7 @@ export interface CreateNodeInput {
   verificationText?: string | null;
   verificationUrl?: string | null;
   verificationVideoUrl?: string | null;
+  verificationVideoPosterUrl?: string | null;
   assigneeIds?: string[];
 }
 
@@ -299,6 +300,7 @@ export async function createNode(
       verificationText: input.verificationText ?? null,
       verificationUrl: input.verificationUrl ?? null,
       verificationVideoUrl: input.verificationVideoUrl ?? null,
+      verificationVideoPosterUrl: input.verificationVideoPosterUrl ?? null,
       assigneeIds: input.assigneeIds ?? [],
       tags: [],
       customFields: {},
@@ -396,6 +398,7 @@ export interface UpdateNodeInput {
   verificationText?: string | null;
   verificationUrl?: string | null;
   verificationVideoUrl?: string | null;
+  verificationVideoPosterUrl?: string | null;
   // Orchestration substrate (#111)
   claimedBySession?: string | null;
   claimedAt?: string | null;
@@ -519,6 +522,8 @@ export async function updateNode(
   if (input.verificationUrl !== undefined) updates.verificationUrl = input.verificationUrl;
   if (input.verificationVideoUrl !== undefined)
     updates.verificationVideoUrl = input.verificationVideoUrl;
+  if (input.verificationVideoPosterUrl !== undefined)
+    updates.verificationVideoPosterUrl = input.verificationVideoPosterUrl;
   // Orchestration substrate (#111)
   if (input.claimedBySession !== undefined) updates.claimedBySession = input.claimedBySession;
   if (input.claimedAt !== undefined) updates.claimedAt = input.claimedAt ? new Date(input.claimedAt) : null;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -231,6 +231,9 @@ export const nodes = pgTable('nodes', {
   verificationText: text('verification_text'),
   verificationUrl: text('verification_url'),
   verificationVideoUrl: text('verification_video_url'),
+  // Still frame for the video's <video poster>. Only meaningful alongside
+  // verification_video_url.
+  verificationVideoPosterUrl: text('verification_video_poster_url'),
 
   // ── Phase ─────────────────────────────────────────────────────
   // References a PhaseDef.id from maps.phases (statusWorkflow idiom,

--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -41,6 +41,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     claimedBySession: null,
     claimedAt: null,
     revision: 0,

--- a/packages/server/src/lint/__tests__/engine.test.ts
+++ b/packages/server/src/lint/__tests__/engine.test.ts
@@ -42,6 +42,7 @@ function makeNode(overrides: Partial<Node> & { id: string }): Node {
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     claimedBySession: null,
     claimedAt: null,
     revision: 0,

--- a/packages/server/src/routes/__tests__/verification-fields-route.test.ts
+++ b/packages/server/src/routes/__tests__/verification-fields-route.test.ts
@@ -60,6 +60,7 @@ const NODE_ID = 'nnnn-nnnn-nnnn-nnnn';
 const ANLEITUNG = '1. Als Treuhänder einloggen\n2. Mandat öffnen\n\n**Erwartet:** Badge sichtbar';
 const PRUEF_URL = 'https://staging.example.com/mandates/42';
 const VIDEO_URL = 'https://videos.example.com/abnahme/man-14.mp4';
+const POSTER_URL = 'https://videos.example.com/abnahme/man-14-poster.jpg';
 
 /** Minimal CoreNode-shaped stub the routes can broadcast/sync safely. */
 function stubNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -74,6 +75,7 @@ function stubNode(overrides: Record<string, unknown> = {}): Record<string, unkno
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     ...overrides,
   };
 }
@@ -171,6 +173,65 @@ describe('PUT /api/maps/:id/nodes/:nodeId — verification fields round-trip', (
     await app.close();
 
     expect('verificationVideoUrl' in (updateNodeMock.mock.calls[0][1] as object)).toBe(false);
+  });
+
+  // The poster URL rides the same wiring, and has the same failure mode:
+  // the route body type is hand-maintained, so a field missing from it is
+  // dropped between the client and the DB layer with a 200 and a green
+  // suite. These pin the round trip on both write routes.
+  it('forwards verificationVideoPosterUrl on update and echoes it back', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ verificationVideoPosterUrl: POSTER_URL }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { verificationVideoPosterUrl: POSTER_URL },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ verificationVideoPosterUrl: POSTER_URL });
+    expect(res.json().verificationVideoPosterUrl).toBe(POSTER_URL);
+  });
+
+  it('forwards verificationVideoPosterUrl: null (clear)', async () => {
+    updateNodeMock.mockResolvedValueOnce(stubNode({ verificationVideoPosterUrl: null }));
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/maps/${MAP_ID}/nodes/${NODE_ID}`,
+      payload: { verificationVideoPosterUrl: null },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(updateNodeMock.mock.calls[0][1]).toEqual({ verificationVideoPosterUrl: null });
+    expect(res.json().verificationVideoPosterUrl).toBeNull();
+  });
+
+  it('forwards verificationVideoPosterUrl on create', async () => {
+    createNodeMock.mockResolvedValueOnce(
+      stubNode({ verificationVideoUrl: VIDEO_URL, verificationVideoPosterUrl: POSTER_URL }),
+    );
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/maps/${MAP_ID}/nodes`,
+      payload: {
+        parentId: 'pppp-pppp',
+        text: 'stub node',
+        verificationVideoUrl: VIDEO_URL,
+        verificationVideoPosterUrl: POSTER_URL,
+      },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(201);
+    expect(createNodeMock.mock.calls[0][0]).toMatchObject({
+      verificationVideoUrl: VIDEO_URL,
+      verificationVideoPosterUrl: POSTER_URL,
+    });
+    expect(res.json().verificationVideoPosterUrl).toBe(POSTER_URL);
   });
 });
 

--- a/packages/server/src/routes/maps.ts
+++ b/packages/server/src/routes/maps.ts
@@ -558,6 +558,7 @@ export async function mapRoutes(app: FastifyInstance): Promise<void> {
           verificationText: null,
           verificationUrl: null,
           verificationVideoUrl: null,
+          verificationVideoPosterUrl: null,
           // Orchestration substrate (#111)
           claimedBySession: null,
           claimedAt: null,

--- a/packages/server/src/routes/nodes.ts
+++ b/packages/server/src/routes/nodes.ts
@@ -176,6 +176,7 @@ export async function nodeRoutes(app: FastifyInstance): Promise<void> {
       verificationText?: string | null;
       verificationUrl?: string | null;
       verificationVideoUrl?: string | null;
+      verificationVideoPosterUrl?: string | null;
       assigneeIds?: string[];
       /**
        * Set to `true` when the caller wants to disable the `^#NNNN`

--- a/packages/server/src/services/__tests__/pull-queue.test.ts
+++ b/packages/server/src/services/__tests__/pull-queue.test.ts
@@ -71,6 +71,7 @@ function makeNode(overrides: Partial<CoreNode> & { id: string }): CoreNode {
     verificationText: null,
     verificationUrl: null,
     verificationVideoUrl: null,
+    verificationVideoPosterUrl: null,
     claimedBySession: null,
     claimedAt: null,
     scopes: [],

--- a/packages/tool-kit/src/tools/__tests__/node.test.ts
+++ b/packages/tool-kit/src/tools/__tests__/node.test.ts
@@ -941,6 +941,56 @@ describe('requirement fields', () => {
     expect(recorder.lastUpdate?.fields).toMatchObject({ verificationVideoUrl: null });
   });
 
+  // Same reasoning as verificationVideoUrl above, and the same trap: the
+  // handler spreads `...fields`, so a handler-level assertion passes even
+  // when the zod shape never declares the field — and the shape is the
+  // whole MCP surface. The recording pipeline writes a poster.jpg per
+  // clip; an agent that cannot name the field has nowhere to put it.
+  it('declares verificationVideoPosterUrl on the update_node schema', () => {
+    const schema = z.object(updateNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      nodeId: 'n1',
+      verificationVideoPosterUrl: 'https://videos.example.com/man-14-poster.jpg',
+    });
+    expect(parsed.verificationVideoPosterUrl).toBe(
+      'https://videos.example.com/man-14-poster.jpg',
+    );
+  });
+
+  it('declares verificationVideoPosterUrl on the create_node schema', () => {
+    const schema = z.object(createNodeTool.schema);
+    const parsed = schema.parse({
+      mapId: 'm1',
+      parentId: 'p1',
+      text: 'Neue Anforderung',
+      verificationVideoPosterUrl: 'https://videos.example.com/admin-demo-poster.jpg',
+    });
+    expect(parsed.verificationVideoPosterUrl).toBe(
+      'https://videos.example.com/admin-demo-poster.jpg',
+    );
+  });
+
+  it('accepts null on verificationVideoPosterUrl to clear it', () => {
+    const schema = z.object(updateNodeTool.schema);
+    expect(
+      schema.parse({ mapId: 'm1', nodeId: 'n1', verificationVideoPosterUrl: null })
+        .verificationVideoPosterUrl,
+    ).toBeNull();
+  });
+
+  it('forwards verificationVideoPosterUrl through to the backend', async () => {
+    const recorder = makeRecordingBackend();
+    await updateNodeTool.handler(recorder.backend, {
+      mapId: 'm1',
+      nodeId: 'n1',
+      verificationVideoPosterUrl: 'https://videos.example.com/man-14-poster.jpg',
+    } as never);
+    expect(recorder.lastUpdate?.fields).toMatchObject({
+      verificationVideoPosterUrl: 'https://videos.example.com/man-14-poster.jpg',
+    });
+  });
+
   it('forwards verification fields on create', async () => {
     const recorder = makeRecordingBackend();
     await createNodeTool.handler(recorder.backend, {

--- a/packages/tool-kit/src/tools/node.ts
+++ b/packages/tool-kit/src/tools/node.ts
@@ -73,6 +73,11 @@ export const createNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('Link to a short demo video showing this requirement in action. Rendered as a "watch video" button on the review surface next to the verification link.'),
+    verificationVideoPosterUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Still image shown in the video player before playback starts (the <video> poster). Only used when verificationVideoUrl is also set. Without it the player shows the recording\'s own first frame, which for a screen capture is usually a blank page.'),
   },
   handler: async (backend, { mapId, parentId, text, ...fields }) => {
     const cleanFields: Record<string, unknown> = {};
@@ -186,6 +191,11 @@ export const updateNodeTool = defineTool({
       .nullable()
       .optional()
       .describe('Link to a short demo video showing this requirement in action, shown as a "watch video" button on the review surface. null clears it.'),
+    verificationVideoPosterUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .describe('Still image shown in the video player before playback starts (the <video> poster). Only used when verificationVideoUrl is also set. null clears it, and the player falls back to the recording\'s own first frame.'),
     // Orchestration substrate (#111)
     scopes: z
       .array(z.string())


### PR DESCRIPTION
Der Player in **Prüfanleitungen** stand als leeres Rechteck, bis jemand Play drückte. Bei zwei Clips fällt das kaum auf; bei den geplanten 60–90 sieht die Fläche kaputt aus, obwohl sie funktioniert.

## Warum der billige Weg nicht trägt

Zuerst geprüft, am echten Browser (Chromium) gegen die zwei echten Clips unter `https://mind.project.li/api/media/…`:

| geprüft | Ergebnis |
|---|---|
| `Accept-Ranges` / Range-Requests | **funktioniert** — beide Dateien antworten mit `206`. (Randnotiz: das `moov`-Atom liegt am Dateiende, kein `faststart` — ohne Range-Support wäre schon `preload="metadata"` kaputt.) |
| `preload="metadata"` | **war bereits gesetzt**, und der Browser zeichnet damit auch Frame 0. Daran ist nichts zu gewinnen. |
| `#t=0.1` | **kein Gewinn** — malt bei beiden Clips exakt dasselbe weisse Bild. |
| grösserer Offset (`#t=5`) | sichtbar, aber **disqualifiziert**: das Fragment setzt `currentTime`, Play würde den Anfang genau der Anleitung überspringen, für die der Clip da ist. |

Das eigentliche Problem war also nicht „kein Frame", sondern „Frame 0 ist leer": Frame 0 einer Bildschirmaufnahme ist die noch weisse Seite, auf die der Recorder gewartet hat. Und wie lange, ist pro Clip verschieden — **MAN-01 ~1 s, PEN-01 ~3 s**. Ein fester Offset, der für den einen passt, ist für den anderen leer:

![Media-Fragment-Messung](https://mind.project.li/api/media/4e358ef8b8a7342531fa5258605a04309f558573/fragment-evidence.png)

Damit fällt der Weg ohne Schema-Änderung weg.

## Was stattdessen drin ist

Ein echtes Feld `verificationVideoPosterUrl`, exakt an `verificationVideoUrl` gespiegelt, gerendert als `<video poster>`:

| Schicht | Datei |
|---|---|
| core-Typ | `packages/core/src/types.ts` |
| Drizzle-Spalte | `packages/server/src/db/schema.ts` |
| Migration (`ADD COLUMN IF NOT EXISTS`, nullable, kein Backfill) | `packages/server/src/db/migrate.ts` |
| Row → Node Mapping | `packages/server/src/db/helpers.ts` |
| Tracked Fields (change history) | `packages/server/src/db/events.ts` |
| DB create + update | `packages/server/src/db/nodes.ts` |
| REST-Body + Clone-Stub | `packages/server/src/routes/nodes.ts`, `routes/maps.ts` |
| MCP-Typ-Mirror | `packages/mcp/src/api.ts` |
| Zod: `create_node` **und** `update_node` | `packages/tool-kit/src/tools/node.ts` |
| Store-Default | `packages/mindmap/src/store.ts` |
| Verification-Helper + Guide-Entry | `packages/mindmap/src/verification.ts`, `guide.ts` |
| PropertyPanel (Textfeld + „Standbild hochladen…") | `packages/mindmap/src/PropertyPanel.tsx` |
| Player | `packages/mindmap/src/GuideView.tsx` |

Zwei bewusste Abweichungen vom reinen Spiegeln:

- **Ein Poster allein macht kein Kriterium „dokumentiert".** `verificationOf` zählt ihn nicht mit — sonst bekäme eine Zeile im Register einen Marker, der ein Video verspricht, das es nicht gibt.
- **`posterUrl` ist im Guide-Entry an `videoUrl` gekoppelt.** Ohne Clip wird kein Player gerendert, also darf auch kein Poster durchkommen. `isHttpUrl` gilt für den Poster wie für den Clip — die Spalte ist Freitext und landet in einem Attribut.

## Im Browser angeschaut

Modifiziertes Frontend lokal gegen die Live-API, mit einem echten `poster.jpg` — genau so erzeugt, wie die Aufnahme-Pipeline es tut (ffmpeg-Frame bei 30 % der Laufzeit), hochgeladen über `POST /api/media`. An den Daten der Karte wurde nichts geändert.

![vorher / nachher](https://mind.project.li/api/media/c5899364e92d27680676fb9a47466abb8c56ae4f/compare.png)

Gesehen: Standbild steht sofort, ohne Play. Die Dauer unter dem Scrubber (`0:00 / 1:31`) bleibt — `preload="metadata"` ist deshalb absichtlich geblieben. `currentTime` bleibt `0`, Play startet am Anfang. Ohne Poster verhält sich der Player unverändert wie heute.

Schmal (860 px, unter dem 880-px-Breakpoint): Layout stapelt wie gehabt, Poster füllt die Spaltenbreite:

![schmal](https://mind.project.li/api/media/e29b1363dce851c2b99702ffc44047f02d8097c5/shot-after-860-PEN-01.png)

## Tests

`pnpm typecheck` und `pnpm test` grün (1265 Tests).

Assertions gegen die geparste `z.object(...).parse()`-Form, nicht gegen den Handler — der spreadet `...fields` durch und sieht ein fehlendes Zod-Feld nicht. Mutations-verifiziert:

- Zod-Deklarationen entfernt → **3 Schema-Tests rot**, der Handler-Test **blieb grün**. Genau die Falle.
- `videoUrl != null`-Gate im Guide entfernt → „drops a poster with no clip to put it on" rot.
- Poster aus `db/helpers.ts` entfernt → `tsc` rot (das core-Feld ist required, das erzwingt das Read-back-Mapping).

## Wie das Bild dorthin kommt

`tools/demo-recording/scripts/compose.mjs` (CRM-Repo) schreibt bereits ein `poster.jpg` neben dem Clip — Frame bei 30 % der Laufzeit. Heute hat es nur keinen Ort. Der Weg ist derselbe wie beim Clip:

1. `POST https://mind.project.li/api/media` (multipart, `Authorization: Bearer mb_…`) → antwortet mit `{ url }`. `image/jpeg` ist ein Inline-Typ, wird also mit echtem Content-Type ausgeliefert.
2. Die URL auf den Knoten schreiben — `update_node` mit `verificationVideoPosterUrl`, oder `PUT /api/maps/<map>/nodes/<node>`.

In der Oberfläche geht es auch von Hand: im PropertyPanel steht „Standbild hochladen…" direkt unter dem Video-Link.

## Hinweise

- **Nicht gemergt, nicht deployed** — wie gewünscht.
- Zwei offene PRs berühren je eine von mir angefasste Datei: #269 (`packages/mcp/src/api.ts`, ich füge dort eine Zeile hinzu) und #122 (`packages/core/src/__tests__/dependencies.test.ts`, eine Fixture-Zeile). Beide trivial, aber je nach Merge-Reihenfolge ein kleiner Konflikt.
- Der Migrationsschritt ist `ADD COLUMN IF NOT EXISTS` auf nullable TEXT ohne Backfill — die zwei bestehenden Video-Zeilen laufen unverändert weiter und zeigen den bisherigen Frame 0, bis jemand ein Standbild hinterlegt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA8w91iL479URbh3wC1m4v
