### PR TITLE
feat(export): Legende erklärt Lieferstand-Notizen als Anmerkung, nicht Bestellinhalt

### DIFF
--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -114,6 +114,12 @@ describe('buildRegisterData — Abnahme verdicts', () => {
     const md = renderMarkdown(data);
     expect(md).toContain('Business: T. Muster ✗ 17.07. («kaputt»)');
   });
+
+  it('explains the Lieferstand convention in the legend', () => {
+    const md = renderMarkdown(build(nodes, []));
+    expect(md).toContain('**Lieferstand-Notizen:**');
+    expect(md).toContain('nicht** Teil der bestellten Anforderung');
+  });
 });
 
 describe('buildRegisterData — Release column', () => {

--- a/packages/server/src/export/__tests__/requirementsDoc.test.ts
+++ b/packages/server/src/export/__tests__/requirementsDoc.test.ts
@@ -114,10 +114,19 @@ describe('buildRegisterData — Abnahme verdicts', () => {
     const md = renderMarkdown(data);
     expect(md).toContain('Business: T. Muster ✗ 17.07. («kaputt»)');
   });
+});
 
-  it('explains the Lieferstand convention in the legend', () => {
+describe('renderMarkdown — legend', () => {
+  const nodes = [
+    makeNode({ id: 'root', childrenIds: ['ch'] }),
+    makeNode({ id: 'ch', parentId: 'root', childrenIds: ['r1'], text: 'Bereich' }),
+    makeNode({ id: 'r1', parentId: 'ch', requirementId: 'MAN-01', percentComplete: 100 }),
+  ];
+
+  it('explains the Lieferstand convention', () => {
     const md = renderMarkdown(build(nodes, []));
     expect(md).toContain('**Lieferstand-Notizen:**');
+    expect(md).toContain('«Lieferstand TT.MM.JJJJ:»');
     expect(md).toContain('nicht** Teil der bestellten Anforderung');
   });
 });

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -399,6 +399,7 @@ const LEGEND = [
   '**Code %** (Code-Fortschritt): Anteil der erledigten Arbeitspakete unter einer Anforderung. Misst, wie viel Software gebaut wurde — **nicht**, ob das Ergebnis fachlich stimmt. 100 % bedeutet «Gebaut», nicht «Abgenommen».',
   '**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» ab Gebaut): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen',
   '**Abnahme:** zwei Stufen, je eine Zeile — **IT** (funktioniert es?) und **Business** (ist es das, was wir bestellt haben?) · ✓ erteilt, mit Name und Datum · ✗ zurückgewiesen (mit Begründung) · «offen» = gebaut, aber diese Unterschrift fehlt noch · ⚠ seit dem Urteil geändert · «—» noch nicht so weit',
+  '**Lieferstand-Notizen:** Trägt eine Anforderung einen Block «Lieferstand TT.MM.JJJJ: …», ist das eine Anmerkung des Projektteams zum aktuellen Stand der Lieferung (bekannte Lücken, Fundorte in der Oberfläche, laufende Fixes) — sie ist **nicht** Teil der bestellten Anforderung.',
 ];
 
 /**

--- a/packages/server/src/export/requirementsDoc.ts
+++ b/packages/server/src/export/requirementsDoc.ts
@@ -399,7 +399,7 @@ const LEGEND = [
   '**Code %** (Code-Fortschritt): Anteil der erledigten Arbeitspakete unter einer Anforderung. Misst, wie viel Software gebaut wurde — **nicht**, ob das Ergebnis fachlich stimmt. 100 % bedeutet «Gebaut», nicht «Abgenommen».',
   '**Aufwand** (Gesamt-Referenz) und **Rest** (verbleibend; «—» ab Gebaut): **S** ≤ 2 Tage · **M** 3–5 Tage · **L** 1–3 Wochen · **XL** > 3 Wochen',
   '**Abnahme:** zwei Stufen, je eine Zeile — **IT** (funktioniert es?) und **Business** (ist es das, was wir bestellt haben?) · ✓ erteilt, mit Name und Datum · ✗ zurückgewiesen (mit Begründung) · «offen» = gebaut, aber diese Unterschrift fehlt noch · ⚠ seit dem Urteil geändert · «—» noch nicht so weit',
-  '**Lieferstand-Notizen:** Trägt eine Anforderung einen Block «Lieferstand TT.MM.JJJJ: …», ist das eine Anmerkung des Projektteams zum aktuellen Stand der Lieferung (bekannte Lücken, Fundorte in der Oberfläche, laufende Fixes) — sie ist **nicht** Teil der bestellten Anforderung.',
+  '**Lieferstand-Notizen:** Anmerkungen des Projektteams zum aktuellen Stand der Lieferung (bekannte Lücken, Fundorte in der Oberfläche, laufende Fixes), meist eingeleitet mit «Lieferstand TT.MM.JJJJ:» oder «Noch offen:» — sie sind **nicht** Teil der bestellten Anforderung.',
 ];
 
 /**


### PR DESCRIPTION
Die Requirement-Texte im Register tragen seit 08.08. einheitliche Blöcke «Lieferstand TT.MM.JJJJ: …» (bekannte Lücken, Fundorte in der Oberfläche, laufende Fixes) am Zeilenende. Ohne Legende liest ein Business-Empfänger diese Blöcke als Teil der bestellten Anforderung.

Neue Legenden-Zeile in der gemeinsamen `LEGEND`-Liste (wirkt in md **und** docx, der docx-Renderer strippt die `**`-Marker wie bei den bestehenden Zeilen). Test ergänzt und mutation-verifiziert (Zeile entfernt → Test rot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011X5fXXrUPbft91ZdVDXLP4