### PR TITLE
fix(mindmap): Mehrfachauswahl ankert am zuletzt angeklickten Knoten

### DIFF
--- a/packages/mindmap/src/__tests__/selection.test.ts
+++ b/packages/mindmap/src/__tests__/selection.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// The store module reads localStorage at import time (auth-token bootstrap);
+// shim it for the node test environment BEFORE the dynamic import below.
+if (typeof globalThis.localStorage === 'undefined') {
+  const mem = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => void mem.set(k, String(v)),
+    removeItem: (k: string) => void mem.delete(k),
+    clear: () => mem.clear(),
+    key: () => null,
+    get length() {
+      return mem.size;
+    },
+  } as Storage;
+}
+
+const { useMindmapStore } = await import('../store.js');
+
+/**
+ * `selectedNodeId` is the anchor of a multi-selection: the Property panel
+ * renders it, and the keyboard navigation moves from it. It must therefore
+ * follow the node the user touched last, not the one they touched first —
+ * shift-clicking three nodes used to leave the panel on node one.
+ */
+describe('selection anchor', () => {
+  beforeEach(() => {
+    useMindmapStore.setState({ selectedNodeIds: [], selectedNodeId: null } as never);
+  });
+
+  const state = () => {
+    const s = useMindmapStore.getState();
+    return { ids: s.selectedNodeIds, anchor: s.selectedNodeId };
+  };
+
+  it('anchors on the node just added to the selection', () => {
+    const { toggleSelectNode } = useMindmapStore.getState();
+    toggleSelectNode('a');
+    expect(state()).toEqual({ ids: ['a'], anchor: 'a' });
+
+    toggleSelectNode('b');
+    expect(state()).toEqual({ ids: ['a', 'b'], anchor: 'b' });
+
+    toggleSelectNode('c');
+    expect(state()).toEqual({ ids: ['a', 'b', 'c'], anchor: 'c' });
+  });
+
+  it('falls back to the last remaining node when one is deselected', () => {
+    const { toggleSelectNode } = useMindmapStore.getState();
+    toggleSelectNode('a');
+    toggleSelectNode('b');
+    toggleSelectNode('c');
+
+    // Removing the anchor hands it to what is still selected...
+    toggleSelectNode('c');
+    expect(state()).toEqual({ ids: ['a', 'b'], anchor: 'b' });
+
+    // ...and removing a non-anchor leaves the anchor alone.
+    toggleSelectNode('a');
+    expect(state()).toEqual({ ids: ['b'], anchor: 'b' });
+  });
+
+  it('clears the anchor when the last node is deselected', () => {
+    const { toggleSelectNode } = useMindmapStore.getState();
+    toggleSelectNode('a');
+    toggleSelectNode('a');
+    expect(state()).toEqual({ ids: [], anchor: null });
+  });
+
+  it('selectNode replaces the whole selection', () => {
+    const { toggleSelectNode, selectNode } = useMindmapStore.getState();
+    toggleSelectNode('a');
+    toggleSelectNode('b');
+
+    selectNode('z');
+    expect(state()).toEqual({ ids: ['z'], anchor: 'z' });
+
+    selectNode(null);
+    expect(state()).toEqual({ ids: [], anchor: null });
+  });
+});

--- a/packages/mindmap/src/store.ts
+++ b/packages/mindmap/src/store.ts
@@ -904,7 +904,16 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
     const ids = state.selectedNodeIds.includes(id)
       ? state.selectedNodeIds.filter((i) => i !== id)
       : [...state.selectedNodeIds, id];
-    set({ selectedNodeIds: ids, selectedNodeId: ids[0] ?? null, editingNodeId: null });
+    // Der zuletzt angefasste Knoten ist der Anker, nicht der zuerst
+    // selektierte. `selectedNodeId` steuert das Property-Panel und die
+    // Tastaturnavigation: mit ids[0] zeigte das Panel nach Shift-Klick auf
+    // drei Knoten den ersten an, also den, den man am wenigsten gerade im
+    // Sinn hat. Beim Abwählen rückt der letzte verbliebene nach.
+    set({
+      selectedNodeIds: ids,
+      selectedNodeId: ids[ids.length - 1] ?? null,
+      editingNodeId: null,
+    });
   },
 
   selectAllNodes: () => {


### PR DESCRIPTION
## Problem

`selectedNodeId` ist der Anker einer Mehrfachauswahl: das Property-Panel rendert ihn, und die Tastaturnavigation bewegt sich von ihm aus. `toggleSelectNode` setzte ihn auf `ids[0]`:

```ts
set({ selectedNodeIds: ids, selectedNodeId: ids[0] ?? null, editingNodeId: null });
```

Nach Shift-Klick auf drei Knoten zeigte das Panel damit Knoten **eins** — den, den man am wenigsten gerade im Sinn hat. Fiel bisher kaum auf, weil das Panel neben den Arbeits-Panels ohnehin unsichtbar war (bis #298).

## Änderung

Anker ist der zuletzt angefasste Knoten. Beim Abwählen rückt der letzte verbliebene nach; ist nichts mehr selektiert, wird er `null`.

**Nicht angefasst:** die Löschroute (`store.ts:1436`) fällt nach dem Entfernen selektierter Knoten weiterhin auf `remainingSelected[0]` zurück. Dort gibt es kein "zuletzt angeklickt" mehr, das man retten könnte — das ist eine Reparatur, keine Auswahl.

## Test plan

- Neuer `selection.test.ts` deckt die Auswahl-Logik ab: Anker beim Hinzufügen, Nachrücken beim Abwählen des Ankers, Anker bleibt beim Abwählen eines anderen, Leerung, und `selectNode` als vollständiger Ersatz der Auswahl.
- **Gegenprobe gemacht**: mit `ids[0]` fallen 2 der 4 Fälle, mit der neuen Fassung keiner. Der Test prüft also das Verhalten und nicht bloss, dass die Funktion existiert.
- `pnpm turbo typecheck` grün; `packages/mindmap` ungecacht **155/155** (9 Dateien).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsE7J58UqUnzhkSV1X9tWi