### PR TITLE
fix(requirements): Zeilenklick wählt aus, statt aus dem Register zu springen

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -779,6 +779,7 @@ export function RequirementsView() {
                   updateNode={updateNode}
                   jumpToNode={jumpToNode}
                   jumpToGuide={jumpToGuide}
+                  selectNode={selectNode}
                   currentUserId={user?.id ?? null}
                   toggleAcceptance={toggleAcceptance}
                   rejectRequirement={rejectRequirement}
@@ -807,6 +808,7 @@ function ChapterGroup({
   updateNode,
   jumpToNode,
   jumpToGuide,
+  selectNode,
   currentUserId,
   toggleAcceptance,
   rejectRequirement,
@@ -823,6 +825,7 @@ function ChapterGroup({
   updateNode: (id: string, updates: Partial<Node>) => void;
   jumpToNode: (node: Node) => void;
   jumpToGuide: (node: Node) => void;
+  selectNode: (id: string) => void;
   currentUserId: string | null;
   toggleAcceptance: (row: ReqRow, gate: RequirementGate) => void;
   rejectRequirement: (row: ReqRow, gate: RequirementGate) => void;
@@ -854,10 +857,17 @@ function ChapterGroup({
         <tr
           key={r.node.id}
           ref={current ? selectedRowRef : undefined}
-          onClick={() => jumpToNode(r.node)}
+          // Auswählen, nicht wegspringen. Der Zeilenklick rief bis hierher
+          // jumpToNode und damit setActiveView('mindmap') (#207) — das
+          // Register verschwand also unter dem Finger, und die Eigenschaften
+          // des angeklickten Requirements sah man nur noch in der Mindmap.
+          // Jetzt bleibt man im Register und das Property-Panel öffnet sich
+          // rechts daneben. Den Sprung macht weiterhin das ↗ in der
+          // Requirement-Spalte, das genau dafür schon da war.
+          onClick={() => selectNode(r.node.id)}
           onMouseEnter={(e) => (e.currentTarget.style.background = '#eff6ff')}
           onMouseLeave={(e) => (e.currentTarget.style.background = rowBackground)}
-          title="Open in mindmap"
+          title="Auswählen — Eigenschaften erscheinen rechts (↗ öffnet in der Mindmap)"
           style={{
             background: rowBackground,
             borderBottom: '1px solid #f1f5f9',


### PR DESCRIPTION
## Problem

Auf der Requirements-Seite passierte beim Klick auf eine Zeile nicht das, was man erwartet: `onClick={() => jumpToNode(r.node)}` ruft `setActiveView('mindmap')`. Das Register verschwindet also unter dem Finger, und die Eigenschaften des angeklickten Requirements sieht man nur noch in der Mindmap.

Das kommt aus #207 und war damals bewusst so gebaut. Seit #298 kann das Property-Panel aber neben *jeder* Ansicht stehen — nur erreichte man es vom Register aus nie, weil der Klick vorher wegnavigierte.

## Änderung

Der Zeilenklick selektiert jetzt nur noch (`selectNode`). Man bleibt im Register, die Zeile bekommt ihre ohnehin schon implementierte Markierung (inset-Balken + Hintergrund, war bisher nur für Sprünge aus den Prüfanleitungen sichtbar), und das Property-Panel öffnet rechts daneben. Status, Schätzung, Prüflink, Prüfanleitung lassen sich damit direkt pflegen, ohne die gefilterte Liste zu verlieren.

Der Sprung in die Mindmap geht **nicht** verloren: dafür ist das **↗** in der Requirement-Spalte da, das genau diesen Zweck schon hatte (`title="Show in mindmap"`). Jede der beiden Absichten hat jetzt ihre eigene Trefferfläche, statt dass die eine die andere verdeckt.

Unverändert: die Zellen mit Inline-Editoren (REQ-ID, Titel, Beschreibung, Priorität, Release, Fortschritt auf Blättern, Acceptance) stoppen die Propagierung weiterhin selbst, klicken dort editiert wie bisher.

## Test plan

- `pnpm turbo typecheck` grün; `packages/mindmap` ungecacht: **151/151** Tests.
- Verhalten mit Wegwerf-Harness geprüft (Store gestubbt auf `activeView: 'requirements'`, Register + Property-Panel im nachgebauten App-Container, Playwright; danach gelöscht):
  - vor dem Klick: `view = requirements`, kein Panel
  - nach dem Zeilenklick: `view = requirements` (**bleibt**), Panel offen, Tabelle weiterhin da, Panel zeigt den geklickten Knoten (`Mandatsliquidation`, REQ-ID `MAN-01`, Req. Priority `Must`)
  - nach Klick auf ↗: `view = mindmap` — der Sprung funktioniert unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsE7J58UqUnzhkSV1X9tWi