### PR TITLE
fix(requirements): Zeilenauswahl in die Capture-Phase — die Zellen schluckten sie

### DIFF
--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -857,14 +857,21 @@ function ChapterGroup({
         <tr
           key={r.node.id}
           ref={current ? selectedRowRef : undefined}
-          // Auswählen, nicht wegspringen. Der Zeilenklick rief bis hierher
-          // jumpToNode und damit setActiveView('mindmap') (#207) — das
-          // Register verschwand also unter dem Finger, und die Eigenschaften
-          // des angeklickten Requirements sah man nur noch in der Mindmap.
-          // Jetzt bleibt man im Register und das Property-Panel öffnet sich
-          // rechts daneben. Den Sprung macht weiterhin das ↗ in der
-          // Requirement-Spalte, das genau dafür schon da war.
-          onClick={() => selectNode(r.node.id)}
+          // Auswählen, nicht wegspringen (#299): das Register bleibt stehen,
+          // das Property-Panel rechts zeigt die geklickte Zeile. Den Sprung in
+          // die Mindmap macht das ↗ in der Requirement-Spalte.
+          //
+          // Capture-Phase, nicht Bubble. Fünf der neun Zellen rufen
+          // stopPropagation, um ihre eigene Bedienung zu schützen (REQ-ID,
+          // Requirement-Text, Priority, Release, Acceptance) — ein
+          // Bubble-Handler auf der Zeile sah deren Klicks deshalb nie. Zum
+          // Auswählen blieben Status und Remaining übrig, also gerade nicht
+          // die Stellen, auf die ein Mensch zielt: Klicks auf den Titel
+          // öffneten den Inline-Editor, und das Panel zeigte weiter die
+          // vorherige Zeile. Capture läuft vor den Zellen-Handlern, damit
+          // trifft jeder Klick in der Zeile die Auswahl, ohne dass eine der
+          // Zellen ihre eigene Reaktion verliert.
+          onClickCapture={() => selectNode(r.node.id)}
           onMouseEnter={(e) => (e.currentTarget.style.background = '#eff6ff')}
           onMouseLeave={(e) => (e.currentTarget.style.background = rowBackground)}
           title="Auswählen — Eigenschaften erscheinen rechts (↗ öffnet in der Mindmap)"


### PR DESCRIPTION
## Problem

#299 hat den Zeilenklick von "in die Mindmap springen" auf "auswählen" umgestellt — aber als **Bubble**-Handler auf dem `<tr>`. Fünf der neun Zellen rufen `stopPropagation`, um ihre eigene Bedienung zu schützen:

| Zelle | stoppt | Folge |
|---|---|---|
| REQ-ID | ja | Klick öffnet nur den Editor |
| **Requirement (Titel + Beschreibung)** | ja | **Klick öffnet nur den Editor** |
| Priority | ja | Klick bedient nur das Select |
| Release | ja | Klick bedient nur das Select |
| Acceptance | ja | Klick bedient nur ✓/✗ |
| Status, Code Progress (Eltern), Remaining, GitHub | nein | wählt aus |

Übrig zum Auswählen blieben also *Status* und *Remaining* — gerade nicht die Stellen, auf die ein Mensch zielt. Wer auf den Titel klickte, öffnete den Inline-Editor, und das Panel zeigte weiter die vorher gewählte Zeile. Von aussen: "das Panel wechselt nicht".

Die `stopPropagation` auf der Requirement-Spalte kam in **#296** dazu (vorher lag sie auf dem inneren Span) — die Trefferfläche ist mit demselben Schwung geschrumpft, mit dem der Titel sichtbar wurde. Beides meine PRs; #299 hat es dann nicht geheilt, weil ich die Zeile getestet habe, aber nicht die Zellen.

## Änderung

`onClickCapture` statt `onClick` auf dem `<tr>`. Die Capture-Phase läuft vor den Zellen-Handlern, damit trifft jeder Klick in der Zeile die Auswahl, ohne dass eine Zelle ihre eigene Reaktion verliert. Eine Zeile Diff.

## Test plan

Dieselbe Sonde vor und nach der Änderung, im Harness (Store gestubbt, Playwright, danach gelöscht). Gemessen wird die **REQ-ID im Panel**, nicht die Optik.

**Vorher** (= heutiger Prod-Stand), Start auf MAN-02:
```
Klick auf Titel MAN-01        -> markiert bleibt MAN-02
Klick auf REQ-ID MAN-01       -> markiert bleibt MAN-02
Klick auf Beschreibung MAN-01 -> markiert bleibt MAN-02
```

**Nachher:**
```
Start: Status-Zelle MAN-02     -> Panel zeigt: MAN-02
Klick auf Titel MAN-01         -> Panel zeigt: MAN-01
Klick auf Beschreibung MAN-02  -> Panel zeigt: MAN-02
Klick auf REQ-ID MAN-01        -> Panel zeigt: MAN-01
Klick auf Priority MAN-02      -> Panel zeigt: MAN-02
Inline-Editor beim Titelklick offen: true
```

Kein Rückschritt bei #299: `activeView` direkt aus dem Store gelesen — `requirements` nach dem Titelklick, `mindmap` nach Klick auf ↗.

`pnpm turbo typecheck --force` und `pnpm turbo test --force` grün über alle Pakete (0 cached): core 178, tool-kit 117, mindmap 155, mcp 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsE7J58UqUnzhkSV1X9tWi