### PR TITLE
feat(requirements): Node-Titel im Register zeigen, nicht nur die Beschreibung

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -927,28 +927,37 @@ function ChapterGroup({
             )}
           </td>
 
-          {/* Title — inline editable (stopPropagation); ↗ is an explicit jump too */}
-          <td
-            style={tdStyle}
-            onClick={(e) => {
-              e.stopPropagation();
-              setEditingCell({ nodeId: r.node.id, field: 'text' });
-            }}
-          >
+          {/* Requirement — node title on top, business phrasing below.
+              Both inline editable, each into its own field (stopPropagation so
+              editing doesn't navigate); ↗ is an explicit jump too. */}
+          <td style={tdStyle} onClick={(e) => e.stopPropagation()}>
             {isEditing(r.node.id, 'text') ? (
               <input
                 autoFocus
-                defaultValue={r.node.requirementText ?? r.node.text}
+                defaultValue={r.node.text}
                 onBlur={(e) => {
                   const v = e.target.value.trim();
-                  // Business phrasing edits go to requirementText when one is
-                  // set — never touching the (GitHub-synced) node text.
-                  if (r.node.requirementText != null) {
-                    if (v !== r.node.requirementText) {
-                      updateNode(r.node.id, { requirementText: v || null });
-                    }
-                  } else if (v && v !== r.node.text) {
-                    updateNode(r.node.id, { text: v });
+                  // Never blanks the node text: it is the label on the canvas
+                  // and (unlike requirementText) syncs out to GitHub.
+                  if (v && v !== r.node.text) updateNode(r.node.id, { text: v });
+                  setEditingCell(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                  if (e.key === 'Escape') setEditingCell(null);
+                  e.stopPropagation();
+                }}
+                style={{ ...inputStyle, width: '100%', padding: '2px 6px' }}
+              />
+            ) : isEditing(r.node.id, 'requirementText') ? (
+              <input
+                autoFocus
+                defaultValue={r.node.requirementText ?? ''}
+                placeholder="Business phrasing (falls back to the node title)"
+                onBlur={(e) => {
+                  const v = e.target.value.trim();
+                  if (v !== (r.node.requirementText ?? '')) {
+                    updateNode(r.node.id, { requirementText: v || null });
                   }
                   setEditingCell(null);
                 }}
@@ -960,7 +969,7 @@ function ChapterGroup({
                 style={{ ...inputStyle, width: '100%', padding: '2px 6px' }}
               />
             ) : (
-              <span style={{ cursor: 'text', display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+              <span style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
                 <span
                   style={{
                     flexShrink: 0,
@@ -972,38 +981,51 @@ function ChapterGroup({
                   }}
                   title={`Health: ${r.health}`}
                 />
-                {/* Requirement statements are sentences — wrap to two lines
-                    rather than truncating mid-clause. */}
-                <span
-                  style={{
-                    // Shrink-to-fit, not grow — keeps ↗ next to the title
-                    // instead of stranding it at the far edge of a wide column.
-                    flex: '0 1 auto',
-                    minWidth: 0,
-                    display: '-webkit-box',
-                    WebkitBoxOrient: 'vertical',
-                    WebkitLineClamp: 2,
-                    overflow: 'hidden',
-                    lineHeight: 1.4,
-                  }}
-                  title={
-                    r.node.requirementText != null && r.node.requirementText !== r.node.text
-                      ? `Node: ${r.node.text}`
-                      : (r.node.requirementText ?? r.node.text)
-                  }
-                >
-                  {r.node.requirementText ?? r.node.text}
+                <span style={{ flex: '1 1 auto', minWidth: 0 }}>
+                  <span style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+                    {/* The node title. It is what the row is called everywhere
+                        else (canvas, Kanban, GitHub), so it is the scanning
+                        anchor even when a business phrasing exists — the
+                        register used to hide it in a tooltip. */}
+                    <span
+                      onClick={() => setEditingCell({ nodeId: r.node.id, field: 'text' })}
+                      title={`${r.node.text} — click to edit the node title`}
+                      style={reqTitleStyle(
+                        r.node.requirementText != null && r.node.requirementText !== r.node.text,
+                      )}
+                    >
+                      {r.node.text}
+                    </span>
+                    {/* Rides on the title line, not on the cell: as a sibling
+                        of the whole two-line block it ended up alone at the
+                        far edge of a 600px column. */}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        jumpToNode(r.node);
+                      }}
+                      title="Show in mindmap"
+                      style={jumpButtonStyle}
+                    >
+                      ↗
+                    </button>
+                  </span>
+                  {/* Requirement statements are sentences — wrap to two lines
+                      rather than truncating mid-clause. Only rendered when it
+                      says something the title doesn't. */}
+                  {r.node.requirementText != null &&
+                    r.node.requirementText !== r.node.text && (
+                      <span
+                        onClick={() =>
+                          setEditingCell({ nodeId: r.node.id, field: 'requirementText' })
+                        }
+                        title={`${r.node.requirementText} — click to edit the business phrasing`}
+                        style={reqStatementStyle}
+                      >
+                        {r.node.requirementText}
+                      </span>
+                    )}
                 </span>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    jumpToNode(r.node);
-                  }}
-                  title="Show in mindmap"
-                  style={jumpButtonStyle}
-                >
-                  ↗
-                </button>
               </span>
             )}
           </td>
@@ -1622,6 +1644,42 @@ const inlineSelectStyle: React.CSSProperties = {
   fontFamily: 'inherit',
   color: '#334155',
   cursor: 'pointer',
+};
+
+/**
+ * The node title line. Clamped to one line when a business phrasing follows
+ * it — two rows of bold title would out-shout the statement it introduces —
+ * and to two when it is the only thing in the cell (then it IS the
+ * requirement statement, and cutting a sentence mid-clause loses meaning).
+ */
+function reqTitleStyle(hasStatement: boolean): React.CSSProperties {
+  return {
+    // Shrink-to-fit, not grow — keeps ↗ next to the title rather than at the
+    // far edge of a wide column.
+    flex: '0 1 auto',
+    minWidth: 0,
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: hasStatement ? 1 : 2,
+    overflow: 'hidden',
+    fontWeight: 600,
+    color: '#1e293b',
+    lineHeight: 1.4,
+    cursor: 'text',
+  };
+}
+
+/** The business phrasing under the title — secondary, but still readable. */
+const reqStatementStyle: React.CSSProperties = {
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+  overflow: 'hidden',
+  marginTop: 2,
+  fontSize: 11.5,
+  color: '#64748b',
+  lineHeight: 1.4,
+  cursor: 'text',
 };
 
 const jumpButtonStyle: React.CSSProperties = {

--- a/packages/mindmap/src/mobile/MobileRequirementsView.tsx
+++ b/packages/mindmap/src/mobile/MobileRequirementsView.tsx
@@ -197,7 +197,13 @@ export function MobileRequirementsView({
                 </span>
               )}
             </div>
-            <div className="mb-req-text">{node.requirementText ?? node.text}</div>
+            {/* Node title first, business phrasing under it — same order as
+                the desktop register. Showing only the phrasing hid the name
+                the node carries everywhere else. */}
+            <div className="mb-req-text">{node.text}</div>
+            {node.requirementText != null && node.requirementText !== node.text && (
+              <div className="mb-req-statement">{node.requirementText}</div>
+            )}
             {chapterText && <div className="mb-req-chapter">{chapterText}</div>}
           </button>
         );

--- a/packages/mindmap/src/mobile/mobile.css
+++ b/packages/mindmap/src/mobile/mobile.css
@@ -923,6 +923,14 @@ body.mobile {
   line-height: 1.4;
 }
 
+/* Business phrasing under the title — secondary, but a full sentence, so it
+   wraps rather than clamping to one line like the pills above it. */
+.mb-req-statement {
+  font-size: 12.5px;
+  color: #64748b;
+  line-height: 1.4;
+}
+
 .mb-req-chapter {
   font-size: 11px;
   color: #94a3b8;


### PR DESCRIPTION
## Problem

Die Requirement-Spalte des Registers rendert `requirementText ?? text`. Sobald eine Business-Formulierung gesetzt ist, verschwindet der **Node-Titel komplett** — er lebt nur noch im `title`-Tooltip. Genau der Titel ist aber der Name, unter dem die Zeile überall sonst läuft (Canvas, Kanban, GitHub-Issue), und damit der Anker, an dem man eine Zeile beim Scannen wiedererkennt.

## Änderung

Zweizeilige Zelle: **Titel** fett oben, Business-Formulierung grau darunter.

- Die zweite Zeile entfällt, wenn kein `requirementText` gesetzt ist **oder** er identisch zum Titel ist — sonst stünde dasselbe zweimal da.
- Ohne Beschreibung klemmt der Titel auf zwei Zeilen statt einer: dann *ist* er die Anforderung, und ein Satz darf nicht mitten im Nebensatz abgeschnitten werden.
- Beide Zeilen einzeln inline-editierbar (Titel → `node.text`, Satz → `requirementText`). Vorher lief beides über ein Feld — nicht mehr eindeutig, wenn man beide sieht. Der Titel lässt sich nicht leerschreiben, er syncht nach GitHub raus.
- Das ↗ hängt jetzt an der Titelzeile statt am ganzen Block; als Geschwister der zwei Zeilen strandete es bei mehrzeiligen Rows allein am rechten Rand der 615px-Spalte.
- `MobileRequirementsView` hatte dieselbe Stelle mit demselben `??` und ist mitgezogen (gleiche Reihenfolge, neue Klasse `.mb-req-statement`).

Keine Feldänderung — reine Darstellung vorhandener Daten, also keine der Schichten aus der Definition of Done betroffen (Typ/DB/REST/MCP unverändert).

## Test plan

- `pnpm turbo typecheck` und `pnpm turbo test` grün (auf diesem Branch, nach der letzten Änderung).
- Visuell verifiziert mit der Wegwerf-Harness (zustand-Store gestubbt, Playwright, danach gelöscht) über eine bewusst schiefe Fixture:
  - Titel + Beschreibung → beide Zeilen (MAN-01, MAN-02, BUC-01)
  - kein `requirementText` → nur Titel, zweizeilig umbrochen (MAN-03)
  - `requirementText` identisch zum Titel → wird **nicht** doppelt gerendert (BUC-02)
  - Spaltenbreiten unverändert (fixed layout, Requirement 615px bei 1600px Viewport)
  - Klick auf Titel öffnet Input mit `node.text`, Klick auf den Satz mit `requirementText` — per Playwright nachgemessen
- Mobile-Karte bei 390px geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsE7J58UqUnzhkSV1X9tWi