### PR TITLE
fix(i18n): Prüfanleitungen-Oberfläche auf Englisch, wie der Rest der App

### DIFF
--- a/packages/mindmap/src/App.tsx
+++ b/packages/mindmap/src/App.tsx
@@ -865,7 +865,7 @@ const VIEW_TABS: { id: ActiveView; label: string; enabled: boolean }[] = [
   // Reads the same requirement nodes as the register, for the opposite
   // reader: "how do I check this?" rather than "where does this stand?".
   // Sits next to it so the switch between the two is one click.
-  { id: 'guide', label: 'Prüfanleitungen', enabled: true },
+  { id: 'guide', label: 'How to verify', enabled: true },
   { id: 'list', label: 'List', enabled: true },
   { id: 'calendar', label: 'Calendar', enabled: true },
   { id: 'hill', label: 'Hill Chart', enabled: true },
@@ -2213,13 +2213,13 @@ export function App() {
             onClose={() => setPlanHealthPanelOpen(false)}
           />
         ) : null}
-        {/* The Anwenderansicht keeps its own selection in `selectedNodeId`
-            (that is what makes a link to one criterion shareable), and the
-            property panel opens on any selection. Docking a 320px editor
-            of estimates, statuses and blocked-reasons beside a view whose
-            entire premise is "three facts, not nine" would undo it — so
-            that one view suppresses the panel and offers "Anleitung
-            bearbeiten" instead, which jumps to the mindmap where the panel
+        {/* The "How to verify" view keeps its own selection in
+            `selectedNodeId` (that is what makes a link to one criterion
+            shareable), and the property panel opens on any selection. Docking
+            a 320px editor of estimates, statuses and blocked-reasons beside a
+            view whose entire premise is "three facts, not nine" would undo it
+            — so that one view suppresses the panel and offers "Edit the
+            steps" instead, which jumps to the mindmap where the panel
             belongs. Every other view is untouched. */}
         {activeView !== 'guide' && <PropertyPanel />}
       </div>

--- a/packages/mindmap/src/AttachmentsSection.tsx
+++ b/packages/mindmap/src/AttachmentsSection.tsx
@@ -63,7 +63,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
     // `example.com` without a scheme — is answered instantly rather than
     // as a round-trip 400.
     if (!isHttpUrl(url)) {
-      setError('Bitte eine vollständige Adresse mit http:// oder https://');
+      setError('Enter a full address starting with http:// or https://');
       return;
     }
     setError(null);
@@ -73,7 +73,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
       setLinkTitle('');
       setLinkOpen(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Konnte den Link nicht speichern');
+      setError(err instanceof Error ? err.message : 'Could not save the link');
     }
   }
 
@@ -83,7 +83,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
     try {
       await onRemove(id);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Konnte den Anhang nicht entfernen');
+      setError(err instanceof Error ? err.message : 'Could not remove the attachment');
     } finally {
       setBusyId(null);
     }
@@ -93,7 +93,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
       {attachments.length === 0 && (
         <div style={{ fontSize: 11, color: '#94a3b8' }}>
-          Noch nichts angehängt.
+          Nothing attached yet.
         </div>
       )}
 
@@ -128,7 +128,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
               onClick={() => void remove(a.id)}
               onKeyDown={(e) => e.stopPropagation()}
               disabled={busyId === a.id}
-              aria-label={`${a.title} entfernen`}
+              aria-label={`Remove ${a.title}`}
               style={{
                 border: 'none',
                 background: 'transparent',
@@ -149,7 +149,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
       <MediaUploadButton
         // No filter — the default is already everything. Anything the
         // server won't render inline comes back as a download.
-        label="Datei hochladen…"
+        label="Upload file…"
         onUploaded={(media) =>
           void onAdd({
             kind: 'file',
@@ -158,7 +158,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
             mimeType: media.contentType,
             sizeBytes: media.size,
           }).catch((err) =>
-            setError(err instanceof Error ? err.message : 'Konnte die Datei nicht anhängen'),
+            setError(err instanceof Error ? err.message : 'Could not attach the file'),
           )
         }
       />
@@ -180,7 +180,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
             textAlign: 'left',
           }}
         >
-          Link hinzufügen…
+          Add link…
         </button>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -211,7 +211,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
               if (e.key === 'Enter') void submitLink();
               if (e.key === 'Escape') setLinkOpen(false);
             }}
-            placeholder="Beschriftung (optional)"
+            placeholder="Label (optional)"
             style={{
               width: '100%',
               padding: '6px 8px',
@@ -237,7 +237,7 @@ export function AttachmentsSection({ attachments, onAdd, onRemove }: Props) {
                 cursor: 'pointer',
               }}
             >
-              Hinzufügen
+              Add
             </button>
             <button
               type="button"

--- a/packages/mindmap/src/GuideView.tsx
+++ b/packages/mindmap/src/GuideView.tsx
@@ -35,7 +35,7 @@ import {
  * Same store as RequirementsView.tsx and the same derivation rules (chapter
  * = parent node, REQ-ID order), but a separate surface. The two are linked
  * in both directions through `selectedNodeId` alone: the register's marker
- * sets it and switches here, "Im Register ansehen" does the reverse. No
+ * sets it and switches here, "Show in register" does the reverse. No
  * shared state beyond the selection the URL already carries.
  */
 
@@ -179,7 +179,7 @@ export function GuideView() {
   if (!rootNodeId) {
     return (
       <div style={containerStyle}>
-        <Placeholder title="Keine Karte geöffnet" body="Öffne eine Karte, um ihre Kriterien zu sehen." />
+        <Placeholder title="No map open" body="Open a map to see its criteria." />
       </div>
     );
   }
@@ -192,16 +192,16 @@ export function GuideView() {
       <style>{guideCss}</style>
 
       <div style={headerStyle}>
-        <h2 style={{ margin: 0, fontSize: 16, color: INK }}>Prüfanleitungen</h2>
+        <h2 style={{ margin: 0, fontSize: 16, color: INK }}>How to verify</h2>
         <div style={{ fontSize: 11, color: MUTED, marginTop: 3 }}>
-          {entries.length} Kriterien · {withGuide} mit Prüfanleitung · {withVideo} mit Video
+          {entries.length} criteria · {withGuide} with steps · {withVideo} with a clip
         </div>
       </div>
 
       {entries.length === 0 ? (
         <Placeholder
-          title="Noch keine Kriterien"
-          body="Diese Ansicht zeigt jeden Knoten mit einer Requirement-ID. Vergib eine im Eigenschaften-Panel, dann steht er hier."
+          title="No criteria yet"
+          body="This view lists every node that has a requirement ID. Give one out in the property panel and it shows up here."
         />
       ) : (
         <div className="mb-guide-grid">
@@ -214,8 +214,8 @@ export function GuideView() {
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={(e) => e.stopPropagation()}
-                placeholder="Kriterium oder Kürzel suchen…"
-                aria-label="Kriterium suchen"
+                placeholder="Search criterion or ID…"
+                aria-label="Search criteria"
                 style={searchStyle}
               />
             </div>
@@ -223,7 +223,7 @@ export function GuideView() {
             <div style={{ flex: 1, overflowY: 'auto', padding: '0 10px 24px' }}>
               {visibleChapters.length === 0 ? (
                 <div style={{ padding: '18px 6px', fontSize: 12.5, color: MUTED }}>
-                  Nichts gefunden für „{query.trim()}“.
+                  Nothing found for “{query.trim()}”.
                 </div>
               ) : (
                 visibleChapters.map((chapter) => (
@@ -251,11 +251,11 @@ export function GuideView() {
               />
             ) : (
               <Placeholder
-                title="Wähle links ein Kriterium"
+                title="Pick a criterion on the left"
                 body={
                   chapters.length > 1
-                    ? `${chapters.length} Kapitel, ${entries.length} Kriterien. Zu jedem steht hier, wie du es selbst nachprüfst — Schritte und, wo vorhanden, ein kurzer Clip.`
-                    : 'Zu jedem Kriterium steht hier, wie du es selbst nachprüfst.'
+                    ? `${chapters.length} chapters, ${entries.length} criteria. For each one, this is where it says how to check it yourself — the steps and, where there is one, a short clip.`
+                    : 'For every criterion, this is where it says how to check it yourself.'
                 }
               />
             )}
@@ -311,7 +311,7 @@ function ChapterBlock({
               className="mb-guide-item"
               onClick={() => onSelect(entry)}
               aria-current={current}
-              title={entry.available ? entry.title : `${entry.title} — noch nicht verfügbar`}
+              title={entry.available ? entry.title : `${entry.title} — not available yet`}
               style={{
                 ...itemStyle,
                 background: current ? ACCENT_SOFT : 'transparent',
@@ -357,10 +357,10 @@ function ChapterBlock({
 function Marker({ marker }: { marker: ReturnType<typeof guideMarker> }) {
   const label =
     marker === 'video'
-      ? 'Prüfanleitung und Video vorhanden'
+      ? 'Has written steps and a clip'
       : marker === 'guide'
-        ? 'Prüfanleitung vorhanden'
-        : 'Noch keine Prüfanleitung';
+        ? 'Has written steps'
+        : 'No steps written yet';
   if (marker === 'video') {
     return (
       <span title={label} aria-label={label} style={{ fontSize: 9, color: ACCENT, lineHeight: 1 }}>
@@ -412,12 +412,12 @@ function GuideCard({
           <span style={noticeDotStyle} />
           <div>
             <b style={{ fontWeight: 600, color: INK_SOFT }}>
-              Diese Funktion ist noch nicht verfügbar.
+              This feature is not available yet.
             </b>
             <br />
             {entry.guideText != null
-              ? 'Die Anleitung unten ist bereits geschrieben — prüfbar wird sie, sobald die Funktion ausgeliefert ist.'
-              : 'Sobald sie da ist, steht hier, wie du sie prüfst.'}
+              ? 'The steps below are already written — they become checkable once the feature ships.'
+              : 'Once it is there, this is where it will say how to check it.'}
           </div>
         </div>
       )}
@@ -460,7 +460,7 @@ function GuideCard({
 
       {entry.guideText != null ? (
         <>
-          <div style={sectionLabelStyle}>Schritte</div>
+          <div style={sectionLabelStyle}>Steps</div>
           <div className="mb-guide-md" style={stepsStyle}>
             <ReactMarkdown remarkPlugins={[remarkGfm]} components={guideMarkdownComponents}>
               {entry.guideText}
@@ -473,10 +473,10 @@ function GuideCard({
             <span style={noticeDotStyle} />
             <div>
               <b style={{ fontWeight: 600, color: INK_SOFT }}>
-                Für dieses Kriterium ist noch keine Prüfanleitung hinterlegt.
+                No steps have been written for this criterion yet.
               </b>
               <br />
-              Über „Anleitung bearbeiten“ kannst du sie schreiben.
+              Use “Edit the steps” to write them.
             </div>
           </div>
         )
@@ -536,24 +536,24 @@ function GuideCard({
             rel="noreferrer"
             style={primaryBtnStyle}
           >
-            In der Anwendung öffnen ↗
+            Open in the application ↗
           </a>
         )}
         <button
           className="mb-guide-btn"
           onClick={onEdit}
-          title="Öffnet das Kriterium in der Mindmap; die Prüf-Felder stehen im Eigenschaften-Panel"
+          title="Opens the criterion in the mindmap; the verification fields live in the property panel"
           style={quietBtnStyle}
         >
-          Anleitung bearbeiten
+          Edit the steps
         </button>
         <button
           className="mb-guide-btn"
           onClick={onShowInRegister}
-          title="Zeigt dieses Kriterium im Anforderungsregister — Status, Release, Abnahme"
+          title="Shows this criterion in the requirements register — status, release, sign-off"
           style={quietBtnStyle}
         >
-          Im Register ansehen
+          Show in register
         </button>
       </div>
     </div>

--- a/packages/mindmap/src/MediaUploadButton.tsx
+++ b/packages/mindmap/src/MediaUploadButton.tsx
@@ -29,7 +29,7 @@ type Status =
 export function MediaUploadButton({
   onUploaded,
   accept = '*/*',
-  label = 'Datei hochladen…',
+  label = 'Upload file…',
   disabled = false,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -48,7 +48,7 @@ export function MediaUploadButton({
     } catch (err) {
       setStatus({
         kind: 'error',
-        message: err instanceof Error ? err.message : 'Upload fehlgeschlagen',
+        message: err instanceof Error ? err.message : 'Upload failed',
       });
     }
   }
@@ -87,7 +87,7 @@ export function MediaUploadButton({
           textAlign: 'left',
         }}
       >
-        {busy ? `Lädt… ${Math.round(status.fraction * 100)} %` : label}
+        {busy ? `Uploading… ${Math.round(status.fraction * 100)} %` : label}
       </button>
 
       {busy && (

--- a/packages/mindmap/src/PropertyPanel.tsx
+++ b/packages/mindmap/src/PropertyPanel.tsx
@@ -474,7 +474,7 @@ function PropertyPanelInner({
         {/* Verification how-to + deep link — the review surface reads these */}
         {(node.requirementId != null || requirementId.trim() !== '') && (
           <>
-            <Field label="Prüfanleitung">
+            <Field label="How to verify">
               <textarea
                 value={verificationText}
                 onChange={(e) => setVerificationText(e.target.value)}
@@ -492,10 +492,10 @@ function PropertyPanelInner({
                   resize: 'vertical',
                   fontFamily: 'inherit',
                 }}
-                placeholder={'Wie prüfen? Markdown, z.B.\n1. Einloggen als …\n2. …\n\n**Erwartet:** …\n**Testen mit:** …'}
+                placeholder={'How is this checked? Markdown, e.g.\n1. Sign in as …\n2. …\n\n**Expected:** …\n**Test data:** …'}
               />
             </Field>
-            <Field label="Prüf-Link">
+            <Field label="Where to check">
               <input
                 value={verificationUrl}
                 onChange={(e) => setVerificationUrl(e.target.value)}
@@ -508,10 +508,10 @@ function PropertyPanelInner({
                 }}
                 onKeyDown={(e) => e.stopPropagation()}
                 style={inputStyle}
-                placeholder="https://staging… (wo wird geprüft?)"
+                placeholder="https://staging… (where is it checked?)"
               />
             </Field>
-            <Field label="Video-Link">
+            <Field label="Demo video">
               <input
                 value={verificationVideoUrl}
                 onChange={(e) => setVerificationVideoUrl(e.target.value)}
@@ -524,7 +524,7 @@ function PropertyPanelInner({
                 }}
                 onKeyDown={(e) => e.stopPropagation()}
                 style={inputStyle}
-                placeholder="https://… (kurzes Demo-Video)"
+                placeholder="https://… (short demo clip)"
               />
               {/* The field still takes a pasted URL — YouTube, a link from
                   somewhere else. The upload is the second way in, for the
@@ -534,7 +534,7 @@ function PropertyPanelInner({
                   anything, so there is no blur to wait for. */}
               <MediaUploadButton
                 accept="video/*"
-                label="Video hochladen…"
+                label="Upload video…"
                 onUploaded={(media) => {
                   setVerificationVideoUrl(media.url);
                   directUpdate(nodeId, { verificationVideoUrl: media.url });
@@ -546,7 +546,7 @@ function PropertyPanelInner({
                 one it would show for free — frame 0 — is the blank page
                 the screen recorder was still waiting on. Directly under
                 the video link because it is only read when that is set. */}
-            <Field label="Video-Standbild">
+            <Field label="Video poster">
               <input
                 value={verificationVideoPosterUrl}
                 onChange={(e) => setVerificationVideoPosterUrl(e.target.value)}
@@ -559,11 +559,11 @@ function PropertyPanelInner({
                 }}
                 onKeyDown={(e) => e.stopPropagation()}
                 style={inputStyle}
-                placeholder="https://… (Standbild für den Player)"
+                placeholder="https://… (still frame for the player)"
               />
               <MediaUploadButton
                 accept="image/*"
-                label="Standbild hochladen…"
+                label="Upload poster…"
                 onUploaded={(media) => {
                   setVerificationVideoPosterUrl(media.url);
                   directUpdate(nodeId, { verificationVideoPosterUrl: media.url });
@@ -765,7 +765,7 @@ function PropertyPanelInner({
             requirements. Unlike the verification block above, this doesn't
             wait for a Requirement ID: hanging a document on a task is
             useful long before that task is a formally tracked requirement. */}
-        <Field label="Anhänge">
+        <Field label="Attachments">
           <AttachmentsSection
             attachments={node.attachments ?? []}
             onAdd={async (attachment) => {

--- a/packages/mindmap/src/RequirementsView.tsx
+++ b/packages/mindmap/src/RequirementsView.tsx
@@ -652,7 +652,7 @@ export function RequirementsView() {
               }
             }}
             disabled={exporting}
-            title="Als Anforderungsdokument (Word) exportieren — aktive Filter werden übernommen"
+            title="Export as Anforderungsdokument (Word) — the active filters carry over"
             style={secondaryButtonStyle(exporting)}
           >
             {exporting ? 'Exporting…' : 'Export Word'}
@@ -874,7 +874,7 @@ function ChapterGroup({
           onClickCapture={() => selectNode(r.node.id)}
           onMouseEnter={(e) => (e.currentTarget.style.background = '#eff6ff')}
           onMouseLeave={(e) => (e.currentTarget.style.background = rowBackground)}
-          title="Auswählen — Eigenschaften erscheinen rechts (↗ öffnet in der Mindmap)"
+          title="Select — properties appear on the right (↗ opens it in the mindmap)"
           style={{
             background: rowBackground,
             borderBottom: '1px solid #f1f5f9',
@@ -933,8 +933,8 @@ function ChapterGroup({
                       e.currentTarget.style.color = '#a5b4fc';
                       e.currentTarget.style.background = 'transparent';
                     }}
-                    title="Prüfanleitung ansehen"
-                    aria-label={`Prüfanleitung zu ${r.node.requirementId} ansehen`}
+                    title="See how to verify this"
+                    aria-label={`See how to verify ${r.node.requirementId}`}
                     style={guideMarkerStyle}
                   >
                     ≡

--- a/packages/mindmap/src/__tests__/uploadMedia.test.ts
+++ b/packages/mindmap/src/__tests__/uploadMedia.test.ts
@@ -183,11 +183,11 @@ describe('uploadMedia', () => {
     instance.respond(
       413,
       JSON.stringify({
-        error: { code: 'FILE_TOO_LARGE', message: 'Datei überschreitet das Limit von 100 MB' },
+        error: { code: 'FILE_TOO_LARGE', message: 'File exceeds the 100 MB limit' },
       }),
     );
 
-    await expect(promise).rejects.toThrow('Datei überschreitet das Limit von 100 MB');
+    await expect(promise).rejects.toThrow('File exceeds the 100 MB limit');
     await promise.catch((err) => {
       expect(err).toBeInstanceOf(ApiError);
       expect(err.status).toBe(413);

--- a/packages/server/src/routes/media.ts
+++ b/packages/server/src/routes/media.ts
@@ -210,7 +210,7 @@ export async function mediaRoutes(app: FastifyInstance): Promise<void> {
 
     if (aborted) {
       return reply.status(400).send({
-        error: { code: 'UPLOAD_ABORTED', message: 'Upload wurde unterbrochen' },
+        error: { code: 'UPLOAD_ABORTED', message: 'Upload was interrupted' },
       });
     }
 
@@ -218,7 +218,7 @@ export async function mediaRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(413).send({
         error: {
           code: 'FILE_TOO_LARGE',
-          message: `Datei überschreitet das Limit von ${Math.floor(limit / (1024 * 1024))} MB`,
+          message: `File exceeds the ${Math.floor(limit / (1024 * 1024))} MB limit`,
           maxBytes: limit,
         },
       });


### PR DESCRIPTION
Die Prüf-Felder und die Guide-Ansicht waren deutsch, alles andere in MindBlown englisch.

## Übersetzt (nur Oberflächen-Strings)

| Fläche | Beispiele |
|---|---|
| Guide-Ansicht, komplett | „Prüfanleitungen" → **How to verify**, Zählzeile, Suchfeld, Leerzustände, `Schritte` → **Steps**, `Anleitung bearbeiten` → **Edit the steps**, `Im Register ansehen` → **Show in register** |
| Property-Panel | **How to verify** / **Where to check** / **Demo video** / **Video poster** / **Attachments**, samt Platzhaltern und Upload-Knöpfen |
| Register | Tooltip der Prüf-Lupe, Export-Tooltip, Zeilen-Tooltip |
| View-Tab | „Prüfanleitungen" → **How to verify** |
| Anhänge | Leerzustand, Fehlermeldungen, `Link hinzufügen…` → **Add link…** |
| Upload-Knopf | Label, Fortschritt (`Lädt…` → **Uploading…**), Fehlermeldung |
| Server | zwei Meldungen aus `routes/media.ts`, die im Upload-Dialog landen (Limit überschritten, Upload abgebrochen) + der Test, der sie zitiert |

## Nicht angefasst

- **Der Word-Export bleibt deutsch.** Das Anforderungsdokument ist per Definition das Dokument für den Abnehmer.
- **Karteninhalte.** Requirement-Texte und geschriebene Anleitungen sind Nutzerdaten und bleiben in ihrer Sprache — im Screenshot unten sieht man das: Oberfläche englisch, Inhalt deutsch.
- Code-Kommentare.

## Test plan

Gegengeprüft **nicht am Diff, sondern an der gerenderten Ansicht**: ein Harness-Lauf (Guide-Ansicht + Property-Panel, Store gestubbt, danach gelöscht) sammelt sämtliche sichtbaren Textknoten plus `title` / `aria-label` / `placeholder` ein und prüft sie gegen eine Wortliste.

```
deutsche Reste in der gerenderten Ansicht: keine
```

Zwei Zustände abgedeckt: Kriterium **mit** Anleitung (Steps, Aktionsknöpfe, Prüf-Link) und **ohne** (`This feature is not available yet.` / `Once it is there, this is where it will say how to check it.`).

Der Grund für den DOM-Scan: meine erste Inventur per Umlaut-Suche über die Quelle hatte JSX-Textknoten ohne Attribut übersehen und `AttachmentsSection.tsx` komplett — also ungefähr ein Drittel der Strings. Eine Wortliste über die Quelle hätte dieselbe Lücke gehabt.

`pnpm turbo typecheck --force` und `test --force` grün, 0 cached: core 178, tool-kit 117, mindmap 155, mcp 26, server 793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsE7J58UqUnzhkSV1X9tWi