### PR TITLE
feat(auth): Passwort ändern + Admin-Reset in den Workspace-Settings

### DIFF
--- a/packages/mindmap/src/AdminPasswordResetPanel.tsx
+++ b/packages/mindmap/src/AdminPasswordResetPanel.tsx
@@ -1,0 +1,173 @@
+/**
+ * Admin-only panel for resetting another user's password. There is no reset
+ * email on this instance — the server generates a temporary password, shows
+ * it here exactly once, and the admin hands it to the user out-of-band. The
+ * user then changes it via the Change Password form. Hides itself for
+ * non-admins, same as RegistrationPolicyPanel.
+ */
+
+import { useCallback, useState } from 'react';
+import { adminResetPassword } from './api.js';
+import { useMindmapStore } from './store.js';
+
+export function AdminPasswordResetPanel() {
+  const user = useMindmapStore((s) => s.user);
+  const [email, setEmail] = useState('');
+  const [resetting, setResetting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ email: string; tempPassword: string } | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const isAdmin = Boolean(user?.isAdmin);
+
+  const onReset = useCallback(async () => {
+    const target = email.trim();
+    if (!target) return;
+    if (!confirm(`Reset the password for ${target}? Their current password stops working immediately.`)) {
+      return;
+    }
+    setResetting(true);
+    setError(null);
+    setResult(null);
+    setCopied(false);
+    try {
+      setResult(await adminResetPassword(target));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reset password');
+    } finally {
+      setResetting(false);
+    }
+  }, [email]);
+
+  const onCopy = useCallback(async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result.tempPassword);
+      setCopied(true);
+    } catch {
+      // Clipboard unavailable (http, permissions) — the password is visible
+      // in the box; nothing to do.
+    }
+  }, [result]);
+
+  if (!isAdmin) return null;
+
+  const canReset = !resetting && email.trim().length > 0;
+
+  return (
+    <div style={{ marginTop: 24, paddingTop: 24, borderTop: '1px solid #f1f5f9' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#1e293b" strokeWidth="2">
+          <path d="M21 2l-2 2m-7.6 7.6a5.5 5.5 0 11-7.78 7.78 5.5 5.5 0 017.78-7.78zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
+        </svg>
+        <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#1e293b' }}>
+          Reset a User&apos;s Password
+        </h3>
+      </div>
+
+      <p style={{ fontSize: 12, color: '#64748b', margin: '0 0 12px' }}>
+        Generates a temporary password for the account and shows it once. Pass it
+        to the user directly — they should change it after logging in.
+      </p>
+
+      {error && (
+        <div
+          style={{
+            fontSize: 12,
+            color: '#dc2626',
+            background: '#fef2f2',
+            padding: '8px 12px',
+            borderRadius: 6,
+            marginBottom: 12,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        <input
+          type="email"
+          placeholder="user@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && canReset && onReset()}
+          style={{
+            flex: 1,
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid #e2e8f0',
+            fontSize: 13,
+            fontFamily: 'inherit',
+            color: '#1e293b',
+            background: '#fff',
+          }}
+        />
+        <button
+          onClick={onReset}
+          disabled={!canReset}
+          style={{
+            background: canReset ? '#dc2626' : '#e2e8f0',
+            color: canReset ? '#fff' : '#94a3b8',
+            border: 'none',
+            borderRadius: 8,
+            padding: '8px 16px',
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: canReset ? 'pointer' : 'default',
+            fontFamily: 'inherit',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {resetting ? 'Resetting...' : 'Reset password'}
+        </button>
+      </div>
+
+      {result && (
+        <div
+          style={{
+            background: '#f0fdf4',
+            border: '1px solid #bbf7d0',
+            borderRadius: 8,
+            padding: '12px 16px',
+          }}
+        >
+          <div style={{ fontSize: 12, color: '#166534', marginBottom: 8 }}>
+            Temporary password for <strong>{result.email}</strong> — shown only once:
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <code
+              style={{
+                fontSize: 14,
+                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                background: '#fff',
+                border: '1px solid #bbf7d0',
+                borderRadius: 6,
+                padding: '6px 10px',
+                color: '#1e293b',
+              }}
+            >
+              {result.tempPassword}
+            </code>
+            <button
+              onClick={onCopy}
+              style={{
+                background: 'none',
+                border: '1px solid #86efac',
+                borderRadius: 6,
+                padding: '5px 12px',
+                fontSize: 12,
+                fontWeight: 600,
+                color: '#166534',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/mindmap/src/ChangePasswordPanel.tsx
+++ b/packages/mindmap/src/ChangePasswordPanel.tsx
@@ -1,0 +1,157 @@
+/**
+ * Self-serve password change form. Rendered inside WorkspaceSettings for
+ * every logged-in user (workspace-wide view only).
+ */
+
+import { useCallback, useState } from 'react';
+import { changePassword } from './api.js';
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 12px',
+  borderRadius: 8,
+  border: '1px solid #e2e8f0',
+  fontSize: 13,
+  fontFamily: 'inherit',
+  color: '#1e293b',
+  background: '#fff',
+  boxSizing: 'border-box',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: 11,
+  fontWeight: 600,
+  color: '#64748b',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  marginBottom: 6,
+};
+
+export function ChangePasswordPanel() {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const mismatch = confirmPassword.length > 0 && newPassword !== confirmPassword;
+  const tooShort = newPassword.length > 0 && newPassword.length < 8;
+  const canSave =
+    !saving &&
+    currentPassword.length > 0 &&
+    newPassword.length >= 8 &&
+    newPassword === confirmPassword;
+
+  const onSave = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await changePassword(currentPassword, newPassword);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setSavedAt(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to change password');
+    } finally {
+      setSaving(false);
+    }
+  }, [currentPassword, newPassword]);
+
+  return (
+    <div style={{ marginTop: 24, paddingTop: 24, borderTop: '1px solid #f1f5f9' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#1e293b" strokeWidth="2">
+          <rect x="3" y="11" width="18" height="11" rx="2" />
+          <path d="M7 11V7a5 5 0 0110 0v4" />
+        </svg>
+        <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600, color: '#1e293b' }}>
+          Change Password
+        </h3>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            fontSize: 12,
+            color: '#dc2626',
+            background: '#fef2f2',
+            padding: '8px 12px',
+            borderRadius: 6,
+            marginBottom: 12,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ marginBottom: 12 }}>
+        <label style={labelStyle}>Current password</label>
+        <input
+          type="password"
+          autoComplete="current-password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={{ marginBottom: 12 }}>
+        <label style={labelStyle}>New password</label>
+        <input
+          type="password"
+          autoComplete="new-password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          style={inputStyle}
+        />
+        {tooShort && (
+          <div style={{ fontSize: 11, color: '#dc2626', marginTop: 6 }}>
+            At least 8 characters.
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginBottom: 12 }}>
+        <label style={labelStyle}>Confirm new password</label>
+        <input
+          type="password"
+          autoComplete="new-password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          style={inputStyle}
+        />
+        {mismatch && (
+          <div style={{ fontSize: 11, color: '#dc2626', marginTop: 6 }}>
+            Passwords do not match.
+          </div>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <button
+          onClick={onSave}
+          disabled={!canSave}
+          style={{
+            background: canSave ? '#4f46e5' : '#e2e8f0',
+            color: canSave ? '#fff' : '#94a3b8',
+            border: 'none',
+            borderRadius: 8,
+            padding: '8px 16px',
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: canSave ? 'pointer' : 'default',
+            fontFamily: 'inherit',
+          }}
+        >
+          {saving ? 'Saving...' : 'Change password'}
+        </button>
+        {savedAt && Date.now() - savedAt < 3000 && (
+          <span style={{ fontSize: 12, color: '#16a34a' }}>Password changed</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/mindmap/src/WorkspaceSettings.tsx
+++ b/packages/mindmap/src/WorkspaceSettings.tsx
@@ -13,6 +13,8 @@ import {
 import type { GitHubInstallStatus, GitHubRepoInfo } from './api.js';
 import { useMindmapStore } from './store.js';
 import { RegistrationPolicyPanel } from './RegistrationPolicyPanel.js';
+import { ChangePasswordPanel } from './ChangePasswordPanel.js';
+import { AdminPasswordResetPanel } from './AdminPasswordResetPanel.js';
 import { ClaudeConnectPanel } from './ClaudeConnectPanel.js';
 import { SettingsApiKeys } from './SettingsApiKeys.js';
 import { AiProviderPanel } from './AiProviderPanel.js';
@@ -420,8 +422,14 @@ export function WorkspaceSettings({
           {/* Connect to Claude (legacy stdio MCP shim) — shown only in workspace-wide view */}
           {!mapId && <ClaudeConnectPanel />}
 
+          {/* Account password — shown only in workspace-wide view */}
+          {!mapId && <ChangePasswordPanel />}
+
           {/* Registration policy — shown only in workspace-wide view */}
           {!mapId && <RegistrationPolicyPanel />}
+
+          {/* Admin password reset — shown only in workspace-wide view */}
+          {!mapId && <AdminPasswordResetPanel />}
 
           {/* AI chat provider — shown only in workspace-wide view */}
           {!mapId && <AiProviderPanel />}

--- a/packages/mindmap/src/api.ts
+++ b/packages/mindmap/src/api.ts
@@ -255,6 +255,20 @@ export function getMe(): Promise<AuthUser> {
   return request<AuthUser>('/api/auth/me');
 }
 
+export function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  return request<void>('/api/auth/change-password', {
+    method: 'POST',
+    body: JSON.stringify({ currentPassword, newPassword }),
+  });
+}
+
+export function adminResetPassword(email: string): Promise<{ email: string; tempPassword: string }> {
+  return request<{ email: string; tempPassword: string }>('/api/system/reset-password', {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  });
+}
+
 // ── Comments ────────────────────────────────────────────────────
 
 export function fetchComments(mapId: string, nodeId: string): Promise<Comment[]> {

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -267,6 +267,48 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
+  // ── POST /api/auth/change-password ─────────────────────────────
+  // Self-serve password change for a logged-in user. Requires the current
+  // password (so a hijacked session can't silently lock the owner out) and
+  // a web session — API keys can't rotate the credential that outlives them.
+  app.post('/api/auth/change-password', async (req, reply) => {
+    const { userId, authSource } = req as { userId?: string; authSource?: 'jwt' | 'api-key' };
+    if (!userId) {
+      return reply.status(401).send({
+        error: { code: 'UNAUTHORIZED', message: 'Not authenticated' },
+      });
+    }
+    if (authSource === 'api-key') {
+      return reply.status(403).send({
+        error: { code: 'FORBIDDEN', message: 'Password changes require a web session, not an API key' },
+      });
+    }
+
+    const body = req.body as { currentPassword?: string; newPassword?: string };
+    if (!body.currentPassword || !body.newPassword) {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: 'currentPassword and newPassword are required' },
+      });
+    }
+    if (body.newPassword.length < 8) {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: 'New password must be at least 8 characters' },
+      });
+    }
+
+    const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user || !user.passwordHash || !(await verifyPassword(body.currentPassword, user.passwordHash))) {
+      return reply.status(401).send({
+        error: { code: 'INVALID_CREDENTIALS', message: 'Current password is incorrect' },
+      });
+    }
+
+    const passwordHash = await hashPassword(body.newPassword);
+    await db.update(users).set({ passwordHash }).where(eq(users.id, userId));
+
+    return reply.status(204).send();
+  });
+
   // ── POST /api/auth/long-lived-token ───────────────────────────
   // Mint a 1-year JWT for the caller — intended for the MCP server and
   // other headless clients. Caller must already be authed via session

--- a/packages/server/src/routes/__tests__/admin-endpoints-guard.test.ts
+++ b/packages/server/src/routes/__tests__/admin-endpoints-guard.test.ts
@@ -68,6 +68,7 @@ vi.mock('../../db/schema.js', () => ({
   versions: {},
   nodes: {},
   maps: {},
+  users: {},
 }));
 vi.mock('../../db/nodes.js', () => ({
   getNode: vi.fn(),
@@ -191,6 +192,19 @@ describe('admin endpoints — non-admin JWT (negative control)', () => {
     expect(res.json().error?.code).toBe('FORBIDDEN');
   });
 
+  it('POST /api/system/reset-password → 403 for non-admin JWT', async () => {
+    requireAdminReturn = false;
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/system/reset-password',
+      payload: { email: 'someone@example.com' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error?.code).toBe('FORBIDDEN');
+  });
+
   it('POST /api/maps/sync/audit-drift → 403 for non-admin JWT', async () => {
     requireAdminReturn = false;
     const app = await buildApp('jwt');
@@ -234,6 +248,19 @@ describe('admin endpoints — API-key auth (closes #69)', () => {
       method: 'PUT',
       url: '/api/system/ai-provider',
       payload: { preference: 'anthropic' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error?.code).toBe('FORBIDDEN');
+  });
+
+  it('POST /api/system/reset-password → 403 even when user is admin', async () => {
+    requireAdminReturn = true;
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/system/reset-password',
+      payload: { email: 'someone@example.com' },
     });
     await app.close();
     expect(res.statusCode).toBe(403);

--- a/packages/server/src/routes/__tests__/password-routes.test.ts
+++ b/packages/server/src/routes/__tests__/password-routes.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Behavior tests for the two password write paths:
+ *
+ *   POST /api/auth/change-password   — self-serve, needs the current password
+ *   POST /api/system/reset-password  — admin-only, mints a temp password
+ *
+ * The DB is a chain-shaped stub (select→from→where→limit, update→set→where)
+ * with a per-test queue of select results, so both the routes' own lookups
+ * and requireAdmin's is_admin probe run against controlled rows. Hashing is
+ * the real scrypt implementation — the assertions round-trip the stored hash
+ * through verifyPassword.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// ── DB stub ───────────────────────────────────────────────────────
+let selectQueue: unknown[][] = [];
+let updateSetCalls: Record<string, unknown>[] = [];
+
+vi.mock('../../db/connection.js', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => selectQueue.shift() ?? [],
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: async () => {
+          updateSetCalls.push(values);
+        },
+      }),
+    }),
+  },
+}));
+vi.mock('../../db/schema.js', () => ({ users: {}, pendingInvites: {} }));
+vi.mock('../../db/permissions.js', () => ({
+  resolvePendingInvites: vi.fn(async () => 0),
+}));
+vi.mock('../../db/settings.js', () => ({
+  getRegistrationPolicy: vi.fn(async () => ({ mode: 'open', allowlist: [] })),
+  setRegistrationPolicy: vi.fn(async (p: unknown) => p),
+  getAiProviderSettings: vi.fn(async () => ({ preference: 'auto' })),
+  setAiProviderSettings: vi.fn(async (s: unknown) => s),
+}));
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }));
+
+import { authRoutes, hashPassword, verifyPassword } from '../../auth.js';
+import { systemRoutes } from '../system.js';
+
+const UID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+async function buildApp(authSource: 'jwt' | 'api-key' | 'none'): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.addHook('preHandler', async (req) => {
+    if (authSource === 'none') return;
+    req.userId = UID;
+    req.authSource = authSource;
+  });
+  await app.register(authRoutes);
+  await app.register(systemRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  selectQueue = [];
+  updateSetCalls = [];
+});
+
+// ── POST /api/auth/change-password ───────────────────────────────
+
+describe('POST /api/auth/change-password', () => {
+  it('401 when unauthenticated', async () => {
+    const app = await buildApp('none');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/change-password',
+      payload: { currentPassword: 'a', newPassword: 'bbbbbbbb' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('403 for api-key auth even with valid credentials', async () => {
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/change-password',
+      payload: { currentPassword: 'a', newPassword: 'bbbbbbbb' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+    expect(updateSetCalls).toHaveLength(0);
+  });
+
+  it('400 when fields are missing', async () => {
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/change-password',
+      payload: { currentPassword: 'a' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error?.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('400 when the new password is under 8 characters', async () => {
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/change-password',
+      payload: { currentPassword: 'old-pass', newPassword: 'short' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    expect(updateSetCalls).toHaveLength(0);
+  });
+
+  it('401 when the current password is wrong, and does not write', async () => {
+    selectQueue = [[{ id: UID, passwordHash: await hashPassword('right-password') }]];
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/change-password',
+      payload: { currentPassword: 'wrong-password', newPassword: 'new-password-1' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error?.code).toBe('INVALID_CREDENTIALS');
+    expect(updateSetCalls).toHaveLength(0);
+  });
+
+  it('204 on success and the stored hash verifies against the new password', async () => {
+    selectQueue = [[{ id: UID, passwordHash: await hashPassword('old-password') }]];
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/change-password',
+      payload: { currentPassword: 'old-password', newPassword: 'new-password-1' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(204);
+    expect(updateSetCalls).toHaveLength(1);
+    const stored = updateSetCalls[0].passwordHash as string;
+    expect(await verifyPassword('new-password-1', stored)).toBe(true);
+    expect(await verifyPassword('old-password', stored)).toBe(false);
+  });
+});
+
+// ── POST /api/system/reset-password ──────────────────────────────
+
+describe('POST /api/system/reset-password', () => {
+  it('403 for a non-admin JWT user', async () => {
+    selectQueue = [[{ isAdmin: false }]]; // requireAdmin's probe
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/system/reset-password',
+      payload: { email: 'marcel@example.com' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+    expect(updateSetCalls).toHaveLength(0);
+  });
+
+  it('403 for api-key auth even when the user is an admin', async () => {
+    // requireAdmin short-circuits on authSource before its DB probe.
+    const app = await buildApp('api-key');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/system/reset-password',
+      payload: { email: 'marcel@example.com' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(403);
+    expect(selectQueue).toHaveLength(0);
+  });
+
+  it('400 when email is missing', async () => {
+    selectQueue = [[{ isAdmin: true }]];
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/system/reset-password',
+      payload: {},
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('404 when no user has that email', async () => {
+    selectQueue = [[{ isAdmin: true }], []];
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/system/reset-password',
+      payload: { email: 'nobody@example.com' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error?.code).toBe('USER_NOT_FOUND');
+    expect(updateSetCalls).toHaveLength(0);
+  });
+
+  it('200 returns a temp password whose hash was stored', async () => {
+    selectQueue = [
+      [{ isAdmin: true }],
+      [{ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', email: 'marcel@example.com' }],
+    ];
+    const app = await buildApp('jwt');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/system/reset-password',
+      payload: { email: 'marcel@example.com' },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { email: string; tempPassword: string };
+    expect(body.email).toBe('marcel@example.com');
+    expect(body.tempPassword).toMatch(/^mb-/);
+    expect(body.tempPassword.length).toBeGreaterThanOrEqual(12);
+    expect(updateSetCalls).toHaveLength(1);
+    const stored = updateSetCalls[0].passwordHash as string;
+    expect(await verifyPassword(body.tempPassword, stored)).toBe(true);
+  });
+});

--- a/packages/server/src/routes/system.ts
+++ b/packages/server/src/routes/system.ts
@@ -4,6 +4,7 @@
  * signup is closed); writes are admin-only.
  */
 
+import { randomBytes } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import {
   getRegistrationPolicy,
@@ -14,7 +15,10 @@ import {
   type AiProviderSettings,
   type AiProviderPreference,
 } from '../db/settings.js';
-import { requireAdmin } from '../auth.js';
+import { requireAdmin, hashPassword } from '../auth.js';
+import { db } from '../db/connection.js';
+import { users } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
 
 export async function systemRoutes(app: FastifyInstance): Promise<void> {
   // ── GET /api/system/registration-policy ────────────────────────
@@ -93,5 +97,39 @@ export async function systemRoutes(app: FastifyInstance): Promise<void> {
       preference: preference as AiProviderPreference,
     });
     return saved;
+  });
+
+  // ── POST /api/system/reset-password ────────────────────────────
+  // Admin-only. Sets a server-generated temporary password on the given
+  // account and returns it once — there is no reset email; the admin hands
+  // the temp password to the user out-of-band, who then changes it via
+  // /api/auth/change-password.
+  app.post('/api/system/reset-password', async (req, reply) => {
+    if (!(await requireAdmin(req))) {
+      return reply.status(403).send({
+        error: { code: 'FORBIDDEN', message: 'Admin access required' },
+      });
+    }
+    const body = req.body as { email?: string };
+    const email = body?.email?.trim();
+    if (!email) {
+      return reply.status(400).send({
+        error: { code: 'VALIDATION_ERROR', message: 'email is required' },
+      });
+    }
+    const [user] = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+    if (!user) {
+      return reply.status(404).send({
+        error: { code: 'USER_NOT_FOUND', message: `No user with email ${email}` },
+      });
+    }
+    const tempPassword = `mb-${randomBytes(9).toString('base64url')}`;
+    const passwordHash = await hashPassword(tempPassword);
+    await db.update(users).set({ passwordHash }).where(eq(users.id, user.id));
+    return { email: user.email, tempPassword };
   });
 }


### PR DESCRIPTION
## Was

Bisher gab es **keinen Passwort-Schreibpfad ausser der Registrierung** — ein vergessenes Passwort hiess manuelles `UPDATE` auf der Prod-DB. Dieser PR schliesst die Lücke mit den zwei minimalen Bausteinen:

### 1. Self-Service: Passwort ändern
- `POST /api/auth/change-password` — verlangt das aktuelle Passwort, neues min. 8 Zeichen
- Nur per Web-Session: API-Keys werden abgelehnt (gleiche Konvention wie `/api/api-keys` / `requireAdmin`, #69)
- UI: **ChangePasswordPanel** in den WorkspaceSettings (alle eingeloggten User)

### 2. Admin-Reset
- `POST /api/system/reset-password` — admin-only via `requireAdmin`, generiert ein temporäres Passwort (`mb-…`, 12 Zeichen) und gibt es **genau einmal** zurück; kein Reset-Mail / SMTP nötig
- UI: **AdminPasswordResetPanel** in den WorkspaceSettings (versteckt sich für Nicht-Admins, wie RegistrationPolicyPanel), mit Copy-Button und Bestätigungsdialog

## Tests
- `password-routes.test.ts` (11 Tests): 401/403/400-Pfade, falsches aktuelles Passwort schreibt nicht, Erfolgs-Roundtrip verifiziert den gespeicherten Hash mit echtem scrypt
- `admin-endpoints-guard.test.ts`: +2 Guard-Fälle für den neuen Admin-Endpunkt (Non-Admin-JWT, API-Key)
- `pnpm turbo typecheck` + `pnpm turbo test` grün (807 Tests)

Kein MCP-Surface nötig: Passwort-Flows sind bewusst session-only — ein API-Key-Agent soll das Credential, das ihn überlebt, nicht rotieren können.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL8GouvG4rJk6PAgLQWqvL