### PR TITLE
docs(deploy): Ownership-Falle beim Redeploy benennen

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -278,6 +278,28 @@ systemctl reload caddy   # only if you changed the Caddyfile
 
 The API runs migrations on every startup, so schema changes apply automatically.
 
+**The `sudo -u mindblown` covers the pull, not just the build — keep it that way.**
+Pulling as root and building as `mindblown` works for a long time and then doesn't:
+root-owned files pile up in the tree, and nothing complains until a build has to
+*delete* one. Vite's `emptyDir` on `packages/mindmap/dist` is where it surfaces:
+
+```
+EPERM: operation not permitted, unlink '/opt/mindblown/packages/mindmap/dist/assets/index-<hash>.js'
+    at emptyDir (…/vite/dist/node/chunks/…)
+ERROR  @mindblown/mindmap#build: command (/opt/mindblown/packages/mindmap) … exited (1)
+```
+
+That is an ownership error, not a disk or dependency error. Recover with:
+
+```bash
+chown -R mindblown:mindblown /opt/mindblown   # as root
+find /opt/mindblown -path ./.git -prune -o -user root -print   # empty = clean
+```
+
+then re-run the redeploy block above. Anything that writes into `/opt/mindblown`
+— including ad-hoc `git pull`s while debugging — has to run as `mindblown`, since
+that is the user in the systemd unit.
+
 ## GitHub-sync observability (Uptime-Kuma push monitors)
 
 The API exposes four passive heartbeats for the GitHub→MindBlown sync


### PR DESCRIPTION
## Warum

`deploy/README.md` wickelt Pull *und* Build korrekt in `sudo -u mindblown` — aber nirgends steht, dass das kein Stilfrage ist. Wer den Pull als root laufen lässt (typisch: von Hand beim Debuggen, oder eine abgeschriebene Kurzfassung des Kommandos), sät root-eigene Dateien in einen Baum, den der Builder beschreiben muss.

Auffallen tut das **nicht** beim Pull und nicht beim nächsten Build, sondern erst, wenn ein Build eine root-eigene Datei *löschen* muss. Dann wirft vites `emptyDir` auf `packages/mindmap/dist` ein `EPERM`, und turbo meldet nach oben nur:

```
ERROR  @mindblown/mindmap#build: command (/opt/mindblown/packages/mindmap) … exited (1)
```

Das liest sich wie ein Dependency- oder Plattenproblem, ist aber ein Rechteproblem.

## Was passiert ist

Am 03.08.2026 ist genau daran ein Prod-Deploy gescheitert. Beim Nachsehen war die Verschmutzung längst breit: `src`, `dist`, `node_modules`, `.turbo/cache` — angelegt von einem Deploy am 01.08., der komplett als root lief, plus dem Pull-als-root am 03.08. Repariert mit `chown -R mindblown:mindblown /opt/mindblown`, danach lief der dokumentierte Block sauber durch.

## Änderung

Docs-only. Ergänzt unter "Updates / redeploys" das Symptom (inkl. der Fehlermeldung, nach der man sucht), die Ursache und das `chown` samt Verifikations-`find`.

## Test plan

Kein Code berührt, kein Deploy nötig. Der dokumentierte Recovery-Pfad ist auf Prod ausgeführt und verifiziert worden: nach dem `chown` meldet `find /opt/mindblown -path ./.git -prune -o -user root -print` nichts mehr, und `pnpm build` als `mindblown` läuft durch (Bundle-Hash ist danach von `index-D9eNo2hT.js` auf `index-PpJW2tPB.js` gewechselt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsE7J58UqUnzhkSV1X9tWi