### PR TITLE
fix(mindmap): Property-Panel neben den Arbeits-Panels + Dev-Server gleiche Herkunft

### DIFF
--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -2187,6 +2187,17 @@ export function App() {
           {activeView === 'hill' && <HillChart />}
           {activeView === 'workload' && <WorkloadView />}
         </div>
+        {/* Die vier Arbeits-Panels bleiben untereinander exklusiv — jeweils
+            eines rechts. Das Property-Panel steht daneben statt in derselben
+            else-Kette: es hing vorher am Ende der Kette und war damit
+            unsichtbar, solange eines der anderen offen war. Genau aus dem
+            Blocked- und dem Sprint-Panel heraus klickt man aber Knoten an
+            (BlockedPanel.tsx:39, SprintPanel.tsx:258) — die Auswahl passierte,
+            die Eigenschaften dazu blieben verborgen, bis man das Panel schloss.
+
+            Reihenfolge: das Arbeits-Panel innen, das Property-Panel aussen am
+            Rand. Damit sitzt es immer an derselben Stelle, egal was sonst
+            offen ist. */}
         {blockedPanelOpen ? (
           <BlockedPanel onClose={() => setBlockedPanelOpen(false)} />
         ) : sprintPanelOpen ? (
@@ -2201,17 +2212,16 @@ export function App() {
             mapId={currentMapId}
             onClose={() => setPlanHealthPanelOpen(false)}
           />
-        ) : activeView === 'guide' ? null : (
-          /* The Anwenderansicht keeps its own selection in `selectedNodeId`
-             (that is what makes a link to one criterion shareable), and the
-             property panel opens on any selection. Docking a 320px editor
-             of estimates, statuses and blocked-reasons beside a view whose
-             entire premise is "three facts, not nine" would undo it — so
-             that one view suppresses the panel and offers "Anleitung
-             bearbeiten" instead, which jumps to the mindmap where the panel
-             belongs. Every other view is untouched. */
-          <PropertyPanel />
-        )}
+        ) : null}
+        {/* The Anwenderansicht keeps its own selection in `selectedNodeId`
+            (that is what makes a link to one criterion shareable), and the
+            property panel opens on any selection. Docking a 320px editor
+            of estimates, statuses and blocked-reasons beside a view whose
+            entire premise is "three facts, not nine" would undo it — so
+            that one view suppresses the panel and offers "Anleitung
+            bearbeiten" instead, which jumps to the mindmap where the panel
+            belongs. Every other view is untouched. */}
+        {activeView !== 'guide' && <PropertyPanel />}
       </div>
 
       {/* Command Palette */}

--- a/packages/mindmap/src/BlockedPanel.tsx
+++ b/packages/mindmap/src/BlockedPanel.tsx
@@ -44,6 +44,10 @@ export function BlockedPanel({ onClose }: { onClose: () => void }) {
     <div
       style={{
         width: PANEL_WIDTH,
+        // Das Property-Panel steht seit App.tsx:2184 daneben statt in derselben
+        // else-Kette, also können zwei Panels nebeneinander liegen. Ohne dies
+        // schrumpfen beide, sobald der Platz knapp wird.
+        flexShrink: 0,
         height: '100%',
         borderLeft: '1px solid #e2e8f0',
         background: '#ffffff',

--- a/packages/mindmap/src/PlanHealthPanel.tsx
+++ b/packages/mindmap/src/PlanHealthPanel.tsx
@@ -77,6 +77,10 @@ export function PlanHealthPanel({ mapId, onClose }: { mapId: string; onClose: ()
     <div
       style={{
         width: PANEL_WIDTH,
+        // Das Property-Panel steht seit App.tsx:2184 daneben statt in derselben
+        // else-Kette, also können zwei Panels nebeneinander liegen. Ohne dies
+        // schrumpfen beide, sobald der Platz knapp wird.
+        flexShrink: 0,
         height: '100%',
         borderLeft: '1px solid #e2e8f0',
         background: '#ffffff',

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -239,6 +239,10 @@ function PropertyPanelInner({
     <div
       style={{
         width: PANEL_WIDTH,
+        // Das Property-Panel steht seit App.tsx:2184 daneben statt in derselben
+        // else-Kette, also können zwei Panels nebeneinander liegen. Ohne dies
+        // schrumpfen beide, sobald der Platz knapp wird.
+        flexShrink: 0,
         height: '100%',
         borderLeft: '1px solid #e2e8f0',
         background: '#ffffff',

--- a/packages/mindmap/src/ShareDialog.tsx
+++ b/packages/mindmap/src/ShareDialog.tsx
@@ -3,7 +3,16 @@ import * as api from './api.js';
 import type { Permission, PendingInvite } from './api.js';
 import { useMindmapStore } from './store.js';
 
-const BASE_URL: string = (import.meta as any).env?.VITE_APP_URL ?? window.location.origin;
+/**
+ * Basis für die geteilten Links. Funktion statt Modul-Konstante aus demselben
+ * Grund wie `wsBase()` in ws.ts: `window` beim Import zu lesen macht das Modul
+ * ausserhalb des Browsers unimportierbar. Hier ist noch nichts daran
+ * gescheitert — dieses Modul hängt bloss an keinem Test — aber der erste
+ * Test, der es importiert, würde ohne DOM sofort fallen.
+ */
+function baseUrl(): string {
+  return (import.meta as any).env?.VITE_APP_URL ?? window.location.origin;
+}
 
 export function ShareDialog({
   mapId,
@@ -110,7 +119,7 @@ export function ShareDialog({
 
   const handleCopyLink = () => {
     if (!publicToken) return;
-    const url = `${BASE_URL}/public/${mapId}?token=${publicToken}`;
+    const url = `${baseUrl()}/public/${mapId}?token=${publicToken}`;
     navigator.clipboard.writeText(url).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
@@ -120,7 +129,7 @@ export function ShareDialog({
   const handleCopyInviteLink = (email: string) => {
     // Prefills the register form with this email. The existing pending_invites
     // row is resolved automatically when the user signs up with that email.
-    const url = `${BASE_URL}/?email=${encodeURIComponent(email)}&mode=register`;
+    const url = `${baseUrl()}/?email=${encodeURIComponent(email)}&mode=register`;
     navigator.clipboard.writeText(url).then(() => {
       setCopiedInviteEmail(email);
       setTimeout(() => setCopiedInviteEmail(null), 2000);
@@ -548,7 +557,7 @@ export function ShareDialog({
               <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
                 <input
                   readOnly
-                  value={`${BASE_URL}/public/${mapId}?token=${publicToken}`}
+                  value={`${baseUrl()}/public/${mapId}?token=${publicToken}`}
                   style={{
                     flex: 1,
                     padding: '8px 10px',

--- a/packages/mindmap/src/SprintPanel.tsx
+++ b/packages/mindmap/src/SprintPanel.tsx
@@ -663,6 +663,10 @@ export function SprintPanel({ onClose }: { onClose: () => void }) {
     <div
       style={{
         width: PANEL_WIDTH,
+        // Das Property-Panel steht seit App.tsx:2184 daneben statt in derselben
+        // else-Kette, also können zwei Panels nebeneinander liegen. Ohne dies
+        // schrumpfen beide, sobald der Platz knapp wird.
+        flexShrink: 0,
         height: '100%',
         borderLeft: '1px solid #e2e8f0',
         background: '#ffffff',

--- a/packages/mindmap/src/TriagePanel.tsx
+++ b/packages/mindmap/src/TriagePanel.tsx
@@ -617,6 +617,10 @@ export function TriagePanel({
       data-testid="triage-panel"
       style={{
         width: PANEL_WIDTH,
+        // Das Property-Panel steht seit App.tsx:2184 daneben statt in derselben
+        // else-Kette, also können zwei Panels nebeneinander liegen. Ohne dies
+        // schrumpfen beide, sobald der Platz knapp wird.
+        flexShrink: 0,
         height: '100%',
         borderLeft: '1px solid #e2e8f0',
         background: '#ffffff',

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -9,7 +9,13 @@ import type {
   RequirementStage,
 } from '@mindblown/core';
 
-const BASE_URL: string = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
+// Leer = gleiche Herkunft. Im Dev-Betrieb proxied Vite `/api` und `/ws` an den
+// Server (siehe vite.config.ts), im Produktivbetrieb liegen Oberfläche und API
+// ohnehin hinter demselben Host. Der frühere Default `http://localhost:3001`
+// funktionierte nur, wenn der Browser auf derselben Maschine lief wie der
+// Server — von jedem anderen Rechner zeigte er auf dessen eigenen localhost.
+// Wer die API woanders hat, setzt VITE_API_URL explizit.
+const BASE_URL: string = import.meta.env.VITE_API_URL ?? '';
 
 // ── Token helpers ────────────────────────────────────────────────
 

--- a/packages/mindmap/src/ws.ts
+++ b/packages/mindmap/src/ws.ts
@@ -2,7 +2,25 @@ import { getToken } from './api.js';
 
 type MessageHandler = (data: unknown) => void;
 
-const WS_BASE: string = (import.meta.env.VITE_API_URL ?? 'http://localhost:3001').replace(/^http/, 'ws');
+/**
+ * Ohne VITE_API_URL: gleiche Herkunft wie die Seite, Schema aus dem Protokoll
+ * abgeleitet (https -> wss). Ein leerer Basis-String würde eine relative
+ * WebSocket-URL ergeben, die der Browser nicht auflöst — anders als bei fetch
+ * braucht `new WebSocket()` eine absolute Adresse.
+ *
+ * Bewusst eine Funktion und keine Modul-Konstante: `window` beim Import zu
+ * lesen macht das Modul in Node unimportierbar, und `store.ts` zieht es mit
+ * herein. Die Tests laufen in der node-Umgebung ohne DOM, also fiel dort die
+ * ganze Suite mit `ReferenceError: window is not defined` aus — obwohl keiner
+ * der Tests je eine Verbindung aufbaut. Erst beim Verbinden auszuwerten kostet
+ * nichts und hält den Import seiteneffektfrei.
+ */
+function wsBase(): string {
+  const configured = import.meta.env.VITE_API_URL;
+  if (configured) return (configured as string).replace(/^http/, 'ws');
+  const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  return `${scheme}://${window.location.host}`;
+}
 
 const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000];
 
@@ -27,9 +45,10 @@ export function connectWs(mapId: string, onMessage: MessageHandler, onStatusChan
 
     try {
       const token = getToken();
+      const base = wsBase();
       const url = token
-        ? `${WS_BASE}/ws/maps/${mapId}?token=${encodeURIComponent(token)}`
-        : `${WS_BASE}/ws/maps/${mapId}`;
+        ? `${base}/ws/maps/${mapId}?token=${encodeURIComponent(token)}`
+        : `${base}/ws/maps/${mapId}`;
       ws = new WebSocket(url);
     } catch {
       scheduleReconnect();

--- a/packages/mindmap/vite.config.ts
+++ b/packages/mindmap/vite.config.ts
@@ -16,5 +16,14 @@ export default defineConfig({
     // über Tailscale von anderen Rechnern aus benutzt, und der Default bindet
     // nur [::1] — von dort ist die Oberfläche sonst nicht erreichbar.
     host: true,
+    // API und WebSocket über den Dev-Server proxien, damit die Oberfläche
+    // gleiche Herkunft hat wie ihre Datenquelle. Sonst lädt der Browser die
+    // Seite von claudia, ruft die API aber auf SEINEM eigenen localhost:3001 —
+    // und selbst mit korrigierter Adresse müsste die Herkunft in der
+    // CORS-Allowlist des Servers stehen. Mit Proxy entfällt beides.
+    proxy: {
+      '/api': { target: 'http://localhost:3001', changeOrigin: true },
+      '/ws': { target: 'ws://localhost:3001', ws: true },
+    },
   },
 });


### PR DESCRIPTION
Zwei Fixes, beide im Frontend.

## 1. Property-Panel war hinter den Arbeits-Panels versteckt

`App.tsx` rendert die rechte Spalte als eine `if/else`-Kette: Blocked → Sprint → Triage → Plan-Health → **dann erst** Property-Panel. Solange eines der vier offen war, wurde das Property-Panel gar nicht gerendert, auch bei selektiertem Knoten.

Das Tückische daran: aus dem Blocked- und dem Sprint-Panel heraus klickt man Knoten an (`BlockedPanel.tsx:39`, `SprintPanel.tsx:258`). Die Auswahl passiert, sichtbar wird sie nicht — die Eigenschaften erscheinen erst, wenn man das Panel schliesst, dann mit dem vorhin angeklickten Knoten. Das Panel hat keinen eigenen Öffnen-Zustand (`isOpen = !!node`), es hängt allein an `selectedNodeId`, deshalb sah es wie ein kaputter Klick aus.

Jetzt steht es daneben statt in derselben Kette. Die vier Arbeits-Panels bleiben untereinander exklusiv (Präzedenz unverändert). Reihenfolge: Arbeits-Panel innen, Property-Panel aussen am Rand — so sitzt es immer an derselben Stelle, egal was sonst offen ist. Die bewusste Ausnahme aus #295 (Guide-Ansicht unterdrückt das Panel) bleibt erhalten.

Damit können erstmals zwei Panels nebeneinander liegen, also bekommen alle fünf Container `flexShrink: 0`. Ohne das teilen sie sich bei knappem Platz die Breite, statt die Zeichenfläche schrumpfen zu lassen.

## 2. Dev-Server gleiche Herkunft, keine Browser-APIs beim Import

`VITE_API_URL` fiel auf `http://localhost:3001` zurück — korrekt nur, wenn der Browser auf derselben Maschine läuft wie der Server; von jedem anderen Rechner zeigte es auf dessen eigenen localhost. Jetzt leer = gleiche Herkunft, plus Vite-Proxy für `/api` und `/ws` im Dev-Betrieb (sonst müsste die Oberfläche zusätzlich in der CORS-Allowlist des Servers stehen).

Die daraus nötige Schema-Ableitung (`https` → `wss`) als Modul-Konstante zu schreiben machte `ws.ts` in Node unimportierbar, und `store.ts` zieht es mit herein: **die komplette `viewScope`-Suite fiel mit `ReferenceError: window is not defined` aus**, obwohl kein Test je eine Verbindung aufbaut. Jetzt eine Funktion, ausgewertet beim Verbinden.

`ShareDialog.tsx:6` hatte denselben Defekt (`window.location.origin` auf Modulebene) — bisher folgenlos, weil kein Test das Modul importiert, aber der erste, der es täte, wäre ohne DOM sofort gefallen. Als Klassenfix mitgezogen.

Bewusst nicht angefasst: `store.ts:224` ruft `api.getToken()` im Initial-State und liest damit `localStorage` beim Import. Derselbe Geruch, aber der Test shimmt es bereits, und ein Umbau der Store-Initialisierung wäre kein Fix mehr.

## Test plan

- `pnpm turbo typecheck` und `pnpm turbo test` grün; `packages/mindmap` zusätzlich ungecacht: **101/101** (vorher fiel `viewScope` als ganze Suite aus, 64 statt 101 Tests liefen).
- Panel-Layout visuell verifiziert mit einer Wegwerf-Harness (Store gestubbt, Playwright, danach gelöscht): Blocked-Panel + Property-Panel nebeneinander, das Property-Panel zeigt den im Blocked-Panel angeklickten Knoten samt Status/Blocked-Reason.
- Breiten nachgemessen statt geschätzt — 1600px Viewport: `[900, 380, 320]`, 1100px: `[400, 380, 320]`. Beide Panels halten ihre Breite, die Zeichenfläche fängt die Differenz auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsE7J58UqUnzhkSV1X9tWi